### PR TITLE
Add Biome linting and prepare 0.1.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] — Unreleased
+## [0.1.0] — 2026-07-14
 
 Initial release.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A persistent, policy-guarded Playwright browser for AI agents.**
 
-![BetterWright — an agent operating a browser](docs/assets/hero.png)
+![BetterWright — an agent operating a browser](https://raw.githubusercontent.com/CuriosityOS/betterwright/main/docs/assets/hero.png)
 
 Playwright gives you a browser automation API. BetterWright is the layer you
 need on top of it when the thing driving the browser is a language model rather

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -7,8 +7,8 @@
 //   betterwright repl             run blank-line-separated snippets from stdin
 
 import { spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "files": {
+    "includes": ["src/**", "bin/**", "scripts/**", "tests/**"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "postinstall": "node bin/betterwright.mjs setup || true",
     "test": "node --test tests/node/*.test.mjs",
-    "lint": "for f in src/*.mjs bin/*.mjs; do node --check \"$f\" || exit 1; done"
+    "lint": "biome ci src bin scripts tests"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -44,9 +44,16 @@
     "web-agent"
   ],
   "license": "MIT",
+  "author": "BetterWright contributors",
   "repository": {
     "type": "git",
-    "url": "https://github.com/CuriosityOS/betterwright.git"
+    "url": "git+https://github.com/CuriosityOS/betterwright.git"
   },
-  "homepage": "https://github.com/CuriosityOS/betterwright#readme"
+  "bugs": {
+    "url": "https://github.com/CuriosityOS/betterwright/issues"
+  },
+  "homepage": "https://github.com/CuriosityOS/betterwright#readme",
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.3"
+  }
 }

--- a/python/src/betterwright/_worker/worker.mjs
+++ b/python/src/betterwright/_worker/worker.mjs
@@ -15,8 +15,8 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
-import vm from "node:vm";
 import { pathToFileURL } from "node:url";
+import vm from "node:vm";
 
 import { detectBotChallenge, isPublicSearchNavigation } from "./challenges.mjs";
 import {
@@ -1725,7 +1725,7 @@ async function summarize(value, seen = new WeakSet(), depth = 0) {
   return redactDeep(output);
 }
 
-function compileCode(code, context) {
+function compileCode(code) {
   const expression = `(async () => (${code}\n))()`;
   try {
     return new vm.Script(expression, {
@@ -1800,7 +1800,7 @@ async function execute(message) {
     await ensureBrowser(message.config);
     await ensureSessionPage(session);
     const { context } = buildSandbox(session, consoleMessages);
-    const script = compileCode(String(message.code || ""), context);
+    const script = compileCode(String(message.code || ""));
     const promise = script.runInContext(context, {
       timeout: SAFE_SYNC_VM_TIMEOUT_MS,
     });

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,5 +1,5 @@
-export { BetterWright, BrowserError, NetworkPolicy } from "./client.mjs";
 export { ensureChromeCdp, findChromeExecutable } from "./chrome.mjs";
+export { BetterWright, BrowserError, NetworkPolicy } from "./client.mjs";
+export { piImageContent } from "./pi.mjs";
 export { METADATA_ADDRESSES, METADATA_HOSTNAMES } from "./policy.mjs";
 export { agentSystemPrompt } from "./prompt.mjs";
-export { piImageContent } from "./pi.mjs";

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -15,8 +15,8 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
-import vm from "node:vm";
 import { pathToFileURL } from "node:url";
+import vm from "node:vm";
 
 import { detectBotChallenge, isPublicSearchNavigation } from "./challenges.mjs";
 import {
@@ -1725,7 +1725,7 @@ async function summarize(value, seen = new WeakSet(), depth = 0) {
   return redactDeep(output);
 }
 
-function compileCode(code, context) {
+function compileCode(code) {
   const expression = `(async () => (${code}\n))()`;
   try {
     return new vm.Script(expression, {
@@ -1800,7 +1800,7 @@ async function execute(message) {
     await ensureBrowser(message.config);
     await ensureSessionPage(session);
     const { context } = buildSandbox(session, consoleMessages);
-    const script = compileCode(String(message.code || ""), context);
+    const script = compileCode(String(message.code || ""));
     const promise = script.runInContext(context, {
       timeout: SAFE_SYNC_VM_TIMEOUT_MS,
     });

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -2,9 +2,9 @@
 // policy suite still runs on machines without the runtime installed.
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { createRequire } from "node:module";
 import { test } from "node:test";
 
 import { BetterWright, NetworkPolicy } from "../../src/index.mjs";
@@ -108,7 +108,7 @@ test("captcha.drag performs a smooth pointer drag and returns a fresh snapshot",
           document.addEventListener('mouseup', event => {
             if (started && event.clientX > 200) document.querySelector('#status').textContent = 'Dragged';
           });
-        <\/script>
+        </script>
       \`);
       const bounds = await page.locator('#handle').boundingBox();
       const from = {x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2};
@@ -157,7 +157,7 @@ test("human helpers use shaped pointer, keyboard, and wheel events", opts, async
           document.querySelector('#go').addEventListener('click', () => {
             document.querySelector('#status').textContent = 'Clicked';
           });
-        <\/script>
+        </script>
       \`);
       await human.click(page.locator('#go'));
       await human.type('#name', 'Ada');


### PR DESCRIPTION
## Summary

Gets the repo release-ready for the first `0.1.0` publish to npm and PyPI, and closes the JS-vs-Python lint asymmetry.

### Linting
- Lint the JavaScript side with **Biome** (single Rust binary, zero JS deps) — the analogue of the Python side's `ruff`. `npm run lint` is now `biome ci`, which CI already invokes.
- Biome immediately caught a dead `context` parameter in `compileCode` (removed), no-op string escapes in test fixtures, and unsorted imports (organized to mirror ruff's `I`/isort rule).

### Release prep for 0.1.0
- README hero image now uses an absolute `raw.githubusercontent.com` URL so it renders on npmjs.com regardless of npm's (flaky) relative-link rewriting. `python/README.md` (PyPI's page) has no relative refs.
- `package.json`: added `author` and `bugs`, canonicalized `repository.url` to `git+https` form.
- Dated the `0.1.0` changelog entry.

## Verification
- ✅ `twine check` passes on wheel **and** sdist; both bundle the worker `.mjs` files (self-contained `pip` install)
- ✅ `npm publish --dry-run` clean — 13 files, worker included
- ✅ `betterwright` name free on both npm and PyPI
- ✅ All 34 Node tests pass; worker copies in sync

## Not included
- `package-lock.json` is intentionally left untracked to preserve the repo's no-lockfile convention (CI uses `npm install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized the `0.1.0` release date in the changelog.
  * Updated the README hero image reference for reliable display.

* **Chores**
  * Added Biome linting configuration and expanded lint coverage.
  * Improved package metadata, including author, repository, and issue links.

* **Refactor**
  * Simplified worker code handling while preserving runtime behavior.
  * Reorganized imports and exports for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->