### PR TITLE
Add interactive, diff, selector, and depth snapshot options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `snapshot()` options for cheaper page observation: `interactive` (actionable
+  elements only), `diff` (only the lines changed since the previous snapshot),
+  `selector` (scope to a CSS selector), and `depth` (limit tree depth).
+- Documented that snapshot `[ref=eN]` markers are directly actionable via
+  `page.locator('aria-ref=eN')`.
+
+### Changed
+
+- Result envelopes omit empty `console`/`events`/`artifacts`/`warnings`
+  collections instead of sending empty arrays.
+
 ## [0.1.0] — 2026-07-14
 
 Initial release.

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -52,15 +52,33 @@ return { a: await a.title(), b: await b.title() };
 ## Reading the page
 
 `snapshot(options?)` returns an accessibility-tree snapshot of the current page —
-a compact, model-friendly view of the interactive elements, far cheaper than
-full HTML. Options: `maxChars` (default 10000, capped at 20000) and `timeout`.
+a compact, model-friendly view far cheaper than full HTML. Every element carries
+a `[ref=eN]` marker you can act on directly with an `aria-ref` locator, so there
+is no need to reverse-engineer a CSS selector from the snapshot:
 
 ```js
-return await snapshot();      // "page page-1 https://…\n- button \"Sign in\"\n- textbox …"
+return await snapshot({interactive: true}); // "page page-1 https://…\n- button \"Sign in\" [ref=e12]…"
+// then, in a later run:
+await human.click(page.locator('aria-ref=e12'));
 ```
 
-For anything Playwright can read — text, attributes, computed state — use the
-normal `page.locator(...)` API.
+Refs are assigned fresh on every snapshot and go stale when the page changes —
+re-snapshot after navigations or re-renders before using one.
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `interactive` | `false` | Keep only actionable elements (buttons, links, inputs, `cursor: pointer`, …) plus their ancestors. The cheapest way to see what you can do on a page. |
+| `diff` | `false` | Return only the `+`/`-` lines changed since the previous same-shaped snapshot of this page, or `(no changes since previous snapshot)`. |
+| `selector` | — | Scope the snapshot to a CSS selector, e.g. `{selector: '#main'}`. |
+| `depth` | — | Limit tree depth. |
+| `maxChars` | `10000` | Truncation limit, capped at 20000. |
+| `timeout` | `10000` | Milliseconds. |
+
+Prefer `snapshot({interactive: true})` for deciding what to click and
+`snapshot({diff: true})` for checking what an action changed; take a full
+`snapshot()` only when you need to read page content wholesale. For anything
+Playwright can read — text, attributes, computed state — use the normal
+`page.locator(...)` API.
 
 ## Human-shaped interactions
 

--- a/python/src/betterwright/_worker/snapshot.mjs
+++ b/python/src/betterwright/_worker/snapshot.mjs
@@ -1,0 +1,132 @@
+// Pure text transforms for aria snapshots (mode: "ai"). Kept free of
+// Playwright imports so they can be unit-tested without a browser.
+
+// Roles an agent can act on. Mirrors the set agent-browser refs, minus
+// container roles that only matter with a name (covered by cursor=pointer).
+const INTERACTIVE_ROLE = new RegExp(
+  "^\\s*- (?:button|link|textbox|searchbox|combobox|checkbox|radio|switch|" +
+    "slider|spinbutton|menuitem(?:checkbox|radio)?|option|tab|treeitem|" +
+    "listbox|iframe)\\b",
+);
+
+function indentOf(line) {
+  let count = 0;
+  while (line[count] === " ") count += 1;
+  return count;
+}
+
+/**
+ * Reduce an aria snapshot to interactive elements plus the ancestor lines
+ * needed to keep the tree readable. Property lines (`- /url: …`) survive when
+ * their element does.
+ */
+export function filterInteractive(text) {
+  const lines = String(text).split("\n");
+  const keep = new Array(lines.length).fill(false);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const isProperty = /^\s*- \//.test(line);
+    if (
+      isProperty ||
+      !(INTERACTIVE_ROLE.test(line) || line.includes("[cursor=pointer]"))
+    )
+      continue;
+    keep[i] = true;
+    let indent = indentOf(line);
+    // Walk up the tree keeping each ancestor once.
+    for (let j = i - 1; j >= 0 && indent > 0; j -= 1) {
+      const parentIndent = indentOf(lines[j]);
+      if (parentIndent < indent) {
+        keep[j] = true;
+        indent = parentIndent;
+      }
+    }
+    // Keep property lines nested directly under this element.
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (!/^\s*- \//.test(lines[j]) || indentOf(lines[j]) <= indentOf(line))
+        break;
+      keep[j] = true;
+    }
+  }
+  const kept = lines.filter((_, i) => keep[i]);
+  return kept.length ? kept.join("\n") : "(no interactive elements)";
+}
+
+// Beyond this many lines per side an LCS table stops being cheap; callers
+// fall back to the full snapshot.
+const MAX_DIFF_LINES = 3_000;
+
+/**
+ * Line diff between two snapshots. Returns `{changed: false}` when equal,
+ * `{changed: true, diff, additions, removals}` with only `+`/`-` lines
+ * otherwise, or `{tooLarge: true}` when either side exceeds MAX_DIFF_LINES.
+ */
+export function diffSnapshots(previous, current) {
+  if (previous === current) return { changed: false };
+  let before = String(previous).split("\n");
+  let after = String(current).split("\n");
+  // Trim the common prefix and suffix so the LCS table only covers the
+  // changed region.
+  let start = 0;
+  while (
+    start < before.length &&
+    start < after.length &&
+    before[start] === after[start]
+  )
+    start += 1;
+  let endBefore = before.length;
+  let endAfter = after.length;
+  while (
+    endBefore > start &&
+    endAfter > start &&
+    before[endBefore - 1] === after[endAfter - 1]
+  ) {
+    endBefore -= 1;
+    endAfter -= 1;
+  }
+  before = before.slice(start, endBefore);
+  after = after.slice(start, endAfter);
+  if (before.length > MAX_DIFF_LINES || after.length > MAX_DIFF_LINES)
+    return { changed: true, tooLarge: true };
+
+  // Longest-common-subsequence table over the changed region.
+  const rows = before.length + 1;
+  const cols = after.length + 1;
+  const table = new Uint32Array(rows * cols);
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    for (let j = after.length - 1; j >= 0; j -= 1) {
+      table[i * cols + j] =
+        before[i] === after[j]
+          ? table[(i + 1) * cols + j + 1] + 1
+          : Math.max(table[(i + 1) * cols + j], table[i * cols + j + 1]);
+    }
+  }
+  const out = [];
+  let additions = 0;
+  let removals = 0;
+  let i = 0;
+  let j = 0;
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      i += 1;
+      j += 1;
+    } else if (table[(i + 1) * cols + j] >= table[i * cols + j + 1]) {
+      out.push(`- ${before[i]}`);
+      removals += 1;
+      i += 1;
+    } else {
+      out.push(`+ ${after[j]}`);
+      additions += 1;
+      j += 1;
+    }
+  }
+  for (; i < before.length; i += 1) {
+    out.push(`- ${before[i]}`);
+    removals += 1;
+  }
+  for (; j < after.length; j += 1) {
+    out.push(`+ ${after[j]}`);
+    additions += 1;
+  }
+  return { changed: true, diff: out.join("\n"), additions, removals };
+}

--- a/python/src/betterwright/_worker/worker.mjs
+++ b/python/src/betterwright/_worker/worker.mjs
@@ -26,6 +26,7 @@ import {
   scrollWheel,
   typeText,
 } from "./human.mjs";
+import { diffSnapshots, filterInteractive } from "./snapshot.mjs";
 
 const playwrightCoreDir = process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH || "";
 const playwrightModule = playwrightCoreDir
@@ -107,6 +108,11 @@ function sendResult(message) {
     message.console = [];
     message.events = [];
     message.pages = (message.pages || []).slice(0, 4);
+  }
+  // Empty collections carry no information; both clients default them.
+  for (const key of Object.keys(message)) {
+    if (Array.isArray(message[key]) && message[key].length === 0)
+      delete message[key];
   }
   send(message);
 }
@@ -840,16 +846,45 @@ async function ensureSessionPage(session) {
   return adoptPage(unowned || (await browserContext.newPage()), session.id);
 }
 
+// Last snapshot text per page, keyed by the options that shape it, so
+// `diff: true` always compares like against like.
+const lastSnapshots = new WeakMap();
+
 async function snapshotPage(page, options = {}) {
-  const text = await page.locator("body").ariaSnapshot({
+  const depth = Math.floor(Number(options?.depth) || 0);
+  const scope = options?.selector
+    ? page.locator(String(options.selector))
+    : page.locator("body");
+  let text = await scope.ariaSnapshot({
     mode: "ai",
     timeout: Number(options?.timeout || 10_000),
+    ...(depth > 0 ? { depth } : {}),
   });
+  if (options?.interactive) text = filterInteractive(text);
+
+  const key = JSON.stringify([
+    String(options?.selector || ""),
+    Boolean(options?.interactive),
+    depth,
+  ]);
+  const store = lastSnapshots.get(page) || new Map();
+  lastSnapshots.set(page, store);
+  const previous = store.get(key);
+  store.set(key, text);
+
+  const header = `page ${pageId(page)} ${page.url()}`;
+  if (options?.diff && previous !== undefined) {
+    const result = diffSnapshots(previous, text);
+    if (!result.changed)
+      return `${header}\n(no changes since previous snapshot)`;
+    if (!result.tooLarge)
+      text = `diff vs previous snapshot (+${result.additions} -${result.removals})\n${result.diff}`;
+  }
   const limit = Math.max(
     1_000,
     Math.min(Number(options?.maxChars || 10_000), 20_000),
   );
-  return `page ${pageId(page)} ${page.url()}\n${text.length > limit ? `${text.slice(0, limit)}\n[truncated]` : text}`;
+  return `${header}\n${text.length > limit ? `${text.slice(0, limit)}\n[truncated]` : text}`;
 }
 
 function captchaBounds(value, label = "bounds") {

--- a/python/src/betterwright/prompt.py
+++ b/python/src/betterwright/prompt.py
@@ -34,8 +34,10 @@ do it themselves, and do not add "are you sure?" friction to the ordinary steps
 of a task they already asked for. You are the operator, not a bystander.
 
 ## Work autonomously
-- Inspect the page (`snapshot()` or ordinary Playwright reads), act, and keep
-  going until the task is complete. Ordinary, reversible decisions are yours.
+- Inspect the page with `snapshot({interactive: true})` (act on its
+  `[ref=eN]` markers via `page.locator('aria-ref=eN')`), check what changed
+  with `snapshot({diff: true})`, and keep going until the task is complete.
+  Ordinary, reversible decisions are yours.
 - Recover from routine failures — a slow load, a moved element, a validation
   error — by retrying or taking another path, the way a person would.
 - Open several tabs when it helps (`openPage`, `Promise.all`).

--- a/scripts/sync-worker.mjs
+++ b/scripts/sync-worker.mjs
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const files = ["worker.mjs", "challenges.mjs", "human.mjs"];
+const files = ["worker.mjs", "challenges.mjs", "human.mjs", "snapshot.mjs"];
 const targetDir = path.join(root, "python", "src", "betterwright", "_worker");
 
 const check = process.argv.includes("--check");

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -25,8 +25,10 @@ do it themselves, and do not add "are you sure?" friction to the ordinary steps
 of a task they already asked for. You are the operator, not a bystander.
 
 ## Work autonomously
-- Inspect the page (\`snapshot()\` or ordinary Playwright reads), act, and keep
-  going until the task is complete. Ordinary, reversible decisions are yours.
+- Inspect the page with \`snapshot({interactive: true})\` (act on its
+  \`[ref=eN]\` markers via \`page.locator('aria-ref=eN')\`), check what changed
+  with \`snapshot({diff: true})\`, and keep going until the task is complete.
+  Ordinary, reversible decisions are yours.
 - Recover from routine failures — a slow load, a moved element, a validation
   error — by retrying or taking another path, the way a person would.
 - Open several tabs when it helps (\`openPage\`, \`Promise.all\`).

--- a/src/snapshot.mjs
+++ b/src/snapshot.mjs
@@ -1,0 +1,132 @@
+// Pure text transforms for aria snapshots (mode: "ai"). Kept free of
+// Playwright imports so they can be unit-tested without a browser.
+
+// Roles an agent can act on. Mirrors the set agent-browser refs, minus
+// container roles that only matter with a name (covered by cursor=pointer).
+const INTERACTIVE_ROLE = new RegExp(
+  "^\\s*- (?:button|link|textbox|searchbox|combobox|checkbox|radio|switch|" +
+    "slider|spinbutton|menuitem(?:checkbox|radio)?|option|tab|treeitem|" +
+    "listbox|iframe)\\b",
+);
+
+function indentOf(line) {
+  let count = 0;
+  while (line[count] === " ") count += 1;
+  return count;
+}
+
+/**
+ * Reduce an aria snapshot to interactive elements plus the ancestor lines
+ * needed to keep the tree readable. Property lines (`- /url: …`) survive when
+ * their element does.
+ */
+export function filterInteractive(text) {
+  const lines = String(text).split("\n");
+  const keep = new Array(lines.length).fill(false);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const isProperty = /^\s*- \//.test(line);
+    if (
+      isProperty ||
+      !(INTERACTIVE_ROLE.test(line) || line.includes("[cursor=pointer]"))
+    )
+      continue;
+    keep[i] = true;
+    let indent = indentOf(line);
+    // Walk up the tree keeping each ancestor once.
+    for (let j = i - 1; j >= 0 && indent > 0; j -= 1) {
+      const parentIndent = indentOf(lines[j]);
+      if (parentIndent < indent) {
+        keep[j] = true;
+        indent = parentIndent;
+      }
+    }
+    // Keep property lines nested directly under this element.
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (!/^\s*- \//.test(lines[j]) || indentOf(lines[j]) <= indentOf(line))
+        break;
+      keep[j] = true;
+    }
+  }
+  const kept = lines.filter((_, i) => keep[i]);
+  return kept.length ? kept.join("\n") : "(no interactive elements)";
+}
+
+// Beyond this many lines per side an LCS table stops being cheap; callers
+// fall back to the full snapshot.
+const MAX_DIFF_LINES = 3_000;
+
+/**
+ * Line diff between two snapshots. Returns `{changed: false}` when equal,
+ * `{changed: true, diff, additions, removals}` with only `+`/`-` lines
+ * otherwise, or `{tooLarge: true}` when either side exceeds MAX_DIFF_LINES.
+ */
+export function diffSnapshots(previous, current) {
+  if (previous === current) return { changed: false };
+  let before = String(previous).split("\n");
+  let after = String(current).split("\n");
+  // Trim the common prefix and suffix so the LCS table only covers the
+  // changed region.
+  let start = 0;
+  while (
+    start < before.length &&
+    start < after.length &&
+    before[start] === after[start]
+  )
+    start += 1;
+  let endBefore = before.length;
+  let endAfter = after.length;
+  while (
+    endBefore > start &&
+    endAfter > start &&
+    before[endBefore - 1] === after[endAfter - 1]
+  ) {
+    endBefore -= 1;
+    endAfter -= 1;
+  }
+  before = before.slice(start, endBefore);
+  after = after.slice(start, endAfter);
+  if (before.length > MAX_DIFF_LINES || after.length > MAX_DIFF_LINES)
+    return { changed: true, tooLarge: true };
+
+  // Longest-common-subsequence table over the changed region.
+  const rows = before.length + 1;
+  const cols = after.length + 1;
+  const table = new Uint32Array(rows * cols);
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    for (let j = after.length - 1; j >= 0; j -= 1) {
+      table[i * cols + j] =
+        before[i] === after[j]
+          ? table[(i + 1) * cols + j + 1] + 1
+          : Math.max(table[(i + 1) * cols + j], table[i * cols + j + 1]);
+    }
+  }
+  const out = [];
+  let additions = 0;
+  let removals = 0;
+  let i = 0;
+  let j = 0;
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      i += 1;
+      j += 1;
+    } else if (table[(i + 1) * cols + j] >= table[i * cols + j + 1]) {
+      out.push(`- ${before[i]}`);
+      removals += 1;
+      i += 1;
+    } else {
+      out.push(`+ ${after[j]}`);
+      additions += 1;
+      j += 1;
+    }
+  }
+  for (; i < before.length; i += 1) {
+    out.push(`- ${before[i]}`);
+    removals += 1;
+  }
+  for (; j < after.length; j += 1) {
+    out.push(`+ ${after[j]}`);
+    additions += 1;
+  }
+  return { changed: true, diff: out.join("\n"), additions, removals };
+}

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -26,6 +26,7 @@ import {
   scrollWheel,
   typeText,
 } from "./human.mjs";
+import { diffSnapshots, filterInteractive } from "./snapshot.mjs";
 
 const playwrightCoreDir = process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH || "";
 const playwrightModule = playwrightCoreDir
@@ -107,6 +108,11 @@ function sendResult(message) {
     message.console = [];
     message.events = [];
     message.pages = (message.pages || []).slice(0, 4);
+  }
+  // Empty collections carry no information; both clients default them.
+  for (const key of Object.keys(message)) {
+    if (Array.isArray(message[key]) && message[key].length === 0)
+      delete message[key];
   }
   send(message);
 }
@@ -840,16 +846,45 @@ async function ensureSessionPage(session) {
   return adoptPage(unowned || (await browserContext.newPage()), session.id);
 }
 
+// Last snapshot text per page, keyed by the options that shape it, so
+// `diff: true` always compares like against like.
+const lastSnapshots = new WeakMap();
+
 async function snapshotPage(page, options = {}) {
-  const text = await page.locator("body").ariaSnapshot({
+  const depth = Math.floor(Number(options?.depth) || 0);
+  const scope = options?.selector
+    ? page.locator(String(options.selector))
+    : page.locator("body");
+  let text = await scope.ariaSnapshot({
     mode: "ai",
     timeout: Number(options?.timeout || 10_000),
+    ...(depth > 0 ? { depth } : {}),
   });
+  if (options?.interactive) text = filterInteractive(text);
+
+  const key = JSON.stringify([
+    String(options?.selector || ""),
+    Boolean(options?.interactive),
+    depth,
+  ]);
+  const store = lastSnapshots.get(page) || new Map();
+  lastSnapshots.set(page, store);
+  const previous = store.get(key);
+  store.set(key, text);
+
+  const header = `page ${pageId(page)} ${page.url()}`;
+  if (options?.diff && previous !== undefined) {
+    const result = diffSnapshots(previous, text);
+    if (!result.changed)
+      return `${header}\n(no changes since previous snapshot)`;
+    if (!result.tooLarge)
+      text = `diff vs previous snapshot (+${result.additions} -${result.removals})\n${result.diff}`;
+  }
   const limit = Math.max(
     1_000,
     Math.min(Number(options?.maxChars || 10_000), 20_000),
   );
-  return `page ${pageId(page)} ${page.url()}\n${text.length > limit ? `${text.slice(0, limit)}\n[truncated]` : text}`;
+  return `${header}\n${text.length > limit ? `${text.slice(0, limit)}\n[truncated]` : text}`;
 }
 
 function captchaBounds(value, label = "bounds") {

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -180,3 +180,84 @@ test("human helpers use shaped pointer, keyboard, and wheel events", opts, async
     await bw.close();
   }
 });
+
+test("interactive snapshots expose refs that aria-ref locators can act on", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const snap = await bw.run(`
+      await page.setContent(\`
+        <h1>Title</h1><p>Lots of static prose.</p>
+        <button id="go">Go</button>
+        <script>
+          document.querySelector('#go').addEventListener('click', () => {
+            document.querySelector('h1').textContent = 'Done';
+          });
+        </script>
+      \`);
+      return snapshot({interactive: true});
+    `);
+    assert.equal(snap.ok, true, snap.error);
+    assert.match(snap.result, /button "Go" \[ref=(e\d+)\]/);
+    assert.ok(!snap.result.includes("static prose"), snap.result);
+    const ref = snap.result.match(/button "Go" \[ref=(e\d+)\]/)[1];
+    const clicked = await bw.run(`
+      await page.locator('aria-ref=${ref}').click();
+      return page.locator('h1').textContent();
+    `);
+    assert.equal(clicked.ok, true, clicked.error);
+    assert.equal(clicked.result, "Done");
+  } finally {
+    await bw.close();
+  }
+});
+
+test("snapshot diff returns only what changed", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent('<button id="go">Go</button><p id="status">Idle</p>');
+      const first = await snapshot({diff: true});
+      const unchanged = await snapshot({diff: true});
+      await page.locator('#status').evaluate(el => { el.textContent = 'Running'; });
+      const changed = await snapshot({diff: true});
+      return {first, unchanged, changed};
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.match(result.result.first, /button "Go"/);
+    assert.match(result.result.unchanged, /no changes since previous snapshot/);
+    assert.match(result.result.changed, /diff vs previous snapshot \(\+\d+ -\d+\)/);
+    assert.match(result.result.changed, /\+.*Running/);
+    assert.ok(!result.result.changed.includes('button "Go"'), result.result.changed);
+  } finally {
+    await bw.close();
+  }
+});
+
+test("snapshot scopes to a selector", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent('<nav><a href="#x">Away</a></nav><main id="m"><button>In</button></main>');
+      return snapshot({selector: '#m'});
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.match(result.result, /button "In"/);
+    assert.ok(!result.result.includes("Away"), result.result);
+  } finally {
+    await bw.close();
+  }
+});
+
+test("empty envelope collections are omitted, not sent as []", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run("return 1 + 1");
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result, 2);
+    assert.ok(!("console" in result), "console should be omitted when empty");
+    assert.ok(!("events" in result), "events should be omitted when empty");
+    assert.ok(!("artifacts" in result), "artifacts should be omitted when empty");
+  } finally {
+    await bw.close();
+  }
+});

--- a/tests/node/snapshot.test.mjs
+++ b/tests/node/snapshot.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { diffSnapshots, filterInteractive } from "../../src/snapshot.mjs";
+
+const TREE = [
+  '- generic [active] [ref=e1]:',
+  '  - navigation [ref=e2]:',
+  '    - link "Home" [ref=e3] [cursor=pointer]:',
+  '      - /url: "#a"',
+  '  - main [ref=e5]:',
+  '    - heading "Title" [level=1] [ref=e6]',
+  '    - paragraph [ref=e7]: Static text.',
+  '    - generic [ref=e8]:',
+  '      - textbox "Email" [ref=e9]',
+  '      - button "Submit" [ref=e10]',
+].join("\n");
+
+test("filterInteractive keeps actionable elements and their ancestors", () => {
+  const filtered = filterInteractive(TREE);
+  assert.ok(filtered.includes('link "Home"'));
+  assert.ok(filtered.includes('- /url: "#a"'));
+  assert.ok(filtered.includes('textbox "Email"'));
+  assert.ok(filtered.includes('button "Submit"'));
+  // Ancestors survive so the tree stays readable.
+  assert.ok(filtered.includes("navigation [ref=e2]"));
+  assert.ok(filtered.includes("main [ref=e5]"));
+  // Non-interactive content is dropped.
+  assert.ok(!filtered.includes("heading"));
+  assert.ok(!filtered.includes("Static text"));
+});
+
+test("filterInteractive reports pages with nothing to click", () => {
+  const filtered = filterInteractive('- heading "Only text" [ref=e1]');
+  assert.equal(filtered, "(no interactive elements)");
+});
+
+test("diffSnapshots detects no change", () => {
+  assert.deepEqual(diffSnapshots(TREE, TREE), { changed: false });
+});
+
+test("diffSnapshots returns only changed lines", () => {
+  const after = TREE.replace(
+    '      - button "Submit" [ref=e10]',
+    '      - button "Sending…" [disabled] [ref=e10]\n      - alert [ref=e11]: Sent!',
+  );
+  const result = diffSnapshots(TREE, after);
+  assert.equal(result.changed, true);
+  assert.equal(result.additions, 2);
+  assert.equal(result.removals, 1);
+  const lines = result.diff.split("\n");
+  assert.equal(lines.length, 3);
+  assert.ok(lines.includes('- ' + '      - button "Submit" [ref=e10]'));
+  assert.ok(
+    lines.includes('+ ' + '      - button "Sending…" [disabled] [ref=e10]'),
+  );
+});
+
+test("diffSnapshots flags oversized inputs instead of stalling", () => {
+  const big = Array.from({ length: 3_100 }, (_, i) => `- item ${i}`).join("\n");
+  const result = diffSnapshots("- item x", big);
+  assert.equal(result.changed, true);
+  assert.equal(result.tooLarge, true);
+});


### PR DESCRIPTION
Closes the per-observation token-efficiency gap vs agent-browser while keeping BetterWright's bounded-by-default output caps.

- `snapshot({interactive: true})` — actionable elements plus ancestors only
- `snapshot({diff: true})` — only the +/- lines changed since the previous same-shaped snapshot
- `snapshot({selector, depth})` — scope to a CSS selector / limit tree depth
- Documented that `[ref=eN]` markers are directly actionable via `page.locator('aria-ref=eN')`
- Result envelopes omit empty console/events/artifacts/warnings collections
- Pure helpers live in `src/snapshot.mjs` (synced into the Python package), unit-tested plus four new browser e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnudPSsUfLLdAM81e2L74J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive page snapshots with actionable `aria-ref` markers.
  * Added snapshot filtering by selector, depth, and interactive elements.
  * Added snapshot diffing to highlight page changes between reads.
  * Snapshot results now include clearer page context and support large-output handling.

* **Bug Fixes**
  * Empty result collections are no longer included in responses.
  * Documented behavior when snapshot references become stale.

* **Documentation**
  * Expanded snapshot usage guidance, options, and recommended workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->