### PR TITLE
Let the agent solve reCAPTCHA image grids in one attempt

### DIFF
--- a/docs/captcha.md
+++ b/docs/captcha.md
@@ -70,10 +70,39 @@ await page.locator('button[type="submit"]').click();
 return snapshot();
 ```
 
+## Image-grid challenge (reCAPTCHA)
+
+A checkbox click frequently escalates to an image grid — "select all images with
+bicycles". There is no separate helper for this: the grid is solved with the
+primitives you already have — a screenshot for your own vision, and tile clicks
+by `[ref=eN]`. Treat the escalation as part of the same single attempt, not a
+dead end.
+
+```js
+// 1. See the grid. snapshot() gives every tile a [ref=eN]; a screenshot gives
+//    your vision the actual images to judge.
+const shot = await screenshot({name: 'captcha-grid'});
+const tree = await snapshot();   // rows of button [ref=…] tiles + a Verify button
+```
+
+On the next turn, having looked at the screenshot, click each matching tile and
+submit in one pass:
+
+```js
+for (const ref of ['f4e14', 'f4e30', 'f4e37']) {   // the tiles your vision picked
+  await human.click(page.locator(`aria-ref=${ref}`));
+}
+await human.click(page.getByRole('button', {name: 'Verify'}));
+return snapshot();               // confirm it cleared, or report if still blocked
+```
+
+Solve the whole grid before clicking Verify, make one honest pass, and stop and
+report if it stays blocked rather than looping through fresh challenges.
+
 ## Limits
 
 These helpers reproduce normal mouse interaction and provide a token-efficient
 vision crop. They do not manufacture reCAPTCHA, hCaptcha, or Turnstile tokens,
 and they cannot guarantee that a provider will accept an automated browser. An
-invisible, scored, multi-image, or still-blocked challenge should be reported to
-the user rather than retried.
+invisible or scored challenge, or one still blocked after an honest attempt,
+should be reported to the user rather than retried in a loop.

--- a/python/src/betterwright/prompt.py
+++ b/python/src/betterwright/prompt.py
@@ -54,12 +54,20 @@ of a task they already asked for. You are the operator, not a bystander.
   sites and use their own search instead of repeatedly querying Google or Bing.
 - A CAPTCHA or "verify you are human" page is not a routine navigation failure.
   Do not repeatedly retry it or rotate through other public search engines. Take
-  a direct-site route instead. When that specific page is truly necessary, make
-  one native attempt: use `captcha.click(bounds)` for a checkbox,
-  `captcha.drag(from, to)` for a slider, or `captcha.readText(bounds)` to attach
-  a tightly cropped text challenge for your own vision. Inspect the returned
-  snapshot or challenge report after the attempt. If it remains blocked, stop
-  and report it instead of repeatedly retrying.
+  a direct-site route instead. When that specific page is truly necessary — or
+  the user explicitly asks you to solve it — make one honest attempt with the
+  native helpers: `captcha.click(bounds)` for a checkbox, `captcha.drag(from,
+  to)` for a slider, or `captcha.readText(bounds)` to attach a tightly cropped
+  text challenge for your own vision.
+- A checkbox often escalates to an image grid ("select all images with …"). That
+  escalation is part of the same one attempt, not a wall: `screenshot()` the
+  challenge, use your own vision to decide which tiles match, click each matching
+  tile with `human.click(page.locator('aria-ref=eN'))` using the `[ref=eN]`
+  markers from the snapshot, then click the challenge's Verify button. Solve the
+  whole grid in one pass before verifying.
+- After the attempt, inspect the returned snapshot or challenge report. If it
+  cleared, continue. If it remains blocked, stop and report it instead of
+  repeatedly retrying — one honest attempt, not a loop.
 
 ## Credentials
 Passwords needed for a task are authorized task data. Use the `credentials`

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -45,12 +45,20 @@ of a task they already asked for. You are the operator, not a bystander.
   sites and use their own search instead of repeatedly querying Google or Bing.
 - A CAPTCHA or "verify you are human" page is not a routine navigation failure.
   Do not repeatedly retry it or rotate through other public search engines. Take
-  a direct-site route instead. When that specific page is truly necessary, make
-  one native attempt: use \`captcha.click(bounds)\` for a checkbox,
-  \`captcha.drag(from, to)\` for a slider, or \`captcha.readText(bounds)\` to attach
-  a tightly cropped text challenge for your own vision. Inspect the returned
-  snapshot or challenge report after the attempt. If it remains blocked, stop
-  and report it instead of repeatedly retrying.
+  a direct-site route instead. When that specific page is truly necessary — or
+  the user explicitly asks you to solve it — make one honest attempt with the
+  native helpers: \`captcha.click(bounds)\` for a checkbox, \`captcha.drag(from,
+  to)\` for a slider, or \`captcha.readText(bounds)\` to attach a tightly cropped
+  text challenge for your own vision.
+- A checkbox often escalates to an image grid ("select all images with …"). That
+  escalation is part of the same one attempt, not a wall: \`screenshot()\` the
+  challenge, use your own vision to decide which tiles match, click each matching
+  tile with \`human.click(page.locator('aria-ref=eN'))\` using the \`[ref=eN]\`
+  markers from the snapshot, then click the challenge's Verify button. Solve the
+  whole grid in one pass before verifying.
+- After the attempt, inspect the returned snapshot or challenge report. If it
+  cleared, continue. If it remains blocked, stop and report it instead of
+  repeatedly retrying — one honest attempt, not a loop.
 
 ## Credentials
 Passwords needed for a task are authorized task data. Use the \`credentials\`

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -261,3 +261,49 @@ test("empty envelope collections are omitted, not sent as []", opts, async () =>
     await bw.close();
   }
 });
+
+test("an image-grid challenge is solvable with aria-ref tile clicks and Verify", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    // A synthetic reCAPTCHA-style grid: three "correct" tiles must be selected,
+    // then Verify reveals success. Exercises the documented flow — snapshot for
+    // refs, click tiles by aria-ref, click Verify — without touching a provider.
+    const result = await bw.run(`
+      await page.setContent(\`
+        <div role="dialog" aria-label="Select all images with bicycles">
+          <button aria-label="tile 0" data-correct="1"></button>
+          <button aria-label="tile 1"></button>
+          <button aria-label="tile 2" data-correct="1"></button>
+          <button aria-label="tile 3"></button>
+          <button aria-label="tile 4" data-correct="1"></button>
+          <button id="verify">Verify</button>
+          <p id="status" aria-live="polite">Unsolved</p>
+        </div>
+        <script>
+          const chosen = new Set();
+          for (const b of document.querySelectorAll('button[aria-label^="tile"]')) {
+            b.addEventListener('click', () => { b.dataset.on = '1'; chosen.add(b); });
+          }
+          document.querySelector('#verify').addEventListener('click', () => {
+            const correct = [...document.querySelectorAll('button[data-correct]')];
+            const ok = correct.every(b => b.dataset.on === '1') &&
+              [...chosen].every(b => b.dataset.correct === '1');
+            document.querySelector('#status').textContent = ok ? 'Verified' : 'Try again';
+          });
+        </script>
+      \`);
+      const tree = await snapshot({interactive: true});
+      const refFor = (label) =>
+        (tree.match(new RegExp('"' + label + '" \\\\[ref=(e\\\\d+)\\\\]')) || [])[1];
+      for (const label of ['tile 0', 'tile 2', 'tile 4']) {
+        await human.click(page.locator('aria-ref=' + refFor(label)));
+      }
+      await human.click(page.locator('aria-ref=' + refFor('Verify')));
+      return page.locator('#status').textContent();
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result, "Verified");
+  } finally {
+    await bw.close();
+  }
+});


### PR DESCRIPTION
## Problem

Observed on pi: BetterWright's `captcha.click` **works** — on Google's reCAPTCHA it clicked the checkbox, which escalated to an image grid ("select all images with bicycles"). But the agent then gave up, and refused even when the user explicitly said "try the image captcha."

Root cause is guidance, not mechanics: the operator prompt framed the one native attempt as checkbox/slider/text only and said to stop when a challenge "remains blocked," so a checkbox→grid escalation dead-ended. `docs/captcha.md` even said multi-image challenges should be reported rather than retried.

## Fix

The image grid is solvable with primitives already present — a screenshot for the model's vision, and tile clicks by `[ref=eN]`. Guidance now treats the escalation as part of the *same* single attempt: screenshot the grid, pick matching tiles with vision, click each by `aria-ref`, then Verify — one honest pass, then report if still blocked. Explicit user instruction to solve a challenge counts as authorization to attempt it.

- `src/prompt.mjs` + `python/.../prompt.py` — expanded bot-challenge guidance (existing prompt-test substrings preserved)
- `docs/captcha.md` — new image-grid section; softened the absolute "report rather than retry" to "one honest attempt, then report"
- `tests/node/browser.test.mjs` — synthetic image-grid e2e proving the snapshot→aria-ref tile clicks→Verify flow

No third-party solver, no token forging — unchanged. This only removes a false wall in front of the one authorized attempt.

Node 44/44, Python 50/50, lint + worker-sync green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnudPSsUfLLdAM81e2L74J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for handling CAPTCHA image-grid challenges, including selecting matching tiles and verifying results.
  * Improved instructions for making a single honest CAPTCHA attempt and reporting when access remains blocked.

* **Documentation**
  * Documented image-grid challenge workflows, limitations, and when to stop retrying.

* **Tests**
  * Added coverage for completing image-grid challenges using interactive element references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->