### PR TITLE
Require approval for browser downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Approval-gated browser downloads with configurable `ask`, `allow`, and `deny`
+  policies in both clients, plus MCP elicitation through `browser_download`.
 - `snapshot()` options for cheaper page observation: `interactive` (actionable
   elements only), `diff` (only the lines changed since the previous snapshot),
   `selector` (scope to a CSS selector), and `depth` (limit tree depth).
@@ -31,6 +33,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `CredentialVault` methods remain available to trusted host code.
 - Cancel oversized downloads through Chromium progress events and bound
   screenshots by pixels and encoded bytes before writing artifact files.
+- Deny downloads before ordinary browser runs and close each approved download
+  window before the next run; attached browsers fail closed when bounded CDP
+  download controls are unavailable.
 
 ## [0.1.0] — 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ instead of repeatedly retrying search. See [attach mode](docs/attach-mode.md).
 Point your agent (or coding agent) at **[SETUP.md](SETUP.md)** — it's written to
 be followed by an AI agent and walks it through integrating BetterWright into the
 host, whether that's an MCP client (Claude Code, Cursor, …), a Python or
-JavaScript agent, or a shell-only tool. The whole surface is one tool call, so
-the integration is a thin adapter.
+JavaScript agent, or a shell-only tool. Browser work stays on one main tool;
+downloads use a separate approval-gated tool by default.
 
 For MCP clients specifically, BetterWright ships a server:
 
@@ -143,6 +143,9 @@ claude mcp add betterwright -- python -m betterwright.integrations.mcp_server
 - **[Proof artifacts](docs/browser-api.md#screenshots-and-artifacts)** —
   screenshots tagged `proof`, `question`, or `debug`, returned as
   `MEDIA:<path>` references a host UI can render.
+- **Download approval** — ordinary browser runs deny downloads. A trusted host
+  approves one download run at a time; deployments can configure `ask`, `allow`,
+  or `deny` without weakening the byte and artifact quotas.
 - **[Native CAPTCHA helpers](docs/captcha.md)** — checkbox clicks, smooth
   slider drags, and tightly cropped text-challenge images for the agent's
   existing vision, with no external solving service or API key.

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,8 +8,9 @@ not shown here.
 
 BetterWright gives an agent a persistent, policy-guarded browser it drives with
 ordinary async Playwright JavaScript. The entire tool surface is one call:
-`run(code)`. Integrating means registering one tool that forwards a `code` string
-to that call, and adding the operator guidance to the system prompt.
+`run(code)`. Integrating means registering a browser tool plus a separate
+approval-gated download tool, and adding the operator guidance to the system
+prompt.
 
 ---
 
@@ -44,9 +45,10 @@ After integrating, do **§5 — Verify** and offer **§6 — Safeguards**.
 
 ## §1 — MCP client (Claude Code, Cursor, and similar)
 
-BetterWright ships an MCP server that exposes a `browser` tool and a
-`browser_doctor` tool. You register it once; the model then has a first-class
-browser tool.
+BetterWright ships an MCP server that exposes `browser`, `browser_download`, and
+`browser_doctor`. `browser_download` uses MCP elicitation to ask the user before
+any download-capable code runs. You register the server once; the model then has
+a first-class browser tool.
 
 **Claude Code:**
 ```bash
@@ -75,13 +77,18 @@ servers) and confirm a `browser` tool appears. Then do **§5**.
 The server keeps one browser alive for its lifetime, so pages and logins persist
 across tool calls.
 
+The default `BETTERWRIGHT_DOWNLOAD_POLICY=ask` fails closed when an MCP client
+cannot present elicitation. Set it to `allow` to remove approval prompts or
+`deny` to disable downloads completely.
+
 ---
 
 ## §2 — Python agent
 
 Keep **one** `BetterWright` instance alive for the whole process (not one per
-call — that would throw away the persistent session). Register a tool that
-forwards to `run()`, and prepend the operator guidance to your system prompt.
+call — that would throw away the persistent session). Register an ordinary
+browser tool and an approval-gated download tool, and prepend the operator
+guidance to your system prompt.
 
 ```python
 from betterwright import BetterWright, NetworkPolicy, agent_system_prompt
@@ -128,13 +135,18 @@ SYSTEM_PROMPT = MY_EXISTING_SYSTEM_PROMPT + "\n\n" + agent_system_prompt()
 ```
 
 Register `BROWSER_TOOL` with your agent's tool registry and route its calls to
-`run_browser`. That is the whole integration. Then do **§5**.
+`run_browser`. Register a second `browser_download` tool with the same model
+parameters. Its trusted host handler must apply the configured policy: confirm
+through the host UI in `ask` mode, skip the prompt in `allow` mode, and refuse in
+`deny` mode. Only after approval should it call
+`browser.run(..., approved_downloads=True)`. Never expose `approved_downloads`
+as a model-controlled tool parameter. Then do **§5**.
 
 ---
 
 ## §3 — JavaScript / TypeScript agent
 
-Identical shape. Keep one client alive; forward one tool to `run()`.
+Identical shape. Keep one client alive and expose ordinary and download tools.
 
 ```js
 import { BetterWright, NetworkPolicy, agentSystemPrompt } from "betterwright";
@@ -175,7 +187,11 @@ const browserTool = {
 const systemPrompt = `${MY_EXISTING_SYSTEM_PROMPT}\n\n${agentSystemPrompt()}`;
 ```
 
-Register `browserTool` and route it to `runBrowser`. Then do **§5**.
+Register `browserTool` and route it to `runBrowser`. Add `browser_download` with
+the same model parameters; its trusted handler confirms in `ask`, skips the
+prompt in `allow`, refuses in `deny`, and only then calls
+`browser.run(code, { approvedDownloads: true })`. Never expose
+`approvedDownloads` as a model-controlled tool parameter. Then do **§5**.
 
 ---
 
@@ -225,6 +241,9 @@ blocked). Tighten or loosen it deliberately. Two independent layers:
 | Allow the private network | `allow_private_network=True` | `BETTERWRIGHT_ALLOW_PRIVATE_NETWORK=1` |
 | Restrict to specific sites | `allow_hosts=("example.com",)` | `BETTERWRIGHT_ALLOW_HOSTS=example.com` |
 | Block specific sites | `block_hosts=("ads.example.com",)` | `BETTERWRIGHT_BLOCK_HOSTS=ads.example.com` |
+| Ask before each download | `download_policy="ask"` / `downloadPolicy: "ask"` | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
+| Remove download approval | `download_policy="allow"` / `downloadPolicy: "allow"` | `BETTERWRIGHT_DOWNLOAD_POLICY=allow` |
+| Disable all downloads | `download_policy="deny"` / `downloadPolicy: "deny"` | `BETTERWRIGHT_DOWNLOAD_POLICY=deny` |
 
 Cloud metadata endpoints can never be allowlisted. See
 [docs/network-policy.md](docs/network-policy.md).

--- a/docs/attach-mode.md
+++ b/docs/attach-mode.md
@@ -127,6 +127,9 @@ it didn't start:
 - **Still active:** the per-request [`NetworkPolicy`](network-policy.md) via
   request interception. It still blocks metadata endpoints and private networks
   by default — but as a single layer, not the defense-in-depth of launch mode.
+- **Downloads:** BetterWright keeps its browser-wide byte limit when the attached
+  Chrome exposes that CDP control. Otherwise it disables downloads for the
+  attached pages instead of allowing unbounded writes to disk.
 
 Every run in attach mode returns a warning saying the floor is inactive.
 

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -17,16 +17,36 @@ new BetterWright({
   executablePath,   // explicit Chromium binary; otherwise CLOAKBROWSER_BINARY_PATH
   headless = true,
   defaultTimeout = 30,   // per-snippet seconds, min 5
+  downloadPolicy = "ask", // "ask" (default), "allow", or "deny"
 });
 ```
 
 | Method | Description |
 | --- | --- |
-| `run(code, { session, note, timeout }) => Promise<envelope>` | Execute one snippet. Calls are queued and run one at a time. |
+| `run(code, { session, note, timeout, approvedDownloads }) => Promise<envelope>` | Execute one snippet. Calls are queued and run one at a time. |
 | `close() => Promise<void>` | Shut the worker down. Idempotent. |
 | `policy` | The active `NetworkPolicy`. |
 
 There is no context-manager sugar in JS — call `close()` in a `finally`.
+
+### Download approval
+
+`downloadPolicy: "ask"` is the default. Ordinary `run()` calls execute while
+Chromium downloads are denied. A trusted host must obtain explicit user approval
+first and then mark only that run with `{ approvedDownloads: true }`:
+
+```js
+if (await hostUi.confirm("Allow this download?")) {
+  await bw.run("await page.locator('#download').click()", {
+    approvedDownloads: true,
+  });
+}
+```
+
+Use `downloadPolicy: "allow"` to remove the approval gate while keeping byte and
+artifact quotas. Use `"deny"` to block downloads even from approved runs. The
+approval bit is worker transport metadata; model-authored browser code cannot set
+it from inside the sandbox.
 
 ### The result envelope
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -18,12 +18,13 @@ BetterWright(
     executable_path: str | None = None,    # explicit binary; otherwise CLOAKBROWSER_BINARY_PATH
     headless: bool = True,
     default_timeout: int = 30,             # per-snippet seconds, min 5
+    download_policy: str = "ask",          # "ask", "allow", or "deny"
 )
 ```
 
 | Method / property | Description |
 | --- | --- |
-| `run(code, *, session="default", note=None, timeout=None) -> RunResult` | Execute one snippet. |
+| `run(code, *, session="default", note=None, timeout=None, approved_downloads=False) -> RunResult` | Execute one snippet. |
 | `session(name) -> Session` | A handle bound to one named session. |
 | `policy -> NetworkPolicy` | The active policy. |
 | `vault -> CredentialVault \| None` | The active vault, if any. |
@@ -33,11 +34,19 @@ BetterWright(
 worker is always closed. `note` is a present-tense status line for host UIs and
 is not interpreted by the browser.
 
+### Download approval
+
+The default `download_policy="ask"` keeps Chromium downloads denied during
+ordinary runs. A trusted host must ask the user first, then set
+`approved_downloads=True` on that one run. Set `download_policy="allow"` to
+remove the approval prompt while retaining size and artifact quotas, or `"deny"`
+to block downloads even from approved runs.
+
 ## `Session`
 
 ```python
 session = bw.session("checkout")
-session.run(code, *, note=None, timeout=None) -> RunResult
+session.run(code, *, note=None, timeout=None, approved_downloads=False) -> RunResult
 ```
 
 A thin handle that forwards to `bw.run(..., session=name)`.

--- a/python/src/betterwright/_worker/downloads.mjs
+++ b/python/src/betterwright/_worker/downloads.mjs
@@ -1,3 +1,29 @@
+const DOWNLOAD_POLICIES = new Set(["ask", "allow", "deny"]);
+
+export function normalizeDownloadPolicy(value) {
+  const policy = String(value || "ask")
+    .trim()
+    .toLowerCase();
+  if (!DOWNLOAD_POLICIES.has(policy)) {
+    throw new TypeError(
+      `downloadPolicy must be "ask", "allow", or "deny"; received ${JSON.stringify(value)}`,
+    );
+  }
+  return policy;
+}
+
+export function downloadBehaviorParams(allowed, downloadPath) {
+  return allowed
+    ? {
+        // Playwright's Download object tracks the browser-assigned GUID. Keep
+        // that filename so download.path() and saveAs() address the same file.
+        behavior: "allowAndName",
+        downloadPath,
+        eventsEnabled: true,
+      }
+    : { behavior: "deny", eventsEnabled: true };
+}
+
 export function isUnsupportedBrowserDownloadGuard(error) {
   return /browser context management is not supported/i.test(
     String(error?.message || error || ""),

--- a/python/src/betterwright/_worker/downloads.mjs
+++ b/python/src/betterwright/_worker/downloads.mjs
@@ -1,0 +1,5 @@
+export function isUnsupportedBrowserDownloadGuard(error) {
+  return /browser context management is not supported/i.test(
+    String(error?.message || error || ""),
+  );
+}

--- a/python/src/betterwright/_worker/worker.mjs
+++ b/python/src/betterwright/_worker/worker.mjs
@@ -19,7 +19,11 @@ import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 import { detectBotChallenge, isPublicSearchNavigation } from "./challenges.mjs";
-import { isUnsupportedBrowserDownloadGuard } from "./downloads.mjs";
+import {
+  downloadBehaviorParams,
+  isUnsupportedBrowserDownloadGuard,
+  normalizeDownloadPolicy,
+} from "./downloads.mjs";
 import {
   movePointer,
   pointInside,
@@ -79,6 +83,7 @@ let guardProxyServer = null;
 let guardProxyPort = null;
 let downloadCdpSession = null;
 let downloadGuardReady = false;
+let currentDownloadBehavior = "deny";
 let attachedDownloadsDenied = false;
 let pageDownloadGuards = new WeakMap();
 const pageDownloadCdpSessions = new Set();
@@ -89,6 +94,7 @@ const pageIds = new WeakMap();
 const facadeToRaw = new WeakMap();
 const pendingRpc = new Map();
 const activeSecrets = new Set();
+const pendingDownloadTasks = new Set();
 const guardProxySockets = new Set();
 let rpcCounter = 0;
 let pageCounter = 0;
@@ -615,12 +621,12 @@ async function installDownloadGuard(context) {
     if (!oversized || event?.state !== "inProgress") return;
     void session.send("Browser.cancelDownload", { guid: event.guid }).catch(() => {});
   });
+  const allowed = normalizeDownloadPolicy(launchConfig.downloadPolicy) === "allow";
   try {
-    await session.send("Browser.setDownloadBehavior", {
-      behavior: "allow",
-      downloadPath: launchConfig.downloadsDir,
-      eventsEnabled: true,
-    });
+    await session.send(
+      "Browser.setDownloadBehavior",
+      downloadBehaviorParams(allowed, launchConfig.downloadsDir),
+    );
   } catch (error) {
     await session.detach().catch(() => {});
     if (!connectedMode || !isUnsupportedBrowserDownloadGuard(error))
@@ -636,6 +642,39 @@ async function installDownloadGuard(context) {
   }
   downloadCdpSession = session;
   downloadGuardReady = true;
+  currentDownloadBehavior = allowed ? "allow" : "deny";
+}
+
+async function setDownloadPermission(allowed) {
+  if (attachedDownloadsDenied) {
+    if (allowed) {
+      throw new Error(
+        "Downloads cannot be approved because this attached Chrome does not " +
+          "provide bounded browser-wide download controls.",
+      );
+    }
+    currentDownloadBehavior = "deny";
+    return;
+  }
+  if (!downloadCdpSession || !downloadGuardReady) {
+    if (!allowed) return;
+    throw new Error("Bounded download controls are unavailable.");
+  }
+  const behavior = allowed ? "allow" : "deny";
+  if (currentDownloadBehavior === behavior) return;
+  try {
+    await downloadCdpSession.send(
+      "Browser.setDownloadBehavior",
+      downloadBehaviorParams(allowed, launchConfig.downloadsDir),
+    );
+    currentDownloadBehavior = behavior;
+  } catch (error) {
+    downloadGuardReady = false;
+    const failure =
+      error instanceof Error ? error : new Error(String(error || "Unknown error"));
+    failure.code = "BW_DOWNLOAD_GUARD";
+    throw failure;
+  }
 }
 
 async function denyAttachedPageDownloads(context, page) {
@@ -669,6 +708,7 @@ async function closeDownloadGuard() {
   const session = downloadCdpSession;
   downloadCdpSession = null;
   downloadGuardReady = false;
+  currentDownloadBehavior = "deny";
   attachedDownloadsDenied = false;
   if (session) {
     await session
@@ -917,6 +957,16 @@ async function handleDownload(page, download) {
   const limit = downloadByteLimit();
   let releaseReservation = null;
   try {
+    if (currentDownloadBehavior !== "allow") {
+      await download.cancel();
+      await download.delete().catch(() => {});
+      pushEvent(session, {
+        type: "download-rejected",
+        name: download.suggestedFilename(),
+        reason: "explicit user approval required",
+      });
+      return;
+    }
     if (!downloadGuardReady) {
       await download.cancel();
       await download.delete().catch(() => {});
@@ -986,6 +1036,35 @@ async function handleDownload(page, download) {
   }
 }
 
+function trackDownload(page, download) {
+  const task = handleDownload(page, download);
+  pendingDownloadTasks.add(task);
+  void task.finally(() => pendingDownloadTasks.delete(task));
+}
+
+async function waitForPendingDownloads(timeoutMs) {
+  const deadline = Date.now() + Math.max(1, Number(timeoutMs) || 1);
+  while (pendingDownloadTasks.size) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const error = new Error("Browser download timed out before completion.");
+      error.code = "BW_TIMEOUT";
+      throw error;
+    }
+    let timer;
+    await Promise.race([
+      Promise.allSettled([...pendingDownloadTasks]),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          const error = new Error("Browser download timed out before completion.");
+          error.code = "BW_TIMEOUT";
+          reject(error);
+        }, remaining);
+      }),
+    ]).finally(() => clearTimeout(timer));
+  }
+}
+
 async function handleDialog(page, dialog) {
   const sid = pageToSession.get(page) || activeExecutionSession || "default";
   const session = sessionFor(sid);
@@ -1042,7 +1121,7 @@ function adoptPage(page, sessionId) {
         pushEvent(owner, { type: "page-crash", pageId: id, url: page.url() });
     });
     page.on("download", (download) => {
-      void handleDownload(page, download);
+      trackDownload(page, download);
     });
     page.on("dialog", (dialog) => {
       void handleDialog(page, dialog);
@@ -1050,12 +1129,16 @@ function adoptPage(page, sessionId) {
     page.on("popup", (popup) => {
       const owner =
         pageToSession.get(page) || activeExecutionSession || session.id;
-      adoptPage(popup, owner);
-      pushEvent(sessionFor(owner), {
-        type: "popup",
-        pageId: pageId(popup),
-        openerPageId: id,
-      });
+      void denyAttachedPageDownloads(browserContext, popup)
+        .then(() => {
+          adoptPage(popup, owner);
+          pushEvent(sessionFor(owner), {
+            type: "popup",
+            pageId: pageId(popup),
+            openerPageId: id,
+          });
+        })
+        .catch(() => popup.close().catch(() => {}));
     });
   }
   return page;
@@ -1622,7 +1705,10 @@ function wrap(value, realm) {
         validateMethodPaths(objectKind(value), property, prepared);
         const result = member.apply(value, prepared);
         if (result && typeof result.then === "function") {
-          return result.then((item) => wrap(item, realm));
+          return result.then(async (item) => {
+            await guardReturnedPages(item);
+            return wrap(item, realm);
+          });
         }
         return wrap(result, realm);
       });
@@ -1648,6 +1734,15 @@ function wrap(value, realm) {
   realm.cache.set(value, facade);
   facadeToRaw.set(facade, value);
   return facade;
+}
+
+async function guardReturnedPages(value) {
+  if (Array.isArray(value)) {
+    await Promise.all(value.map((item) => guardReturnedPages(item)));
+    return;
+  }
+  if (objectKind(value) === "Page")
+    await denyAttachedPageDownloads(browserContext, value);
 }
 
 async function currentOrigin(session) {
@@ -2029,9 +2124,21 @@ async function execute(message) {
   const firstEvent = session.events.length;
   const firstArtifact = session.artifacts.length;
   let restartWorker = false;
+  let downloadRunConfigured = false;
+  let downloadPolicy = "ask";
+  let downloadDeadline = 0;
   activeExecutionSession = session.id;
   try {
     await ensureBrowser(message.config);
+    downloadPolicy = normalizeDownloadPolicy(message.config.downloadPolicy);
+    if (downloadPolicy === "deny" && message.approvedDownloads === true) {
+      throw new Error("Downloads are disabled by downloadPolicy=deny.");
+    }
+    const downloadsAllowed =
+      downloadPolicy === "allow" ||
+      (downloadPolicy === "ask" && message.approvedDownloads === true);
+    await setDownloadPermission(downloadsAllowed);
+    downloadRunConfigured = true;
     await ensureSessionPage(session);
     const { context } = buildSandbox(session, consoleMessages);
     const script = compileCode(String(message.code || ""));
@@ -2039,6 +2146,7 @@ async function execute(message) {
       timeout: SAFE_SYNC_VM_TIMEOUT_MS,
     });
     const timeoutMs = Math.max(1_000, Number(message.timeoutMs || 30_000));
+    downloadDeadline = Date.now() + timeoutMs;
     let timer;
     const result = await Promise.race([
       Promise.resolve(promise),
@@ -2052,6 +2160,9 @@ async function execute(message) {
         }, timeoutMs);
       }),
     ]).finally(() => clearTimeout(timer));
+    await waitForPendingDownloads(downloadDeadline - Date.now());
+    await setDownloadPermission(downloadPolicy === "allow");
+    downloadRunConfigured = false;
     const summarized = await summarize(result);
     await enforceArtifactQuota(session);
     const challenges = await detectSessionChallenges(session);
@@ -2118,12 +2229,24 @@ async function execute(message) {
       durationMs: Math.round((performance.now() - started) * 10) / 10,
     });
   } catch (error) {
-    restartWorker = error?.code === "BW_TIMEOUT";
+    let failure = error;
+    if (downloadRunConfigured) {
+      try {
+        // Close the approval window before waiting on a failed or timed-out
+        // download. This prevents background page work from starting another.
+        await setDownloadPermission(downloadPolicy === "allow");
+        downloadRunConfigured = false;
+        await waitForPendingDownloads(2_000);
+      } catch (resetError) {
+        failure = resetError;
+      }
+    }
+    restartWorker = ["BW_TIMEOUT", "BW_DOWNLOAD_GUARD"].includes(failure?.code);
     sendResult({
       type: "result",
       id: message.id,
       ok: false,
-      error: redactText(error?.message || String(error)),
+      error: redactText(failure?.message || String(failure)),
       console: redactDeep(consoleMessages),
       events: redactDeep(session.events.slice(firstEvent)),
       artifacts: redactDeep(session.artifacts.slice(firstArtifact)),

--- a/python/src/betterwright/_worker/worker.mjs
+++ b/python/src/betterwright/_worker/worker.mjs
@@ -19,6 +19,7 @@ import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 import { detectBotChallenge, isPublicSearchNavigation } from "./challenges.mjs";
+import { isUnsupportedBrowserDownloadGuard } from "./downloads.mjs";
 import {
   movePointer,
   pointInside,
@@ -78,6 +79,9 @@ let guardProxyServer = null;
 let guardProxyPort = null;
 let downloadCdpSession = null;
 let downloadGuardReady = false;
+let attachedDownloadsDenied = false;
+let pageDownloadGuards = new WeakMap();
+const pageDownloadCdpSessions = new Set();
 
 const sessions = new Map();
 const pageToSession = new WeakMap();
@@ -611,24 +615,78 @@ async function installDownloadGuard(context) {
     if (!oversized || event?.state !== "inProgress") return;
     void session.send("Browser.cancelDownload", { guid: event.guid }).catch(() => {});
   });
-  await session.send("Browser.setDownloadBehavior", {
-    behavior: "allow",
-    downloadPath: launchConfig.downloadsDir,
-    eventsEnabled: true,
-  });
+  try {
+    await session.send("Browser.setDownloadBehavior", {
+      behavior: "allow",
+      downloadPath: launchConfig.downloadsDir,
+      eventsEnabled: true,
+    });
+  } catch (error) {
+    await session.detach().catch(() => {});
+    if (!connectedMode || !isUnsupportedBrowserDownloadGuard(error))
+      throw error;
+    attachedDownloadsDenied = true;
+    await Promise.all(
+      context.pages().map((page) => denyAttachedPageDownloads(context, page)),
+    );
+    profileWarning +=
+      " This Chrome does not expose browser-wide bounded download controls, " +
+      "so downloads are disabled while attached.";
+    return;
+  }
   downloadCdpSession = session;
   downloadGuardReady = true;
+}
+
+async function denyAttachedPageDownloads(context, page) {
+  if (!attachedDownloadsDenied || page.isClosed()) return;
+  const existing = pageDownloadGuards.get(page);
+  if (existing) return existing;
+  const guard = (async () => {
+    const session = await context.newCDPSession(page);
+    try {
+      await session.send("Page.setDownloadBehavior", { behavior: "deny" });
+    } catch (error) {
+      await session.detach().catch(() => {});
+      throw error;
+    }
+    pageDownloadCdpSessions.add(session);
+    page.once("close", () => {
+      pageDownloadCdpSessions.delete(session);
+      void session.detach().catch(() => {});
+    });
+  })();
+  pageDownloadGuards.set(page, guard);
+  try {
+    await guard;
+  } catch (error) {
+    pageDownloadGuards.delete(page);
+    throw error;
+  }
 }
 
 async function closeDownloadGuard() {
   const session = downloadCdpSession;
   downloadCdpSession = null;
   downloadGuardReady = false;
-  if (!session) return;
-  await session
-    .send("Browser.setDownloadBehavior", { behavior: "default" })
-    .catch(() => {});
-  await session.detach().catch(() => {});
+  attachedDownloadsDenied = false;
+  if (session) {
+    await session
+      .send("Browser.setDownloadBehavior", { behavior: "default" })
+      .catch(() => {});
+    await session.detach().catch(() => {});
+  }
+  const pageSessions = [...pageDownloadCdpSessions];
+  pageDownloadCdpSessions.clear();
+  pageDownloadGuards = new WeakMap();
+  await Promise.all(
+    pageSessions.map(async (pageSession) => {
+      await pageSession
+        .send("Page.setDownloadBehavior", { behavior: "default" })
+        .catch(() => {});
+      await pageSession.detach().catch(() => {});
+    }),
+  );
 }
 
 function redactText(value) {
@@ -1007,10 +1065,14 @@ async function ensureSessionPage(session) {
   const selected = session.currentId
     ? session.pages.get(session.currentId)
     : null;
-  if (selected && !selected.isClosed()) return selected;
+  if (selected && !selected.isClosed()) {
+    await denyAttachedPageDownloads(browserContext, selected);
+    return selected;
+  }
   for (const [id, page] of session.pages) {
     if (!page.isClosed()) {
       session.currentId ||= id;
+      await denyAttachedPageDownloads(browserContext, page);
       return page;
     }
   }
@@ -1024,7 +1086,9 @@ async function ensureSessionPage(session) {
       `Browser page limit (${MAX_PAGES_PER_SESSION}) reached for this session.`,
     );
   }
-  return adoptPage(unowned || (await browserContext.newPage()), session.id);
+  const page = unowned || (await browserContext.newPage());
+  await denyAttachedPageDownloads(browserContext, page);
+  return adoptPage(page, session.id);
 }
 
 // Last snapshot text per page, keyed by the options that shape it, so
@@ -1247,7 +1311,11 @@ async function ensureBrowser(config) {
       await installDownloadGuard(attachedContext);
       attachedContext.on("page", (page) => {
         const owner = activeExecutionSession || "default";
-        if (!pageToSession.has(page)) adoptPage(page, owner);
+        void denyAttachedPageDownloads(attachedContext, page)
+          .then(() => {
+            if (!pageToSession.has(page)) adoptPage(page, owner);
+          })
+          .catch(() => page.close().catch(() => {}));
       });
       // Adopt the tabs that are already open so the agent sees them immediately.
       for (const page of attachedContext.pages()) {
@@ -1680,7 +1748,9 @@ function buildSandbox(session, consoleMessages) {
         `Browser page limit (${MAX_PAGES_PER_SESSION}) reached for this session.`,
       );
     }
-    const page = adoptPage(await browserContext.newPage(), session.id);
+    const rawPage = await browserContext.newPage();
+    await denyAttachedPageDownloads(browserContext, rawPage);
+    const page = adoptPage(rawPage, session.id);
     if (url) await page.goto(String(url), options);
     return wrap(page, realm);
   });

--- a/python/src/betterwright/bridge.py
+++ b/python/src/betterwright/bridge.py
@@ -36,6 +36,17 @@ logger = logging.getLogger("betterwright")
 
 _DEFAULT_TIMEOUT_SECONDS = 30
 _WORKER_START_TIMEOUT_SECONDS = 15
+_DOWNLOAD_POLICIES = frozenset({"ask", "allow", "deny"})
+
+
+def _normalize_download_policy(value: str) -> str:
+    policy = str(value or "ask").strip().lower()
+    if policy not in _DOWNLOAD_POLICIES:
+        raise ValueError(
+            'download_policy must be "ask", "allow", or "deny"; '
+            f"received {value!r}"
+        )
+    return policy
 
 
 class WorkerStartError(RuntimeError):
@@ -71,6 +82,7 @@ class Bridge:
         default_timeout: int = _DEFAULT_TIMEOUT_SECONDS,
         connect_over_cdp: str | None = None,
         search_min_interval_ms: int = 0,
+        download_policy: str = "ask",
     ) -> None:
         self.home = Path(home).expanduser().resolve() if home else betterwright_home()
         self.policy = policy if policy is not None else NetworkPolicy()
@@ -84,6 +96,7 @@ class Bridge:
         self.default_timeout = max(int(default_timeout), 5)
         self.connect_over_cdp = (connect_over_cdp or "").strip()
         self.search_min_interval_ms = max(int(search_min_interval_ms), 0)
+        self.download_policy = _normalize_download_policy(download_policy)
 
         self._process: subprocess.Popen[str] | None = None
         self._reader: threading.Thread | None = None
@@ -132,6 +145,7 @@ class Bridge:
             "headless": bool(self.headless),
             "cdpEndpoint": self.connect_over_cdp,
             "searchMinIntervalMs": self.search_min_interval_ms,
+            "downloadPolicy": self.download_policy,
             "outputLimit": 12_000,
             "maxArtifactBytes": 100 * 1024 * 1024,
             "maxDownloadBytes": 50 * 1024 * 1024,
@@ -311,7 +325,12 @@ class Bridge:
     # -- execution --------------------------------------------------------
 
     def execute(
-        self, code: str, session_id: str = "default", *, timeout: int | None = None
+        self,
+        code: str,
+        session_id: str = "default",
+        *,
+        timeout: int | None = None,
+        approved_downloads: bool = False,
     ) -> dict:
         """Run one Playwright snippet and return the worker's result envelope."""
 
@@ -344,6 +363,7 @@ class Bridge:
                         "id": request_id,
                         "sessionId": str(session_id or "default"),
                         "code": code,
+                        "approvedDownloads": approved_downloads is True,
                         "timeoutMs": timeout_seconds * 1000,
                         "config": config,
                     }

--- a/python/src/betterwright/client.py
+++ b/python/src/betterwright/client.py
@@ -195,6 +195,10 @@ class BetterWright:
     search_min_interval_ms:
         Minimum spacing between top-level Google, Bing, or DuckDuckGo search
         navigations. ``0`` (the default) disables pacing.
+    download_policy:
+        ``"ask"`` (the default) requires a trusted host to mark each download
+        run approved. ``"allow"`` removes that approval gate while retaining
+        byte limits, and ``"deny"`` blocks downloads entirely.
     """
 
     def __init__(
@@ -208,6 +212,7 @@ class BetterWright:
         default_timeout: int = 30,
         connect_over_cdp: str | None = None,
         search_min_interval_ms: int = 0,
+        download_policy: str = "ask",
     ) -> None:
         resolved_vault: CredentialVault | None
         if vault is True:
@@ -228,6 +233,7 @@ class BetterWright:
             default_timeout=default_timeout,
             connect_over_cdp=connect_over_cdp,
             search_min_interval_ms=search_min_interval_ms,
+            download_policy=download_policy,
         )
 
     @property
@@ -245,6 +251,7 @@ class BetterWright:
         session: str = "default",
         note: str | None = None,
         timeout: int | None = None,
+        approved_downloads: bool = False,
     ) -> RunResult:
         """Execute one Playwright snippet and return a :class:`RunResult`.
 
@@ -256,7 +263,12 @@ class BetterWright:
         """
 
         _ = note  # Reserved for host status surfaces; kept out of the sandbox.
-        envelope = self._bridge.execute(code, session, timeout=timeout)
+        envelope = self._bridge.execute(
+            code,
+            session,
+            timeout=timeout,
+            approved_downloads=approved_downloads,
+        )
         return RunResult._from_envelope(envelope)
 
     def session(self, name: str) -> Session:
@@ -282,9 +294,20 @@ class Session:
         self.name = name
 
     def run(
-        self, code: str, *, note: str | None = None, timeout: int | None = None
+        self,
+        code: str,
+        *,
+        note: str | None = None,
+        timeout: int | None = None,
+        approved_downloads: bool = False,
     ) -> RunResult:
-        return self._browser.run(code, session=self.name, note=note, timeout=timeout)
+        return self._browser.run(
+            code,
+            session=self.name,
+            note=note,
+            timeout=timeout,
+            approved_downloads=approved_downloads,
+        )
 
 
 __all__ = ["Artifact", "BetterWright", "BrowserError", "RunResult", "Session"]

--- a/python/src/betterwright/integrations/mcp_server.py
+++ b/python/src/betterwright/integrations/mcp_server.py
@@ -1,9 +1,9 @@
 """A Model Context Protocol server exposing BetterWright as a browser tool.
 
 This lets any MCP client — Claude Code, Cursor, Windsurf, and others — drive a
-persistent, policy-guarded browser. It exposes one tool, ``browser``, that runs
-async Playwright JavaScript, plus a ``browser_doctor`` tool that reports whether
-the runtime is installed.
+persistent, policy-guarded browser. It exposes ``browser`` for ordinary runs,
+``browser_download`` for approval-gated downloads, and ``browser_doctor`` for
+runtime diagnostics.
 
 Run it directly (stdio transport):
 
@@ -21,6 +21,7 @@ Configuration is read from the environment so the same command works everywhere:
     BETTERWRIGHT_ALLOW_PRIVATE_NETWORK=1 allow RFC1918 / *.internal hosts
     BETTERWRIGHT_ALLOW_HOSTS=a.com,b.com always-allow list (comma-separated)
     BETTERWRIGHT_BLOCK_HOSTS=ads.com     always-block list (comma-separated)
+    BETTERWRIGHT_DOWNLOAD_POLICY=ask     ask (default), allow, or deny downloads
     BETTERWRIGHT_HEADLESS=0              run Chromium headed (visible window)
     BETTERWRIGHT_CONNECT_OVER_CDP=http://127.0.0.1:9222
                                          attach to an existing Chrome instead of
@@ -41,7 +42,8 @@ from betterwright import BetterWright, NetworkPolicy
 from betterwright.runtime import diagnose
 
 try:
-    from mcp.server.fastmcp import FastMCP, Image
+    from mcp.server.fastmcp import Context, FastMCP, Image
+    from pydantic import BaseModel, Field
 except ImportError as exc:  # pragma: no cover - guidance for a missing extra
     raise SystemExit(
         "The MCP SDK is required. Install it with "
@@ -67,6 +69,15 @@ def _policy_from_env() -> NetworkPolicy:
     )
 
 
+def _download_policy_from_env() -> str:
+    policy = os.environ.get("BETTERWRIGHT_DOWNLOAD_POLICY", "ask").strip().lower()
+    if policy not in {"ask", "allow", "deny"}:
+        raise SystemExit(
+            'BETTERWRIGHT_DOWNLOAD_POLICY must be "ask", "allow", or "deny".'
+        )
+    return policy
+
+
 mcp = FastMCP("betterwright")
 
 # One persistent browser for the life of the server, so pages and logins survive
@@ -77,11 +88,43 @@ _headless: bool | str = "auto"
 if os.environ.get("BETTERWRIGHT_HEADLESS", "").strip():
     _headless = _bool_env("BETTERWRIGHT_HEADLESS")
 
+_download_policy = _download_policy_from_env()
+
 _browser = BetterWright(
     policy=_policy_from_env(),
     headless=_headless,
     connect_over_cdp=os.environ.get("BETTERWRIGHT_CONNECT_OVER_CDP", "").strip() or None,
+    download_policy=_download_policy,
 )
+
+
+class DownloadApproval(BaseModel):
+    """Explicit user decision for one proposed browser download run."""
+
+    approved: bool = Field(description="Approve this browser download?")
+
+
+def _content_for_result(result) -> list:
+    summary = {
+        "ok": result.ok,
+        "result": result.value,
+        "error": result.error,
+        "console": result.console,
+        # Screenshots are returned as image content below, not as paths. Other
+        # files (downloads, spilled output) are listed here as paths only.
+        "files": [{"kind": a.kind, "path": a.path} for a in result.files()],
+        "pages": result.pages,
+        "challenges": result.challenges,
+        "warnings": result.warnings,
+        "duration_ms": result.duration_ms,
+    }
+    content: list = [json.dumps(summary, default=str, ensure_ascii=False)]
+    for shot in result.screenshots():
+        try:
+            content.append(Image(path=shot.path))
+        except OSError:
+            pass
+    return content
 
 
 @mcp.tool()
@@ -102,30 +145,55 @@ def browser(code: str, session: str = "default", note: str = "") -> list:
     """
 
     result = _browser.run(code, session=session, note=note or None)
-    summary = {
-        "ok": result.ok,
-        "result": result.value,
-        "error": result.error,
-        "console": result.console,
-        # Screenshots are returned as image content below, not as paths. Other
-        # files (downloads, spilled output) are listed here as paths only — never
-        # attach them as images.
-        "files": [{"kind": a.kind, "path": a.path} for a in result.files()],
-        "pages": result.pages,
-        "challenges": result.challenges,
-        "warnings": result.warnings,
-        "duration_ms": result.duration_ms,
-    }
-    # Return the JSON summary as text plus each screenshot as native MCP image
-    # content, so the client renders images without guessing MIME types from a
-    # path. This is what prevents "unsupported image MIME type" errors.
-    content: list = [json.dumps(summary, default=str, ensure_ascii=False)]
-    for shot in result.screenshots():
+    return _content_for_result(result)
+
+
+@mcp.tool()
+async def browser_download(
+    code: str,
+    ctx: Context,
+    session: str = "default",
+    note: str = "",
+) -> list:
+    """Run browser code that may download a file, with user approval first.
+
+    Use this instead of ``browser`` whenever the Playwright code will click a
+    download link or otherwise save a remote file. In the default ``ask`` mode,
+    the MCP client presents a confirmation before any browser code runs. Set
+    ``BETTERWRIGHT_DOWNLOAD_POLICY=allow`` to remove that prompt, or ``deny`` to
+    disable all downloads.
+    """
+
+    if _download_policy == "deny":
+        raise RuntimeError("Downloads are disabled by BETTERWRIGHT_DOWNLOAD_POLICY=deny.")
+    if _download_policy == "ask":
         try:
-            content.append(Image(path=shot.path))
-        except OSError:
-            pass
-    return content
+            decision = await ctx.elicit(
+                message=(
+                    "Allow BetterWright to run browser code that may download a file?"
+                    + (f" Requested action: {note}" if note else "")
+                ),
+                schema=DownloadApproval,
+            )
+        except Exception as exc:  # noqa: BLE001 - unsupported clients fail closed
+            raise RuntimeError(
+                "This MCP client cannot present download approval; the download was blocked."
+            ) from exc
+        approved = (
+            decision.action == "accept"
+            and decision.data is not None
+            and decision.data.approved is True
+        )
+        if not approved:
+            raise RuntimeError("The user declined or cancelled the download.")
+
+    result = _browser.run(
+        code,
+        session=session,
+        note=note or None,
+        approved_downloads=True,
+    )
+    return _content_for_result(result)
 
 
 @mcp.tool()

--- a/python/src/betterwright/prompt.py
+++ b/python/src/betterwright/prompt.py
@@ -46,6 +46,12 @@ of a task they already asked for. You are the operator, not a bystander.
   when you need Playwright's exact action or navigation semantics.
 - Put a short present-tense `note` on every call so the user can follow along.
 
+## Downloads
+Use the host's approval-gated download tool whenever browser code will save a
+remote file. Do not try to download through an ordinary browser run. The host
+must obtain explicit user approval before enabling that one bounded download
+run.
+
 ## Search and bot challenges
 - For broad discovery, prefer a web-research/search tool supplied by the host when
   one is available; use this browser to open results and work on first-party sites.

--- a/python/tests/test_artifacts_and_display.py
+++ b/python/tests/test_artifacts_and_display.py
@@ -100,3 +100,13 @@ def test_explicit_binary_wins_over_cloak_env(monkeypatch, tmp_path):
     bridge = Bridge(home=tmp_path, executable_path="/opt/chromium")
     assert bridge.executable_path == "/opt/chromium"
     assert bridge.browser_flavor == "chromium"
+
+
+def test_download_policy_defaults_to_ask_and_is_configurable(tmp_path):
+    guarded = Bridge(home=tmp_path / "guarded")
+    allowed = Bridge(home=tmp_path / "allowed", download_policy="allow")
+    assert guarded.download_policy == "ask"
+    assert guarded._worker_config()["downloadPolicy"] == "ask"
+    assert allowed.download_policy == "allow"
+    with pytest.raises(ValueError, match="download_policy"):
+        Bridge(home=tmp_path / "invalid", download_policy="sometimes")

--- a/python/tests/test_mcp_download_approval.py
+++ b/python/tests/test_mcp_download_approval.py
@@ -1,0 +1,169 @@
+"""Approval-boundary tests for the optional MCP integration."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+class FakeBrowser:
+    instances: list[FakeBrowser] = []
+
+    def __init__(self, **options):
+        self.options = options
+        self.calls: list[dict] = []
+        self.__class__.instances.append(self)
+
+    def run(self, code, **options):
+        self.calls.append({"code": code, **options})
+        return SimpleNamespace(
+            ok=True,
+            value="done",
+            error=None,
+            console=[],
+            pages=[],
+            challenges=[],
+            warnings=[],
+            duration_ms=1,
+            files=lambda: [],
+            screenshots=lambda: [],
+        )
+
+
+class FakeFastMCP:
+    def __init__(self, _name):
+        pass
+
+    def tool(self):
+        return lambda function: function
+
+    def run(self):
+        pass
+
+
+class FakeBaseModel:
+    pass
+
+
+class FakeContext:
+    pass
+
+
+@pytest.fixture
+def load_server(monkeypatch):
+    loaded = []
+
+    def load(policy="ask"):
+        import betterwright
+
+        FakeBrowser.instances.clear()
+        monkeypatch.setenv("BETTERWRIGHT_DOWNLOAD_POLICY", policy)
+        monkeypatch.setattr(betterwright, "BetterWright", FakeBrowser)
+
+        fastmcp = ModuleType("mcp.server.fastmcp")
+        fastmcp.Context = FakeContext
+        fastmcp.FastMCP = FakeFastMCP
+        fastmcp.Image = object
+        monkeypatch.setitem(sys.modules, "mcp", ModuleType("mcp"))
+        monkeypatch.setitem(sys.modules, "mcp.server", ModuleType("mcp.server"))
+        monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp)
+
+        pydantic = ModuleType("pydantic")
+        pydantic.BaseModel = FakeBaseModel
+        pydantic.Field = lambda **_options: None
+        monkeypatch.setitem(sys.modules, "pydantic", pydantic)
+
+        module_name = "betterwright.integrations.mcp_server"
+        sys.modules.pop(module_name, None)
+        module = importlib.import_module(module_name)
+        loaded.append(module_name)
+        return module, FakeBrowser.instances[-1]
+
+    yield load
+    for module_name in loaded:
+        sys.modules.pop(module_name, None)
+
+
+class DecisionContext:
+    def __init__(self, action="accept", approved=True, error=None, events=None):
+        self.action = action
+        self.approved = approved
+        self.error = error
+        self.events = events if events is not None else []
+
+    async def elicit(self, message, schema):
+        self.events.append(("approval", message, schema))
+        if self.error:
+            raise self.error
+        return SimpleNamespace(
+            action=self.action,
+            data=SimpleNamespace(approved=self.approved),
+        )
+
+
+def test_ask_mode_approves_before_browser_code_runs(load_server):
+    server, browser = load_server()
+    events = []
+    context = DecisionContext(events=events)
+    original_run = browser.run
+
+    def recorded_run(*args, **kwargs):
+        events.append(("run", args, kwargs))
+        return original_run(*args, **kwargs)
+
+    browser.run = recorded_run
+    result = asyncio.run(
+        server.browser_download("return 1", context, note="Get report")
+    )
+
+    assert [event[0] for event in events] == ["approval", "run"]
+    assert "Get report" in events[0][1]
+    assert browser.calls == [
+        {
+            "code": "return 1",
+            "session": "default",
+            "note": "Get report",
+            "approved_downloads": True,
+        }
+    ]
+    assert '"ok": true' in result[0]
+
+
+@pytest.mark.parametrize(
+    ("context", "message"),
+    [
+        (DecisionContext(action="decline"), "declined or cancelled"),
+        (DecisionContext(approved=False), "declined or cancelled"),
+        (DecisionContext(error=NotImplementedError()), "cannot present download approval"),
+    ],
+)
+def test_ask_mode_fails_closed_without_approval(load_server, context, message):
+    server, browser = load_server()
+
+    with pytest.raises(RuntimeError, match=message):
+        asyncio.run(server.browser_download("return 1", context))
+
+    assert browser.calls == []
+
+
+def test_allow_mode_removes_prompt_but_keeps_approved_worker_run(load_server):
+    server, browser = load_server("allow")
+    context = DecisionContext(error=AssertionError("must not prompt"))
+
+    asyncio.run(server.browser_download("return 1", context))
+
+    assert context.events == []
+    assert browser.calls[0]["approved_downloads"] is True
+
+
+def test_deny_mode_blocks_before_browser_code_runs(load_server):
+    server, browser = load_server("deny")
+
+    with pytest.raises(RuntimeError, match="disabled"):
+        asyncio.run(server.browser_download("return 1", DecisionContext()))
+
+    assert browser.calls == []

--- a/python/tests/test_prompt.py
+++ b/python/tests/test_prompt.py
@@ -16,6 +16,8 @@ def test_default_prompt_is_permissive():
     assert "human.click(target)" in compact
     assert "human.type(target, text)" in compact
     assert "human.scroll(deltaY)" in compact
+    assert "host's approval-gated download tool" in compact
+    assert "before enabling that one bounded download run" in compact
     assert "If it remains blocked, stop" in compact
     assert "Inspect the returned image itself before citing it" in compact
     assert "fix the page and retake it" in compact

--- a/scripts/sync-worker.mjs
+++ b/scripts/sync-worker.mjs
@@ -7,7 +7,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const files = ["worker.mjs", "challenges.mjs", "human.mjs", "snapshot.mjs"];
+const files = [
+  "worker.mjs",
+  "challenges.mjs",
+  "downloads.mjs",
+  "human.mjs",
+  "snapshot.mjs",
+];
 const targetDir = path.join(root, "python", "src", "betterwright", "_worker");
 
 const check = process.argv.includes("--check");

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -12,6 +12,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
 
+import { normalizeDownloadPolicy } from "./downloads.mjs";
 import { NetworkPolicy } from "./policy.mjs";
 
 const WORKER_PATH = fileURLToPath(new URL("./worker.mjs", import.meta.url));
@@ -70,6 +71,9 @@ export class BetterWright {
    *   this mode — only the per-request policy applies.
    * @param {number} [options.searchMinIntervalMs=0] minimum spacing between
    *   top-level Google, Bing, or DuckDuckGo search navigations
+   * @param {"ask"|"allow"|"deny"} [options.downloadPolicy="ask"] require a
+   *   trusted host to mark an individual run approved, allow every run, or
+   *   deny downloads entirely
    */
   constructor(options = {}) {
     this.home = options.home || defaultHome();
@@ -81,6 +85,7 @@ export class BetterWright {
     this.headless = resolveHeadless(options.headless);
     this.connectOverCdp = (options.connectOverCdp || "").trim();
     this.searchMinIntervalMs = Math.max(Number(options.searchMinIntervalMs) || 0, 0);
+    this.downloadPolicy = normalizeDownloadPolicy(options.downloadPolicy);
     this.defaultTimeout = Math.max(Number(options.defaultTimeout) || DEFAULT_TIMEOUT_SECONDS, 5);
 
     this._process = null;
@@ -110,6 +115,7 @@ export class BetterWright {
       headless: this.headless,
       cdpEndpoint: this.connectOverCdp,
       searchMinIntervalMs: this.searchMinIntervalMs,
+      downloadPolicy: this.downloadPolicy,
       outputLimit: 12_000,
       maxArtifactBytes: 100 * 1024 * 1024,
       maxDownloadBytes: 50 * 1024 * 1024,
@@ -213,7 +219,7 @@ export class BetterWright {
   /**
    * Execute one Playwright snippet and resolve with a result object.
    * @param {string} code asynchronous Playwright JavaScript
-   * @param {object} [options] { session, note, timeout }
+   * @param {object} [options] { session, note, timeout, approvedDownloads }
    */
   run(code, options = {}) {
     const task = this._queue.then(() => this._runNow(code, options));
@@ -258,6 +264,7 @@ export class BetterWright {
           id,
           sessionId: String(options.session || "default"),
           code,
+          approvedDownloads: options.approvedDownloads === true,
           timeoutMs: timeoutSeconds * 1000,
           config,
         });

--- a/src/downloads.mjs
+++ b/src/downloads.mjs
@@ -1,3 +1,29 @@
+const DOWNLOAD_POLICIES = new Set(["ask", "allow", "deny"]);
+
+export function normalizeDownloadPolicy(value) {
+  const policy = String(value || "ask")
+    .trim()
+    .toLowerCase();
+  if (!DOWNLOAD_POLICIES.has(policy)) {
+    throw new TypeError(
+      `downloadPolicy must be "ask", "allow", or "deny"; received ${JSON.stringify(value)}`,
+    );
+  }
+  return policy;
+}
+
+export function downloadBehaviorParams(allowed, downloadPath) {
+  return allowed
+    ? {
+        // Playwright's Download object tracks the browser-assigned GUID. Keep
+        // that filename so download.path() and saveAs() address the same file.
+        behavior: "allowAndName",
+        downloadPath,
+        eventsEnabled: true,
+      }
+    : { behavior: "deny", eventsEnabled: true };
+}
+
 export function isUnsupportedBrowserDownloadGuard(error) {
   return /browser context management is not supported/i.test(
     String(error?.message || error || ""),

--- a/src/downloads.mjs
+++ b/src/downloads.mjs
@@ -1,0 +1,5 @@
+export function isUnsupportedBrowserDownloadGuard(error) {
+  return /browser context management is not supported/i.test(
+    String(error?.message || error || ""),
+  );
+}

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -38,6 +38,12 @@ of a task they already asked for. You are the operator, not a bystander.
   when you need Playwright's exact action or navigation semantics.
 - Put a short present-tense \`note\` on every call so the user can follow along.
 
+## Downloads
+Use the host's approval-gated download tool whenever browser code will save a
+remote file. Do not try to download through an ordinary browser run. The host
+must obtain explicit user approval before enabling that one bounded download
+run.
+
 ## Search and bot challenges
 - For broad discovery, prefer a web-research/search tool supplied by the host when
   one is available; use this browser to open results and work on first-party sites.

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -19,7 +19,11 @@ import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 import { detectBotChallenge, isPublicSearchNavigation } from "./challenges.mjs";
-import { isUnsupportedBrowserDownloadGuard } from "./downloads.mjs";
+import {
+  downloadBehaviorParams,
+  isUnsupportedBrowserDownloadGuard,
+  normalizeDownloadPolicy,
+} from "./downloads.mjs";
 import {
   movePointer,
   pointInside,
@@ -79,6 +83,7 @@ let guardProxyServer = null;
 let guardProxyPort = null;
 let downloadCdpSession = null;
 let downloadGuardReady = false;
+let currentDownloadBehavior = "deny";
 let attachedDownloadsDenied = false;
 let pageDownloadGuards = new WeakMap();
 const pageDownloadCdpSessions = new Set();
@@ -89,6 +94,7 @@ const pageIds = new WeakMap();
 const facadeToRaw = new WeakMap();
 const pendingRpc = new Map();
 const activeSecrets = new Set();
+const pendingDownloadTasks = new Set();
 const guardProxySockets = new Set();
 let rpcCounter = 0;
 let pageCounter = 0;
@@ -615,12 +621,12 @@ async function installDownloadGuard(context) {
     if (!oversized || event?.state !== "inProgress") return;
     void session.send("Browser.cancelDownload", { guid: event.guid }).catch(() => {});
   });
+  const allowed = normalizeDownloadPolicy(launchConfig.downloadPolicy) === "allow";
   try {
-    await session.send("Browser.setDownloadBehavior", {
-      behavior: "allow",
-      downloadPath: launchConfig.downloadsDir,
-      eventsEnabled: true,
-    });
+    await session.send(
+      "Browser.setDownloadBehavior",
+      downloadBehaviorParams(allowed, launchConfig.downloadsDir),
+    );
   } catch (error) {
     await session.detach().catch(() => {});
     if (!connectedMode || !isUnsupportedBrowserDownloadGuard(error))
@@ -636,6 +642,39 @@ async function installDownloadGuard(context) {
   }
   downloadCdpSession = session;
   downloadGuardReady = true;
+  currentDownloadBehavior = allowed ? "allow" : "deny";
+}
+
+async function setDownloadPermission(allowed) {
+  if (attachedDownloadsDenied) {
+    if (allowed) {
+      throw new Error(
+        "Downloads cannot be approved because this attached Chrome does not " +
+          "provide bounded browser-wide download controls.",
+      );
+    }
+    currentDownloadBehavior = "deny";
+    return;
+  }
+  if (!downloadCdpSession || !downloadGuardReady) {
+    if (!allowed) return;
+    throw new Error("Bounded download controls are unavailable.");
+  }
+  const behavior = allowed ? "allow" : "deny";
+  if (currentDownloadBehavior === behavior) return;
+  try {
+    await downloadCdpSession.send(
+      "Browser.setDownloadBehavior",
+      downloadBehaviorParams(allowed, launchConfig.downloadsDir),
+    );
+    currentDownloadBehavior = behavior;
+  } catch (error) {
+    downloadGuardReady = false;
+    const failure =
+      error instanceof Error ? error : new Error(String(error || "Unknown error"));
+    failure.code = "BW_DOWNLOAD_GUARD";
+    throw failure;
+  }
 }
 
 async function denyAttachedPageDownloads(context, page) {
@@ -669,6 +708,7 @@ async function closeDownloadGuard() {
   const session = downloadCdpSession;
   downloadCdpSession = null;
   downloadGuardReady = false;
+  currentDownloadBehavior = "deny";
   attachedDownloadsDenied = false;
   if (session) {
     await session
@@ -917,6 +957,16 @@ async function handleDownload(page, download) {
   const limit = downloadByteLimit();
   let releaseReservation = null;
   try {
+    if (currentDownloadBehavior !== "allow") {
+      await download.cancel();
+      await download.delete().catch(() => {});
+      pushEvent(session, {
+        type: "download-rejected",
+        name: download.suggestedFilename(),
+        reason: "explicit user approval required",
+      });
+      return;
+    }
     if (!downloadGuardReady) {
       await download.cancel();
       await download.delete().catch(() => {});
@@ -986,6 +1036,35 @@ async function handleDownload(page, download) {
   }
 }
 
+function trackDownload(page, download) {
+  const task = handleDownload(page, download);
+  pendingDownloadTasks.add(task);
+  void task.finally(() => pendingDownloadTasks.delete(task));
+}
+
+async function waitForPendingDownloads(timeoutMs) {
+  const deadline = Date.now() + Math.max(1, Number(timeoutMs) || 1);
+  while (pendingDownloadTasks.size) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const error = new Error("Browser download timed out before completion.");
+      error.code = "BW_TIMEOUT";
+      throw error;
+    }
+    let timer;
+    await Promise.race([
+      Promise.allSettled([...pendingDownloadTasks]),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          const error = new Error("Browser download timed out before completion.");
+          error.code = "BW_TIMEOUT";
+          reject(error);
+        }, remaining);
+      }),
+    ]).finally(() => clearTimeout(timer));
+  }
+}
+
 async function handleDialog(page, dialog) {
   const sid = pageToSession.get(page) || activeExecutionSession || "default";
   const session = sessionFor(sid);
@@ -1042,7 +1121,7 @@ function adoptPage(page, sessionId) {
         pushEvent(owner, { type: "page-crash", pageId: id, url: page.url() });
     });
     page.on("download", (download) => {
-      void handleDownload(page, download);
+      trackDownload(page, download);
     });
     page.on("dialog", (dialog) => {
       void handleDialog(page, dialog);
@@ -1050,12 +1129,16 @@ function adoptPage(page, sessionId) {
     page.on("popup", (popup) => {
       const owner =
         pageToSession.get(page) || activeExecutionSession || session.id;
-      adoptPage(popup, owner);
-      pushEvent(sessionFor(owner), {
-        type: "popup",
-        pageId: pageId(popup),
-        openerPageId: id,
-      });
+      void denyAttachedPageDownloads(browserContext, popup)
+        .then(() => {
+          adoptPage(popup, owner);
+          pushEvent(sessionFor(owner), {
+            type: "popup",
+            pageId: pageId(popup),
+            openerPageId: id,
+          });
+        })
+        .catch(() => popup.close().catch(() => {}));
     });
   }
   return page;
@@ -1622,7 +1705,10 @@ function wrap(value, realm) {
         validateMethodPaths(objectKind(value), property, prepared);
         const result = member.apply(value, prepared);
         if (result && typeof result.then === "function") {
-          return result.then((item) => wrap(item, realm));
+          return result.then(async (item) => {
+            await guardReturnedPages(item);
+            return wrap(item, realm);
+          });
         }
         return wrap(result, realm);
       });
@@ -1648,6 +1734,15 @@ function wrap(value, realm) {
   realm.cache.set(value, facade);
   facadeToRaw.set(facade, value);
   return facade;
+}
+
+async function guardReturnedPages(value) {
+  if (Array.isArray(value)) {
+    await Promise.all(value.map((item) => guardReturnedPages(item)));
+    return;
+  }
+  if (objectKind(value) === "Page")
+    await denyAttachedPageDownloads(browserContext, value);
 }
 
 async function currentOrigin(session) {
@@ -2029,9 +2124,21 @@ async function execute(message) {
   const firstEvent = session.events.length;
   const firstArtifact = session.artifacts.length;
   let restartWorker = false;
+  let downloadRunConfigured = false;
+  let downloadPolicy = "ask";
+  let downloadDeadline = 0;
   activeExecutionSession = session.id;
   try {
     await ensureBrowser(message.config);
+    downloadPolicy = normalizeDownloadPolicy(message.config.downloadPolicy);
+    if (downloadPolicy === "deny" && message.approvedDownloads === true) {
+      throw new Error("Downloads are disabled by downloadPolicy=deny.");
+    }
+    const downloadsAllowed =
+      downloadPolicy === "allow" ||
+      (downloadPolicy === "ask" && message.approvedDownloads === true);
+    await setDownloadPermission(downloadsAllowed);
+    downloadRunConfigured = true;
     await ensureSessionPage(session);
     const { context } = buildSandbox(session, consoleMessages);
     const script = compileCode(String(message.code || ""));
@@ -2039,6 +2146,7 @@ async function execute(message) {
       timeout: SAFE_SYNC_VM_TIMEOUT_MS,
     });
     const timeoutMs = Math.max(1_000, Number(message.timeoutMs || 30_000));
+    downloadDeadline = Date.now() + timeoutMs;
     let timer;
     const result = await Promise.race([
       Promise.resolve(promise),
@@ -2052,6 +2160,9 @@ async function execute(message) {
         }, timeoutMs);
       }),
     ]).finally(() => clearTimeout(timer));
+    await waitForPendingDownloads(downloadDeadline - Date.now());
+    await setDownloadPermission(downloadPolicy === "allow");
+    downloadRunConfigured = false;
     const summarized = await summarize(result);
     await enforceArtifactQuota(session);
     const challenges = await detectSessionChallenges(session);
@@ -2118,12 +2229,24 @@ async function execute(message) {
       durationMs: Math.round((performance.now() - started) * 10) / 10,
     });
   } catch (error) {
-    restartWorker = error?.code === "BW_TIMEOUT";
+    let failure = error;
+    if (downloadRunConfigured) {
+      try {
+        // Close the approval window before waiting on a failed or timed-out
+        // download. This prevents background page work from starting another.
+        await setDownloadPermission(downloadPolicy === "allow");
+        downloadRunConfigured = false;
+        await waitForPendingDownloads(2_000);
+      } catch (resetError) {
+        failure = resetError;
+      }
+    }
+    restartWorker = ["BW_TIMEOUT", "BW_DOWNLOAD_GUARD"].includes(failure?.code);
     sendResult({
       type: "result",
       id: message.id,
       ok: false,
-      error: redactText(error?.message || String(error)),
+      error: redactText(failure?.message || String(failure)),
       console: redactDeep(consoleMessages),
       events: redactDeep(session.events.slice(firstEvent)),
       artifacts: redactDeep(session.artifacts.slice(firstArtifact)),

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -19,6 +19,7 @@ import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 import { detectBotChallenge, isPublicSearchNavigation } from "./challenges.mjs";
+import { isUnsupportedBrowserDownloadGuard } from "./downloads.mjs";
 import {
   movePointer,
   pointInside,
@@ -78,6 +79,9 @@ let guardProxyServer = null;
 let guardProxyPort = null;
 let downloadCdpSession = null;
 let downloadGuardReady = false;
+let attachedDownloadsDenied = false;
+let pageDownloadGuards = new WeakMap();
+const pageDownloadCdpSessions = new Set();
 
 const sessions = new Map();
 const pageToSession = new WeakMap();
@@ -611,24 +615,78 @@ async function installDownloadGuard(context) {
     if (!oversized || event?.state !== "inProgress") return;
     void session.send("Browser.cancelDownload", { guid: event.guid }).catch(() => {});
   });
-  await session.send("Browser.setDownloadBehavior", {
-    behavior: "allow",
-    downloadPath: launchConfig.downloadsDir,
-    eventsEnabled: true,
-  });
+  try {
+    await session.send("Browser.setDownloadBehavior", {
+      behavior: "allow",
+      downloadPath: launchConfig.downloadsDir,
+      eventsEnabled: true,
+    });
+  } catch (error) {
+    await session.detach().catch(() => {});
+    if (!connectedMode || !isUnsupportedBrowserDownloadGuard(error))
+      throw error;
+    attachedDownloadsDenied = true;
+    await Promise.all(
+      context.pages().map((page) => denyAttachedPageDownloads(context, page)),
+    );
+    profileWarning +=
+      " This Chrome does not expose browser-wide bounded download controls, " +
+      "so downloads are disabled while attached.";
+    return;
+  }
   downloadCdpSession = session;
   downloadGuardReady = true;
+}
+
+async function denyAttachedPageDownloads(context, page) {
+  if (!attachedDownloadsDenied || page.isClosed()) return;
+  const existing = pageDownloadGuards.get(page);
+  if (existing) return existing;
+  const guard = (async () => {
+    const session = await context.newCDPSession(page);
+    try {
+      await session.send("Page.setDownloadBehavior", { behavior: "deny" });
+    } catch (error) {
+      await session.detach().catch(() => {});
+      throw error;
+    }
+    pageDownloadCdpSessions.add(session);
+    page.once("close", () => {
+      pageDownloadCdpSessions.delete(session);
+      void session.detach().catch(() => {});
+    });
+  })();
+  pageDownloadGuards.set(page, guard);
+  try {
+    await guard;
+  } catch (error) {
+    pageDownloadGuards.delete(page);
+    throw error;
+  }
 }
 
 async function closeDownloadGuard() {
   const session = downloadCdpSession;
   downloadCdpSession = null;
   downloadGuardReady = false;
-  if (!session) return;
-  await session
-    .send("Browser.setDownloadBehavior", { behavior: "default" })
-    .catch(() => {});
-  await session.detach().catch(() => {});
+  attachedDownloadsDenied = false;
+  if (session) {
+    await session
+      .send("Browser.setDownloadBehavior", { behavior: "default" })
+      .catch(() => {});
+    await session.detach().catch(() => {});
+  }
+  const pageSessions = [...pageDownloadCdpSessions];
+  pageDownloadCdpSessions.clear();
+  pageDownloadGuards = new WeakMap();
+  await Promise.all(
+    pageSessions.map(async (pageSession) => {
+      await pageSession
+        .send("Page.setDownloadBehavior", { behavior: "default" })
+        .catch(() => {});
+      await pageSession.detach().catch(() => {});
+    }),
+  );
 }
 
 function redactText(value) {
@@ -1007,10 +1065,14 @@ async function ensureSessionPage(session) {
   const selected = session.currentId
     ? session.pages.get(session.currentId)
     : null;
-  if (selected && !selected.isClosed()) return selected;
+  if (selected && !selected.isClosed()) {
+    await denyAttachedPageDownloads(browserContext, selected);
+    return selected;
+  }
   for (const [id, page] of session.pages) {
     if (!page.isClosed()) {
       session.currentId ||= id;
+      await denyAttachedPageDownloads(browserContext, page);
       return page;
     }
   }
@@ -1024,7 +1086,9 @@ async function ensureSessionPage(session) {
       `Browser page limit (${MAX_PAGES_PER_SESSION}) reached for this session.`,
     );
   }
-  return adoptPage(unowned || (await browserContext.newPage()), session.id);
+  const page = unowned || (await browserContext.newPage());
+  await denyAttachedPageDownloads(browserContext, page);
+  return adoptPage(page, session.id);
 }
 
 // Last snapshot text per page, keyed by the options that shape it, so
@@ -1247,7 +1311,11 @@ async function ensureBrowser(config) {
       await installDownloadGuard(attachedContext);
       attachedContext.on("page", (page) => {
         const owner = activeExecutionSession || "default";
-        if (!pageToSession.has(page)) adoptPage(page, owner);
+        void denyAttachedPageDownloads(attachedContext, page)
+          .then(() => {
+            if (!pageToSession.has(page)) adoptPage(page, owner);
+          })
+          .catch(() => page.close().catch(() => {}));
       });
       // Adopt the tabs that are already open so the agent sees them immediately.
       for (const page of attachedContext.pages()) {
@@ -1680,7 +1748,9 @@ function buildSandbox(session, consoleMessages) {
         `Browser page limit (${MAX_PAGES_PER_SESSION}) reached for this session.`,
       );
     }
-    const page = adoptPage(await browserContext.newPage(), session.id);
+    const rawPage = await browserContext.newPage();
+    await denyAttachedPageDownloads(browserContext, rawPage);
+    const page = adoptPage(rawPage, session.id);
     if (url) await page.goto(String(url), options);
     return wrap(page, realm);
   });

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -84,7 +84,12 @@ async function closeExternalChromium(runtime) {
       once(runtime.child, "exit"),
       new Promise((resolve) => setTimeout(resolve, 3_000)),
     ]);
-  fs.rmSync(runtime.profileDir, { recursive: true, force: true });
+  fs.rmSync(runtime.profileDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 100,
+  });
 }
 
 function unsupportedDownloadGuardModule() {

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -10,6 +10,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { pathToFileURL } from "node:url";
 
 import { BetterWright, NetworkPolicy } from "../../src/index.mjs";
 
@@ -86,6 +87,45 @@ async function closeExternalChromium(runtime) {
   fs.rmSync(runtime.profileDir, { recursive: true, force: true });
 }
 
+function unsupportedDownloadGuardModule() {
+  const actualDir =
+    process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH ||
+    path.dirname(require.resolve("playwright-core"));
+  const actualUrl = pathToFileURL(path.join(actualDir, "index.mjs")).href;
+  const wrapperDir = tempHome();
+  fs.writeFileSync(
+    path.join(wrapperDir, "index.mjs"),
+    `import * as actual from ${JSON.stringify(actualUrl)};
+export * from ${JSON.stringify(actualUrl)};
+export const chromium = new Proxy(actual.chromium, {
+  get(target, property) {
+    if (property !== "connectOverCDP") return Reflect.get(target, property);
+    return async (...args) => {
+      const browser = await target.connectOverCDP(...args);
+      const original = browser.newBrowserCDPSession.bind(browser);
+      browser.newBrowserCDPSession = async () => {
+        const session = await original();
+        const send = session.send.bind(session);
+        session.send = async (method, params) => {
+          if (method === "Browser.setDownloadBehavior") {
+            throw new Error(
+              "Protocol error (Browser.setDownloadBehavior): " +
+              "Browser context management is not supported.",
+            );
+          }
+          return send(method, params);
+        };
+        return session;
+      };
+      return browser;
+    };
+  },
+});
+`,
+  );
+  return wrapperDir;
+}
+
 function tempHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-test-"));
 }
@@ -140,20 +180,71 @@ test("navigate and read the title", opts, async () => {
 
 test("attach mode can drive an externally launched Chromium", opts, async () => {
   const runtime = await externalChromium();
+  const wrapperDir = unsupportedDownloadGuardModule();
+  const previousCorePath = process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH;
+  process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH = wrapperDir;
+  let downloadRequests = 0;
+  const server = await listen((request, response) => {
+    response.setHeader("content-type", "text/html");
+    if (request.url === "/popup") {
+      response.end("<title>Guarded Popup</title><h1>Popup</h1>");
+      return;
+    }
+    if (request.url === "/report.txt") {
+      downloadRequests += 1;
+      response.setHeader("content-type", "text/plain");
+      response.setHeader(
+        "content-disposition",
+        'attachment; filename="report.txt"',
+      );
+      response.end("must not be saved");
+      return;
+    }
+    response.end(
+      '<title>Attach Host</title>' +
+        '<a id="popup" href="/popup" target="_blank">Open</a>' +
+        '<a id="download" href="/report.txt" download>Download</a>',
+    );
+  });
   const bw = new BetterWright({
     home: path.join(runtime.profileDir, "betterwright"),
     connectOverCdp: runtime.endpoint,
+    policy: new NetworkPolicy({ allowLoopback: true }),
   });
   try {
-    const result = await bw.run(
-      "await page.goto('https://example.com'); return page.title()",
-    );
+    const result = await bw.run(`
+      await page.goto(${JSON.stringify(server.origin)});
+      const host = page;
+      const popupPromise = host.waitForEvent('popup');
+      await host.locator('#popup').click();
+      const popup = await popupPromise;
+      await popup.waitForLoadState();
+      await host.evaluate(() => {
+        setTimeout(() => document.querySelector('#download').click(), 0);
+      });
+      await host.waitForTimeout(100);
+      return {hostTitle: await host.title(), popupTitle: await popup.title()};
+    `);
     assert.equal(result.ok, true, result.error);
-    assert.equal(result.result, "Example Domain");
+    assert.deepEqual(result.result, {
+      hostTitle: "Attach Host",
+      popupTitle: "Guarded Popup",
+    });
     assert.equal(result.profileMode, "attached");
+    assert.match(result.warnings.join(" "), /downloads are disabled while attached/);
+    assert.equal(
+      (result.artifacts || []).filter((item) => item.kind === "download").length,
+      0,
+    );
+    assert.equal(downloadRequests, 1);
   } finally {
     await bw.close();
+    await server.close();
     await closeExternalChromium(runtime);
+    fs.rmSync(wrapperDir, { recursive: true, force: true });
+    if (previousCorePath === undefined)
+      delete process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH;
+    else process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH = previousCorePath;
   }
 });
 
@@ -365,6 +456,7 @@ test("downloads are canceled while crossing the byte limit", opts, async () => {
     {
       home,
       headless: true,
+      downloadPolicy: "allow",
       policy: new NetworkPolicy({ allowLoopback: true }),
     },
     { maxArtifactBytes: maxDownloadBytes, maxDownloadBytes },
@@ -395,6 +487,77 @@ test("downloads are canceled while crossing the byte limit", opts, async () => {
     clearInterval(observer);
     await bw.close();
     await server.close();
+  }
+});
+
+test("downloads require a trusted per-run approval by default", opts, async () => {
+  const body = Buffer.from("approved download contents");
+  const server = await listen((request, response) => {
+    if (request.url === "/") {
+      response.setHeader("content-type", "text/html");
+      response.end('<a id="download" href="/report.txt" download>Download</a>');
+      return;
+    }
+    response.setHeader("content-type", "text/plain");
+    response.setHeader(
+      "content-disposition",
+      'attachment; filename="report.txt"',
+    );
+    response.end(body);
+  });
+  const home = tempHome();
+  const bw = new BetterWright({
+    home,
+    headless: true,
+    policy: new NetworkPolicy({ allowLoopback: true }),
+  });
+  const code = `
+    await page.goto(${JSON.stringify(server.origin)});
+    await page.locator('#download').click();
+    await page.waitForTimeout(100);
+    return 'done';
+  `;
+  try {
+    const blocked = await bw.run(code);
+    assert.equal(blocked.ok, true, blocked.error);
+    assert.equal(
+      directorySize(path.join(home, "artifacts", "downloads")),
+      0,
+    );
+    assert.equal(
+      (blocked.artifacts || []).filter((item) => item.kind === "download").length,
+      0,
+    );
+
+    const approved = await bw.run(code, { approvedDownloads: true });
+    assert.equal(approved.ok, true, approved.error);
+    const downloads = (approved.artifacts || []).filter(
+      (item) => item.kind === "download",
+    );
+    assert.equal(downloads.length, 1, JSON.stringify(approved.events));
+    assert.deepEqual(fs.readFileSync(downloads[0].path), body);
+  } finally {
+    await bw.close();
+    await server.close();
+  }
+});
+
+test("downloadPolicy deny rejects even trusted approval", opts, async () => {
+  const bw = new BetterWright({
+    home: tempHome(),
+    headless: true,
+    downloadPolicy: "deny",
+  });
+  try {
+    const result = await bw.run("state.executed = true; return 'ran'", {
+      approvedDownloads: true,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error || "", /downloadPolicy=deny/);
+    const state = await bw.run("return state.executed ?? false");
+    assert.equal(state.result, false);
+  } finally {
+    await bw.close();
   }
 });
 

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -53,6 +53,8 @@ async function externalChromium() {
       "--remote-debugging-address=127.0.0.1",
       `--user-data-dir=${profileDir}`,
       "--headless=new",
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
       "--no-first-run",
       "--no-default-browser-check",
       "about:blank",

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -1,10 +1,12 @@
 // End-to-end Node tests. Skipped unless a Chromium build is resolvable, so the
 // policy suite still runs on machines without the runtime installed.
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -27,6 +29,60 @@ function runtimeReady() {
 
 const ready = runtimeReady();
 const opts = { skip: ready ? false : "browser runtime not installed" };
+
+async function unusedPort() {
+  const server = net.createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function externalChromium() {
+  const core = process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH
+    ? path.join(process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH, "index.js")
+    : "playwright-core";
+  const { chromium } = require(core);
+  const port = await unusedPort();
+  const profileDir = tempHome();
+  const child = spawn(
+    chromium.executablePath(),
+    [
+      `--remote-debugging-port=${port}`,
+      "--remote-debugging-address=127.0.0.1",
+      `--user-data-dir=${profileDir}`,
+      "--headless=new",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "about:blank",
+    ],
+    { stdio: "ignore" },
+  );
+  const endpoint = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${endpoint}/json/version`);
+      if (response.ok) return { child, endpoint, profileDir };
+    } catch {
+      // Chrome is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  child.kill("SIGTERM");
+  throw new Error(`External Chromium did not start at ${endpoint}.`);
+}
+
+async function closeExternalChromium(runtime) {
+  if (runtime.child.exitCode === null) runtime.child.kill("SIGTERM");
+  if (runtime.child.exitCode === null)
+    await Promise.race([
+      once(runtime.child, "exit"),
+      new Promise((resolve) => setTimeout(resolve, 3_000)),
+    ]);
+  fs.rmSync(runtime.profileDir, { recursive: true, force: true });
+}
 
 function tempHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-test-"));
@@ -77,6 +133,25 @@ test("navigate and read the title", opts, async () => {
     assert.equal(result.result, "Example Domain");
   } finally {
     await bw.close();
+  }
+});
+
+test("attach mode can drive an externally launched Chromium", opts, async () => {
+  const runtime = await externalChromium();
+  const bw = new BetterWright({
+    home: path.join(runtime.profileDir, "betterwright"),
+    connectOverCdp: runtime.endpoint,
+  });
+  try {
+    const result = await bw.run(
+      "await page.goto('https://example.com'); return page.title()",
+    );
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result, "Example Domain");
+    assert.equal(result.profileMode, "attached");
+  } finally {
+    await bw.close();
+    await closeExternalChromium(runtime);
   }
 });
 

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -60,7 +60,10 @@ async function externalChromium() {
       "--no-default-browser-check",
       "about:blank",
     ],
-    { stdio: "ignore" },
+    {
+      stdio: "ignore",
+      detached: process.platform !== "win32",
+    },
   );
   const endpoint = `http://127.0.0.1:${port}`;
   const deadline = Date.now() + 10_000;
@@ -73,17 +76,32 @@ async function externalChromium() {
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  child.kill("SIGTERM");
+  signalExternalChromium(child, "SIGTERM");
   throw new Error(`External Chromium did not start at ${endpoint}.`);
 }
 
+function signalExternalChromium(child, signal) {
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // The process group may already have exited; fall back to the parent.
+    }
+  }
+  if (child.exitCode === null) child.kill(signal);
+}
+
 async function closeExternalChromium(runtime) {
-  if (runtime.child.exitCode === null) runtime.child.kill("SIGTERM");
+  signalExternalChromium(runtime.child, "SIGTERM");
   if (runtime.child.exitCode === null)
     await Promise.race([
       once(runtime.child, "exit"),
       new Promise((resolve) => setTimeout(resolve, 3_000)),
     ]);
+  // Chrome may fork profile-writing children before the tracked parent exits.
+  signalExternalChromium(runtime.child, "SIGKILL");
+  await new Promise((resolve) => setTimeout(resolve, 250));
   fs.rmSync(runtime.profileDir, {
     recursive: true,
     force: true,

--- a/tests/node/client.test.mjs
+++ b/tests/node/client.test.mjs
@@ -3,6 +3,23 @@ import { test } from "node:test";
 
 import { BetterWright } from "../../src/index.mjs";
 
+test("download approval is required by default and configurable", async () => {
+  const guarded = new BetterWright();
+  const allowed = new BetterWright({ downloadPolicy: "allow" });
+  try {
+    assert.equal(guarded.downloadPolicy, "ask");
+    assert.equal(guarded._workerConfig().downloadPolicy, "ask");
+    assert.equal(allowed.downloadPolicy, "allow");
+    assert.throws(
+      () => new BetterWright({ downloadPolicy: "sometimes" }),
+      /downloadPolicy must be "ask", "allow", or "deny"/,
+    );
+  } finally {
+    await guarded.close();
+    await allowed.close();
+  }
+});
+
 test("CLOAKBROWSER_BINARY_PATH opts into an installed Cloak binary", async () => {
   const previous = process.env.CLOAKBROWSER_BINARY_PATH;
   process.env.CLOAKBROWSER_BINARY_PATH = "/opt/cloak/chrome";

--- a/tests/node/downloads.test.mjs
+++ b/tests/node/downloads.test.mjs
@@ -1,7 +1,30 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { isUnsupportedBrowserDownloadGuard } from "../../src/downloads.mjs";
+import {
+  downloadBehaviorParams,
+  isUnsupportedBrowserDownloadGuard,
+  normalizeDownloadPolicy,
+} from "../../src/downloads.mjs";
+
+test("normalizes the three download policies", () => {
+  assert.equal(normalizeDownloadPolicy(undefined), "ask");
+  assert.equal(normalizeDownloadPolicy(" ALLOW "), "allow");
+  assert.equal(normalizeDownloadPolicy("deny"), "deny");
+  assert.throws(() => normalizeDownloadPolicy("later"), /downloadPolicy/);
+});
+
+test("download behavior is denied until an approved run enables it", () => {
+  assert.deepEqual(downloadBehaviorParams(false, "/tmp/downloads"), {
+    behavior: "deny",
+    eventsEnabled: true,
+  });
+  assert.deepEqual(downloadBehaviorParams(true, "/tmp/downloads"), {
+    behavior: "allowAndName",
+    downloadPath: "/tmp/downloads",
+    eventsEnabled: true,
+  });
+});
 
 test("recognizes the attach-mode browser context limitation", () => {
   assert.equal(

--- a/tests/node/downloads.test.mjs
+++ b/tests/node/downloads.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isUnsupportedBrowserDownloadGuard } from "../../src/downloads.mjs";
+
+test("recognizes the attach-mode browser context limitation", () => {
+  assert.equal(
+    isUnsupportedBrowserDownloadGuard(
+      new Error(
+        "cdpSession.send: Protocol error (Browser.setDownloadBehavior): " +
+          "Browser context management is not supported.",
+      ),
+    ),
+    true,
+  );
+  assert.equal(
+    isUnsupportedBrowserDownloadGuard(
+      new Error("Protocol error (Browser.setDownloadBehavior): Not allowed"),
+    ),
+    false,
+  );
+});

--- a/tests/node/prompt.test.mjs
+++ b/tests/node/prompt.test.mjs
@@ -15,6 +15,8 @@ test("default prompt is permissive", () => {
   assert.ok(compact.includes("human.click(target)"));
   assert.ok(compact.includes("human.type(target, text)"));
   assert.ok(compact.includes("human.scroll(deltaY)"));
+  assert.ok(compact.includes("host's approval-gated download tool"));
+  assert.ok(compact.includes("before enabling that one bounded download run"));
   assert.ok(compact.includes("If it remains blocked, stop"));
   assert.ok(compact.includes("Inspect the returned image itself before citing it"));
   assert.ok(compact.includes("fix the page and retake it"));


### PR DESCRIPTION
## Summary
- deny Chromium downloads before ordinary browser runs and enable them only for a host-approved run
- add configurable `ask` (default), `allow`, and `deny` policies to the JavaScript, Python, and MCP integrations
- expose an MCP `browser_download` tool that elicits approval before browser code executes and fails closed when elicitation is unavailable
- retain download byte/artifact quotas, use GUID-backed CDP filenames, and reset the approval window after each run
- fail closed in attached Chrome when bounded browser-wide controls are unavailable, including new-popup coverage

## Validation
- `npm test` (58 passed)
- `npm run lint`
- `pytest -q` (58 passed)
- `ruff check .`
- `node scripts/sync-worker.mjs --check`
- real MCP SDK discovery: `browser`, `browser_download`, `browser_doctor`

## Review follow-up
- addresses the CodeRabbit popup exposure race by guarding returned/new pages before they are exposed to model code
- directly exercises the attached-Chrome page-level download-denial fallback