### PR TITLE
feat: optional password-manager prompt guidance

### DIFF
--- a/docs/agent-prompt.md
+++ b/docs/agent-prompt.md
@@ -94,6 +94,7 @@ const systemPrompt = agentSystemPrompt({
 | `forbid_account_creation` / `forbidAccountCreation` | Never create accounts; use existing credentials only. |
 | `spending_limit` / `spendingLimit` | A per-purchase cap, included verbatim (e.g. `"$50"`). |
 | `extra_rules` / `extraRules` | Extra lines appended verbatim. |
+| `password_manager` / `passwordManager` | Name of a password-manager extension present and unlocked in this browser (e.g. `"1Password"`). Adds a short inline-menu how-to **only when set**, so it costs no tokens otherwise. Pair with attach mode. |
 
 When any guardrail is set, the guidance gains a **"Guardrails for this session"**
 section that overrides the autonomy above where they conflict.

--- a/python/src/betterwright/prompt.py
+++ b/python/src/betterwright/prompt.py
@@ -134,6 +134,11 @@ class Guardrails:
     spending_limit: str | None = None
     #: Additional rules appended verbatim as bullet points.
     extra_rules: tuple[str, ...] = field(default_factory=tuple)
+    #: Name of a password-manager extension present and unlocked in this browser
+    #: (e.g. "1Password"). When set, the prompt gains a short section telling the
+    #: model to fill logins through the manager's inline menu. Leave ``None`` to
+    #: spend no tokens on it.
+    password_manager: str | None = None
 
     def clauses(self) -> list[str]:
         """Return the guardrail lines implied by this configuration."""
@@ -172,27 +177,51 @@ class Guardrails:
         return rules
 
 
+def _password_manager_section(name: str) -> str:
+    display = (
+        "1Password"
+        if name.strip().lower() in {"1password", "1 password"}
+        else name.strip()
+    )
+    return (
+        "## Password manager\n"
+        f"A {display} extension is installed and unlocked in this browser. Prefer "
+        "it for logging in and signing up: focus the field with `human.click`, "
+        f"click the {display} badge at the right edge of the field to open its "
+        "inline menu, then click the matching entry in the small menu that drops "
+        "below the field. Click that entry by its on-screen position — it is not "
+        "an ordinary DOM element, so CSS selectors and keyboard shortcuts do not "
+        f"reach it. {display} fills the secret; you never see or type it. If it "
+        "is locked or has no entry for the site, fall back to the trusted "
+        "host-side fill."
+    )
+
+
 def agent_system_prompt(guardrails: Guardrails | None = None) -> str:
     """Return operator guidance to include in a browser agent's system prompt.
 
     With no ``guardrails`` (or the default :class:`Guardrails`), the agent is told
     to act on what the user asks — including logging in, signing up, and buying —
-    and to ask only for genuine blockers. Passing a configured
-    :class:`Guardrails` appends a "Guardrails for this session" section with the
-    limits you chose.
+    and to ask only for genuine blockers. A configured :class:`Guardrails` appends
+    a "Guardrails for this session" section with the limits you chose; setting
+    ``password_manager`` adds a short section on filling logins through that
+    extension. Sections are added only when relevant, so the base prompt stays
+    lean.
     """
 
     guardrails = guardrails or Guardrails()
+    sections = [_BASE_GUIDANCE]
+    if guardrails.password_manager:
+        sections.append(_password_manager_section(guardrails.password_manager))
     clauses = guardrails.clauses()
-    if not clauses:
-        return _BASE_GUIDANCE
-    body = "\n".join(f"- {clause}" for clause in clauses)
-    return (
-        f"{_BASE_GUIDANCE}\n\n"
-        "## Guardrails for this session\n"
-        "These limits override the autonomy above where they conflict:\n"
-        f"{body}"
-    )
+    if clauses:
+        body = "\n".join(f"- {clause}" for clause in clauses)
+        sections.append(
+            "## Guardrails for this session\n"
+            "These limits override the autonomy above where they conflict:\n"
+            f"{body}"
+        )
+    return "\n\n".join(sections)
 
 
 __all__ = ["Guardrails", "agent_system_prompt"]

--- a/python/tests/test_prompt.py
+++ b/python/tests/test_prompt.py
@@ -65,3 +65,28 @@ def test_extra_rules_appended():
 def test_forbid_account_creation():
     prompt = agent_system_prompt(Guardrails(forbid_account_creation=True))
     assert "Do not create new accounts" in prompt
+
+
+def test_password_manager_section_omitted_by_default():
+    assert "## Password manager" not in agent_system_prompt()
+
+
+def test_password_manager_section_added_when_set():
+    prompt = agent_system_prompt(Guardrails(password_manager="1Password"))
+    assert "## Password manager" in prompt
+    assert "1Password badge" in prompt
+    assert "on-screen position" in prompt
+
+
+def test_password_manager_name_normalized():
+    prompt = agent_system_prompt(Guardrails(password_manager="1password"))
+    assert "A 1Password extension" in prompt
+
+
+def test_password_manager_precedes_guardrails():
+    prompt = agent_system_prompt(
+        Guardrails(password_manager="1Password", confirm_before_purchase=True)
+    )
+    assert prompt.index("## Password manager") < prompt.index(
+        "## Guardrails for this session"
+    )

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -109,6 +109,9 @@ when there is no meaningful visible end state.`;
  * @property {boolean} [forbidAccountCreation] never create new accounts
  * @property {string} [spendingLimit] per-purchase cap included verbatim, e.g. "$50"
  * @property {string[]} [extraRules] additional rules appended verbatim
+ * @property {string} [passwordManager] name of a password-manager extension
+ *   present and unlocked in this browser (e.g. "1Password"); adds a short
+ *   inline-menu how-to only when set, so it costs no tokens otherwise
  */
 
 function guardrailClauses(g) {
@@ -145,19 +148,43 @@ function guardrailClauses(g) {
   return rules;
 }
 
+function passwordManagerSection(name) {
+  const display = ["1password", "1 password"].includes(
+    String(name).trim().toLowerCase(),
+  )
+    ? "1Password"
+    : String(name).trim();
+  return (
+    "## Password manager\n" +
+    `A ${display} extension is installed and unlocked in this browser. Prefer ` +
+    "it for logging in and signing up: focus the field with `human.click`, " +
+    `click the ${display} badge at the right edge of the field to open its ` +
+    "inline menu, then click the matching entry in the small menu that drops " +
+    "below the field. Click that entry by its on-screen position — it is not " +
+    "an ordinary DOM element, so CSS selectors and keyboard shortcuts do not " +
+    `reach it. ${display} fills the secret; you never see or type it. If it ` +
+    "is locked or has no entry for the site, fall back to the trusted " +
+    "host-side fill."
+  );
+}
+
 /**
  * Operator guidance to include in a browser agent's system prompt.
  * @param {Guardrails} [guardrails]
  * @returns {string}
  */
 export function agentSystemPrompt(guardrails = {}) {
+  const sections = [BASE_GUIDANCE];
+  if (guardrails.passwordManager)
+    sections.push(passwordManagerSection(guardrails.passwordManager));
   const clauses = guardrailClauses(guardrails);
-  if (!clauses.length) return BASE_GUIDANCE;
-  const body = clauses.map((clause) => `- ${clause}`).join("\n");
-  return (
-    `${BASE_GUIDANCE}\n\n` +
-    "## Guardrails for this session\n" +
-    "These limits override the autonomy above where they conflict:\n" +
-    body
-  );
+  if (clauses.length) {
+    const body = clauses.map((clause) => `- ${clause}`).join("\n");
+    sections.push(
+      "## Guardrails for this session\n" +
+        "These limits override the autonomy above where they conflict:\n" +
+        body,
+    );
+  }
+  return sections.join("\n\n");
 }

--- a/tests/node/prompt.test.mjs
+++ b/tests/node/prompt.test.mjs
@@ -47,3 +47,25 @@ test("extra rules are appended", () => {
   const prompt = agentSystemPrompt({ extraRules: ["Only browse example.com."] });
   assert.ok(prompt.includes("Only browse example.com."));
 });
+
+test("password manager section is omitted by default", () => {
+  assert.ok(!agentSystemPrompt().includes("## Password manager"));
+});
+
+test("password manager section is added only when set", () => {
+  const prompt = agentSystemPrompt({ passwordManager: "1Password" });
+  assert.ok(prompt.includes("## Password manager"));
+  assert.ok(prompt.includes("1Password badge"));
+  assert.ok(prompt.includes("on-screen position"));
+});
+
+test("password manager name is normalized", () => {
+  assert.ok(agentSystemPrompt({ passwordManager: "1password" }).includes("A 1Password extension"));
+});
+
+test("password manager section precedes guardrails", () => {
+  const prompt = agentSystemPrompt({ passwordManager: "1Password", confirmBeforePurchase: true });
+  assert.ok(prompt.includes("## Password manager"));
+  assert.ok(prompt.includes("## Guardrails for this session"));
+  assert.ok(prompt.indexOf("## Password manager") < prompt.indexOf("## Guardrails for this session"));
+});


### PR DESCRIPTION
## What

Follow-up to #7. Teaches models how to drive a password-manager extension's inline autofill — but only spends the tokens when one is actually present.

- New `password_manager` / `passwordManager` field on `Guardrails`.
- When set (e.g. `"1Password"`), `agent_system_prompt` / `agentSystemPrompt` appends a short **## Password manager** section: focus the field with `human.click`, click the badge to open the inline menu, then click the matching entry **by its on-screen position** — it is not a selectable DOM node, so CSS selectors and keyboard shortcuts miss it (the exact detail that made the naive attempt fail during live testing).
- Omitted entirely when unset, so the base prompt is unchanged and costs zero extra tokens. `"1password"` normalizes to `"1Password"`.

## Why

Live-verified in #7 that BetterWright's trusted CDP clicks can drive 1Password's inline menu (logged into a real router). This gives the model the specific how-to so it reaches for that path reliably in attach mode — without bloating the prompt for the common case where no manager is present.

## Tests

- Python: 85 passed (4 new prompt cases). Node: 95 passed / 1 pre-existing skip (4 new prompt cases). biome ✓, ruff ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnudPSsUfLLdAM81e2L74J