### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-14
+
 ### Added
 
 - Trusted credential fill: `fill_credential` / `fillCredential` and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with a network policy, an encrypted credential vault, proof screenshots, and native CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "betterwright"
-version = "0.2.0"
+version = "0.3.0"
 description = "A persistent, policy-guarded Playwright browser for AI agents."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/betterwright/__init__.py
+++ b/python/src/betterwright/__init__.py
@@ -36,7 +36,7 @@ from betterwright.vault import (
     normalize_http_origin,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "Artifact",


### PR DESCRIPTION
Cuts the **v0.3.0** release: bumps the package version (`package.json`, `python/pyproject.toml`, `betterwright.__version__`) and promotes the `[Unreleased]` changelog section.

### Included since v0.2.0
- **Trusted credential fill** — `fill_credential` / `fillCredential` and `generate_and_fill_credential` / `generateAndFillCredential`; host-side password typing with `confirm_password_selector` (signup) and optional `submit_selector`, returning only non-secret metadata. Replaces the previously advertised-but-unimplemented host-side login handoff.
- **`connect_over_cdp="auto"` / `ensure_chrome_cdp`** — reuse a running debug Chrome or launch real Google Chrome with a persistent profile, enabling password-manager (e.g. 1Password) inline-autofill in attach mode.
- **Optional password-manager prompt hint** — `Guardrails(password_manager=…)` / `passwordManager` adds a short inline-menu how-to only when set.
- Examples: `signup_with_generated_password.py`, `onepassword_attach.py`; fixed `login_with_vault.py`.

### Verification
- Node: 95 passing / 1 skipped
- Python: 65 passing / 20 skipped
- Worker copies in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnudPSsUfLLdAM81e2L74J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **0.3.0** across supported distributions.
* **Documentation**
  * Added a changelog entry for the **0.3.0** release dated July 14, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->