### PR TITLE
release: prepare npm v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,30 +5,40 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  worker-sync:
-    name: Worker copies in sync
+  package-integrity:
+    name: Package integrity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: node scripts/sync-worker.mjs --check
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run check:worker
+      - run: npm run check:versions
+      - run: npm run lint
+      - run: npm run test:unit
+      - run: npm run test:types
+      - run: npm run check:package
 
   node:
-    name: Node tests
+    name: Node browser tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: npm install
+          cache: npm
+      - run: npm ci --ignore-scripts
       - name: Install deterministic Chromium test backend
-        run: node bin/betterwright.mjs setup --chromium
-      - run: npm run lint
-      # The broad suite uses explicit Chromium; Cloak has a separate opt-in E2E.
+        run: node node_modules/playwright-core/cli.js install chromium --no-shell
+      # The broad suite selects explicit Chromium; Cloak has a separate opt-in E2E.
       - run: npm test
 
   python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   package-integrity:
-    name: Package integrity
+    # Keep this display name stable because main branch protection requires it.
+    name: Worker copies in sync
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +28,8 @@ jobs:
       - run: npm run check:package
 
   node:
-    name: Node browser tests
+    # Keep this display name stable because main branch protection requires it.
+    name: Node tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,60 @@
+name: Publish npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish trusted package
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Trusted Publishing capable npm
+        run: npm install --global npm@11.5.1
+      - name: Verify release source and tag
+        shell: bash
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/main
+          node scripts/check-versions.mjs --tag "${{ github.event.release.tag_name }}"
+      - name: Check whether this version already exists
+        id: existing
+        shell: bash
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "$NAME@$VERSION is already published; nothing to do."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install locked dependencies
+        if: steps.existing.outputs.published != 'true'
+        run: npm ci --ignore-scripts
+      - name: Install deterministic Chromium test backend
+        if: steps.existing.outputs.published != 'true'
+        run: node node_modules/playwright-core/cli.js install chromium --no-shell
+      - name: Run browser integration suite
+        if: steps.existing.outputs.published != 'true'
+        run: npm test
+      - name: Publish to npm with provenance
+        if: steps.existing.outputs.published != 'true'
+        run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-07-15
+
+### Added
+
+- First-class npm distribution with typed conditional exports for the public
+  JavaScript API and subpath modules.
+- Release checks for synchronized versions, worker copies, TypeScript
+  declarations, npm tarball contents, clean installation, imports, and CLI use.
+- Provenance-ready npm publishing through GitHub Actions after the initial
+  package bootstrap.
+
+### Changed
+
+- Browser installation is now an explicit `betterwright setup` step instead of
+  a hidden ~200 MB npm `postinstall` download.
+- npm CI uses a committed lockfile and reproducible `npm ci` installs.
+- `doctor` reports the resolved Cloak browser binary version and tier separately
+  from the pinned wrapper version.
+- Public npm subpaths now resolve through explicit runtime and declaration
+  conditions, including the existing worker entry point.
+
 ## [0.3.0] — 2026-07-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ the other and update both suites.
 cd python && pip install -e '.[dev]' && pytest
 
 # Node
-npm install && npm test
+npm ci && npm test
 ```
 
 The browser-integration tests skip automatically unless the runtime is installed
@@ -58,8 +58,9 @@ The browser-integration tests skip automatically unless the runtime is installed
 ## Style
 
 - Python: `ruff` (config in `pyproject.toml`). Type hints on public functions.
-- JavaScript: ESM, no build step, no runtime dependencies beyond
-  `playwright-core`. `npm run lint` syntax-checks the sources.
+- JavaScript: ESM, no build step, and exact runtime dependency pins.
+  `npm run lint` syntax-checks the sources and `npm run test:types` verifies the
+  published declarations.
 - Comments explain *why*, not *what*. Match the surrounding code.
 
 ## Scope
@@ -75,3 +76,34 @@ The Playwright version is pinned in three places: `package.json`,
 `python/src/betterwright/runtime.py` (`PINNED_PLAYWRIGHT_VERSION`), and
 `bin/betterwright.mjs`. A bump changes all three and is tested against the
 matching Chromium build.
+
+## Releasing
+
+### One-time npm bootstrap
+
+Trusted Publishing can only be attached after the package exists. For the first
+release only:
+
+1. Merge the release commit to `main`, run `npm ci` and
+   `npm run release:check`, then sign in with `npm login`.
+2. Claim the package with `npm publish --access public` before creating the
+   GitHub release.
+3. In the npm package settings, add the GitHub Trusted Publisher for owner
+   `CuriosityOS`, repository `betterwright`, workflow `publish-npm.yml`, and
+   environment `npm`.
+4. Protect release tags and the repository's `npm` environment before enabling
+   future maintainers to create releases.
+
+### Normal releases
+
+1. Update `CHANGELOG.md` and keep the npm/Python versions aligned.
+2. Run `npm ci` followed by `npm run release:check`.
+3. Merge the release commit, create the matching `vX.Y.Z` tag from `main`, and
+   publish a GitHub Release for that tag.
+4. `publish-npm.yml` verifies that the release commit belongs to `main`, runs
+   the complete Node suite against the pinned Chromium build, and publishes
+   through npm Trusted Publishing with provenance.
+
+The npm tarball intentionally excludes browser binaries, profiles, Python
+artifacts, tests, documentation images, and repository caches. Browser
+installation remains an explicit setup step.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,20 @@ betterwright doctor       # confirms everything resolves
 ### JavaScript
 
 ```bash
-npm install betterwright  # postinstall downloads the managed Cloak browser
+npm install betterwright
+npx betterwright setup     # downloads the managed Cloak browser (~200 MB, once)
 npx betterwright doctor
 ```
 
-Both packages ship the identical worker and pin the same Playwright and
-CloakBrowser wrapper versions. The browser binary is fetched and signature
-verified by the official CloakBrowser wrapper, then cached outside this package.
+BetterWright never downloads a browser as a hidden npm lifecycle side effect,
+so installs remain predictable and work with `--ignore-scripts`. Both packages
+ship the identical worker and pin the same Playwright and CloakBrowser wrapper
+versions. The browser binary is fetched and signature verified by the official
+CloakBrowser wrapper, then cached outside this package.
+
+Update the JavaScript package with `npm update betterwright` (or
+`npm install betterwright@latest`). Run `npx betterwright setup` again after an
+update only when `doctor` reports that the managed runtime is missing.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,14 +23,17 @@ prompt.
    - Python host: `pip install betterwright`
    - JavaScript host: `npm install betterwright`
    - MCP path (any host): `pip install "betterwright[mcp]"`
-3. **Download the managed browser** (one-time, ~200 MB): `betterwright setup`.
+3. **Download the managed browser** (one-time, ~200 MB):
+   - Python/MCP install: `betterwright setup`
+   - JavaScript install: `npx betterwright setup`
+
    The official CloakBrowser wrapper downloads its signed binary directly from
    CloakHQ and verifies it before extraction; BetterWright does not redistribute
-   that separately licensed binary.
-4. **Verify** it is ready — this must print `BetterWright is ready.`:
-   ```bash
-   betterwright doctor
-   ```
+   that separately licensed binary. npm installation itself has no hidden
+   browser-download lifecycle script.
+4. **Verify** it is ready and must print `BetterWright is ready.`:
+   - Python/MCP install: `betterwright doctor`
+   - JavaScript install: `npx betterwright doctor`
    If it does not, stop and report exactly what `doctor` printed.
 
 Then go to the matching section:
@@ -83,7 +86,8 @@ across tool calls.
 Managed launches use CloakBrowser by default to reduce common automation false
 positives. This is not a guarantee of undetectability. Set
 `BETTERWRIGHT_BROWSER=chromium` only for the explicit stock-browser fallback;
-run `betterwright setup --chromium` once before selecting it.
+run `betterwright setup --chromium` (Python) or
+`npx betterwright setup --chromium` (JavaScript) once before selecting it.
 
 Public search-result UIs are blocked by default. Broad discovery should use the
 host's web-search tool, then open selected first-party pages in BetterWright.
@@ -251,7 +255,8 @@ the path you just wired. Have the agent (or run yourself) this two-step check:
    and confirm you get back a `MEDIA:` path that exists on disk.
 
 If both succeed, the integration is live. If the first fails with a runtime
-error, rerun `betterwright doctor` — the browser is probably not installed.
+error, rerun `betterwright doctor` (Python) or `npx betterwright doctor`
+(JavaScript); the browser is probably not installed.
 
 For an agent research check, give it a broad discovery task and confirm it uses
 the host's web-search tool, then opens returned results or first-party pages in

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -44,7 +44,15 @@ function resolveCloakDir() {
 
 async function cloakRuntime() {
   const dir = resolveCloakDir();
-  if (!dir) return { dir: null, version: null, binary: null, installed: false };
+  if (!dir)
+    return {
+      dir: null,
+      version: null,
+      binaryVersion: null,
+      tier: null,
+      binary: null,
+      installed: false,
+    };
   let version = null;
   try {
     version = require(path.join(dir, "package.json")).version;
@@ -57,11 +65,20 @@ async function cloakRuntime() {
     return {
       dir,
       version,
+      binaryVersion: info.version || null,
+      tier: info.tier || null,
       binary: info.binaryPath,
       installed: Boolean(info.installed),
     };
   } catch {
-    return { dir, version, binary: null, installed: false };
+    return {
+      dir,
+      version,
+      binaryVersion: null,
+      tier: null,
+      binary: null,
+      installed: false,
+    };
   }
 }
 
@@ -109,6 +126,8 @@ async function cmdDoctor() {
     cloakbrowser: cloak.dir,
     cloakbrowser_version: cloak.version,
     cloakbrowser_pinned: PINNED_CLOAKBROWSER_VERSION,
+    cloakbrowser_binary_version: cloak.binaryVersion,
+    cloakbrowser_binary_tier: cloak.tier,
     cloakbrowser_binary: cloak.binary,
     cloakbrowser_ok:
       cloak.version === PINNED_CLOAKBROWSER_VERSION && cloak.installed,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,13 @@ The worker, the JS facades it builds, Playwright, and the CloakBrowser wrapper
 have to agree, so both wrapper versions are pinned in the Python and JavaScript
 packages. `betterwright setup` installs those exact integrations and asks the
 official CloakBrowser wrapper for its signed browser build. Bumping either
-wrapper is a deliberate, tested change, not a range that floats underneath you.
+wrapper is a deliberate, tested BetterWright change.
+
+The external browser binary has a separate lifecycle: by default it follows the
+pinned wrapper's signed stable channel and can advance without a BetterWright
+package release. `betterwright doctor` reports the resolved binary version and
+tier. Reproducible deployments can set a full `CLOAKBROWSER_VERSION`, while
+`CLOAKBROWSER_AUTO_UPDATE=false` freezes update checks for an installed build.
 
 Managed CloakBrowser reduces common browser-fingerprint false positives but
 does not guarantee undetectability. Stock Chromium remains an explicit

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,12 +17,18 @@ betterwright doctor     # prints what resolved; should end with "BetterWright is
 ### JavaScript
 
 ```bash
-npm install betterwright   # postinstall downloads the managed browser
+npm install betterwright
+npx betterwright setup     # downloads the signed managed browser (~200 MB, once)
 npx betterwright doctor
 ```
 
 If `doctor` reports Node missing, install it from <https://nodejs.org> and rerun
-`setup`. If it reports CloakBrowser missing, rerun `betterwright setup`.
+`setup`. If a JavaScript install reports CloakBrowser missing, rerun
+`npx betterwright setup`; Python installs use `betterwright setup`.
+
+Upgrade with `npm update betterwright` or `npm install betterwright@latest`.
+Package updates are intentional rather than automatic, so application lockfiles
+continue to control when a new BetterWright version is adopted.
 
 ### Managed CloakBrowser backend
 
@@ -43,6 +49,12 @@ The managed backend keeps one stable fingerprint seed and persistent profile.
 That removes several stock automation signals and can reduce false positives;
 it cannot guarantee that a site will accept the session or never issue a
 challenge.
+
+BetterWright pins the CloakBrowser npm wrapper, while the separately cached
+browser binary follows CloakBrowser's signed stable channel. `betterwright
+doctor` reports both versions. For a reproducible deployment, set a full
+`CLOAKBROWSER_VERSION`; to keep an already installed build from checking for a
+newer stable build, set `CLOAKBROWSER_AUTO_UPDATE=false`.
 
 ### Explicit Chromium fallback
 

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -202,4 +202,5 @@ agentSystemPrompt(guardrails?) => string
 Operator guidance for a browser agent's system prompt — identical text to the
 Python `agent_system_prompt`. Guardrail fields: `confirmBeforePurchase`,
 `confirmBeforeIrreversible`, `forbidPurchases`, `forbidAccountCreation`,
-`spendingLimit`, `extraRules`. See [agent-prompt.md](agent-prompt.md).
+`spendingLimit`, `extraRules`, and `passwordManager`. See
+[agent-prompt.md](agent-prompt.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,330 @@
+{
+  "name": "betterwright",
+  "version": "0.3.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "betterwright",
+      "version": "0.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "cloakbrowser": "0.4.10",
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "betterwright": "bin/betterwright.mjs"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.3",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
+      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.3",
+        "@biomejs/cli-darwin-x64": "2.5.3",
+        "@biomejs/cli-linux-arm64": "2.5.3",
+        "@biomejs/cli-linux-arm64-musl": "2.5.3",
+        "@biomejs/cli-linux-x64": "2.5.3",
+        "@biomejs/cli-linux-x64-musl": "2.5.3",
+        "@biomejs/cli-win32-arm64": "2.5.3",
+        "@biomejs/cli-win32-x64": "2.5.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
+      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
+      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
+      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cloakbrowser": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.4.10.tgz",
+      "integrity": "sha512-Juc5343WIZ9kF0pQ+UJESovhXqez09sS/XSx+75CeHlRA4N22YxzbsR32P1j18CNrxZftBhc1MohDBtnW3cuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "tar": "^7.0.0"
+      },
+      "bin": {
+        "cloakbrowser": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "mmdb-lib": ">=2.0.0",
+        "playwright-core": ">=1.53.0",
+        "puppeteer-core": ">=21.0.0",
+        "socks-proxy-agent": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mmdb-lib": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "puppeteer-core": {
+          "optional": true
+        },
+        "socks-proxy-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,42 @@
 {
   "name": "betterwright",
-  "version": "0.3.0",
-  "description": "A persistent, policy-guarded Playwright browser for AI agents with a network policy, an encrypted credential vault, proof screenshots, and native CAPTCHA helpers.",
+  "version": "0.3.1",
+  "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",
+  "types": "types/index.d.ts",
   "exports": {
-    ".": "./src/index.mjs",
-    "./chrome": "./src/chrome.mjs",
-    "./policy": "./src/policy.mjs",
-    "./prompt": "./src/prompt.mjs",
-    "./pi": "./src/pi.mjs",
-    "./worker": "./src/worker.mjs"
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./src/index.mjs",
+      "default": "./src/index.mjs"
+    },
+    "./chrome": {
+      "types": "./types/chrome.d.ts",
+      "import": "./src/chrome.mjs",
+      "default": "./src/chrome.mjs"
+    },
+    "./policy": {
+      "types": "./types/policy.d.ts",
+      "import": "./src/policy.mjs",
+      "default": "./src/policy.mjs"
+    },
+    "./prompt": {
+      "types": "./types/prompt.d.ts",
+      "import": "./src/prompt.mjs",
+      "default": "./src/prompt.mjs"
+    },
+    "./pi": {
+      "types": "./types/pi.d.ts",
+      "import": "./src/pi.mjs",
+      "default": "./src/pi.mjs"
+    },
+    "./worker": {
+      "types": "./types/worker.d.ts",
+      "import": "./src/worker.mjs",
+      "default": "./src/worker.mjs"
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "betterwright": "bin/betterwright.mjs"
@@ -18,16 +44,31 @@
   "files": [
     "src",
     "bin",
+    "types",
+    "examples/javascript",
+    "CHANGELOG.md",
+    "SETUP.md",
+    "SECURITY.md",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "postinstall": "node bin/betterwright.mjs setup || true",
     "test": "node --test tests/node/*.test.mjs",
-    "lint": "biome ci src bin scripts tests"
+    "test:unit": "node scripts/run-unit-tests.mjs",
+    "test:types": "tsc --noEmit -p tests/types/tsconfig.json",
+    "lint": "biome ci src bin scripts tests",
+    "check:worker": "node scripts/sync-worker.mjs --check",
+    "check:versions": "node scripts/check-versions.mjs",
+    "check:package": "node scripts/check-package.mjs",
+    "release:check": "npm run check:worker && npm run check:versions && npm run lint && npm run test:unit && npm run test:types && npm run check:package",
+    "prepublishOnly": "npm run release:check"
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "packageManager": "npm@11.5.1",
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "cloakbrowser": "0.4.10",
@@ -55,6 +96,7 @@
   },
   "homepage": "https://github.com/CuriosityOS/betterwright#readme",
   "devDependencies": {
-    "@biomejs/biome": "^2.5.3"
+    "@biomejs/biome": "^2.5.3",
+    "typescript": "^5.9.3"
   }
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "betterwright"
-version = "0.3.0"
+version = "0.3.1"
 description = "A persistent, policy-guarded Playwright browser for AI agents."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/betterwright/__init__.py
+++ b/python/src/betterwright/__init__.py
@@ -36,7 +36,7 @@ from betterwright.vault import (
     normalize_http_origin,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "Artifact",

--- a/python/src/betterwright/runtime.py
+++ b/python/src/betterwright/runtime.py
@@ -150,6 +150,8 @@ def diagnose() -> dict:
         "playwright_ok": core is not None,
         "cloakbrowser": str(cloak) if cloak else None,
         "cloakbrowser_version": PINNED_CLOAKBROWSER_VERSION,
+        "cloakbrowser_binary_version": cloak_binary.get("version") if cloak_binary else None,
+        "cloakbrowser_binary_tier": cloak_binary.get("tier") if cloak_binary else None,
         "cloakbrowser_binary": cloak_binary.get("binaryPath") if cloak_binary else None,
         "cloakbrowser_ok": bool(cloak_binary and cloak_binary.get("installed")),
         "browser": browser,

--- a/python/tests/test_artifacts_and_display.py
+++ b/python/tests/test_artifacts_and_display.py
@@ -184,3 +184,34 @@ def test_runtime_discovery_matches_node_ancestor_lookup(monkeypatch, tmp_path):
 
     assert runtime.playwright_core_dir() == (node_modules / "playwright-core").resolve()
     assert runtime.cloakbrowser_dir() == (node_modules / "cloakbrowser").resolve()
+
+
+def test_diagnose_reports_cloak_binary_identity(monkeypatch, tmp_path):
+    worker = tmp_path / "worker.mjs"
+    worker.write_text("", encoding="utf-8")
+    core = tmp_path / "playwright-core"
+    cloak = tmp_path / "cloakbrowser"
+    core.mkdir()
+    cloak.mkdir()
+
+    monkeypatch.setattr(runtime, "node_executable", lambda: "/usr/bin/node")
+    monkeypatch.setattr(runtime, "worker_path", lambda: worker)
+    monkeypatch.setattr(runtime, "playwright_core_dir", lambda: core)
+    monkeypatch.setattr(runtime, "cloakbrowser_dir", lambda: cloak)
+    monkeypatch.setattr(
+        runtime,
+        "_cloak_binary_info",
+        lambda _node, _cloak: {
+            "version": "145.0.7632.109.2",
+            "tier": "free",
+            "binaryPath": "/cache/cloak/chrome",
+            "installed": True,
+        },
+    )
+    monkeypatch.delenv("BETTERWRIGHT_BROWSER", raising=False)
+
+    report = runtime.diagnose()
+
+    assert report["cloakbrowser_binary_version"] == "145.0.7632.109.2"
+    assert report["cloakbrowser_binary_tier"] == "free"
+    assert report["ready"] is True

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-package-"));
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || root,
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    const details = options.capture ? `${result.stdout || ""}${result.stderr || ""}` : "";
+    throw new Error(`${command} ${args.join(" ")} failed${details ? `\n${details}` : ""}`);
+  }
+  return result.stdout || "";
+}
+
+function npm(args, options = {}) {
+  if (process.env.npm_execpath) {
+    return run(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+  return run(process.platform === "win32" ? "npm.cmd" : "npm", args, options);
+}
+
+try {
+  const output = npm(
+    ["pack", "--json", "--ignore-scripts", "--pack-destination", temp],
+    { capture: true },
+  );
+  const packed = JSON.parse(output)[0];
+  const paths = new Set(packed.files.map((entry) => entry.path));
+  const required = [
+    "LICENSE",
+    "README.md",
+    "SETUP.md",
+    "bin/betterwright.mjs",
+    "src/index.mjs",
+    "src/worker.mjs",
+    "types/index.d.ts",
+    "types/chrome.d.ts",
+    "types/policy.d.ts",
+    "types/prompt.d.ts",
+    "types/pi.d.ts",
+    "types/worker.d.ts",
+  ];
+  const missing = required.filter((name) => !paths.has(name));
+  if (missing.length) throw new Error(`npm tarball is missing: ${missing.join(", ")}`);
+
+  const forbidden = packed.files
+    .map((entry) => entry.path)
+    .filter((name) => /(^|\/)(node_modules|tests|python|artifacts|\.betterwright)(\/|$)/.test(name));
+  if (forbidden.length) throw new Error(`npm tarball contains private/dev files: ${forbidden.join(", ")}`);
+  if (packed.size > 1_000_000) throw new Error(`npm tarball is unexpectedly large: ${packed.size} bytes`);
+
+  const tarball = path.join(temp, packed.filename);
+  const installRoot = path.join(temp, "install");
+  fs.mkdirSync(installRoot);
+  fs.writeFileSync(
+    path.join(installRoot, "package.json"),
+    JSON.stringify({ private: true, type: "module" }),
+  );
+  npm(
+    ["install", tarball, "--ignore-scripts", "--no-audit", "--no-fund"],
+    { cwd: installRoot },
+  );
+
+  const installed = JSON.parse(
+    fs.readFileSync(path.join(installRoot, "node_modules", "betterwright", "package.json"), "utf8"),
+  );
+  if (installed.scripts?.postinstall) throw new Error("published package must not have a postinstall script");
+
+  run(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      [
+        "const root = await import('betterwright');",
+        "const chrome = await import('betterwright/chrome');",
+        "const policy = await import('betterwright/policy');",
+        "const prompt = await import('betterwright/prompt');",
+        "const pi = await import('betterwright/pi');",
+        "if (typeof root.BetterWright !== 'function') throw new Error('missing BetterWright');",
+        "if (typeof chrome.ensureChromeCdp !== 'function') throw new Error('missing chrome export');",
+        "if (typeof policy.NetworkPolicy !== 'function') throw new Error('missing policy export');",
+        "if (typeof prompt.agentSystemPrompt !== 'function') throw new Error('missing prompt export');",
+        "if (typeof pi.piImageContent !== 'function') throw new Error('missing Pi export');",
+      ].join("\n"),
+    ],
+    { cwd: installRoot },
+  );
+
+  fs.writeFileSync(
+    path.join(installRoot, "consumer.ts"),
+    [
+      "import { BetterWright, NetworkPolicy, type RunResult } from 'betterwright';",
+      "import { chromeExecutableCandidates } from 'betterwright/chrome';",
+      "import type { NetworkDecision } from 'betterwright/policy';",
+      "import type { PiImageContentBlock } from 'betterwright/pi';",
+      "import type { Guardrails } from 'betterwright/prompt';",
+      "import { METADATA_RESOLVER_RULES } from 'betterwright/worker';",
+      "const policy = new NetworkPolicy();",
+      "const browser = new BetterWright({ policy, browser: 'cloak' });",
+      "const result: Promise<RunResult<string>> = browser.run<string>('return page.title()');",
+      "const decision: NetworkDecision = policy.check('https://example.com');",
+      "const blocks: PiImageContentBlock[] = [];",
+      "const guardrails: Guardrails = { passwordManager: '1Password' };",
+      "void [result, decision, blocks, guardrails, chromeExecutableCandidates(), METADATA_RESOLVER_RULES];",
+    ].join("\n"),
+  );
+  const typescript = path.join(root, "node_modules", "typescript", "bin", "tsc");
+  run(
+    process.execPath,
+    [
+      typescript,
+      "--noEmit",
+      "--strict",
+      "--target",
+      "ES2022",
+      "--module",
+      "NodeNext",
+      "--moduleResolution",
+      "NodeNext",
+      "consumer.ts",
+    ],
+    { cwd: installRoot },
+  );
+
+  const bin = path.join(
+    installRoot,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "betterwright.cmd" : "betterwright",
+  );
+  const versionOutput = run(bin, ["--version"], { cwd: installRoot, capture: true }).trim();
+  if (versionOutput !== installed.version) {
+    throw new Error(`CLI reported ${versionOutput}, package is ${installed.version}`);
+  }
+
+  const doctor = spawnSync(bin, ["doctor"], {
+    cwd: installRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+    env: process.env,
+  });
+  if (![0, 1].includes(doctor.status)) throw new Error("doctor exited unexpectedly");
+  const doctorOutput = `${doctor.stdout || ""}${doctor.stderr || ""}`;
+  for (const field of ["cloakbrowser_binary_version", "cloakbrowser_binary_tier"]) {
+    if (!doctorOutput.includes(field)) throw new Error(`doctor did not report ${field}`);
+  }
+
+  console.log(
+    `package smoke test passed: ${packed.filename}, ${packed.files.length} files, ${packed.size} bytes`,
+  );
+} finally {
+  fs.rmSync(temp, { recursive: true, force: true });
+}

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (name) => fs.readFileSync(path.join(root, name), "utf8");
+const pkg = JSON.parse(read("package.json"));
+const lock = JSON.parse(read("package-lock.json"));
+const lockRoot = lock.packages?.[""] || {};
+const failures = [];
+
+function expectMatch(label, text, expression, expected) {
+  const actual = text.match(expression)?.[1];
+  if (actual !== expected) failures.push(`${label}: expected ${expected}, found ${actual ?? "nothing"}`);
+}
+
+if (lock.version !== pkg.version || lockRoot.version !== pkg.version) {
+  failures.push(
+    `package-lock.json version must be ${pkg.version}; found ${lock.version}/${lockRoot.version}`,
+  );
+}
+for (const dependency of ["playwright-core", "cloakbrowser"]) {
+  if (lockRoot.dependencies?.[dependency] !== pkg.dependencies[dependency]) {
+    failures.push(
+      `package-lock.json ${dependency} pin does not match package.json`,
+    );
+  }
+}
+const npmVersion = String(pkg.packageManager || "").match(/^npm@(.+)$/)?.[1];
+if (!npmVersion) failures.push("packageManager must pin an exact npm version");
+else {
+  expectMatch(
+    "publish workflow npm version",
+    read(".github/workflows/publish-npm.yml"),
+    /npm install --global npm@([^\s]+)/,
+    npmVersion,
+  );
+}
+
+expectMatch(
+  "python/pyproject.toml version",
+  read("python/pyproject.toml"),
+  /^version = "([^"]+)"/m,
+  pkg.version,
+);
+expectMatch(
+  "Python __version__",
+  read("python/src/betterwright/__init__.py"),
+  /^__version__ = "([^"]+)"/m,
+  pkg.version,
+);
+expectMatch(
+  "Node CLI Playwright pin",
+  read("bin/betterwright.mjs"),
+  /PINNED_PLAYWRIGHT_VERSION = "([^"]+)"/,
+  pkg.dependencies["playwright-core"],
+);
+expectMatch(
+  "Node CLI CloakBrowser pin",
+  read("bin/betterwright.mjs"),
+  /PINNED_CLOAKBROWSER_VERSION = "([^"]+)"/,
+  pkg.dependencies.cloakbrowser,
+);
+expectMatch(
+  "Python Playwright pin",
+  read("python/src/betterwright/runtime.py"),
+  /PINNED_PLAYWRIGHT_VERSION = "([^"]+)"/,
+  pkg.dependencies["playwright-core"],
+);
+expectMatch(
+  "Python CloakBrowser pin",
+  read("python/src/betterwright/runtime.py"),
+  /PINNED_CLOAKBROWSER_VERSION = "([^"]+)"/,
+  pkg.dependencies.cloakbrowser,
+);
+
+if (!read("CHANGELOG.md").includes(`## [${pkg.version}]`)) {
+  failures.push(`CHANGELOG.md has no ${pkg.version} release heading`);
+}
+
+const tagIndex = process.argv.indexOf("--tag");
+if (tagIndex !== -1) {
+  const tag = process.argv[tagIndex + 1] || "";
+  if (tag !== `v${pkg.version}`) failures.push(`release tag ${tag || "<empty>"} does not match v${pkg.version}`);
+}
+
+if (failures.length) {
+  console.error(`Version checks failed:\n- ${failures.join("\n- ")}`);
+  process.exit(1);
+}
+console.log(
+  `versions aligned: betterwright ${pkg.version}, playwright-core ${pkg.dependencies["playwright-core"]}, cloakbrowser ${pkg.dependencies.cloakbrowser}`,
+);

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const testDir = path.join(root, "tests", "node");
+const files = fs
+  .readdirSync(testDir)
+  .filter((name) => name.endsWith(".test.mjs") && name !== "browser.test.mjs")
+  .sort()
+  .map((name) => path.join("tests", "node", name));
+
+if (!files.length) {
+  console.error("No Node unit test files found.");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, ["--test", ...files], {
+  cwd: root,
+  stdio: "inherit",
+});
+process.exit(result.status ?? 1);

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -1,0 +1,64 @@
+import {
+  agentSystemPrompt,
+  BetterWright,
+  type BetterWrightOptions,
+  BrowserError,
+  ensureChromeCdp,
+  findChromeExecutable,
+  type Guardrails,
+  METADATA_ADDRESSES,
+  METADATA_HOSTNAMES,
+  NetworkPolicy,
+  piImageContent,
+  type RunResult,
+} from "betterwright";
+import { chromeExecutableCandidates } from "betterwright/chrome";
+import type { PiImageContentBlock } from "betterwright/pi";
+import type { NetworkDecision } from "betterwright/policy";
+import type { Guardrails as PromptGuardrails } from "betterwright/prompt";
+import { METADATA_RESOLVER_RULES } from "betterwright/worker";
+
+const policy = new NetworkPolicy({
+  allowLoopback: true,
+  custom: (_url, details): NetworkDecision | null =>
+    details.method === "DELETE" ? { allowed: false, reason: "blocked" } : null,
+});
+const options: BetterWrightOptions = {
+  policy,
+  browser: "cloak",
+  headless: "auto",
+  downloadPolicy: "ask",
+};
+const browser = new BetterWright(options);
+const run: Promise<RunResult<{ title: string }>> = browser.run<{ title: string }>(
+  "return { title: await page.title() }",
+  { session: "docs", note: "Reading the page" },
+);
+const promptOptions: Guardrails & PromptGuardrails = {
+  confirmBeforePurchase: true,
+  passwordManager: "1Password",
+};
+const prompt: string = agentSystemPrompt(promptOptions);
+const chrome: string | null = findChromeExecutable();
+const candidates: string[] = chromeExecutableCandidates();
+const cdp = ensureChromeCdp({ port: 9223 });
+const images: Promise<PiImageContentBlock[]> = piImageContent({ artifacts: [] });
+const error: Error = new BrowserError("failed");
+const metadataAddress: boolean = METADATA_ADDRESSES.has("169.254.169.254");
+const metadataHost: boolean = METADATA_HOSTNAMES.has("metadata.google.internal");
+
+// @ts-expect-error BetterWright supports only the two declared browser backends.
+new BetterWright({ browser: "firefox" });
+
+void [
+  run,
+  prompt,
+  chrome,
+  candidates,
+  cdp,
+  images,
+  error,
+  metadataAddress,
+  metadataHost,
+  METADATA_RESOLVER_RULES,
+];

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": []
+  },
+  "include": ["package.test.ts"]
+}

--- a/types/chrome.d.ts
+++ b/types/chrome.d.ts
@@ -1,0 +1,16 @@
+export interface EnsureChromeCdpOptions {
+  home?: string;
+  port?: number;
+  executablePath?: string;
+  timeoutMs?: number;
+}
+
+export interface ChromeCdpResult {
+  endpoint: string;
+  profileDir: string;
+  started: boolean;
+}
+
+export function chromeExecutableCandidates(platform?: string): string[];
+export function findChromeExecutable(explicit?: string): string | null;
+export function ensureChromeCdp(options?: EnsureChromeCdpOptions): Promise<ChromeCdpResult>;

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,0 +1,35 @@
+import type {
+  BetterWrightOptions,
+  CredentialFillResult,
+  FillCredentialOptions,
+  GenerateAndFillCredentialOptions,
+  RunOptions,
+  RunResult,
+} from "./public.js";
+import type { CredentialVault } from "./common.js";
+import type { NetworkPolicy } from "./policy.js";
+
+export class BrowserError extends Error {}
+
+export class BetterWright {
+  constructor(options?: BetterWrightOptions);
+
+  home: string;
+  policy: NetworkPolicy;
+  vault: CredentialVault | null;
+  browserFlavor: "cloak" | "chromium";
+  executablePath: string;
+  headless: boolean;
+  connectOverCdp: string;
+  searchMinIntervalMs: number;
+  publicSearchPolicy: "block" | "allow";
+  downloadPolicy: "ask" | "allow" | "deny";
+  defaultTimeout: number;
+
+  run<T = unknown>(code: string, options?: RunOptions): Promise<RunResult<T>>;
+  fillCredential(options: FillCredentialOptions): Promise<CredentialFillResult>;
+  generateAndFillCredential(
+    options: GenerateAndFillCredentialOptions,
+  ): Promise<CredentialFillResult>;
+  close(): Promise<void>;
+}

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,0 +1,90 @@
+export type BrowserFlavor = "cloak" | "chromium";
+export type HeadlessMode = boolean | "auto";
+export type PublicSearchPolicy = "block" | "allow";
+export type DownloadPolicy = "ask" | "allow" | "deny";
+
+export interface CredentialVault {
+  handleRequest(
+    action: string,
+    payload: Record<string, unknown>,
+    origin: string,
+  ): unknown | Promise<unknown>;
+  redact?(value: unknown): unknown;
+}
+
+export interface BetterWrightArtifact {
+  kind?: string;
+  path?: string;
+  media?: string;
+  size?: number;
+  [key: string]: unknown;
+}
+
+export interface ResultEnvelopeBase {
+  console?: unknown[];
+  events?: unknown[];
+  artifacts?: BetterWrightArtifact[];
+  warnings?: string[];
+  challenges?: unknown[];
+  pages?: unknown[];
+  profileMode?: string;
+  durationMs?: number;
+  envelopeTruncated?: boolean;
+}
+
+export interface SuccessfulRunResult<T = unknown> extends ResultEnvelopeBase {
+  ok: true;
+  result: T;
+  error?: never;
+}
+
+export interface FailedRunResult extends ResultEnvelopeBase {
+  ok: false;
+  error: string;
+  result?: never;
+}
+
+export type RunResult<T = unknown> = SuccessfulRunResult<T> | FailedRunResult;
+
+export interface RunOptions {
+  session?: string;
+  /** Optional host-facing status text. It is never evaluated in the browser sandbox. */
+  note?: string;
+  timeout?: number;
+  approvedDownloads?: boolean;
+}
+
+export interface FillCredentialOptions {
+  passwordSelector: string;
+  usernameSelector?: string;
+  confirmPasswordSelector?: string;
+  submitSelector?: string;
+  id?: string;
+  username?: string;
+  session?: string;
+  timeout?: number;
+}
+
+export interface GenerateAndFillCredentialOptions extends FillCredentialOptions {
+  length?: number;
+  includeSymbols?: boolean;
+  label?: string | null;
+}
+
+export interface CredentialPublicRecord {
+  filled: Array<"username" | "password" | "confirmPassword">;
+  submitted: boolean;
+  [key: string]: unknown;
+}
+
+export type CredentialFillResult =
+  | (ResultEnvelopeBase & {
+      ok: true;
+      result: CredentialPublicRecord;
+      error?: never;
+    })
+  | (ResultEnvelopeBase & {
+      ok: false;
+      error: string;
+      result?: never;
+    });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,6 @@
+export { ensureChromeCdp, findChromeExecutable } from "./chrome.js";
+export { BetterWright, BrowserError } from "./client.js";
+export { METADATA_ADDRESSES, METADATA_HOSTNAMES, NetworkPolicy } from "./policy.js";
+export { piImageContent } from "./pi.js";
+export { agentSystemPrompt } from "./prompt.js";
+export type * from "./public.js";

--- a/types/pi.d.ts
+++ b/types/pi.d.ts
@@ -1,0 +1,26 @@
+export interface BetterWrightArtifactLike {
+  kind?: unknown;
+  media?: unknown;
+  path?: unknown;
+  [key: string]: unknown;
+}
+
+export interface BetterWrightResultLike {
+  artifacts?: readonly BetterWrightArtifactLike[];
+  [key: string]: unknown;
+}
+
+export interface PiImageContentOptions {
+  maxImageBytes?: number;
+}
+
+export interface PiImageContentBlock {
+  type: "image";
+  data: string;
+  mimeType: "image/png" | "image/jpeg" | "image/webp" | "image/gif";
+}
+
+export function piImageContent(
+  result: BetterWrightResultLike | null | undefined,
+  options?: PiImageContentOptions,
+): Promise<PiImageContentBlock[]>;

--- a/types/policy.d.ts
+++ b/types/policy.d.ts
@@ -1,0 +1,41 @@
+export interface NetworkDecision {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface NetworkRequestDetails {
+  [key: string]: unknown;
+}
+
+export type NetworkPolicyCustom = (
+  url: string,
+  details: NetworkRequestDetails,
+) => NetworkDecision | null | undefined;
+
+export interface NetworkPolicyOptions {
+  allowPrivateNetwork?: boolean;
+  allowLoopback?: boolean;
+  allowHosts?: string[];
+  blockHosts?: string[];
+  blockSecretBearingUrls?: boolean;
+  custom?: NetworkPolicyCustom;
+}
+
+export const METADATA_HOSTNAMES: Set<string>;
+export const METADATA_ADDRESSES: Set<string>;
+
+export class NetworkPolicy {
+  constructor(options?: NetworkPolicyOptions);
+
+  allowPrivateNetwork: boolean;
+  allowLoopback: boolean;
+  allowHosts: string[];
+  blockHosts: string[];
+  blockSecretBearingUrls: boolean;
+  custom: NetworkPolicyCustom | null;
+
+  hostMatches(entry: unknown, hostname: string, port: number | null): boolean;
+  isMetadata(hostname: string): boolean;
+  check(url: unknown, details?: NetworkRequestDetails): NetworkDecision;
+  checkHost(hostname: string, port: number | null): NetworkDecision;
+}

--- a/types/prompt.d.ts
+++ b/types/prompt.d.ts
@@ -1,0 +1,11 @@
+export interface Guardrails {
+  confirmBeforePurchase?: boolean;
+  confirmBeforeIrreversible?: boolean;
+  forbidPurchases?: boolean;
+  forbidAccountCreation?: boolean;
+  spendingLimit?: string;
+  extraRules?: string[];
+  passwordManager?: string;
+}
+
+export function agentSystemPrompt(guardrails?: Guardrails): string;

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -1,0 +1,38 @@
+import type { NetworkPolicy } from "./policy.js";
+import type {
+  BrowserFlavor,
+  CredentialVault,
+  DownloadPolicy,
+  HeadlessMode,
+  PublicSearchPolicy,
+} from "./common.js";
+
+export * from "./common.js";
+export type {
+  NetworkDecision,
+  NetworkPolicyCustom,
+  NetworkPolicyOptions,
+  NetworkRequestDetails,
+} from "./policy.js";
+export type { ChromeCdpResult, EnsureChromeCdpOptions } from "./chrome.js";
+export type { Guardrails } from "./prompt.js";
+export type {
+  BetterWrightArtifactLike,
+  BetterWrightResultLike,
+  PiImageContentBlock,
+  PiImageContentOptions,
+} from "./pi.js";
+
+export interface BetterWrightOptions {
+  home?: string;
+  policy?: NetworkPolicy;
+  vault?: CredentialVault;
+  browser?: BrowserFlavor;
+  executablePath?: string;
+  headless?: HeadlessMode;
+  defaultTimeout?: number;
+  connectOverCdp?: string;
+  searchMinIntervalMs?: number;
+  publicSearchPolicy?: PublicSearchPolicy;
+  downloadPolicy?: DownloadPolicy;
+}

--- a/types/worker.d.ts
+++ b/types/worker.d.ts
@@ -1,0 +1,1 @@
+export const METADATA_RESOLVER_RULES: string;


### PR DESCRIPTION
## What changed

- makes Betterwright a first-class npm package with typed root and subpath exports
- removes the hidden browser-download postinstall in favor of explicit `npx betterwright setup`
- adds a committed lockfile, version drift checks, packed-install smoke tests, and TypeScript consumer checks
- adds reproducible CI and a hardened npm Trusted Publishing workflow
- documents package updates and the signed CloakBrowser binary channel
- releases the aligned npm/Python metadata as v0.3.1

## Checks

- `npm run release:check`
- 62 Node unit tests passed, 1 optional Cloak E2E skipped
- packed tarball installed, imported, type-checked, and ran its CLI successfully
- Python Ruff passed
- 66 Python unit tests passed

The browser integration suites remain enforced in GitHub CI, where Chromium can run outside Aside's local process sandbox.