### PR TITLE
fix: isolate stock-Chromium profile from Cloak to prevent version-poison crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The stock-Chromium fallback now uses its own `profile-chromium` directory
+  instead of sharing the Cloak `profile`. Because the fallback ships a newer
+  Chromium than Cloak, a single shared profile let it silently upgrade the
+  profile format, after which the older Cloak binary crashed on launch (an
+  opaque `SIGTRAP` in the AppKit window/session-restore path — "the browser
+  opens then instantly closes"). Cloak keeps the historical `profile` path so
+  existing saved logins survive the upgrade.
+- Launching Cloak against a profile already upgraded by a newer Chromium now
+  fails with a clear, actionable error (naming the offending version and how to
+  reset) instead of crashing during startup.
+
 ## [0.3.1] — 2026-07-15
 
 ### Added

--- a/python/src/betterwright/_worker/cloak.mjs
+++ b/python/src/betterwright/_worker/cloak.mjs
@@ -1,7 +1,40 @@
+import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 let cloakModulePromise = null;
+
+/**
+ * Guard against opening a profile that a newer Chromium already upgraded.
+ * Chromium records its version in a "Last Version" file and does not downgrade
+ * the profile format; an older binary that opens a newer profile crashes during
+ * startup (on macOS the crash surfaces deep in the AppKit window/session-restore
+ * path as an opaque SIGTRAP). Cloak ships an older Chromium than the stock
+ * fallback, so this turns that latent crash into a clear, actionable error.
+ * `runningVersion` is a dotted version like "145.0.7632.109"; a missing or
+ * unparseable version, or a fresh profile, is a no-op.
+ */
+export function assertProfileNotNewer(profileDir, runningVersion) {
+  const major = (value) => Number.parseInt(String(value || "").split(".")[0], 10);
+  const runningMajor = major(runningVersion);
+  if (!Number.isFinite(runningMajor)) return;
+  let stored;
+  try {
+    stored = fs.readFileSync(path.join(profileDir, "Last Version"), "utf8").trim();
+  } catch {
+    return; /* fresh profile, or Chromium has not written the marker yet */
+  }
+  const profileMajor = major(stored);
+  if (Number.isFinite(profileMajor) && profileMajor > runningMajor) {
+    throw new Error(
+      `Browser profile at ${profileDir} was upgraded by a newer Chromium ` +
+        `(${stored}) than the one launching now (${runningVersion}); a newer ` +
+        "profile cannot be opened by an older browser. Reset it by removing " +
+        "that directory (saved logins there are lost), or launch the matching " +
+        "browser version.",
+    );
+  }
+}
 
 function isFreeDarwinV145(binaryInfo) {
   return (

--- a/python/src/betterwright/_worker/worker.mjs
+++ b/python/src/betterwright/_worker/worker.mjs
@@ -24,6 +24,7 @@ import {
   PUBLIC_SEARCH_BLOCK_ADVICE,
 } from "./challenges.mjs";
 import {
+  assertProfileNotNewer,
   cloakBinaryInfo,
   launchCloakPersistentContext,
   managedCloakViewport,
@@ -1529,6 +1530,12 @@ async function ensureBrowser(config) {
       // the only model-facing interaction layer.
       args.push(`--fingerprint=${fingerprintSeedForProfile(profileLock.profileDir)}`);
       const binaryInfo = await cloakBinaryInfo();
+      // Cloak ships an older Chromium than the stock fallback; fail clearly if
+      // this persistent profile was already upgraded by a newer binary rather
+      // than crashing opaquely on launch.
+      if (!profileLock.ephemeral) {
+        assertProfileNotNewer(profileLock.profileDir, binaryInfo?.version);
+      }
       // Patched Cloak builds can report stale lifecycle events to Playwright's
       // protocol-level setContent implementation. The document-write fallback
       // below preserves Page/Frame setContent semantics across Cloak versions.

--- a/python/src/betterwright/bridge.py
+++ b/python/src/betterwright/bridge.py
@@ -183,8 +183,17 @@ class Bridge:
                 directory.chmod(0o700)
             except OSError:
                 pass
+        # Each browser flavor gets its own profile directory. Cloak and the
+        # stock-Chromium fallback ship different Chromium versions; sharing one
+        # profile lets the newer binary silently upgrade it out from under the
+        # older one, after which the older binary crashes on launch (a newer
+        # profile is not downgrade-safe). Cloak keeps the historical "profile"
+        # path so existing saved logins survive an upgrade.
+        profile_name = (
+            "profile-chromium" if self.browser_flavor == "chromium" else "profile"
+        )
         return {
-            "profileDir": str(root / "profile"),
+            "profileDir": str(root / profile_name),
             "runtimeDir": str(runtime),
             "artifactsDir": str(artifacts),
             "downloadsDir": str(downloads),

--- a/python/tests/test_artifacts_and_display.py
+++ b/python/tests/test_artifacts_and_display.py
@@ -1,6 +1,7 @@
 """Tests for artifact handling, image data URLs, and display resolution."""
 
 import base64
+import os
 
 import pytest
 
@@ -101,6 +102,24 @@ def test_cloak_is_the_managed_default(monkeypatch, tmp_path):
     assert bridge.executable_path is None
     assert bridge.browser_flavor == "cloak"
     assert bridge._worker_config()["browserFlavor"] == "cloak"
+
+
+def test_each_flavor_gets_its_own_profile_directory(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLOAKBROWSER_BINARY_PATH", raising=False)
+    # Cloak keeps the historical path so existing saved logins survive.
+    cloak_profile = Bridge(home=tmp_path, browser="cloak")._worker_config()["profileDir"]
+    # The stock-Chromium fallback is isolated so its newer Chromium can never
+    # upgrade cloak's profile out from under it.
+    chromium_profile = Bridge(home=tmp_path, browser="chromium")._worker_config()[
+        "profileDir"
+    ]
+    custom_profile = Bridge(home=tmp_path, executable_path="/opt/chromium")._worker_config()[
+        "profileDir"
+    ]
+    assert os.path.basename(cloak_profile) == "profile"
+    assert os.path.basename(chromium_profile) == "profile-chromium"
+    assert os.path.basename(custom_profile) == "profile-chromium"
+    assert cloak_profile != chromium_profile
 
 
 def test_cloak_binary_env_overrides_managed_binary(monkeypatch, tmp_path):

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -169,7 +169,16 @@ export class BetterWright {
       fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
     }
     return {
-      profileDir: path.join(root, "profile"),
+      // Each browser flavor gets its own profile directory. Cloak and the
+      // stock-Chromium fallback ship different Chromium versions; sharing one
+      // profile lets the newer binary silently upgrade it out from under the
+      // older one, after which the older binary crashes on launch (a newer
+      // profile is not downgrade-safe). Cloak keeps the historical "profile"
+      // path so existing saved logins survive an upgrade.
+      profileDir: path.join(
+        root,
+        this.browserFlavor === "chromium" ? "profile-chromium" : "profile",
+      ),
       runtimeDir: runtime,
       artifactsDir: artifacts,
       downloadsDir: downloads,

--- a/src/cloak.mjs
+++ b/src/cloak.mjs
@@ -1,7 +1,40 @@
+import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 let cloakModulePromise = null;
+
+/**
+ * Guard against opening a profile that a newer Chromium already upgraded.
+ * Chromium records its version in a "Last Version" file and does not downgrade
+ * the profile format; an older binary that opens a newer profile crashes during
+ * startup (on macOS the crash surfaces deep in the AppKit window/session-restore
+ * path as an opaque SIGTRAP). Cloak ships an older Chromium than the stock
+ * fallback, so this turns that latent crash into a clear, actionable error.
+ * `runningVersion` is a dotted version like "145.0.7632.109"; a missing or
+ * unparseable version, or a fresh profile, is a no-op.
+ */
+export function assertProfileNotNewer(profileDir, runningVersion) {
+  const major = (value) => Number.parseInt(String(value || "").split(".")[0], 10);
+  const runningMajor = major(runningVersion);
+  if (!Number.isFinite(runningMajor)) return;
+  let stored;
+  try {
+    stored = fs.readFileSync(path.join(profileDir, "Last Version"), "utf8").trim();
+  } catch {
+    return; /* fresh profile, or Chromium has not written the marker yet */
+  }
+  const profileMajor = major(stored);
+  if (Number.isFinite(profileMajor) && profileMajor > runningMajor) {
+    throw new Error(
+      `Browser profile at ${profileDir} was upgraded by a newer Chromium ` +
+        `(${stored}) than the one launching now (${runningVersion}); a newer ` +
+        "profile cannot be opened by an older browser. Reset it by removing " +
+        "that directory (saved logins there are lost), or launch the matching " +
+        "browser version.",
+    );
+  }
+}
 
 function isFreeDarwinV145(binaryInfo) {
   return (

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -24,6 +24,7 @@ import {
   PUBLIC_SEARCH_BLOCK_ADVICE,
 } from "./challenges.mjs";
 import {
+  assertProfileNotNewer,
   cloakBinaryInfo,
   launchCloakPersistentContext,
   managedCloakViewport,
@@ -1529,6 +1530,12 @@ async function ensureBrowser(config) {
       // the only model-facing interaction layer.
       args.push(`--fingerprint=${fingerprintSeedForProfile(profileLock.profileDir)}`);
       const binaryInfo = await cloakBinaryInfo();
+      // Cloak ships an older Chromium than the stock fallback; fail clearly if
+      // this persistent profile was already upgraded by a newer binary rather
+      // than crashing opaquely on launch.
+      if (!profileLock.ephemeral) {
+        assertProfileNotNewer(profileLock.profileDir, binaryInfo?.version);
+      }
       // Patched Cloak builds can report stale lifecycle events to Playwright's
       // protocol-level setContent implementation. The document-write fallback
       // below preserves Page/Frame setContent semantics across Cloak versions.

--- a/tests/node/client.test.mjs
+++ b/tests/node/client.test.mjs
@@ -47,6 +47,28 @@ test("CloakBrowser is the managed default", async () => {
   }
 });
 
+test("each browser flavor gets its own profile directory", async () => {
+  const cloak = new BetterWright();
+  const chromium = new BetterWright({ browser: "chromium" });
+  const custom = new BetterWright({ executablePath: "/opt/chromium" });
+  try {
+    // Cloak keeps the historical path so existing saved logins survive.
+    assert.match(cloak._workerConfig().profileDir, /[/\\]profile$/);
+    // The stock-Chromium fallback (explicit or via executablePath) is isolated
+    // so its newer Chromium can never upgrade cloak's profile out from under it.
+    assert.match(chromium._workerConfig().profileDir, /[/\\]profile-chromium$/);
+    assert.match(custom._workerConfig().profileDir, /[/\\]profile-chromium$/);
+    assert.notEqual(
+      cloak._workerConfig().profileDir,
+      chromium._workerConfig().profileDir,
+    );
+  } finally {
+    await cloak.close();
+    await chromium.close();
+    await custom.close();
+  }
+});
+
 test("CLOAKBROWSER_BINARY_PATH overrides the managed Cloak binary", async () => {
   const previous = process.env.CLOAKBROWSER_BINARY_PATH;
   process.env.CLOAKBROWSER_BINARY_PATH = "/opt/cloak/chrome";

--- a/tests/node/cloak.test.mjs
+++ b/tests/node/cloak.test.mjs
@@ -5,7 +5,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { managedCloakViewport } from "../../src/cloak.mjs";
+import { assertProfileNotNewer, managedCloakViewport } from "../../src/cloak.mjs";
 import { BetterWright, NetworkPolicy } from "../../src/index.mjs";
 
 const enabled = process.env.BETTERWRIGHT_CLOAK_E2E === "1";
@@ -47,6 +47,28 @@ test("managed Cloak viewports stay coherent on affected builds", () => {
     ),
     undefined,
   );
+});
+
+test("assertProfileNotNewer rejects a profile upgraded by a newer Chromium", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-profver-"));
+  try {
+    // Fresh profile (no marker): no-op regardless of running version.
+    assert.doesNotThrow(() => assertProfileNotNewer(dir, "145.0.7632.109"));
+
+    fs.writeFileSync(path.join(dir, "Last Version"), "149.0.7827.55\n");
+    // Older binary opening a newer profile is the crash we prevent.
+    assert.throws(
+      () => assertProfileNotNewer(dir, "145.0.7632.109"),
+      /upgraded by a newer Chromium \(149\.0\.7827\.55\)/,
+    );
+    // Same or newer binary is fine.
+    assert.doesNotThrow(() => assertProfileNotNewer(dir, "149.0.7827.55"));
+    assert.doesNotThrow(() => assertProfileNotNewer(dir, "150.0.0.0"));
+    // Unknown running version is a no-op (cannot compare safely).
+    assert.doesNotThrow(() => assertProfileNotNewer(dir, ""));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("managed Cloak browser hides test-browser signals and keeps one profile identity", opts, async () => {


### PR DESCRIPTION
## Problem

Cloak and the stock-Chromium fallback ship **different Chromium versions** but shared **one** persistent profile (`~/.betterwright/browser/profile`). The moment the newer fallback binary opens that profile, it silently upgrades the profile format. Afterwards the older Cloak binary crashes on launch — an opaque **`SIGTRAP`** deep in the AppKit window/session-restore path, which presents to users as *"the browser opens then instantly closes."*

It's a nasty footgun: unrecoverable without knowing to wipe the profile, triggered by simply switching flavors (or attaching a newer real Chrome over CDP), and the surfaced error (`Target page… has been closed`) gives zero hint at the cause.

### How it was diagnosed
Bisecting against a copy of a real poisoned profile: fresh profile → survives; real profile → crashes; real profile **minus `Default/`** → survives; minus only GPU caches → still crashes. So the trigger is the newer-versioned profile data (`Last Version = 149.x` vs a Cloak binary of `145.x`), not GPU/fingerprint/viewport flags (all ruled out).

## Fix

- **Per-flavor profile directories.** Cloak keeps the historical `profile` path (so existing saved logins survive an upgrade); the stock/explicit-binary fallback gets an isolated `profile-chromium`. This removes the poisoning path entirely.
- **Version-mismatch guard.** `assertProfileNotNewer()` compares the profile's `Last Version` marker to the running binary before a Cloak launch and fails with a clear, actionable error (naming the offending version and how to reset) instead of crashing opaquely — a backstop for already-poisoned profiles.

Applied to both twins (`src/client.mjs` / `python/.../bridge.py`, and `src/worker.mjs` → `src/cloak.mjs`, synced to the Python `_worker` copies).

## Tests
- Node: flavor-specific profile paths + `assertProfileNotNewer` (fresh/no-op, older-vs-newer throws, equal/newer ok, unknown-version no-op).
- Python: matching flavor-path test in the bridge suite.
- `npm run release:check` passes (lint, worker-sync, unit, types, package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chromium now uses a separate browser profile, preventing conflicts with Cloak profiles.
  * Detects profiles upgraded by a newer Chromium version and displays a clear recovery error instead of crashing.
  * Preserves existing Cloak profile behavior while improving browser startup reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->