### PR TITLE
change: default publicSearchPolicy to "allow"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `publicSearchPolicy` now defaults to `"allow"` instead of `"block"`. Public
+  search-result UIs (Google, Bing, DuckDuckGo) are navigable by default; set
+  `publicSearchPolicy: "block"` (or `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block`) to
+  restore routing broad discovery through a host-supplied search tool. Trade-off:
+  automating public search UIs is more exposed to bot detection, so hosts that
+  rely on the guard should opt back in explicitly.
+
 ### Fixed
 
 - The stock-Chromium fallback now uses its own `profile-chromium` directory

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ client returns the worker's result envelope directly (`result`, `artifacts`,
 
 Long-lived desktop agents can attach to a dedicated real-Chrome profile with
 `ensureChromeCdp()`, but that host-only mode gives up part of the managed launch
-boundary. For broad discovery, use the host's web-search tool and open its
-results in BetterWright instead of automating Google or Bing's public search UI;
-the managed worker blocks public search-result UIs by default.
+boundary. For broad discovery, you can use the host's web-search tool and open
+its results in BetterWright instead of automating Google or Bing's public search
+UI; set `publicSearchPolicy: "block"` to have the managed worker enforce that
+(it is permitted by default).
 Visible bot challenges are surfaced as resumable state. See
 [attach mode](docs/attach-mode.md).
 

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -18,7 +18,7 @@ new BetterWright({
   executablePath,   // explicit binary; also selects the Chromium fallback
   headless: "auto", // visible with a display, headless on servers/CI
   connectOverCdp,   // host-only attach endpoint; see attach mode
-  publicSearchPolicy: "block", // "allow" is an explicit host opt-in
+  publicSearchPolicy: "allow", // default; set "block" to force host-tool search
   searchMinIntervalMs: 0,
   defaultTimeout: 30,   // per-snippet seconds, min 5
   downloadPolicy: "ask", // "ask" (default), "allow", or "deny"

--- a/docs/python.md
+++ b/docs/python.md
@@ -20,7 +20,7 @@ BetterWright(
     headless: bool | str = "auto",
     default_timeout: int = 30,             # per-snippet seconds, min 5
     connect_over_cdp: str | None = None,   # trusted host attach mode only
-    public_search_policy: str | None = None, # "block" default; "allow" opt-in
+    public_search_policy: str | None = None, # "allow" default; "block" opt-in
     search_min_interval_ms: int = 0,
     download_policy: str = "ask",          # "ask", "allow", or "deny"
 )

--- a/python/src/betterwright/bridge.py
+++ b/python/src/betterwright/bridge.py
@@ -64,7 +64,7 @@ def _normalize_public_search_policy(value: str | None) -> str:
     raw = (
         value
         if value is not None
-        else os.environ.get("BETTERWRIGHT_PUBLIC_SEARCH_POLICY", "block")
+        else os.environ.get("BETTERWRIGHT_PUBLIC_SEARCH_POLICY", "allow")
     )
     policy = str(raw).strip().lower()
     if policy not in _PUBLIC_SEARCH_POLICIES:

--- a/python/src/betterwright/client.py
+++ b/python/src/betterwright/client.py
@@ -231,8 +231,8 @@ class BetterWright:
         navigations when public search UI automation is explicitly allowed.
         ``0`` (the default) disables pacing.
     public_search_policy:
-        ``"block"`` (the default) routes discovery through the host search tool;
-        ``"allow"`` permits public search-result UI navigation.
+        ``"allow"`` (the default) permits public search-result UI navigation;
+        ``"block"`` routes discovery through the host search tool instead.
     download_policy:
         ``"ask"`` (the default) requires a trusted host to mark each download
         run approved. ``"allow"`` removes that approval gate while retaining

--- a/python/tests/test_artifacts_and_display.py
+++ b/python/tests/test_artifacts_and_display.py
@@ -162,13 +162,13 @@ def test_download_policy_defaults_to_ask_and_is_configurable(tmp_path):
         Bridge(home=tmp_path / "invalid", download_policy="sometimes")
 
 
-def test_public_search_ui_is_blocked_by_default_and_opt_in(tmp_path):
-    guarded = Bridge(home=tmp_path / "guarded")
-    allowed = Bridge(
-        home=tmp_path / "allowed", public_search_policy="allow"
+def test_public_search_ui_is_allowed_by_default_and_block_is_opt_in(tmp_path):
+    relaxed = Bridge(home=tmp_path / "relaxed")
+    blocked = Bridge(
+        home=tmp_path / "blocked", public_search_policy="block"
     )
-    assert guarded._worker_config()["publicSearchPolicy"] == "block"
-    assert allowed._worker_config()["publicSearchPolicy"] == "allow"
+    assert relaxed._worker_config()["publicSearchPolicy"] == "allow"
+    assert blocked._worker_config()["publicSearchPolicy"] == "block"
     with pytest.raises(ValueError, match="public_search_policy"):
         Bridge(home=tmp_path / "invalid", public_search_policy="pace")
 

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -54,7 +54,7 @@ function resolveBrowser(browser) {
 
 function resolvePublicSearchPolicy(policy) {
   const value = String(
-    policy ?? process.env.BETTERWRIGHT_PUBLIC_SEARCH_POLICY ?? "block",
+    policy ?? process.env.BETTERWRIGHT_PUBLIC_SEARCH_POLICY ?? "allow",
   )
     .trim()
     .toLowerCase();
@@ -127,8 +127,9 @@ export class BetterWright {
    *   a password-manager extension once) and attach to that.
    * @param {number} [options.searchMinIntervalMs=0] minimum spacing between
    *   allowed top-level Google, Bing, or DuckDuckGo search navigations
-   * @param {"block"|"allow"} [options.publicSearchPolicy="block"] route broad
-   *   discovery through the host search tool instead of a public search UI
+   * @param {"block"|"allow"} [options.publicSearchPolicy="allow"] set "block"
+   *   to route broad discovery through the host search tool instead of letting
+   *   the browser use a public search UI (e.g. Google, Bing)
    * @param {"ask"|"allow"|"deny"} [options.downloadPolicy="ask"] require a
    *   trusted host to mark an individual run approved, allow every run, or
    *   deny downloads entirely

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -207,7 +207,12 @@ test("navigate and read the title", opts, async () => {
 });
 
 test("public search UIs route agents to the host search tool", opts, async () => {
-  const bw = new BetterWright({ home: tempHome(), headless: true });
+  // Public search is allowed by default now, so opt into the block routing.
+  const bw = new BetterWright({
+    home: tempHome(),
+    headless: true,
+    publicSearchPolicy: "block",
+  });
   try {
     const direct = await bw.run(
       "await page.goto('https://www.google.com/search?q=betterwright'); return 'loaded'",

--- a/tests/node/client.test.mjs
+++ b/tests/node/client.test.mjs
@@ -20,20 +20,20 @@ test("download approval is required by default and configurable", async () => {
   }
 });
 
-test("public search result UIs are blocked by default and opt-in", async () => {
-  const guarded = new BetterWright();
-  const allowed = new BetterWright({ publicSearchPolicy: "allow" });
+test("public search result UIs are allowed by default and block is opt-in", async () => {
+  const relaxed = new BetterWright();
+  const blocked = new BetterWright({ publicSearchPolicy: "block" });
   try {
-    assert.equal(guarded.publicSearchPolicy, "block");
-    assert.equal(guarded._workerConfig().publicSearchPolicy, "block");
-    assert.equal(allowed._workerConfig().publicSearchPolicy, "allow");
+    assert.equal(relaxed.publicSearchPolicy, "allow");
+    assert.equal(relaxed._workerConfig().publicSearchPolicy, "allow");
+    assert.equal(blocked._workerConfig().publicSearchPolicy, "block");
     assert.throws(
       () => new BetterWright({ publicSearchPolicy: "pace" }),
       /publicSearchPolicy must be "block" or "allow"/,
     );
   } finally {
-    await guarded.close();
-    await allowed.close();
+    await relaxed.close();
+    await blocked.close();
   }
 });
 


### PR DESCRIPTION
## What

Flip the default `publicSearchPolicy` from `"block"` to `"allow"`. Public search-result UIs (Google, Bing, DuckDuckGo) are navigable by default; `"block"` becomes an explicit opt-in.

## Why

The block surfaced as confusing `ERR_BLOCKED_BY_CLIENT` failures — e.g. a human driving the visible browser types a query in the omnibox and it dies instead of searching. The guard makes sense for some agent setups but is a poor default for general/human-driven use.

## Trade-off

Automating public search UIs is more exposed to bot detection. Hosts that want broad discovery routed through a host-supplied search tool should set `publicSearchPolicy: "block"` (or `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block`). Noted in the changelog.

## Changes

- Default flipped in both twins: `src/client.mjs` (`resolvePublicSearchPolicy`) and `python/.../bridge.py` (`_normalize_public_search_policy`).
- Updated JSDoc, Python docstring, `README.md`, `docs/javascript.md`, `docs/python.md`.
- Inverted the default assertions in the JS and Python client tests; kept the `"block"` path as explicit opt-in coverage.
- The worker's advisory prompt guidance (prefer a host search tool) is unchanged — it's best-practice advice, not a policy claim.

`npm run lint`, `check:worker`, and the client tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)