### PR TITLE
change: display-aware default for connectOverCdp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `connectOverCdp` now has a **display-aware default**, mirroring
+  `headless: "auto"`. When both a display and a real Google Chrome are present
+  (a desktop), BetterWright attaches to that Chrome over CDP by default —
+  giving real logins and extensions, with the launch-time network floor
+  inactive (only the per-request policy applies). Headless or Chrome-less
+  environments (servers, containers, CI) continue to launch the managed Cloak
+  sandbox with the floor intact, and a Chrome that fails to attach falls back to
+  the sandbox rather than failing. Pass `connectOverCdp: ""` (or
+  `connect_over_cdp=""`) to force the launched sandbox regardless.
 - `publicSearchPolicy` now defaults to `"allow"` instead of `"block"`. Public
   search-result UIs (Google, Bing, DuckDuckGo) are navigable by default; set
   `publicSearchPolicy: "block"` (or `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block`) to

--- a/docs/attach-mode.md
+++ b/docs/attach-mode.md
@@ -1,9 +1,20 @@
 # Attaching to an existing Chrome (and headed mode)
 
-By default BetterWright launches its **own managed Cloak browser** with an
-isolated persistent profile. There are two ways to change that: run it
-**headed** so you can watch it, and **attach** it to a Chrome you already have
-open.
+`connectOverCdp` chooses between two worlds: BetterWright's **own managed Cloak
+browser** (isolated persistent profile, full launch-time network floor) and
+**attaching to a real Chrome** you have open. The default is *display-aware*,
+mirroring `headless: "auto"`:
+
+- **Desktop with Google Chrome installed** → attaches to a real Chrome
+  (`"auto"`). You get real logins and extensions, but the launch-time network
+  floor is inactive (only the per-request policy applies).
+- **Headless / no Chrome** (servers, containers, CI) → launches the managed
+  Cloak sandbox with the network floor intact.
+
+Pass `connectOverCdp: ""` to force the launched sandbox regardless, an explicit
+endpoint to attach to a specific Chrome, or `"auto"` to force the real-Chrome
+path even where the default would not choose it. The rest of this document
+covers **headed** mode and the **attach** details.
 
 ## Headed vs. headless
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -19,7 +19,7 @@ BetterWright(
     executable_path: str | None = None,    # explicit binary selects Chromium fallback
     headless: bool | str = "auto",
     default_timeout: int = 30,             # per-snippet seconds, min 5
-    connect_over_cdp: str | None = None,   # trusted host attach mode only
+    connect_over_cdp: str | None = None,   # None = display-aware default; "" forces sandbox
     public_search_policy: str | None = None, # "allow" default; "block" opt-in
     search_min_interval_ms: int = 0,
     download_policy: str = "ask",          # "ask", "allow", or "deny"

--- a/python/src/betterwright/bridge.py
+++ b/python/src/betterwright/bridge.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 from betterwright._display import resolve_headless
 from betterwright._home import betterwright_home
+from betterwright.chrome import find_chrome_executable
 from betterwright.policy import NetworkPolicy
 from betterwright.runtime import (
     cloakbrowser_dir,
@@ -70,6 +71,28 @@ def _normalize_public_search_policy(value: str | None) -> str:
     if policy not in _PUBLIC_SEARCH_POLICIES:
         raise ValueError('public_search_policy must be "block" or "allow"')
     return policy
+
+
+def _resolve_connect_over_cdp(value: str | None, headless: bool) -> tuple[str, bool]:
+    """Resolve the connect-over-CDP target, including the display-aware default.
+
+    Precedence: an explicit value (including ``""`` to force the launched
+    sandbox) > the ``BETTERWRIGHT_CONNECT_OVER_CDP`` env override > the default.
+    The default tracks the resolved ``headless`` decision (which already folds in
+    display detection): a headed run with a real Google Chrome installed attaches
+    to that Chrome over CDP; a headless run (server/CI or ``headless=True``) or a
+    machine without Chrome launches the managed sandbox and keeps its network
+    floor. The returned flag marks the auto-selected case so a Chrome that fails
+    to attach can fall back to the sandbox instead of failing the browser.
+    """
+    if value is not None:
+        return value.strip(), False
+    env = os.environ.get("BETTERWRIGHT_CONNECT_OVER_CDP", "").strip()
+    if env:
+        return env, False
+    if not headless and find_chrome_executable():
+        return "auto", True
+    return "", True
 
 
 class WorkerStartError(RuntimeError):
@@ -124,7 +147,9 @@ class Bridge:
         )
         self.headless = resolve_headless(headless)
         self.default_timeout = max(int(default_timeout), 5)
-        self.connect_over_cdp = (connect_over_cdp or "").strip()
+        self.connect_over_cdp, self._cdp_defaulted = _resolve_connect_over_cdp(
+            connect_over_cdp, self.headless
+        )
         self.search_min_interval_ms = max(int(search_min_interval_ms), 0)
         self.public_search_policy = _normalize_public_search_policy(
             public_search_policy
@@ -168,8 +193,16 @@ class Bridge:
         if self.connect_over_cdp.strip().lower() == "auto":
             from betterwright.chrome import ensure_chrome_cdp
 
-            result = ensure_chrome_cdp(home=self.home)
-            self.connect_over_cdp = str(result["endpoint"])
+            try:
+                result = ensure_chrome_cdp(home=self.home)
+                self.connect_over_cdp = str(result["endpoint"])
+            except RuntimeError:
+                # An explicit "auto" request surfaces the failure; the
+                # display-aware default falls back to the launched sandbox
+                # (network floor intact) rather than failing the browser.
+                if not self._cdp_defaulted:
+                    raise
+                self.connect_over_cdp = ""
         self._cdp_resolved = True
 
     def _worker_config(self) -> dict:

--- a/python/src/betterwright/client.py
+++ b/python/src/betterwright/client.py
@@ -225,7 +225,11 @@ class BetterWright:
         applies. Pass ``"auto"`` to reuse a running debug Chrome or otherwise
         launch a real Google Chrome with a persistent BetterWright profile (where
         you install and unlock a password-manager extension once) and attach to
-        it. See ``docs/attach-mode.md``.
+        it. When omitted, the default is display-aware (like ``headless``): a
+        desktop with Google Chrome installed uses ``"auto"`` (real Chrome, no
+        launch-time floor), while headless or Chrome-less environments launch
+        the managed sandbox with the floor intact. Pass ``""`` to force the
+        launched sandbox regardless. See ``docs/attach-mode.md``.
     search_min_interval_ms:
         Minimum spacing between top-level Google, Bing, or DuckDuckGo search
         navigations when public search UI automation is explicitly allowed.

--- a/python/tests/test_artifacts_and_display.py
+++ b/python/tests/test_artifacts_and_display.py
@@ -104,6 +104,44 @@ def test_cloak_is_the_managed_default(monkeypatch, tmp_path):
     assert bridge._worker_config()["browserFlavor"] == "cloak"
 
 
+def test_connect_over_cdp_default_is_display_aware(monkeypatch, tmp_path):
+    from betterwright.chrome import find_chrome_executable
+
+    monkeypatch.delenv("BETTERWRIGHT_CONNECT_OVER_CDP", raising=False)
+
+    # Headless: always the launched sandbox (network floor intact).
+    monkeypatch.setenv("BETTERWRIGHT_DISPLAY", "0")
+    assert Bridge(home=tmp_path / "headless").connect_over_cdp == ""
+
+    # Headed (desktop): real Chrome over CDP when Chrome is installed.
+    monkeypatch.setenv("BETTERWRIGHT_DISPLAY", "1")
+    chrome_present = bool(find_chrome_executable())
+    expected = "auto" if chrome_present else ""
+    assert Bridge(home=tmp_path / "desktop").connect_over_cdp == expected
+
+    # The default tracks the resolved headless decision, not raw display:
+    # headless=True always uses the sandbox even on a desktop, and headless=False
+    # uses CDP (when Chrome exists) even without a display.
+    assert Bridge(home=tmp_path / "forced_headless", headless=True).connect_over_cdp == ""
+    monkeypatch.setenv("BETTERWRIGHT_DISPLAY", "0")
+    assert (
+        Bridge(home=tmp_path / "forced_headed", headless=False).connect_over_cdp
+        == expected
+    )
+    monkeypatch.setenv("BETTERWRIGHT_DISPLAY", "1")
+
+    # Explicit "" forces the sandbox even on a desktop with Chrome.
+    assert Bridge(home=tmp_path / "forced", connect_over_cdp="").connect_over_cdp == ""
+
+    # An explicit endpoint is used verbatim.
+    explicit = Bridge(home=tmp_path / "explicit", connect_over_cdp="http://127.0.0.1:9222")
+    assert explicit.connect_over_cdp == "http://127.0.0.1:9222"
+
+    # The env override applies only when no argument is passed.
+    monkeypatch.setenv("BETTERWRIGHT_CONNECT_OVER_CDP", "http://127.0.0.1:9333")
+    assert Bridge(home=tmp_path / "env").connect_over_cdp == "http://127.0.0.1:9333"
+
+
 def test_each_flavor_gets_its_own_profile_directory(monkeypatch, tmp_path):
     monkeypatch.delenv("CLOAKBROWSER_BINARY_PATH", raising=False)
     # Cloak keeps the historical path so existing saved logins survive.

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -12,6 +12,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
 
+import { findChromeExecutable } from "./chrome.mjs";
 import { normalizeDownloadPolicy } from "./downloads.mjs";
 import { NetworkPolicy } from "./policy.mjs";
 
@@ -50,6 +51,28 @@ function resolveBrowser(browser) {
     throw new TypeError('browser must be "cloak" or "chromium".');
   }
   return value;
+}
+
+/**
+ * Resolve the connect-over-CDP target, including the display-aware default.
+ * Precedence: an explicit option (including `""` to force the launched
+ * sandbox) > the `BETTERWRIGHT_CONNECT_OVER_CDP` env override > the default.
+ * The default tracks the resolved `headless` decision (which already folds in
+ * display detection): when the browser would run headed and a real Google
+ * Chrome is installed, attach to that Chrome over CDP; when headless (a server,
+ * container, CI, or an explicit `headless: true`) or Chrome is absent, launch
+ * the managed sandbox and keep its network floor. `defaulted` marks the
+ * auto-selected case so a Chrome that unexpectedly fails to attach can fall
+ * back to the sandbox instead of failing the browser outright.
+ */
+function resolveConnectOverCdp(value, headless) {
+  if (value != null) return { endpoint: String(value).trim(), defaulted: false };
+  const env = (process.env.BETTERWRIGHT_CONNECT_OVER_CDP || "").trim();
+  if (env) return { endpoint: env, defaulted: false };
+  if (!headless && findChromeExecutable()) {
+    return { endpoint: "auto", defaulted: true };
+  }
+  return { endpoint: "", defaulted: true };
 }
 
 function resolvePublicSearchPolicy(policy) {
@@ -124,7 +147,12 @@ export class BetterWright {
    *   this mode — only the per-request policy applies. Pass "auto" to reuse a
    *   debug Chrome if one is already running, or otherwise launch a real Google
    *   Chrome with a persistent BetterWright profile (where you install and unlock
-   *   a password-manager extension once) and attach to that.
+   *   a password-manager extension once) and attach to that. When omitted, the
+   *   default follows the resolved headless decision: a headed run with Google
+   *   Chrome installed uses "auto" (real Chrome, no launch-time floor), while a
+   *   headless run (server/CI or headless:true) or a machine without Chrome
+   *   launches the managed sandbox with the floor intact. Pass "" to force the
+   *   launched sandbox regardless.
    * @param {number} [options.searchMinIntervalMs=0] minimum spacing between
    *   allowed top-level Google, Bing, or DuckDuckGo search navigations
    * @param {"block"|"allow"} [options.publicSearchPolicy="allow"] set "block"
@@ -145,7 +173,9 @@ export class BetterWright {
       options.executablePath ||
       (this.browserFlavor === "cloak" ? cloakExecutable : "");
     this.headless = resolveHeadless(options.headless);
-    this.connectOverCdp = (options.connectOverCdp || "").trim();
+    const cdp = resolveConnectOverCdp(options.connectOverCdp, this.headless);
+    this.connectOverCdp = cdp.endpoint;
+    this._cdpDefaulted = cdp.defaulted;
     this.searchMinIntervalMs = Math.max(Number(options.searchMinIntervalMs) || 0, 0);
     this.publicSearchPolicy = resolvePublicSearchPolicy(options.publicSearchPolicy);
     this.downloadPolicy = normalizeDownloadPolicy(options.downloadPolicy);
@@ -400,9 +430,16 @@ export class BetterWright {
   async _resolveCdpEndpoint() {
     if (this._cdpResolved) return;
     if (String(this.connectOverCdp || "").trim().toLowerCase() === "auto") {
-      const { ensureChromeCdp } = await import("./chrome.mjs");
-      const { endpoint } = await ensureChromeCdp({ home: this.home });
-      this.connectOverCdp = endpoint;
+      try {
+        const { ensureChromeCdp } = await import("./chrome.mjs");
+        const { endpoint } = await ensureChromeCdp({ home: this.home });
+        this.connectOverCdp = endpoint;
+      } catch (error) {
+        // An explicit "auto" request surfaces the failure; the display-aware
+        // default instead falls back to the launched sandbox (floor intact).
+        if (!this._cdpDefaulted) throw error;
+        this.connectOverCdp = "";
+      }
     }
     this._cdpResolved = true;
   }

--- a/tests/node/client.test.mjs
+++ b/tests/node/client.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { findChromeExecutable } from "../../src/chrome.mjs";
 import { BetterWright } from "../../src/index.mjs";
 
 test("download approval is required by default and configurable", async () => {
@@ -66,6 +67,58 @@ test("each browser flavor gets its own profile directory", async () => {
     await cloak.close();
     await chromium.close();
     await custom.close();
+  }
+});
+
+test("connectOverCdp default is display-aware and explicit values win", async () => {
+  const prevDisplay = process.env.BETTERWRIGHT_DISPLAY;
+  const prevEnv = process.env.BETTERWRIGHT_CONNECT_OVER_CDP;
+  delete process.env.BETTERWRIGHT_CONNECT_OVER_CDP;
+  const made = [];
+  const mk = (opts) => {
+    const bw = new BetterWright(opts);
+    made.push(bw);
+    return bw;
+  };
+  try {
+    // Headless: always the launched sandbox (network floor intact).
+    process.env.BETTERWRIGHT_DISPLAY = "0";
+    assert.equal(mk().connectOverCdp, "");
+
+    // Headed (desktop): real Chrome over CDP when Chrome is installed.
+    process.env.BETTERWRIGHT_DISPLAY = "1";
+    const chromePresent = Boolean(findChromeExecutable());
+    assert.equal(mk().connectOverCdp, chromePresent ? "auto" : "");
+
+    // The default tracks the resolved headless decision, not raw display:
+    // an explicit headless:true always uses the sandbox even on a desktop.
+    assert.equal(mk({ headless: true }).connectOverCdp, "");
+    // ...and headless:false uses CDP (when Chrome exists) even without a display.
+    process.env.BETTERWRIGHT_DISPLAY = "0";
+    assert.equal(
+      mk({ headless: false }).connectOverCdp,
+      chromePresent ? "auto" : "",
+    );
+    process.env.BETTERWRIGHT_DISPLAY = "1";
+
+    // Explicit "" forces the sandbox even on a desktop with Chrome.
+    assert.equal(mk({ connectOverCdp: "" }).connectOverCdp, "");
+
+    // An explicit endpoint is used verbatim.
+    assert.equal(
+      mk({ connectOverCdp: "http://127.0.0.1:9222" }).connectOverCdp,
+      "http://127.0.0.1:9222",
+    );
+
+    // The env override applies only when no option is passed.
+    process.env.BETTERWRIGHT_CONNECT_OVER_CDP = "http://127.0.0.1:9333";
+    assert.equal(mk().connectOverCdp, "http://127.0.0.1:9333");
+  } finally {
+    for (const bw of made) await bw.close();
+    if (prevDisplay === undefined) delete process.env.BETTERWRIGHT_DISPLAY;
+    else process.env.BETTERWRIGHT_DISPLAY = prevDisplay;
+    if (prevEnv === undefined) delete process.env.BETTERWRIGHT_CONNECT_OVER_CDP;
+    else process.env.BETTERWRIGHT_CONNECT_OVER_CDP = prevEnv;
   }
 });
 


### PR DESCRIPTION
## What

When `connectOverCdp` is unspecified, the default now tracks the resolved `headless` decision:

- **Headed** (desktop with a display) **and Google Chrome installed** → attach to that real Chrome over CDP (`"auto"`). Real logins/extensions; launch-time network floor inactive (only per-request policy applies).
- **Headless** (server, container, CI, or `headless: true`) **or no Chrome** → launch the managed Cloak sandbox with the network floor intact.

A Chrome that fails to attach falls back to the sandbox rather than failing the browser.

## Why base it on headless, not raw display?

It matches intent ("attach to the real browser when we'd show a real window") and keeps the whole test suite deterministic — `headless: true` always uses the sandbox, so integration tests don't attach to a stray desktop Chrome. Explicit values still win: pass `""` to force the sandbox, an endpoint or `"auto"` to force CDP, and `BETTERWRIGHT_CONNECT_OVER_CDP` overrides the default.

## Trade-off

On a desktop, `new BetterWright()` now drives your real Chrome by default, which means the launch-time network floor is off there. Headless/server usage is unchanged (sandbox, floor on).

## Changes

- Both twins: `resolveConnectOverCdp` in `src/client.mjs` and `_resolve_connect_over_cdp` in `python/.../bridge.py`, gated on the resolved headless value + `findChromeExecutable`, with a graceful fallback for the auto-selected case.
- JSDoc, Python docstring, `docs/attach-mode.md`, `docs/python.md`, changelog.
- Unit tests in both twins covering the headless/headed/explicit/env/`""` matrix.

Validated locally: full `npm test` (99, browser suite included) and full `pytest` (88) both green; `release:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)