### PR TITLE
release: npm v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-17
+
 ### Added
+
+- **Annotated screenshots** — `screenshot({annotate: true})` overlays a
+  labelled bounding box on every interactive element (including elements inside
+  child iframes, offset to page coordinates) before capturing, so what the
+  model sees in the image maps directly back to an `aria-ref` it can act on.
+  The overlay is removed after capture and the artifact reports an
+  `annotations` count.
+- **Ref-scoped snapshots** — `snapshot({ref: 'e31'})` zooms into one element's
+  subtree using a ref from the previous snapshot, with no CSS selector needed.
+- Snapshot headers now include the page title alongside the page id and URL.
+
+### Changed
+
+- Operator guidance rewritten around an explicit reading-escalation ladder
+  (interactive snapshot → full snapshot → brief wait and re-snapshot →
+  annotated screenshot), ref/URL anti-guessing rules, action–verification
+  batching within a single `run()`, a concrete recovery ladder (fresh snapshot
+  before retry, inspect the hit target on "obscured" clicks, switch approach
+  after two failures), and no-sleep/no-scroll-to-read discipline. The MCP
+  `browser` tool description and the pi extension description carry the same
+  guidance.
 
 - **Local CAPTCHA solver** — `captcha.solve()` and `captcha.detect()` run entirely
   inside the managed browser with no third-party captcha APIs and no heavy ML

--- a/docs/agent-prompt.md
+++ b/docs/agent-prompt.md
@@ -22,8 +22,19 @@ With no guardrails, the guidance tells the model to:
 - **Treat the user's request as authorization.** If they asked it to sign in,
   create an account, fill a form, book, or buy, it does that — without refusing,
   stalling, or adding "are you sure?" friction to ordinary steps.
-- **Work autonomously** — inspect, act, recover from routine failures, use
-  multiple tabs, and keep a running `note`.
+- **Work autonomously** — inspect, act, recover, use multiple tabs, and keep a
+  running `note`.
+- **Read by escalation and never guess.** Start with
+  `snapshot({interactive: true})`, escalate to a full snapshot, a re-snapshot
+  after a brief wait, and finally `screenshot({annotate: true})`; never guess a
+  ref, URL, or page state it has not observed, and never scroll just to read
+  (snapshots already include iframe contents and off-screen elements).
+- **Verify actions and batch steps.** An action is unconfirmed until
+  `snapshot({diff: true})` shows the expected state; action and verification go
+  in one `run()` when the next step needs no fresh ref.
+- **Recover deliberately** — no sleeps after auto-waiting actions, a fresh
+  snapshot before any retry, inspect the real hit target after an "obscured"
+  click, and switch approach after the same path fails twice.
 - **Keep credentials out of the chat.** When authentication is required, use a
   password-manager extension's inline autofill if one is unlocked, or request the
   trusted host-side fill (`bw.fillCredential` / `generateAndFillCredential`);

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -51,33 +51,42 @@ return { a: await a.title(), b: await b.title() };
 ## Reading the page
 
 `snapshot(options?)` returns an accessibility-tree snapshot of the current page —
-a compact, model-friendly view far cheaper than full HTML. Every element carries
-a `[ref=eN]` marker you can act on directly with an `aria-ref` locator, so there
-is no need to reverse-engineer a CSS selector from the snapshot:
+a compact, model-friendly view far cheaper than full HTML. The header line
+carries the page id, URL, and title. Every element carries a `[ref=eN]` marker
+you can act on directly with an `aria-ref` locator, so there is no need to
+reverse-engineer a CSS selector from the snapshot:
 
 ```js
-return await snapshot({interactive: true}); // "page page-1 https://…\n- button \"Sign in\" [ref=e12]…"
+return await snapshot({interactive: true}); // "page page-1 https://… \"Sign in\"\n- button \"Sign in\" [ref=e12]…"
 // then, in a later run:
 await human.click(page.locator('aria-ref=e12'));
 ```
 
+The tree covers the whole page, not just the viewport: off-screen elements are
+included (locator actions scroll to their target on their own, so never scroll
+just to read), and child-iframe contents appear inline with frame-qualified
+refs like `f1e2` that work in `aria-ref` locators exactly like main-frame refs.
+
 Refs are assigned fresh on every snapshot and go stale when the page changes —
-re-snapshot after navigations or re-renders before using one.
+re-snapshot after navigations or re-renders before using one, and never guess a
+ref you have not seen in the current snapshot.
 
 | Option | Default | Notes |
 | --- | --- | --- |
 | `interactive` | `false` | Keep only actionable elements (buttons, links, inputs, `cursor: pointer`, …) plus their ancestors. The cheapest way to see what you can do on a page. |
 | `diff` | `false` | Return only the `+`/`-` lines changed since the previous same-shaped snapshot of this page, or `(no changes since previous snapshot)`. |
+| `ref` | — | Scope the snapshot to one element's subtree by its ref from the previous snapshot, e.g. `{ref: 'e31'}` — no CSS selector needed. |
 | `selector` | — | Scope the snapshot to a CSS selector, e.g. `{selector: '#main'}`. |
 | `depth` | — | Limit tree depth. |
 | `maxChars` | `10000` | Truncation limit, capped at 20000. |
 | `timeout` | `10000` | Milliseconds. |
 
-Prefer `snapshot({interactive: true})` for deciding what to click and
-`snapshot({diff: true})` for checking what an action changed; take a full
-`snapshot()` only when you need to read page content wholesale. For anything
-Playwright can read — text, attributes, computed state — use the normal
-`page.locator(...)` API.
+Escalate reading only as far as the task needs: `snapshot({interactive: true})`
+to decide what to click, a full `snapshot()` to read content wholesale,
+`snapshot({diff: true})` to check what an action changed, and
+`screenshot({annotate: true})` when only the visual layout can answer the
+question. For anything Playwright can read — text, attributes, computed
+state — use the normal `page.locator(...)` API.
 
 ## Human-shaped interactions
 
@@ -112,9 +121,19 @@ than automating Google or Bing's public search UI.
 | --- | --- | --- |
 | `kind` | `"debug"` | `"proof"`, `"question"`, or `"debug"` — how the host UI should treat it. |
 | `name` | `"<kind>.png"` | A `.png`/`.jpg` extension is added if you omit one. |
+| `annotate` | `false` | Draw a labelled box over every interactive element, so what you see maps back to a ref you can act on. |
 | `fullPage` | `false` | Capture the full scrollable page. |
 | `type` | `"png"` | `"png"` or `"jpeg"`. |
 | `quality` | `80` | JPEG only. |
+
+`{annotate: true}` takes a fresh boxes-annotated snapshot, overlays each
+interactive element's bounding box labelled with its ref — including elements
+inside child iframes, offset to page coordinates — captures, then removes the
+overlay. The returned artifact gains an `annotations` count, and the refs shown
+in the image are current, so `page.locator('aria-ref=…')` acts on exactly what
+you see. Use it as the last step of reading escalation: when the accessibility
+tree cannot answer a layout question, or to visually confirm what a ref points
+at before a consequential click.
 
 It returns `{kind, path, media}` where `media` is `MEDIA:<absolute path>`. The
 `MEDIA:` convention lets a host surface render the file when the agent cites it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -118,6 +118,11 @@ Globals available to \`code\`: page, pages, context, state, openPage, usePage,
 closePage, snapshot, screenshot, artifactPath, dialogs, credentials, captcha,
 human. A single trailing expression is returned automatically; a statement
 block must return.
+Read pages with \`snapshot({interactive: true})\` and act on \`[ref=eN]\` via
+\`page.locator('aria-ref=eN')\`. \`snapshot({ref})\` scopes to a subtree,
+\`snapshot({diff: true})\` verifies an action, \`screenshot({annotate: true})\`
+draws each ref's box on the image. Snapshots include iframe contents and
+off-screen elements — do not scroll to read, and never guess refs or URLs.
 Capture \`screenshot({kind: 'proof'})\` before claiming a visible task is done —
 the image is returned inline; you do not need to open any file path.
 When \`challenges\` is returned, preserve the page and call \`captcha.solve()\`

--- a/src/pi-extension.mjs
+++ b/src/pi-extension.mjs
@@ -87,9 +87,12 @@ const TOOL_DESCRIPTION =
   "artifactPath, dialogs, credentials, captcha, human, overlays, controls, media. " +
   "On challenges prefer captcha.solve() (local, no external APIs); if status is " +
   "processing, use the vision artifact/tiles then solve again. Inspect with " +
-  "snapshot({interactive:true}); act on [ref=eN] with page.locator('aria-ref=eN'). " +
-  "Use openPage and Promise.all for independent multi-site research. A trailing " +
-  "expression returns automatically; statement blocks must return.";
+  "snapshot({interactive:true}); act on [ref=eN] with page.locator('aria-ref=eN'); " +
+  "snapshot({ref}) scopes to a subtree, snapshot({diff:true}) verifies an action, " +
+  "screenshot({annotate:true}) draws each ref's box on the image. Snapshots " +
+  "include iframes and off-screen content — do not scroll to read or guess " +
+  "refs/URLs. Use openPage and Promise.all for independent multi-site research. " +
+  "A trailing expression returns automatically; statement blocks must return.";
 
 function envBoolean(name, fallback) {
   const raw = String(process.env[name] || "").trim().toLowerCase();

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -21,16 +21,32 @@ creation, forms, booking, and purchases. Do not refuse, stall, ask the user to d
 them, or add confirmation unless a guardrail below requires it.
 
 ## Workflow
-- Inspect with \`snapshot({interactive: true})\`; target \`[ref=eN]\` using
-  \`page.locator('aria-ref=eN')\`, and verify changes with
-  \`snapshot({diff: true})\`. Retry routine failures or take another route.
+- Read pages by snapshot, escalating only as needed:
+  \`snapshot({interactive: true})\` → full \`snapshot()\` → re-snapshot after a
+  brief wait if the page is still changing → \`screenshot({annotate: true})\`
+  when you must see the layout (it draws each ref's box on the image).
+  Snapshots include iframe contents (\`f1e2\`-style refs) and off-screen
+  elements — never scroll or probe the DOM just to read, and never guess a
+  ref, URL, or page state you have not observed.
+- Act on \`[ref=eN]\` with \`page.locator('aria-ref=eN')\`; zoom into a subtree
+  with \`snapshot({ref: 'eN'})\`. Each snapshot reassigns refs, so re-snapshot
+  after the page changes. An action is unconfirmed until
+  \`snapshot({diff: true})\` shows the expected state. Batch action and
+  verification in one \`run()\` when the next step needs no fresh ref; split
+  when it does.
+- Actions auto-wait — add no sleeps after navigation or clicks. If an action
+  fails, re-snapshot before retrying; an "obscured" click means inspect the
+  real hit target; the same path failing twice means switch approach.
+  Unexpected state usually means a missed, stale, or wrong-target action —
+  suspect that before inferring site-specific rules.
 - Use multiple tabs when useful (\`openPage\`, \`Promise.all\`). Prefer
   \`human.click(target)\`, \`human.type(target, text)\`, and
   \`human.scroll(deltaY)\` for visible actions; use Locator methods when their
   exact semantics matter.
 - Put a short present-tense \`note\` on every call.
 - For broad discovery, use the host's search tool; do not automate Google or
-  Bing's public search UI. Without search, navigate to likely first-party sites.
+  Bing's public search UI. Without search, navigate to likely first-party
+  sites; never fabricate deep URLs.
 - Remote files require the host's approval-gated download tool and explicit user
   approval before enabling that one bounded download run. Never download through
   an ordinary browser run.

--- a/src/snapshot.mjs
+++ b/src/snapshot.mjs
@@ -52,6 +52,47 @@ export function filterInteractive(text) {
   return kept.length ? kept.join("\n") : "(no interactive elements)";
 }
 
+const REF_PATTERN = /\[ref=([a-z0-9]+)\]/;
+const BOX_PATTERN =
+  /\[box=(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?),(\d+(?:\.\d+)?),(\d+(?:\.\d+)?)\]/;
+const IFRAME_LINE = /^\s*- iframe\b/;
+
+/**
+ * Extract interactive elements with page-absolute bounding boxes from an
+ * `ariaSnapshot({mode: "ai", boxes: true})` tree. Child-frame boxes are
+ * reported relative to their own frame's viewport, so each element's box is
+ * offset by the boxes of its ancestor iframes (tracked via indentation).
+ * Returns up to `max` entries of `{ref, x, y, width, height}`.
+ */
+export function parseAnnotationBoxes(text, { max = 150 } = {}) {
+  const stack = [{ indent: -1, dx: 0, dy: 0 }];
+  const boxes = [];
+  for (const line of String(text).split("\n")) {
+    if (/^\s*- \//.test(line)) continue; // property line, e.g. `- /url: …`
+    const boxMatch = BOX_PATTERN.exec(line);
+    if (!boxMatch) continue;
+    const indent = indentOf(line);
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent)
+      stack.pop();
+    const { dx, dy } = stack[stack.length - 1];
+    const box = {
+      x: Number(boxMatch[1]) + dx,
+      y: Number(boxMatch[2]) + dy,
+      width: Number(boxMatch[3]),
+      height: Number(boxMatch[4]),
+    };
+    if (IFRAME_LINE.test(line))
+      stack.push({ indent, dx: box.x, dy: box.y });
+    if (boxes.length >= max) continue;
+    const ref = REF_PATTERN.exec(line)?.[1];
+    if (!ref || box.width <= 0 || box.height <= 0) continue;
+    if (!(INTERACTIVE_ROLE.test(line) || line.includes("[cursor=pointer]")))
+      continue;
+    boxes.push({ ref, ...box });
+  }
+  return boxes;
+}
+
 // Beyond this many lines per side an LCS table stops being cheap; callers
 // fall back to the full snapshot.
 const MAX_DIFF_LINES = 3_000;

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -54,7 +54,11 @@ import {
   scrollWheel,
   typeText,
 } from "./human.mjs";
-import { diffSnapshots, filterInteractive } from "./snapshot.mjs";
+import {
+  diffSnapshots,
+  filterInteractive,
+  parseAnnotationBoxes,
+} from "./snapshot.mjs";
 
 const playwrightCoreDir = process.env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH || "";
 const playwrightModule = playwrightCoreDir
@@ -724,6 +728,71 @@ async function assertScreenshotPixelLimit(page, options) {
   }
 }
 
+// Overlay id namespaced to avoid colliding with page-owned elements. The
+// overlay is pointer-events:none and removed right after capture.
+const ANNOTATION_OVERLAY_ID = "__betterwright_annotations__";
+
+function drawAnnotationOverlay({ boxes, fullPage, overlayId }) {
+  document.getElementById(overlayId)?.remove();
+  const root = document.createElement("div");
+  root.id = overlayId;
+  const dx = fullPage ? window.scrollX : 0;
+  const dy = fullPage ? window.scrollY : 0;
+  root.style.cssText =
+    `position:${fullPage ? "absolute" : "fixed"};left:0;top:0;width:0;` +
+    "height:0;z-index:2147483647;pointer-events:none;";
+  for (const box of boxes) {
+    const frame = document.createElement("div");
+    frame.style.cssText =
+      `position:absolute;left:${box.x + dx}px;top:${box.y + dy}px;` +
+      `width:${box.width}px;height:${box.height}px;` +
+      "border:2px solid #e11d48;border-radius:2px;box-sizing:border-box;";
+    const label = document.createElement("span");
+    label.textContent = box.ref;
+    label.style.cssText =
+      `position:absolute;left:-2px;top:${box.y + dy < 16 ? 0 : -16}px;` +
+      "background:#e11d48;color:#fff;font:11px/14px monospace;" +
+      "padding:0 3px;border-radius:2px;white-space:nowrap;";
+    frame.appendChild(label);
+    root.appendChild(frame);
+  }
+  document.body.appendChild(root);
+}
+
+function removeAnnotationOverlay(overlayId) {
+  document.getElementById(overlayId)?.remove();
+}
+
+// Take a fresh boxes-annotated aria snapshot, draw ref-labelled outlines over
+// the interactive elements (including those inside child iframes, offset to
+// page coordinates), and leave the overlay up for the caller's capture.
+// Returns how many elements were annotated.
+async function addScreenshotAnnotations(page, fullPage) {
+  const tree = await page.locator("body").ariaSnapshot({
+    mode: "ai",
+    boxes: true,
+    timeout: 10_000,
+  });
+  let boxes = parseAnnotationBoxes(tree);
+  if (!fullPage) {
+    const viewport = page.viewportSize();
+    if (viewport)
+      boxes = boxes.filter(
+        (box) =>
+          box.x < viewport.width &&
+          box.y < viewport.height &&
+          box.x + box.width > 0 &&
+          box.y + box.height > 0,
+      );
+  }
+  await page.evaluate(drawAnnotationOverlay, {
+    boxes,
+    fullPage: Boolean(fullPage),
+    overlayId: ANNOTATION_OVERLAY_ID,
+  });
+  return boxes.length;
+}
+
 async function captureScreenshot(page, session, requested, fallback, options) {
   await assertScreenshotPixelLimit(page, options);
   const content = await page.screenshot(options);
@@ -982,9 +1051,16 @@ const lastSnapshots = new WeakMap();
 
 async function snapshotPage(page, options = {}) {
   const depth = Math.floor(Number(options?.depth) || 0);
-  const scope = options?.selector
-    ? page.locator(String(options.selector))
-    : page.locator("body");
+  const ref = options?.ref ? String(options.ref) : "";
+  if (ref && !/^(?:f\d+)*e\d+$/.test(ref))
+    throw new Error(
+      `Invalid snapshot ref "${ref}" — expected a marker like "e12" or "f1e3".`,
+    );
+  const scope = ref
+    ? page.locator(`aria-ref=${ref}`)
+    : options?.selector
+      ? page.locator(String(options.selector))
+      : page.locator("body");
   let text = await scope.ariaSnapshot({
     mode: "ai",
     timeout: Number(options?.timeout || 10_000),
@@ -993,6 +1069,7 @@ async function snapshotPage(page, options = {}) {
   if (options?.interactive) text = filterInteractive(text);
 
   const key = JSON.stringify([
+    ref,
     String(options?.selector || ""),
     Boolean(options?.interactive),
     depth,
@@ -1002,7 +1079,16 @@ async function snapshotPage(page, options = {}) {
   const previous = store.get(key);
   store.set(key, text);
 
-  const header = `page ${pageId(page)} ${page.url()}`;
+  let title = "";
+  try {
+    title = String(await page.title())
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 120);
+  } catch {
+    // A page mid-navigation can refuse title(); the header works without it.
+  }
+  const header = `page ${pageId(page)} ${page.url()}${title ? ` "${title}"` : ""}`;
   if (options?.diff && previous !== undefined) {
     const result = diffSnapshots(previous, text);
     if (!result.changed)
@@ -2266,19 +2352,26 @@ function buildSandbox(session, consoleMessages) {
     // pass `type` explicitly so the two can never disagree.
     let requested = settings.name || `${kind}.${type}`;
     if (!/\.(png|jpe?g)$/i.test(requested)) requested = `${requested}.${type}`;
-    const file = await captureScreenshot(
-      page,
-      session,
-      requested,
-      `${kind}.${type}`,
-      {
+    const fullPage = Boolean(settings.fullPage);
+    let annotations;
+    if (settings.annotate)
+      annotations = await addScreenshotAnnotations(page, fullPage);
+    let file;
+    try {
+      file = await captureScreenshot(page, session, requested, `${kind}.${type}`, {
         type,
-        fullPage: Boolean(settings.fullPage),
+        fullPage,
         animations: "disabled",
         ...(type === "jpeg" ? { quality: Number(settings.quality) || 80 } : {}),
-      },
-    );
+      });
+    } finally {
+      if (settings.annotate)
+        await page
+          .evaluate(removeAnnotationOverlay, ANNOTATION_OVERLAY_ID)
+          .catch(() => {});
+    }
     const artifact = { kind, path: file, media: `MEDIA:${file}` };
+    if (annotations !== undefined) artifact.annotations = annotations;
     session.artifacts.push(artifact);
     if (kind === "question") session.awaitingAnswerSince = Date.now();
     return artifact;

--- a/tests/node/prompt.test.mjs
+++ b/tests/node/prompt.test.mjs
@@ -6,9 +6,21 @@ import { agentSystemPrompt } from "../../src/prompt.mjs";
 test("default prompt is permissive", () => {
   const prompt = agentSystemPrompt();
   const compact = prompt.replace(/\s+/g, " ");
-  assert.ok(prompt.length < 4_000, `default prompt grew to ${prompt.length} characters`);
+  assert.ok(prompt.length < 5_200, `default prompt grew to ${prompt.length} characters`);
   assert.ok(prompt.includes("You are authorized"));
   assert.ok(prompt.toLowerCase().includes("do not refuse"));
+  // Reading escalation, ref discipline, batching, and recovery guidance.
+  assert.ok(compact.includes("snapshot({interactive: true})"));
+  assert.ok(compact.includes("screenshot({annotate: true})"));
+  assert.ok(compact.includes("snapshot({ref: 'eN'})"));
+  assert.ok(compact.includes("snapshot({diff: true})"));
+  assert.ok(compact.includes("never guess a ref, URL, or page state"));
+  assert.ok(compact.includes("iframe contents"));
+  assert.ok(compact.includes("Batch action and verification"));
+  assert.ok(compact.includes("add no sleeps"));
+  assert.ok(compact.includes("inspect the real hit target"));
+  assert.ok(compact.includes("same path failing twice means switch approach"));
+  assert.ok(compact.includes("missed, stale, or wrong-target action"));
   assert.ok(compact.includes("do not automate Google or Bing's public search UI"));
   assert.ok(compact.includes("captcha.inspect(bounds)"));
   assert.ok(compact.includes("captcha.click(bounds)"));

--- a/tests/node/snapshot.test.mjs
+++ b/tests/node/snapshot.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { diffSnapshots, filterInteractive } from "../../src/snapshot.mjs";
+import {
+  diffSnapshots,
+  filterInteractive,
+  parseAnnotationBoxes,
+} from "../../src/snapshot.mjs";
 
 const TREE = [
   '- generic [active] [ref=e1]:',
@@ -54,6 +58,58 @@ test("diffSnapshots returns only changed lines", () => {
   assert.ok(
     lines.includes('+ ' + '      - button "Sending…" [disabled] [ref=e10]'),
   );
+});
+
+const BOXED_TREE = [
+  "- generic [ref=e1] [box=0,0,1200,900]:",
+  '  - heading "Title" [level=1] [ref=e2] [box=10,10,300,40]',
+  '  - button "Top" [ref=e3] [box=10,60,80,24]',
+  '  - link "Away" [ref=e4] [cursor=pointer] [box=10,-30,80,24]:',
+  '    - /url: "#a"',
+  "  - iframe [ref=e5] [box=100,200,400,300]:",
+  '    - button "Inner" [ref=f1e2] [box=8,8,120,24]',
+  '    - iframe [ref=f1e3] [box=20,50,200,100]:',
+  '      - button "Deep" [ref=f2e2] [box=5,5,60,20]',
+  '  - button "Hidden" [ref=e6]',
+  '  - button "Flat" [ref=e7] [box=10,500,80,0]',
+].join("\n");
+
+test("parseAnnotationBoxes keeps interactive elements with page-absolute boxes", () => {
+  const boxes = parseAnnotationBoxes(BOXED_TREE);
+  const byRef = Object.fromEntries(boxes.map((box) => [box.ref, box]));
+  // Non-interactive, box-less, and zero-area elements are dropped.
+  assert.ok(!byRef.e2, "heading should be dropped");
+  assert.ok(!byRef.e6, "element without a box should be dropped");
+  assert.ok(!byRef.e7, "zero-height element should be dropped");
+  // Main-frame boxes pass through unchanged, negatives included.
+  assert.deepEqual(byRef.e3, { ref: "e3", x: 10, y: 60, width: 80, height: 24 });
+  assert.equal(byRef.e4.y, -30);
+  // cursor=pointer counts as interactive.
+  assert.ok(byRef.e4);
+  // Child-frame boxes are offset by every ancestor iframe.
+  assert.deepEqual(byRef.f1e2, {
+    ref: "f1e2",
+    x: 108,
+    y: 208,
+    width: 120,
+    height: 24,
+  });
+  assert.deepEqual(byRef.f2e2, {
+    ref: "f2e2",
+    x: 125,
+    y: 255,
+    width: 60,
+    height: 20,
+  });
+});
+
+test("parseAnnotationBoxes caps output without corrupting iframe offsets", () => {
+  const lines = ["- generic [ref=e1] [box=0,0,1000,1000]:"];
+  for (let i = 0; i < 10; i += 1)
+    lines.push(`  - button "b${i}" [ref=e${i + 2}] [box=0,${i * 30},50,20]`);
+  const boxes = parseAnnotationBoxes(lines.join("\n"), { max: 3 });
+  assert.equal(boxes.length, 3);
+  assert.equal(boxes[0].ref, "e2");
 });
 
 test("diffSnapshots flags oversized inputs instead of stalling", () => {


### PR DESCRIPTION
Prepares the v0.6.0 release: Aside-parity harness upgrades (annotated screenshots, ref-scoped snapshots, page titles in snapshot headers) and the rewritten operator guidance (reading-escalation ladder, anti-guessing rules, action–verification batching, recovery ladder). See the [0.6.0] CHANGELOG section for details.

Release checks: `npm run release:check` green (versions, lint, 111 unit tests, types, package smoke test). Features verified end-to-end against the live browser, including an annotated-proof benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ref-scoped snapshots for focused page inspection.
  * Snapshot headers now include page titles.
  * Added annotated screenshots with labelled interactive-element boundaries, including iframe content.
  * Improved snapshot and screenshot workflows for locating and verifying page elements.

* **Documentation**
  * Updated browser-tool guidance with clearer reading escalation, action verification, and recovery steps.
  * Published release notes for version 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->