### PR TITLE
release: npm v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.7.1] — 2026-07-18
 
+### Added
+
+- **`betterwright exec` now reports what the run cost.** The result JSON carries
+  `toolCalls` (how many `browser`/`login`/`done` calls the model issued) and
+  `usage` (`{ inputTokens, outputTokens, totalTokens }`, summed across turns), and
+  the final stderr line prints a one-line summary — e.g. `done in 6 steps, 7 tool
+  calls, 48,210 tokens (46,880 in / 1,330 out)`. `runAgentTask` returns the same
+  fields. Token counts come from each provider's usage block (Anthropic cache
+  tokens fold into the input total); a field is `0` when a provider omits usage.
+
 ### Fixed
 
 - **`--model` (and `runAgentTask`'s `model`) now accepts a bare model id.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] — 2026-07-18
+
+### Fixed
+
+- **`--model` (and `runAgentTask`'s `model`) now accepts a bare model id.**
+  Passing a model id such as `--model gpt-5.6-sol` no longer errors with
+  `Unknown model`; the backend is inferred from the id's prefix (`gpt-*`/`o*` →
+  codex, `grok-*` → grok, `claude-*` → claude) and the id is used as the model id
+  (an explicit `--model-id` still wins). Adapter names (`claude`/`codex`/`grok`)
+  work exactly as before.
+
 ## [0.7.0] — 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ betterwright auth --login codex        # opens "Sign in to Codex with ChatGPT"
 betterwright exec "find the top Hacker News story and give me its title and points" --model codex
 ```
 
-Pick the model with `--model claude|codex|grok`. `codex` and `grok` sign in
+Pick the model with `--model claude|codex|grok`, or pass a bare model id and let
+BetterWright infer the backend from its prefix (`gpt-*`/`o*` → codex, `grok-*` →
+grok, `claude-*` → claude), e.g. `--model gpt-5.6-sol`. `codex` and `grok` sign in
 through BetterWright's own OAuth flow (`betterwright auth --login codex|grok`) and
 call the ChatGPT / xAI backends directly — no API key to paste, no router; `claude`
 uses the Anthropic SDK (`npm install @anthropic-ai/sdk`, `ANTHROPIC_API_KEY`). The

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -180,8 +180,9 @@ function flagValue(argv, flag, fallback) {
 
 // `exec <task>`: BetterWright's own agent harness (the `aside exec` shape).
 // A model (Claude SDK / codex OAuth / grok OAuth) plugs into the browser-tuned
-// loop and drives the task to completion. Progress notes go to stderr; the
-// final {ok, answer, steps, proof} goes to stdout.
+// loop and drives the task to completion. Progress notes (ending with a cost
+// summary) go to stderr; the final {ok, answer, steps, reason, toolCalls,
+// usage, proof} goes to stdout.
 async function cmdExec(flags) {
   const { runAgentTask } = await import("../src/agent.mjs");
   const argv = process.argv;
@@ -217,8 +218,26 @@ async function cmdExec(flags) {
     console.error(error?.message || String(error));
     return 1;
   }
+  const { inputTokens, outputTokens, totalTokens } = result.usage;
+  process.stderr.write(
+    `  done in ${result.steps} step${result.steps === 1 ? "" : "s"}, ` +
+      `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"}, ` +
+      `${totalTokens.toLocaleString()} tokens (${inputTokens.toLocaleString()} in / ${outputTokens.toLocaleString()} out)\n`,
+  );
   console.log(
-    JSON.stringify({ ok: result.ok, answer: result.answer, steps: result.steps, reason: result.reason, proof: result.proof }, null, 2),
+    JSON.stringify(
+      {
+        ok: result.ok,
+        answer: result.answer,
+        steps: result.steps,
+        reason: result.reason,
+        toolCalls: result.toolCalls,
+        usage: result.usage,
+        proof: result.proof,
+      },
+      null,
+      2,
+    ),
   );
   return result.ok ? 0 : 1;
 }

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -188,7 +188,7 @@ async function cmdExec(flags) {
   const task = argv.slice(3).find((token) => !token.startsWith("-"));
   if (!task) {
     console.error(
-      'Usage: betterwright exec "<task>" [--model claude|codex|grok] [--model-id <id>] [--effort <level>] [--max-steps <n>] [--session <name>] [--headed]',
+      'Usage: betterwright exec "<task>" [--model claude|codex|grok|<model-id>] [--model-id <id>] [--effort <level>] [--max-steps <n>] [--session <name>] [--headed]',
     );
     return 1;
   }

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -22,12 +22,25 @@ coding agent. `betterwright exec` gives BetterWright that scaffold.
 betterwright exec "find the top Hacker News story and give me its title and points" --model claude
 ```
 
-Progress notes stream to stderr as the loop runs; the final result is one JSON
-object on stdout:
+Progress notes stream to stderr as the loop runs — the last one summarizes the
+run's cost (`done in 6 steps, 7 tool calls, 48,210 tokens (46,880 in / 1,330
+out)`) — and the final result is one JSON object on stdout:
 
 ```json
-{ "ok": true, "answer": "…", "steps": 6, "reason": "done", "proof": "/…/proof-….png" }
+{
+  "ok": true,
+  "answer": "…",
+  "steps": 6,
+  "reason": "done",
+  "toolCalls": 7,
+  "usage": { "inputTokens": 46880, "outputTokens": 1330, "totalTokens": 48210 },
+  "proof": "/…/proof-….png"
+}
 ```
+
+`toolCalls` counts the `browser`/`login`/`done` calls the model issued (it can
+exceed `steps` when a turn batches several). `usage` sums the token counts the
+model adapter reported; a field is `0` when the provider returned no usage block.
 
 Flags:
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -33,8 +33,8 @@ Flags:
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `--model <name>` | `claude` | `claude`, `codex`, or `grok` |
-| `--model-id <id>` | per-adapter | Override the model id (e.g. `claude-fable-5`, `grok-4`) |
+| `--model <name>` | `claude` | An adapter name (`claude`, `codex`, `grok`) **or** a bare model id whose backend is inferred from its prefix — `gpt-*`/`o*` → codex, `grok-*` → grok, `claude-*` → claude (e.g. `--model gpt-5.6-sol`) |
+| `--model-id <id>` | per-adapter | Override the model id (e.g. `claude-fable-5`, `grok-4`); wins over an id passed to `--model` |
 | `--effort <level>` | `low` | `low`/`medium`/`high`/`xhigh`/`max` where the model supports it |
 | `--max-steps <n>` | `24` | Hard cap on model turns |
 | `--session <name>` | `default` | Browser session name |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -271,22 +271,40 @@ export async function runAgentTask(options = {}) {
   };
 }
 
+// Infer the backend adapter from a bare model id so `--model gpt-5.6-luna`
+// works like `--model codex --model-id gpt-5.6-luna`.
+function adapterForModelId(id) {
+  if (/^claude/.test(id)) return "claude";
+  if (/^grok/.test(id)) return "grok";
+  if (/^(gpt|o[0-9]|chatgpt|codex)/.test(id)) return "codex";
+  return null;
+}
+
 /**
  * Resolve a model name (or pass-through object) to a model adapter.
- * @param {string|object} model "claude" | "codex" | "grok" (aliases: "anthropic"
- *   → claude, "openai" → codex, "xai" → grok), or an object with an async
- *   `complete` method to use directly.
+ * @param {string|object} model An adapter name — "claude" | "codex" | "grok"
+ *   (aliases: "anthropic" → claude, "openai" → codex, "xai" → grok); a bare
+ *   model id whose backend is inferred from its prefix (`gpt-*`/`o*` → codex,
+ *   `grok-*` → grok, `claude-*` → claude); or an object with an async `complete`
+ *   method to use directly.
  * @param {object} [modelOptions]
  * @returns {{name: string, complete: Function}}
  */
 export function resolveModel(model, modelOptions = {}) {
   if (model && typeof model === "object" && typeof model.complete === "function") return model;
   const name = String(model || "").toLowerCase();
-  if (name === "claude" || name === "anthropic") return claudeModel(modelOptions);
-  if (name === "codex" || name === "openai") return codexModel(modelOptions);
-  if (name === "grok" || name === "xai") return grokModel(modelOptions);
+  const adapters = { claude: claudeModel, anthropic: claudeModel, codex: codexModel, openai: codexModel, grok: grokModel, xai: grokModel };
+  if (adapters[name]) return adapters[name](modelOptions);
+  // Not an adapter name — treat it as a model id and route by its prefix, using
+  // it as the model id unless an explicit --model-id already set one.
+  const inferred = adapterForModelId(name);
+  if (inferred) {
+    const options = { ...modelOptions, model: modelOptions.model || String(model) };
+    return { claude: claudeModel, codex: codexModel, grok: grokModel }[inferred](options);
+  }
   throw new Error(
-    `Unknown model "${model}". Use "claude", "codex", "grok", or pass a model object with a complete() method.`,
+    `Unknown model "${model}". Use an adapter name ("claude", "codex", "grok"), a model id ` +
+      `(e.g. "gpt-5.6-sol", "grok-4.3", "claude-opus-4-8"), or a model object with a complete() method.`,
   );
 }
 

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -94,6 +94,28 @@ const DONE_TOOL_PARAMETERS = {
   required: ["answer"],
 };
 
+// Normalize a provider's token-usage block to a common { inputTokens,
+// outputTokens } shape. Anthropic counts cached input separately, so fold the
+// cache tokens back into the input total.
+function anthropicUsage(usage) {
+  if (!usage) return null;
+  const input =
+    (usage.input_tokens || 0) +
+    (usage.cache_read_input_tokens || 0) +
+    (usage.cache_creation_input_tokens || 0);
+  return { inputTokens: input, outputTokens: usage.output_tokens || 0 };
+}
+
+// Chat Completions uses prompt_/completion_tokens; the Responses API uses
+// input_/output_tokens — accept either.
+function openaiUsage(usage) {
+  if (!usage) return null;
+  return {
+    inputTokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
+    outputTokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+  };
+}
+
 function toolsForHarness({ withLogin }) {
   const tools = [
     { name: "browser", description: BROWSER_TOOL_DESCRIPTION, parameters: BROWSER_TOOL_PARAMETERS },
@@ -172,7 +194,7 @@ function loginOptionsFromInput(input = {}, session) {
  *   browsers only — ignored when an external `browser` is passed, whose own
  *   vault then decides login availability)
  * @param {(event: object) => void} [options.onStep] progress callback per step
- * @returns {Promise<{ok: boolean, answer: string, steps: number, reason: string, transcript: object[], proof: (string|null)}>}
+ * @returns {Promise<{ok: boolean, answer: string, steps: number, reason: string, toolCalls: number, usage: {inputTokens: number, outputTokens: number, totalTokens: number}, transcript: object[], proof: (string|null)}>}
  */
 export async function runAgentTask(options = {}) {
   const task = String(options.task || "").trim();
@@ -202,11 +224,19 @@ export async function runAgentTask(options = {}) {
   let finished = false;
   let reason = "max-steps";
   let steps = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let toolCallCount = 0;
 
   try {
     for (steps = 1; steps <= maxSteps; steps += 1) {
       const response = await model.complete({ system, messages, tools });
       const toolCalls = Array.isArray(response.toolCalls) ? response.toolCalls : [];
+      if (response.usage) {
+        inputTokens += response.usage.inputTokens || 0;
+        outputTokens += response.usage.outputTokens || 0;
+      }
+      toolCallCount += toolCalls.length;
       messages.push({ role: "assistant", text: response.text || "", toolCalls });
 
       // No tool call: the model answered in prose. Treat that text as the
@@ -266,6 +296,15 @@ export async function runAgentTask(options = {}) {
     // On exhaustion the for-loop increments past the cap; report the real count.
     steps: Math.min(steps, maxSteps),
     reason,
+    // How many tool calls the model issued (browser/login/done) — can exceed
+    // `steps` when a turn batches several — and the token usage the adapters
+    // reported (null fields when the provider didn't return a usage block).
+    toolCalls: toolCallCount,
+    usage: {
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    },
     transcript: messages,
     proof,
   };
@@ -338,7 +377,7 @@ function parseAnthropicResponse(message) {
     else if (block.type === "tool_use")
       toolCalls.push({ id: block.id, name: block.name, input: block.input || {} });
   }
-  return { text, toolCalls, stopReason: message.stop_reason };
+  return { text, toolCalls, stopReason: message.stop_reason, usage: anthropicUsage(message.usage) };
 }
 
 /**
@@ -433,7 +472,7 @@ function parseOpenaiResponse(data) {
     synthetic += 1;
     toolCalls.push({ id: tc.id || `call_${synthetic}`, name: tc.function?.name, input });
   }
-  return { text: msg.content || "", toolCalls, stopReason: choice.finish_reason };
+  return { text: msg.content || "", toolCalls, stopReason: choice.finish_reason, usage: openaiUsage(data?.usage) };
 }
 
 /**
@@ -592,6 +631,7 @@ function parseResponsesStream(raw) {
     text: text || fallback.text,
     toolCalls: toolCalls.length ? toolCalls : fallback.toolCalls,
     stopReason: completed?.status || (toolCalls.length ? "tool_calls" : "completed"),
+    usage: openaiUsage(completed?.usage),
   };
 }
 
@@ -645,7 +685,7 @@ function responsesModel(options = {}) {
       if (/^(?:event|data):/m.test(raw)) return parseResponsesStream(raw);
       const data = JSON.parse(raw);
       const parsed = parseResponsesOutput(data.output);
-      return { ...parsed, stopReason: data.status || "completed" };
+      return { ...parsed, stopReason: data.status || "completed", usage: openaiUsage(data.usage) };
     },
   };
 }

--- a/tests/node/agent.test.mjs
+++ b/tests/node/agent.test.mjs
@@ -126,7 +126,26 @@ test("resolveModel maps names, passes objects through, rejects unknown", () => {
   const custom = { name: "mine", complete: async () => ({ text: "", toolCalls: [] }) };
   assert.equal(resolveModel(custom), custom);
   assert.equal(resolveModel("claude", {}).name, "claude");
-  assert.throws(() => resolveModel("gpt"), /Unknown model/);
+  assert.throws(() => resolveModel("mistral-large"), /Unknown model/);
+});
+
+test("resolveModel accepts a bare model id and infers the backend from its prefix", () => {
+  // gpt-* / o* → codex, grok-* → grok, claude-* → claude; the id becomes model id.
+  const codex = resolveModel("gpt-5.6-luna", { apiKey: "k" });
+  assert.equal(codex.name, "codex");
+  assert.equal(codex.modelId, "gpt-5.6-luna");
+
+  const grok = resolveModel("grok-4.3", { apiKey: "k" });
+  assert.equal(grok.name, "grok");
+  assert.equal(grok.modelId, "grok-4.3");
+
+  const claude = resolveModel("claude-opus-4-8");
+  assert.equal(claude.name, "claude");
+  assert.equal(claude.modelId, "claude-opus-4-8");
+
+  // An explicit --model-id wins over the id passed as the model.
+  const pinned = resolveModel("gpt-5.6-luna", { apiKey: "k", model: "gpt-override" });
+  assert.equal(pinned.modelId, "gpt-override");
 });
 
 test("openaiModel translates the transcript and parses tool calls", async () => {

--- a/tests/node/agent.test.mjs
+++ b/tests/node/agent.test.mjs
@@ -83,6 +83,48 @@ test("runAgentTask drives browser then finishes on done", async () => {
   assert.match(toolTurn.results[0].content, /"result":"HN"/);
 });
 
+test("runAgentTask sums token usage and counts every tool call", async () => {
+  const browser = fakeBrowser({
+    runs: [
+      { ok: true, result: "a", artifacts: [], durationMs: 1 },
+      { ok: true, result: "b", artifacts: [], durationMs: 1 },
+    ],
+  });
+  const model = scriptedModel([
+    // One turn batching two browser calls, with a usage block.
+    {
+      text: "",
+      toolCalls: [
+        { id: "c1", name: "browser", input: { code: "1" } },
+        { id: "c2", name: "browser", input: { code: "2" } },
+      ],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    },
+    // A final turn: done + a usage block. Providers that omit usage contribute 0.
+    {
+      text: "",
+      toolCalls: [{ id: "d1", name: "done", input: { answer: "ok" } }],
+      usage: { inputTokens: 50, outputTokens: 10 },
+    },
+  ]);
+
+  const result = await runAgentTask({ task: "count", model, browser });
+
+  // 2 browser + 1 done = 3 tool calls across 2 steps.
+  assert.equal(result.toolCalls, 3);
+  assert.equal(result.usage.inputTokens, 150);
+  assert.equal(result.usage.outputTokens, 30);
+  assert.equal(result.usage.totalTokens, 180);
+});
+
+test("runAgentTask reports zeroed usage when the model omits a usage block", async () => {
+  const browser = fakeBrowser();
+  const model = scriptedModel([{ text: "hi", toolCalls: [] }]);
+  const result = await runAgentTask({ task: "x", model, browser });
+  assert.deepEqual(result.usage, { inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+  assert.equal(result.toolCalls, 0);
+});
+
 test("runAgentTask treats a prose reply (no tool call) as the answer", async () => {
   const browser = fakeBrowser();
   const model = scriptedModel([{ text: "Paris is the capital.", toolCalls: [] }]);
@@ -168,6 +210,7 @@ test("openaiModel translates the transcript and parses tool calls", async () => 
               finish_reason: "tool_calls",
             },
           ],
+          usage: { prompt_tokens: 42, completion_tokens: 8 },
         };
       },
     };
@@ -194,6 +237,8 @@ test("openaiModel translates the transcript and parses tool calls", async () => 
   assert.equal(out.toolCalls[0].name, "browser");
   assert.deepEqual(out.toolCalls[0].input, { code: "return 1" });
   assert.equal(out.toolCalls[0].id, "call_1"); // synthesized
+  // prompt_/completion_tokens are normalized to input/output.
+  assert.deepEqual(out.usage, { inputTokens: 42, outputTokens: 8 });
 });
 
 test("openaiModel surfaces HTTP errors", async () => {
@@ -214,6 +259,7 @@ test("claudeModel maps to the Anthropic shape and parses content", async () => {
             { type: "tool_use", id: "t1", name: "done", input: { answer: "A" } },
           ],
           stop_reason: "tool_use",
+          usage: { input_tokens: 30, cache_read_input_tokens: 12, output_tokens: 5 },
         };
       },
     },
@@ -235,6 +281,8 @@ test("claudeModel maps to the Anthropic shape and parses content", async () => {
   assert.equal(out.text, "sure");
   assert.equal(out.toolCalls[0].name, "done");
   assert.deepEqual(out.toolCalls[0].input, { answer: "A" });
+  // Cached input tokens fold into the input total (30 + 12), output passes through.
+  assert.deepEqual(out.usage, { inputTokens: 42, outputTokens: 5 });
 });
 
 test("codex and grok adapters require credentials", () => {

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -37,7 +37,13 @@ export interface AgentModel {
     system: string;
     messages: AgentMessage[];
     tools: AgentTool[];
-  }): Promise<{ text: string; toolCalls: AgentToolCall[]; stopReason?: string }>;
+  }): Promise<{ text: string; toolCalls: AgentToolCall[]; stopReason?: string; usage?: AgentUsage | null }>;
+}
+
+/** Token usage, normalized across model adapters (0 when a provider omits it). */
+export interface AgentUsage {
+  inputTokens: number;
+  outputTokens: number;
 }
 
 export interface AgentStepEvent {
@@ -66,6 +72,10 @@ export interface AgentResult {
   answer: string;
   steps: number;
   reason: "max-steps" | "answered" | "stopped" | "done";
+  /** How many tool calls the model issued; can exceed `steps` when a turn batches several. */
+  toolCalls: number;
+  /** Summed token usage the model adapters reported (fields are 0 when unavailable). */
+  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
   transcript: AgentMessage[];
   proof: string | null;
 }


### PR DESCRIPTION
## 0.7.1

### Added

- **`betterwright exec` reports what the run cost.** The result JSON now carries `toolCalls` (how many `browser`/`login`/`done` calls the model issued) and `usage` (`{ inputTokens, outputTokens, totalTokens }`, summed across turns), and the final stderr line prints a one-line summary — e.g. `done in 6 steps, 7 tool calls, 48,210 tokens (46,880 in / 1,330 out)`. `runAgentTask` returns the same fields. Anthropic cache tokens fold into the input total; a field is `0` when a provider omits usage.

### Fixed

- `--model` (and `runAgentTask`'s `model`) now accepts a **bare model id**. Passing an id like `--model gpt-5.6-sol` no longer errors with `Unknown model`; the backend is inferred from the id's prefix (`gpt-*`/`o*` → codex, `grok-*` → grok, `claude-*` → claude) and the id is used as the model id. Adapter names (`claude`/`codex`/`grok`) work exactly as before, and an explicit `--model-id` still wins.

New unit tests cover id-prefix inference and usage/tool-call accumulation (per-adapter usage normalization + loop totals). Docs, CLI usage, and README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCYcno5CBwMdLu7gCMiu2
