### PR TITLE
release: npm v0.8.0 — interactive console + ask tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,28 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.1] — 2026-07-18
+## [0.8.0] — 2026-07-18
 
 ### Added
 
+- **Interactive agent console (`betterwright` with no subcommand).** The
+  counterpart to `aside` on its own: a REPL where you type natural-language tasks
+  and watch BetterWright's own agent loop drive the browser to complete them. Each
+  step streams as it happens, then the answer, the proof-screenshot path, and a
+  one-line cost summary. **One browser session persists across tasks**, so a later
+  task builds on where an earlier one left off (still signed in, tabs open). Meta
+  commands: `/model`, `/effort`, `/new`, `/clear`, `/help`, `/exit`. The usual
+  `--model`, `--model-id`, `--effort`, `--session`, `--headed`, and network flags
+  apply.
+- **`ask` tool for interactive runs.** When `runAgentTask` is given an `askUser`
+  handler (the interactive console wires this to the prompt), the loop exposes an
+  `ask` tool so the agent can put a question to the user mid-task — a code it
+  cannot obtain, a consequential choice with no reasonable default, or genuine
+  ambiguity — offering short concrete options and continuing on the reply. The
+  operator guidance switches to an interactive posture accordingly. `betterwright
+  exec` has no user watching, so it runs without the `ask` tool and never stalls.
 - **`betterwright exec` now reports what the run cost.** The result JSON carries
-  `toolCalls` (how many `browser`/`login`/`done` calls the model issued) and
+  `toolCalls` (how many `browser`/`login`/`ask`/`done` calls the model issued) and
   `usage` (`{ inputTokens, outputTokens, totalTokens }`, summed across turns), and
   the final stderr line prints a one-line summary — e.g. `done in 6 steps, 7 tool
   calls, 48,210 tokens (46,880 in / 1,330 out)`. `runAgentTask` returns the same

--- a/README.md
+++ b/README.md
@@ -132,7 +132,19 @@ call the ChatGPT / xAI backends directly — no API key to paste, no router; `cl
 uses the Anthropic SDK (`npm install @anthropic-ai/sdk`, `ANTHROPIC_API_KEY`). The
 model is a small pluggable interface, so you can also plug in your own model or
 agent. The loop observes with `snapshot`, acts, verifies, captures a proof
-screenshot, and finishes — see [docs/agent.md](docs/agent.md).
+screenshot, and finishes, reporting the tokens and tool calls it used — see
+[docs/agent.md](docs/agent.md).
+
+Run **`betterwright`** with no arguments for the interactive counterpart — a
+console (like `aside` on its own) where you type tasks and watch the agent work:
+each step streams as it happens, the browser session persists across tasks, and
+the agent can ask you a question through its `ask` tool when it genuinely needs
+input.
+
+```bash
+betterwright --model codex
+▸ find the top Hacker News story and give me its title and points
+```
 
 ### Pi Coding Agent (native package)
 

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 // BetterWright command-line interface (Node).
 //
+//   betterwright                  interactive agent console (type tasks, watch
+//                                 progress, answer the agent's questions)
 //   betterwright setup            install the managed Cloak browser
 //   betterwright doctor           report runtime readiness
 //   betterwright run <file|-|-c>  execute a Playwright snippet
@@ -21,6 +23,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { pathToFileURL } from "node:url";
 
+import { makeLineReader } from "../src/cli-io.mjs";
 import { doctorReport, resolveCloakDir, resolveCoreDir } from "../src/doctor.mjs";
 import { agentSystemPrompt, BetterWright, NetworkPolicy } from "../src/index.mjs";
 
@@ -178,6 +181,149 @@ function flagValue(argv, flag, fallback) {
   return index !== -1 && index + 1 < argv.length ? argv[index + 1] : fallback;
 }
 
+// ANSI helpers that no-op when stdout is not a TTY or NO_COLOR is set.
+function styler() {
+  const on = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+  return {
+    dim: (s) => (on ? `\x1b[2m${s}\x1b[0m` : s),
+    bold: (s) => (on ? `\x1b[1m${s}\x1b[0m` : s),
+  };
+}
+
+const INTERACTIVE_HELP = `Commands:
+  /help            show this help
+  /model <name>    switch model (claude | codex | grok | a model id)
+  /effort <level>  set reasoning effort (low | medium | high | xhigh | max)
+  /new             start a fresh browser session (close open tabs)
+  /clear           clear the screen
+  /exit            quit (or Ctrl-D)
+
+Anything else is a task: BetterWright drives the browser to complete it,
+streams what it is doing, and asks you a question if it genuinely needs one.`;
+
+// Bare `betterwright` (no subcommand): an interactive agent console — the
+// counterpart to `aside`. You type natural-language tasks; BetterWright's own
+// agent loop drives the browser, streams each step it takes, prints the answer
+// and what the run cost, and can ask you a question through the `ask` tool when
+// it genuinely needs input. One browser session persists across tasks until you
+// exit.
+async function cmdInteractive(flags) {
+  const { runAgentTask } = await import("../src/agent.mjs");
+  const argv = process.argv;
+  const { dim, bold } = styler();
+
+  let model = flagValue(argv, "--model", "claude");
+  const modelOptions = {};
+  const modelId = flagValue(argv, "--model-id");
+  if (modelId) modelOptions.model = modelId;
+  const effort = flagValue(argv, "--effort");
+  if (effort) modelOptions.effort = effort;
+  const session = flagValue(argv, "--session", "default");
+  const headless = !flags.has("--headed");
+
+  const newBrowser = () =>
+    new BetterWright({
+      policy: policyFromFlags(flags),
+      headless,
+      stealthRuntimeFix: flags.has("--stealth") || undefined,
+    });
+  let browser = newBrowser();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const nextLine = makeLineReader(rl);
+  rl.on("SIGINT", () => rl.close());
+
+  const modelLabel = () => `${model}${modelOptions.model ? ` (${modelOptions.model})` : ""}`;
+  console.log(bold("BetterWright") + " — interactive agent console");
+  console.log(dim(`model ${modelLabel()} · session ${session} · ${headless ? "headless" : "headed"}`));
+  console.log(dim("Type a task and press Enter. /help for commands, /exit or Ctrl-D to quit.\n"));
+
+  try {
+    for (;;) {
+      const raw = await nextLine(bold("▸ "));
+      if (raw === null) break; // Ctrl-D / closed
+      const task = raw.trim();
+      if (!task) continue;
+
+      if (task.startsWith("/")) {
+        const [cmd, ...args] = task.slice(1).split(/\s+/);
+        const arg = args.join(" ").trim();
+        if (cmd === "exit" || cmd === "quit" || cmd === "q") break;
+        if (cmd === "help" || cmd === "h" || cmd === "") {
+          console.log(INTERACTIVE_HELP);
+          continue;
+        }
+        if (cmd === "clear") {
+          console.clear();
+          continue;
+        }
+        if (cmd === "model") {
+          if (arg) model = arg;
+          console.log(dim(`model is ${modelLabel()}`));
+          continue;
+        }
+        if (cmd === "effort") {
+          if (arg) modelOptions.effort = arg;
+          console.log(dim(`effort is ${modelOptions.effort || "low"}`));
+          continue;
+        }
+        if (cmd === "new" || cmd === "reset") {
+          await browser.close();
+          browser = newBrowser();
+          console.log(dim("started a fresh browser session"));
+          continue;
+        }
+        console.log(dim(`unknown command /${cmd} — /help for the list`));
+        continue;
+      }
+
+      let result;
+      try {
+        result = await runAgentTask({
+          task,
+          browser,
+          model,
+          modelOptions,
+          session,
+          onStep: ({ step, tool, note }) => {
+            // `ask` is rendered by the askUser handler below; skip it here.
+            if (tool === "ask") return;
+            process.stdout.write(`${dim(`  · [${step}] ${tool}${note ? `: ${note}` : ""}`)}\n`);
+          },
+          askUser: async ({ question, options }) => {
+            const lines = [bold(`  ? ${question}`)];
+            if (options?.length)
+              for (const [i, o] of options.entries()) lines.push(dim(`      ${i + 1}. ${o}`));
+            console.log(lines.join("\n"));
+            const ans = await nextLine("  answer ▸ ");
+            return ans === null ? "" : ans.trim();
+          },
+        });
+      } catch (error) {
+        // A failed task must not kill the console — report and keep going.
+        console.log(dim(`  ! ${error?.message || error}`));
+        continue;
+      }
+
+      const { inputTokens, outputTokens, totalTokens } = result.usage;
+      console.log(result.answer ? `\n${bold(result.answer)}` : dim("\n(no answer returned)"));
+      if (result.proof) console.log(dim(`proof: ${result.proof}`));
+      console.log(
+        dim(
+          `${result.ok ? "done" : "unfinished"} · ${result.steps} step${result.steps === 1 ? "" : "s"} · ` +
+            `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"} · ` +
+            `${totalTokens.toLocaleString()} tokens (${inputTokens.toLocaleString()} in / ${outputTokens.toLocaleString()} out)\n`,
+        ),
+      );
+    }
+  } finally {
+    rl.close();
+    await browser.close();
+  }
+  console.log(dim("bye"));
+  return 0;
+}
+
 // `exec <task>`: BetterWright's own agent harness (the `aside exec` shape).
 // A model (Claude SDK / codex OAuth / grok OAuth) plugs into the browser-tuned
 // loop and drives the task to completion. Progress notes (ending with a cost
@@ -313,8 +459,27 @@ async function cmdSkills(rest) {
 }
 
 async function main() {
-  const [command, ...rest] = process.argv.slice(2);
-  const flags = new Set(rest.filter((token) => token.startsWith("--")));
+  const tokens = process.argv.slice(2);
+  const flags = new Set(tokens.filter((token) => token.startsWith("--")));
+  const first = tokens[0];
+  // No subcommand (nothing, or only flags like `betterwright --headed`): launch
+  // the interactive agent console. `--version`/`--help` are still honored.
+  if (!first || first.startsWith("-")) {
+    if (flags.has("--version")) {
+      console.log(require("../package.json").version);
+      return 0;
+    }
+    if (flags.has("--help") || tokens.includes("-h")) {
+      console.error(
+        "Usage: betterwright [interactive] | <setup|doctor|run|repl|exec|auth|skill|skills|mcp> [options]\n" +
+          "Run `betterwright` with no arguments for the interactive agent console.",
+      );
+      return 0;
+    }
+    return cmdInteractive(flags);
+  }
+  const command = first;
+  const rest = tokens.slice(1);
   const positional = rest.find((token) => !token.startsWith("-"));
   switch (command) {
     case "setup":
@@ -338,14 +503,12 @@ async function main() {
       await runMcpServer();
       return 0;
     }
-    case "--version":
-      console.log(require("../package.json").version);
-      return 0;
     default:
       console.error(
-        "Usage: betterwright <setup|doctor|run|repl|exec|auth|skill|skills|mcp> [options]",
+        "Usage: betterwright [interactive] | <setup|doctor|run|repl|exec|auth|skill|skills|mcp> [options]\n" +
+          "Run `betterwright` with no arguments for the interactive agent console.",
       );
-      return command ? 1 : 0;
+      return 1;
   }
 }
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -56,6 +56,56 @@ Flags:
 Network flags (`--block-private-network`, `--allow-host`, …) work the same as on
 `run`/`repl`.
 
+## Interactive console (`betterwright`)
+
+`betterwright exec` runs one task and exits. Run **`betterwright`** with no
+subcommand for the interactive counterpart — a console, like `aside` on its own,
+where you type tasks and watch the agent work:
+
+```
+$ betterwright --model codex
+BetterWright — interactive agent console
+model codex · session default · headless
+Type a task and press Enter. /help for commands, /exit or Ctrl-D to quit.
+
+▸ what is the page title of example.com
+  · [1] browser: opening the page and reading its title
+
+The page title is "Example Domain."
+proof: /…/proof-….png
+done · 2 steps · 2 tool calls · 5,081 tokens (4,961 in / 120 out)
+
+▸
+```
+
+Each step the agent takes streams as it happens, then the answer, the proof
+screenshot path, and the same cost summary `exec` prints. **One browser session
+persists across tasks**, so a later task can build on where an earlier one left
+off — you stay signed in, tabs stay open. The same `--model`, `--model-id`,
+`--effort`, `--session`, `--headed`, and network flags apply.
+
+Meta-commands (a line starting with `/`):
+
+| Command | Effect |
+| --- | --- |
+| `/help` | list the commands |
+| `/model <name>` | switch model for the next task |
+| `/effort <level>` | change reasoning effort |
+| `/new` | start a fresh browser session (close open tabs) |
+| `/clear` | clear the screen |
+| `/exit` | quit (or Ctrl-D) |
+
+### The `ask` tool
+
+Because a user is present, the interactive console gives the agent an **`ask`
+tool**: when it genuinely needs input — a code it cannot obtain, a consequential
+choice with no reasonable default, or a task ambiguous enough that guessing risks
+the wrong thing — it asks you a question (offering short concrete options when the
+answer is a choice) and waits for your typed reply before continuing. It still
+acts on its own for ordinary reversible steps; it does not ask permission to
+proceed. `betterwright exec` has no user watching, so it runs without the `ask`
+tool and never stalls on a question.
+
 ## Choosing a model
 
 The three built-in adapters resolve their own credentials:
@@ -105,6 +155,22 @@ const result = await runAgentTask({
   onStep: ({ step, tool, note }) => console.error(`[${step}] ${tool}: ${note}`),
 });
 console.log(result.answer, result.proof);
+console.log(result.toolCalls, result.usage); // e.g. 7, { inputTokens, outputTokens, totalTokens }
+```
+
+Pass an **`askUser`** handler to let the loop ask the human mid-task — this is
+how the interactive console wires the `ask` tool. Given a handler, `runAgentTask`
+exposes an `ask` tool to the model; without one it runs fully autonomously.
+
+```js
+const result = await runAgentTask({
+  task: "book me a table for dinner tonight",
+  model: "codex",
+  askUser: async ({ question, options }) => {
+    // Route to your UI/host; return the user's answer as a string.
+    return await promptTheUser(question, options);
+  },
+});
 ```
 
 `runAgentTask` constructs and closes its own browser unless you pass one:
@@ -148,8 +214,9 @@ model, apiKey })` is a ready-made adapter for any OpenAI-compatible endpoint.
 ## What the loop does
 
 Each turn: the model sees the task, the operator guidance from
-[`agentSystemPrompt`](agent-prompt.md), and the tools (`browser`, `done`, and
-`login` when a vault is present). It calls `browser` with async Playwright
+[`agentSystemPrompt`](agent-prompt.md), and the tools (`browser`, `done`,
+`login` when a vault is present, and `ask` when an `askUser` handler is present).
+It calls `browser` with async Playwright
 JavaScript; BetterWright runs it and feeds back a compact JSON observation
 (`ok`, `result`, `console`, `pages`, `challenges`, `skills`, `warnings`,
 `screenshots`). The loop ends when the model calls `done` (or answers in prose),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -39,7 +39,7 @@ const OBSERVATION_LIMIT = 12_000;
 // How the harness introduces its tools. `agentSystemPrompt()` speaks in terms of
 // `run()`; this preamble maps that onto the `browser` tool so the same operator
 // guidance applies unchanged.
-const HARNESS_PREAMBLE = `You are operating a real, persistent, policy-guarded web browser to complete the user's task end to end, autonomously.
+const HARNESS_PREAMBLE_HEAD = `You are operating a real, persistent, policy-guarded web browser to complete the user's task end to end, autonomously.
 
 Call the \`browser\` tool with async Playwright JavaScript to act — each call is one \`run()\` in the guidance below. A single trailing expression is returned; a statement block must \`return\`. Globals: page, pages, context, state, openPage, usePage, closePage, snapshot, screenshot, artifactPath, dialogs, credentials, captcha, human, overlays, controls, media.
 
@@ -48,17 +48,44 @@ Work in as few \`browser\` calls as the task safely allows: every call is a full
 - Plan, then batch. When you already know what to read and where from — a value on a page, the same field across several pages, a comparison between tabs — do it in ONE call: navigate (or open several tabs with \`Promise.all([openPage(a), openPage(b)])\`), extract each value, compute, and return the finished result. Do not spend one call per page.
 - Prefer direct extraction when the target is unambiguous: \`page.locator(...).innerText()\`, \`getByRole\`, \`allInnerTexts()\`, or \`page.url()\` after a redirect. Known shortcuts (a project's \`/releases/latest\` URL) beat click-through exploration. Compute in JS and return the finished answer, not raw page dumps.
 - When the right element is not obvious — an article's first real sentence (leading nodes are often empty or hatnotes), the "main" result among many — read a scoped \`snapshot({interactive:true})\` or \`snapshot({selector})\` first to see the real structure, then target precisely. If an extraction returns empty, too short, or clearly wrong, do NOT retry the same blind locator — take one snapshot to see the structure, then extract. One snapshot beats three guesses.
-- Use the read → act → verify loop when the page is interactive or its structure is unknown — forms, logins, search boxes, dynamic UIs, or when an action's outcome is uncertain: \`snapshot({interactive: true})\` to see what to click, act on \`[ref=eN]\` via \`page.locator('aria-ref=eN')\`, then \`snapshot({diff: true})\` to confirm. Snapshots cover the whole page including iframes and off-screen elements — never scroll just to read, never guess a ref or URL.
+- Use the read → act → verify loop when the page is interactive or its structure is unknown — forms, logins, search boxes, dynamic UIs, or when an action's outcome is uncertain: \`snapshot({interactive: true})\` to see what to click, act on \`[ref=eN]\` via \`page.locator('aria-ref=eN')\`, then \`snapshot({diff: true})\` to confirm. Snapshots cover the whole page including iframes and off-screen elements — never scroll just to read, never guess a ref or URL.`;
 
-You are operating autonomously: the user is not watching and cannot answer mid-task. Do not ask "shall I proceed?" — for reversible steps that follow from the task, act. Work until the task is genuinely done or you are truly blocked (an MFA code you cannot obtain, a consequential choice with no reasonable default).
+// Autonomy paragraph — two variants. In `exec` no one is watching, so the model
+// must never stall; in an interactive session the `ask` tool exists, so the model
+// may ask when it genuinely needs the user (but still acts on the obvious).
+const HARNESS_AUTONOMY_HEADLESS = `You are operating autonomously: the user is not watching and cannot answer mid-task. Do not ask "shall I proceed?" — for reversible steps that follow from the task, act. Work until the task is genuinely done or you are truly blocked (an MFA code you cannot obtain, a consequential choice with no reasonable default).`;
 
-When finished, call the \`done\` tool with a clear answer for the user. On any task with a visible result, capture \`screenshot({kind: 'proof'})\` of the end state first — do it in the same \`browser\` call as your final action when you can, to save a turn. Call \`done\` exactly once, at the end.`;
+const HARNESS_AUTONOMY_INTERACTIVE = `You are operating in an interactive session: the user is present and can answer through the \`ask\` tool. Still act autonomously — do not ask "shall I proceed?" for reversible steps that follow from the task; just do them. Call \`ask\` only when you genuinely need the user: an input you cannot obtain yourself (an MFA/2FA code, which of several accounts to use), a consequential or irreversible choice with no reasonable default (a purchase, a message to send, a destructive action), or a task ambiguous enough that guessing risks doing the wrong thing. Offer short concrete options and mask any secret (e.g. "account ending 999"). Then keep working until the task is genuinely done.`;
+
+const HARNESS_PREAMBLE_TAIL = `When finished, call the \`done\` tool with a clear answer for the user. On any task with a visible result, capture \`screenshot({kind: 'proof'})\` of the end state first — do it in the same \`browser\` call as your final action when you can, to save a turn. Call \`done\` exactly once, at the end.`;
+
+// Assemble the harness preamble, choosing the autonomy paragraph by whether an
+// `ask` tool is available (interactive) or not (headless `exec`).
+function harnessPreamble({ withAsk } = {}) {
+  const autonomy = withAsk ? HARNESS_AUTONOMY_INTERACTIVE : HARNESS_AUTONOMY_HEADLESS;
+  return `${HARNESS_PREAMBLE_HEAD}\n\n${autonomy}\n\n${HARNESS_PREAMBLE_TAIL}`;
+}
 
 const BROWSER_TOOL_DESCRIPTION = `Run async Playwright JavaScript in the persistent browser and get back a JSON observation ({ok, result, error, console, pages, challenges, skills, warnings, screenshots, duration_ms}). Read with snapshot({interactive:true}); act on [ref=eN] via page.locator('aria-ref=eN'); verify with snapshot({diff:true}). Never type or print a password — use the login tool if present, or a password-manager extension.`;
 
 const DONE_TOOL_DESCRIPTION = `Finish the task. Call this exactly once when the task is complete or genuinely blocked, with the final answer or status for the user. Capture a proof screenshot first when there is a visible result.`;
 
 const LOGIN_TOOL_DESCRIPTION = `Fill a saved or freshly generated credential without the secret ever entering the conversation. The password is fetched, typed, and (with submitSelector) submitted inside the browser worker — never returned, never shown in a snapshot. Provide CSS selectors for the fields. Set generate=true to create and save a new strong password when signing up.`;
+
+const ASK_TOOL_DESCRIPTION = `Ask the present user a question and wait for their typed answer. Use ONLY when you genuinely need input to proceed — a code or credential you cannot obtain, a consequential or irreversible choice with no reasonable default, or genuine ambiguity in the task. Offer short concrete options when the answer is a choice, and mask any secret (e.g. "account ending 999"). Do not use it to ask permission for ordinary reversible steps — just do those.`;
+
+const ASK_TOOL_PARAMETERS = {
+  type: "object",
+  properties: {
+    question: { type: "string", description: "The question to put to the user." },
+    options: {
+      type: "array",
+      items: { type: "string" },
+      description: "Optional short, concrete choices to offer when the answer is a selection.",
+    },
+  },
+  required: ["question"],
+};
 
 const LOGIN_TOOL_PARAMETERS = {
   type: "object",
@@ -116,13 +143,15 @@ function openaiUsage(usage) {
   };
 }
 
-function toolsForHarness({ withLogin }) {
+function toolsForHarness({ withLogin, withAsk }) {
   const tools = [
     { name: "browser", description: BROWSER_TOOL_DESCRIPTION, parameters: BROWSER_TOOL_PARAMETERS },
     { name: "done", description: DONE_TOOL_DESCRIPTION, parameters: DONE_TOOL_PARAMETERS },
   ];
   if (withLogin)
     tools.push({ name: "login", description: LOGIN_TOOL_DESCRIPTION, parameters: LOGIN_TOOL_PARAMETERS });
+  if (withAsk)
+    tools.push({ name: "ask", description: ASK_TOOL_DESCRIPTION, parameters: ASK_TOOL_PARAMETERS });
   return tools;
 }
 
@@ -194,6 +223,10 @@ function loginOptionsFromInput(input = {}, session) {
  *   browsers only — ignored when an external `browser` is passed, whose own
  *   vault then decides login availability)
  * @param {(event: object) => void} [options.onStep] progress callback per step
+ * @param {(q: {question: string, options: string[]}) => (string|Promise<string>)} [options.askUser]
+ *   when provided, the loop exposes an `ask` tool so the model can put a question
+ *   to the user mid-task; the returned string is fed back as the answer. Omit it
+ *   (the `exec` default) to run fully autonomously with no `ask` tool.
  * @returns {Promise<{ok: boolean, answer: string, steps: number, reason: string, toolCalls: number, usage: {inputTokens: number, outputTokens: number, totalTokens: number}, transcript: object[], proof: (string|null)}>}
  */
 export async function runAgentTask(options = {}) {
@@ -204,6 +237,7 @@ export async function runAgentTask(options = {}) {
   const maxSteps = Math.max(1, Number(options.maxSteps) || DEFAULT_MAX_STEPS);
   const session = String(options.session || "default");
   const onStep = typeof options.onStep === "function" ? options.onStep : () => {};
+  const askUser = typeof options.askUser === "function" ? options.askUser : null;
 
   const ownsBrowser = !options.browser;
   const browser =
@@ -214,9 +248,10 @@ export async function runAgentTask(options = {}) {
       ...(options.vault ? { vault: options.vault } : {}),
     });
   const withLogin = Boolean(browser.vault);
+  const withAsk = Boolean(askUser);
 
-  const system = `${HARNESS_PREAMBLE}\n\n${agentSystemPrompt(options.guardrails || {})}`;
-  const tools = toolsForHarness({ withLogin });
+  const system = `${harnessPreamble({ withAsk })}\n\n${agentSystemPrompt(options.guardrails || {})}`;
+  const tools = toolsForHarness({ withLogin, withAsk });
   const messages = [{ role: "user", text: task }];
 
   let answer = "";
@@ -269,6 +304,28 @@ export async function runAgentTask(options = {}) {
             results.push({ id: call.id, name: call.name, content: observationFromResult(result) });
           } catch (error) {
             results.push({ id: call.id, name: call.name, content: `login error: ${error?.message || error}` });
+          }
+          continue;
+        }
+        if (call.name === "ask") {
+          const question = String(call.input?.question ?? "").trim();
+          const choices = Array.isArray(call.input?.options) ? call.input.options.map(String) : [];
+          onStep({ step: steps, tool: "ask", note: question });
+          // The `ask` tool is only offered when askUser was provided, so this is
+          // reachable only in interactive mode; still guard against a stray call.
+          if (!askUser) {
+            results.push({ id: call.id, name: call.name, content: "No user is available to answer in this run." });
+            continue;
+          }
+          try {
+            const reply = String((await askUser({ question, options: choices })) ?? "").trim();
+            results.push({
+              id: call.id,
+              name: call.name,
+              content: reply ? `User answered: ${reply}` : "User gave no answer; use your best judgment or report it blocked.",
+            });
+          } catch (error) {
+            results.push({ id: call.id, name: call.name, content: `ask error: ${error?.message || error}` });
           }
           continue;
         }

--- a/src/cli-io.mjs
+++ b/src/cli-io.mjs
@@ -1,0 +1,42 @@
+// Small stdin helper for the interactive agent console (bin/betterwright.mjs).
+//
+// One readline interface is shared by two readers: the console's top-level task
+// prompt and the agent's `ask` tool. Both pull the *next* line from the same
+// stream, so they must not each attach their own `line` listener and race. This
+// serializes reads through a single queue: callers await `nextLine()`, lines are
+// handed out in arrival order, and any line typed while no one is waiting is
+// buffered for the next caller.
+
+/**
+ * Wrap a readline interface in a serial line reader.
+ * @param {import("node:readline").Interface} rl
+ * @returns {(promptStr?: string) => Promise<string|null>} resolves with the next
+ *   line, or `null` once the interface has closed (Ctrl-D / end of input). When a
+ *   prompt string is given and no line is already buffered, readline renders it so
+ *   line editing stays correct.
+ */
+export function makeLineReader(rl) {
+  const waiters = [];
+  const buffered = [];
+  let closed = false;
+
+  rl.on("line", (line) => {
+    const waiter = waiters.shift();
+    if (waiter) waiter(line);
+    else buffered.push(line);
+  });
+  rl.on("close", () => {
+    closed = true;
+    while (waiters.length) waiters.shift()(null);
+  });
+
+  return (promptStr = "") => {
+    if (buffered.length) return Promise.resolve(buffered.shift());
+    if (closed) return Promise.resolve(null);
+    if (promptStr) {
+      rl.setPrompt(promptStr);
+      rl.prompt();
+    }
+    return new Promise((resolve) => waiters.push(resolve));
+  };
+}

--- a/tests/node/agent.test.mjs
+++ b/tests/node/agent.test.mjs
@@ -164,6 +164,50 @@ test("login tool is offered only with a vault and runs fillCredential", async ()
   assert.ok(!model2.seen[0].tools.some((t) => t.name === "login"));
 });
 
+test("ask tool is offered only with an askUser handler and routes to it", async () => {
+  const browser = fakeBrowser();
+  const asked = [];
+  const askUser = async ({ question, options }) => {
+    asked.push({ question, options });
+    return "the blue one";
+  };
+  const model = scriptedModel([
+    { text: "", toolCalls: [{ id: "a1", name: "ask", input: { question: "Which?", options: ["blue", "red"] } }] },
+    { text: "", toolCalls: [{ id: "d1", name: "done", input: { answer: "picked blue" } }] },
+  ]);
+
+  const result = await runAgentTask({ task: "choose", model, browser, askUser });
+
+  // The tool list handed to the model included ask, and the handler ran.
+  assert.ok(model.seen[0].tools.some((t) => t.name === "ask"));
+  assert.equal(asked.length, 1);
+  assert.deepEqual(asked[0], { question: "Which?", options: ["blue", "red"] });
+  // The user's answer was fed back to the model as the tool result.
+  const toolTurn = result.transcript.find((m) => m.role === "tool");
+  assert.match(toolTurn.results[0].content, /the blue one/);
+  // ask + done both count as tool calls.
+  assert.equal(result.toolCalls, 2);
+
+  // Without askUser, no ask tool is offered and the loop stays autonomous.
+  const noAsk = fakeBrowser();
+  const model2 = scriptedModel([{ text: "done", toolCalls: [] }]);
+  await runAgentTask({ task: "x", model: model2, browser: noAsk });
+  assert.ok(!model2.seen[0].tools.some((t) => t.name === "ask"));
+});
+
+test("interactive preamble invites the ask tool; headless does not", async () => {
+  const browser = fakeBrowser();
+  const withAsk = scriptedModel([{ text: "hi", toolCalls: [] }]);
+  await runAgentTask({ task: "x", model: withAsk, browser, askUser: async () => "" });
+  assert.match(withAsk.seen[0].system, /interactive session/);
+  assert.match(withAsk.seen[0].system, /`ask` tool/);
+
+  const headless = scriptedModel([{ text: "hi", toolCalls: [] }]);
+  await runAgentTask({ task: "x", model: headless, browser: fakeBrowser() });
+  assert.match(headless.seen[0].system, /operating autonomously/);
+  assert.doesNotMatch(headless.seen[0].system, /`ask` tool/);
+});
+
 test("resolveModel maps names, passes objects through, rejects unknown", () => {
   const custom = { name: "mine", complete: async () => ({ text: "", toolCalls: [] }) };
   assert.equal(resolveModel(custom), custom);

--- a/tests/node/cli-io.test.mjs
+++ b/tests/node/cli-io.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { makeLineReader } from "../../src/cli-io.mjs";
+
+// A minimal readline stand-in: emits "line"/"close" and records prompts.
+function fakeReadline() {
+  const rl = new EventEmitter();
+  rl.prompts = [];
+  rl.setPrompt = (p) => rl.prompts.push(p);
+  rl.prompt = () => {};
+  return rl;
+}
+
+test("makeLineReader hands out lines in arrival order to awaiting callers", async () => {
+  const rl = fakeReadline();
+  const nextLine = makeLineReader(rl);
+  const first = nextLine();
+  const second = nextLine();
+  rl.emit("line", "alpha");
+  rl.emit("line", "beta");
+  assert.equal(await first, "alpha");
+  assert.equal(await second, "beta");
+});
+
+test("makeLineReader buffers a line typed while no one is waiting", async () => {
+  const rl = fakeReadline();
+  const nextLine = makeLineReader(rl);
+  rl.emit("line", "early"); // arrives before any awaiter
+  assert.equal(await nextLine(), "early");
+});
+
+test("makeLineReader resolves null at close, for pending and future reads", async () => {
+  const rl = fakeReadline();
+  const nextLine = makeLineReader(rl);
+  const pending = nextLine();
+  rl.emit("close");
+  assert.equal(await pending, null); // pending waiter drained
+  assert.equal(await nextLine(), null); // and every read after close
+});
+
+test("makeLineReader renders a prompt only when it must wait", async () => {
+  const rl = fakeReadline();
+  const nextLine = makeLineReader(rl);
+  rl.emit("line", "buffered");
+  // A buffered line is returned without rendering a prompt.
+  await nextLine("should-not-render ▸ ");
+  assert.deepEqual(rl.prompts, []);
+  // With nothing buffered, the prompt is set and rendered.
+  const waiting = nextLine("ask ▸ ");
+  assert.deepEqual(rl.prompts, ["ask ▸ "]);
+  rl.emit("line", "answer");
+  assert.equal(await waiting, "answer");
+});

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -65,6 +65,13 @@ export interface RunAgentTaskOptions {
   /** Ignored when an external `browser` is passed — that browser's own vault decides login availability. */
   vault?: CredentialVault;
   onStep?: (event: AgentStepEvent) => void;
+  /**
+   * When provided, the loop exposes an `ask` tool so the model can put a
+   * question to the user mid-task; the returned string is fed back as the
+   * answer. Omit it (the `exec` default) to run fully autonomously with no
+   * `ask` tool.
+   */
+  askUser?: (question: { question: string; options: string[] }) => string | Promise<string>;
 }
 
 export interface AgentResult {


### PR DESCRIPTION
## 0.8.0

### Added

- **Interactive agent console (`betterwright` with no subcommand).** The counterpart to `aside` on its own: a REPL where you type natural-language tasks and watch BetterWright's own agent loop drive the browser to complete them. Each step streams as it happens, then the answer, the proof-screenshot path, and a one-line cost summary. **One browser session persists across tasks**, so a later task builds on where an earlier one left off. Meta commands: `/model`, `/effort`, `/new`, `/clear`, `/help`, `/exit`. The usual `--model`, `--model-id`, `--effort`, `--session`, `--headed`, and network flags apply.

- **`ask` tool for interactive runs.** When `runAgentTask` is given an `askUser` handler (the console wires this to the prompt), the loop exposes an `ask` tool so the agent can put a question to the user mid-task — a code it can't obtain, a consequential choice with no reasonable default, or genuine ambiguity — offering short concrete options and continuing on the reply. The operator preamble switches to an interactive posture accordingly. `betterwright exec` has no user watching, so it runs without the tool and never stalls.

- **`betterwright exec` reports what the run cost.** Result JSON carries `toolCalls` and `usage` (`{ inputTokens, outputTokens, totalTokens }`, summed across turns); the final stderr line prints a one-line summary. `runAgentTask` returns the same fields.

### Fixed

- **`--model` accepts a bare model id.** `--model gpt-5.6-sol` no longer errors with `Unknown model`; the backend is inferred from the id's prefix (`gpt-*`/`o*` → codex, `grok-*` → grok, `claude-*` → claude). Adapter names still work as before; an explicit `--model-id` still wins.

### Notes

- Folds in the 0.7.1 work (never published to npm).
- Verified live: interactive task (streaming + usage summary) and the `ask` tool (agent asked a question, consumed the answer, completed the task) both against the codex backend.
- New tests: `src/cli-io.mjs` line-reader (arrival order, buffering, EOF, prompt rendering) and agent-loop coverage for ask-tool routing + the interactive/headless preamble switch. Full gate green (163 tests, types, lint, package smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCYcno5CBwMdLu7gCMiu2
