### PR TITLE
release: npm v0.8.1 — time taken, cache read/write, end-of-task context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] — 2026-07-18
+
+### Added
+
+- **Runs now report the time they took.** `runAgentTask` returns `durationMs`
+  (task wall-clock, excluding teardown of a browser it created for itself), and
+  both `betterwright exec` and the interactive console include it in their cost
+  summary. It is also part of the `exec` stdout JSON.
+- **Cache and end-of-task context in the usage report.** Alongside input/output
+  totals, `usage` now carries `cacheReadTokens` and `cacheWriteTokens` (the cached
+  portion of the input — OpenAI-style backends report only cache reads, so writes
+  stay `0`) and `contextTokens`, the prompt size at the end of the task (the last
+  turn's input — how much context the model was holding when it finished). The
+  summary line reads e.g. `done in 6 steps, 7 tool calls, 11.4s, 48,210 tokens
+  (46,880 in / 1,330 out · 40,000 cache read · 2,000 cache write) · ctx 20,000`.
+
 ## [0.8.0] — 2026-07-18
 
 ### Added

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -181,6 +181,23 @@ function flagValue(argv, flag, fallback) {
   return index !== -1 && index + 1 < argv.length ? argv[index + 1] : fallback;
 }
 
+// Compact wall-clock: milliseconds under a second, otherwise seconds to 1 dp.
+function formatDuration(ms) {
+  const n = Number(ms) || 0;
+  return n < 1000 ? `${n}ms` : `${(n / 1000).toFixed(1)}s`;
+}
+
+// The token portion of a run summary, shared by `exec` and the console:
+//   48,210 tokens (46,880 in / 1,330 out · 40,000 cache read · 2,000 cache write) · ctx 20,000
+function formatUsage(usage) {
+  const n = (x) => Number(x || 0).toLocaleString();
+  return (
+    `${n(usage.totalTokens)} tokens (${n(usage.inputTokens)} in / ${n(usage.outputTokens)} out · ` +
+    `${n(usage.cacheReadTokens)} cache read · ${n(usage.cacheWriteTokens)} cache write) · ` +
+    `ctx ${n(usage.contextTokens)}`
+  );
+}
+
 // ANSI helpers that no-op when stdout is not a TTY or NO_COLOR is set.
 function styler() {
   const on = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
@@ -305,14 +322,13 @@ async function cmdInteractive(flags) {
         continue;
       }
 
-      const { inputTokens, outputTokens, totalTokens } = result.usage;
       console.log(result.answer ? `\n${bold(result.answer)}` : dim("\n(no answer returned)"));
       if (result.proof) console.log(dim(`proof: ${result.proof}`));
       console.log(
         dim(
           `${result.ok ? "done" : "unfinished"} · ${result.steps} step${result.steps === 1 ? "" : "s"} · ` +
-            `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"} · ` +
-            `${totalTokens.toLocaleString()} tokens (${inputTokens.toLocaleString()} in / ${outputTokens.toLocaleString()} out)\n`,
+            `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"} · ${formatDuration(result.durationMs)} · ` +
+            `${formatUsage(result.usage)}\n`,
         ),
       );
     }
@@ -364,11 +380,10 @@ async function cmdExec(flags) {
     console.error(error?.message || String(error));
     return 1;
   }
-  const { inputTokens, outputTokens, totalTokens } = result.usage;
   process.stderr.write(
     `  done in ${result.steps} step${result.steps === 1 ? "" : "s"}, ` +
       `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"}, ` +
-      `${totalTokens.toLocaleString()} tokens (${inputTokens.toLocaleString()} in / ${outputTokens.toLocaleString()} out)\n`,
+      `${formatDuration(result.durationMs)}, ${formatUsage(result.usage)}\n`,
   );
   console.log(
     JSON.stringify(
@@ -379,6 +394,7 @@ async function cmdExec(flags) {
         reason: result.reason,
         toolCalls: result.toolCalls,
         usage: result.usage,
+        durationMs: result.durationMs,
         proof: result.proof,
       },
       null,

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -23,8 +23,9 @@ betterwright exec "find the top Hacker News story and give me its title and poin
 ```
 
 Progress notes stream to stderr as the loop runs — the last one summarizes the
-run's cost (`done in 6 steps, 7 tool calls, 48,210 tokens (46,880 in / 1,330
-out)`) — and the final result is one JSON object on stdout:
+run's cost (`done in 6 steps, 7 tool calls, 11.4s, 48,210 tokens (46,880 in /
+1,330 out · 40,000 cache read · 2,000 cache write) · ctx 20,000`) — and the final
+result is one JSON object on stdout:
 
 ```json
 {
@@ -33,14 +34,29 @@ out)`) — and the final result is one JSON object on stdout:
   "steps": 6,
   "reason": "done",
   "toolCalls": 7,
-  "usage": { "inputTokens": 46880, "outputTokens": 1330, "totalTokens": 48210 },
+  "usage": {
+    "inputTokens": 46880,
+    "outputTokens": 1330,
+    "totalTokens": 48210,
+    "cacheReadTokens": 40000,
+    "cacheWriteTokens": 2000,
+    "contextTokens": 20000
+  },
+  "durationMs": 11400,
   "proof": "/…/proof-….png"
 }
 ```
 
-`toolCalls` counts the `browser`/`login`/`done` calls the model issued (it can
-exceed `steps` when a turn batches several). `usage` sums the token counts the
-model adapter reported; a field is `0` when the provider returned no usage block.
+`toolCalls` counts the `browser`/`login`/`ask`/`done` calls the model issued (it
+can exceed `steps` when a turn batches several). `usage` sums the token counts the
+model adapter reported across turns; a field is `0` when the provider returned no
+usage block. `inputTokens` is the full prompt size (cached tokens included);
+`cacheReadTokens` and `cacheWriteTokens` break out the cached portion (OpenAI-style
+backends report only cache reads, so `cacheWriteTokens` stays `0` there).
+`contextTokens` is the prompt size at the **end** of the task — the last turn's
+input, i.e. how much context the model was holding when it finished. `durationMs`
+is the task wall-clock (it excludes tearing down a browser the loop created for
+itself).
 
 Flags:
 
@@ -73,7 +89,7 @@ Type a task and press Enter. /help for commands, /exit or Ctrl-D to quit.
 
 The page title is "Example Domain."
 proof: /…/proof-….png
-done · 2 steps · 2 tool calls · 5,081 tokens (4,961 in / 120 out)
+done · 2 steps · 2 tool calls · 2.1s · 5,081 tokens (4,961 in / 120 out · 3,072 cache read · 0 cache write) · ctx 4,961
 
 ▸
 ```
@@ -155,7 +171,8 @@ const result = await runAgentTask({
   onStep: ({ step, tool, note }) => console.error(`[${step}] ${tool}: ${note}`),
 });
 console.log(result.answer, result.proof);
-console.log(result.toolCalls, result.usage); // e.g. 7, { inputTokens, outputTokens, totalTokens }
+console.log(result.toolCalls, result.usage, result.durationMs);
+// 7, { inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens, contextTokens }, 11400
 ```
 
 Pass an **`askUser`** handler to let the loop ask the human mid-task — this is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -121,25 +121,39 @@ const DONE_TOOL_PARAMETERS = {
   required: ["answer"],
 };
 
-// Normalize a provider's token-usage block to a common { inputTokens,
-// outputTokens } shape. Anthropic counts cached input separately, so fold the
-// cache tokens back into the input total.
+// Normalize a provider's token-usage block to a common shape:
+//   { inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens }
+// `inputTokens` is the TOTAL prompt size for the turn (cached tokens included),
+// so the final turn's `inputTokens` is the context size at the end of the task;
+// `cacheReadTokens`/`cacheWriteTokens` break out the cached portion.
+//
+// Anthropic reports the uncached prompt in `input_tokens` and the cached parts
+// separately, so the total is the sum.
 function anthropicUsage(usage) {
   if (!usage) return null;
-  const input =
-    (usage.input_tokens || 0) +
-    (usage.cache_read_input_tokens || 0) +
-    (usage.cache_creation_input_tokens || 0);
-  return { inputTokens: input, outputTokens: usage.output_tokens || 0 };
+  const cacheRead = usage.cache_read_input_tokens || 0;
+  const cacheWrite = usage.cache_creation_input_tokens || 0;
+  return {
+    inputTokens: (usage.input_tokens || 0) + cacheRead + cacheWrite,
+    outputTokens: usage.output_tokens || 0,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: cacheWrite,
+  };
 }
 
 // Chat Completions uses prompt_/completion_tokens; the Responses API uses
-// input_/output_tokens — accept either.
+// input_/output_tokens — accept either. Both count cached tokens *inside* the
+// prompt total and expose them under a `*_tokens_details.cached_tokens` field;
+// neither reports a separate cache-write count, so that stays 0.
 function openaiUsage(usage) {
   if (!usage) return null;
+  const cacheRead =
+    usage.prompt_tokens_details?.cached_tokens ?? usage.input_tokens_details?.cached_tokens ?? 0;
   return {
     inputTokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
     outputTokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: 0,
   };
 }
 
@@ -227,7 +241,7 @@ function loginOptionsFromInput(input = {}, session) {
  *   when provided, the loop exposes an `ask` tool so the model can put a question
  *   to the user mid-task; the returned string is fed back as the answer. Omit it
  *   (the `exec` default) to run fully autonomously with no `ask` tool.
- * @returns {Promise<{ok: boolean, answer: string, steps: number, reason: string, toolCalls: number, usage: {inputTokens: number, outputTokens: number, totalTokens: number}, transcript: object[], proof: (string|null)}>}
+ * @returns {Promise<{ok: boolean, answer: string, steps: number, reason: string, toolCalls: number, usage: {inputTokens: number, outputTokens: number, totalTokens: number, cacheReadTokens: number, cacheWriteTokens: number, contextTokens: number}, durationMs: number, transcript: object[], proof: (string|null)}>}
  */
 export async function runAgentTask(options = {}) {
   const task = String(options.task || "").trim();
@@ -261,8 +275,15 @@ export async function runAgentTask(options = {}) {
   let steps = 0;
   let inputTokens = 0;
   let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  // The final turn's prompt size — the context the model was holding when the
+  // task ended. Overwritten each turn that reports usage, so it keeps the last.
+  let contextTokens = 0;
   let toolCallCount = 0;
+  let durationMs = 0;
 
+  const startedAt = Date.now();
   try {
     for (steps = 1; steps <= maxSteps; steps += 1) {
       const response = await model.complete({ system, messages, tools });
@@ -270,6 +291,9 @@ export async function runAgentTask(options = {}) {
       if (response.usage) {
         inputTokens += response.usage.inputTokens || 0;
         outputTokens += response.usage.outputTokens || 0;
+        cacheReadTokens += response.usage.cacheReadTokens || 0;
+        cacheWriteTokens += response.usage.cacheWriteTokens || 0;
+        contextTokens = response.usage.inputTokens || 0;
       }
       toolCallCount += toolCalls.length;
       messages.push({ role: "assistant", text: response.text || "", toolCalls });
@@ -344,6 +368,9 @@ export async function runAgentTask(options = {}) {
       if (finished) break;
     }
   } finally {
+    // Measure task wall-clock before tearing down an owned browser, so the
+    // reported time is the work, not the teardown.
+    durationMs = Date.now() - startedAt;
     if (ownsBrowser) await browser.close();
   }
 
@@ -361,7 +388,14 @@ export async function runAgentTask(options = {}) {
       inputTokens,
       outputTokens,
       totalTokens: inputTokens + outputTokens,
+      // Cached-input breakdown (subsets of the input total, summed across turns)
+      // and the context size at the end of the task (the last turn's prompt).
+      cacheReadTokens,
+      cacheWriteTokens,
+      contextTokens,
     },
+    // Task wall-clock in milliseconds (excludes owned-browser teardown).
+    durationMs,
     transcript: messages,
     proof,
   };

--- a/tests/node/agent.test.mjs
+++ b/tests/node/agent.test.mjs
@@ -98,13 +98,13 @@ test("runAgentTask sums token usage and counts every tool call", async () => {
         { id: "c1", name: "browser", input: { code: "1" } },
         { id: "c2", name: "browser", input: { code: "2" } },
       ],
-      usage: { inputTokens: 100, outputTokens: 20 },
+      usage: { inputTokens: 100, outputTokens: 20, cacheReadTokens: 60, cacheWriteTokens: 40 },
     },
     // A final turn: done + a usage block. Providers that omit usage contribute 0.
     {
       text: "",
       toolCalls: [{ id: "d1", name: "done", input: { answer: "ok" } }],
-      usage: { inputTokens: 50, outputTokens: 10 },
+      usage: { inputTokens: 50, outputTokens: 10, cacheReadTokens: 30, cacheWriteTokens: 0 },
     },
   ]);
 
@@ -115,13 +115,27 @@ test("runAgentTask sums token usage and counts every tool call", async () => {
   assert.equal(result.usage.inputTokens, 150);
   assert.equal(result.usage.outputTokens, 30);
   assert.equal(result.usage.totalTokens, 180);
+  // Cache read/write sum across turns; context is the LAST turn's input size.
+  assert.equal(result.usage.cacheReadTokens, 90);
+  assert.equal(result.usage.cacheWriteTokens, 40);
+  assert.equal(result.usage.contextTokens, 50);
+  // Wall-clock is reported as a non-negative number of milliseconds.
+  assert.equal(typeof result.durationMs, "number");
+  assert.ok(result.durationMs >= 0);
 });
 
 test("runAgentTask reports zeroed usage when the model omits a usage block", async () => {
   const browser = fakeBrowser();
   const model = scriptedModel([{ text: "hi", toolCalls: [] }]);
   const result = await runAgentTask({ task: "x", model, browser });
-  assert.deepEqual(result.usage, { inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+  assert.deepEqual(result.usage, {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    contextTokens: 0,
+  });
   assert.equal(result.toolCalls, 0);
 });
 
@@ -254,7 +268,7 @@ test("openaiModel translates the transcript and parses tool calls", async () => 
               finish_reason: "tool_calls",
             },
           ],
-          usage: { prompt_tokens: 42, completion_tokens: 8 },
+          usage: { prompt_tokens: 42, completion_tokens: 8, prompt_tokens_details: { cached_tokens: 30 } },
         };
       },
     };
@@ -281,8 +295,8 @@ test("openaiModel translates the transcript and parses tool calls", async () => 
   assert.equal(out.toolCalls[0].name, "browser");
   assert.deepEqual(out.toolCalls[0].input, { code: "return 1" });
   assert.equal(out.toolCalls[0].id, "call_1"); // synthesized
-  // prompt_/completion_tokens are normalized to input/output.
-  assert.deepEqual(out.usage, { inputTokens: 42, outputTokens: 8 });
+  // prompt_/completion_tokens normalize to input/output; cached_tokens → cache read.
+  assert.deepEqual(out.usage, { inputTokens: 42, outputTokens: 8, cacheReadTokens: 30, cacheWriteTokens: 0 });
 });
 
 test("openaiModel surfaces HTTP errors", async () => {
@@ -303,7 +317,7 @@ test("claudeModel maps to the Anthropic shape and parses content", async () => {
             { type: "tool_use", id: "t1", name: "done", input: { answer: "A" } },
           ],
           stop_reason: "tool_use",
-          usage: { input_tokens: 30, cache_read_input_tokens: 12, output_tokens: 5 },
+          usage: { input_tokens: 30, cache_read_input_tokens: 12, cache_creation_input_tokens: 8, output_tokens: 5 },
         };
       },
     },
@@ -325,8 +339,8 @@ test("claudeModel maps to the Anthropic shape and parses content", async () => {
   assert.equal(out.text, "sure");
   assert.equal(out.toolCalls[0].name, "done");
   assert.deepEqual(out.toolCalls[0].input, { answer: "A" });
-  // Cached input tokens fold into the input total (30 + 12), output passes through.
-  assert.deepEqual(out.usage, { inputTokens: 42, outputTokens: 5 });
+  // input = uncached + cache read + cache write (30 + 12 + 8); cache parts break out.
+  assert.deepEqual(out.usage, { inputTokens: 50, outputTokens: 5, cacheReadTokens: 12, cacheWriteTokens: 8 });
 });
 
 test("codex and grok adapters require credentials", () => {

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -40,10 +40,16 @@ export interface AgentModel {
   }): Promise<{ text: string; toolCalls: AgentToolCall[]; stopReason?: string; usage?: AgentUsage | null }>;
 }
 
-/** Token usage, normalized across model adapters (0 when a provider omits it). */
+/**
+ * Token usage for one turn, normalized across model adapters (0 when a provider
+ * omits it). `inputTokens` is the full prompt size for the turn, cached tokens
+ * included; `cacheReadTokens`/`cacheWriteTokens` break out the cached portion.
+ */
 export interface AgentUsage {
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
 }
 
 export interface AgentStepEvent {
@@ -81,8 +87,22 @@ export interface AgentResult {
   reason: "max-steps" | "answered" | "stopped" | "done";
   /** How many tool calls the model issued; can exceed `steps` when a turn batches several. */
   toolCalls: number;
-  /** Summed token usage the model adapters reported (fields are 0 when unavailable). */
-  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+  /**
+   * Token usage summed across turns (fields are 0 when unavailable).
+   * `cacheReadTokens`/`cacheWriteTokens` are the cached portion of the input;
+   * `contextTokens` is the prompt size at the end of the task (the last turn's
+   * input), i.e. how much context the model was holding when it finished.
+   */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    contextTokens: number;
+  };
+  /** Task wall-clock in milliseconds (excludes owned-browser teardown). */
+  durationMs: number;
   transcript: AgentMessage[];
   proof: string | null;
 }


### PR DESCRIPTION
## 0.8.1

### Added

- **Time taken.** `runAgentTask` returns `durationMs` (task wall-clock, excluding teardown of a browser it created for itself); `betterwright exec` and the interactive console show it in the cost summary and it's in the `exec` stdout JSON.

- **Cache + end-of-task context in the usage report.** Alongside input/output totals, `usage` now carries:
  - `cacheReadTokens` / `cacheWriteTokens` — the cached portion of the input. Pulled from each provider's usage block (Anthropic `cache_read_input_tokens` / `cache_creation_input_tokens`; OpenAI/Responses `*_tokens_details.cached_tokens`). OpenAI-style backends report only cache reads, so writes stay `0`.
  - `contextTokens` — the prompt size at the **end** of the task (the last turn's input), i.e. how much context the model was holding when it finished.

The summary line now reads:

```
done in 6 steps, 7 tool calls, 11.4s, 48,210 tokens (46,880 in / 1,330 out · 40,000 cache read · 2,000 cache write) · ctx 20,000
```

### Notes

- Verified live against codex (interactive run shows time + cache read + ctx).
- Tests updated for the cache/context accumulation and per-adapter cache normalization; full gate green (types, lint, package smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcCYcno5CBwMdLu7gCMiu2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Run results now include elapsed time (`durationMs`).
  - Usage summaries now report cache-read, cache-write, and context token counts.
  - Interactive console and `exec` output display expanded timing and usage details.
  - `exec` JSON output includes duration and detailed usage fields.

- **Documentation**
  - Updated CLI and programmatic usage examples to reflect the expanded output format.

- **Chores**
  - Released as version 0.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->