### PR TITLE
fix cache-aware token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] — 2026-07-18
+
+### Changed
+
+- **Cache-aware cost reporting.** `usage.inputTokens` now means fresh input: the
+  provider's total input minus `cacheReadTokens` on every turn. The full final
+  prompt size remains available as `usage.context`. Both `betterwright exec` and
+  the interactive console show cache reads in their summaries, and show cache
+  writes only when a provider reports a positive real count. The JSON result
+  continues to expose the provider-reported cache read/write totals; cache writes
+  are never derived from fresh input.
+
 ## [0.8.2] — 2026-07-18
 
 ### Changed

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -23,6 +23,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { pathToFileURL } from "node:url";
 
+import { formatAgentUsage } from "../src/agent-usage.mjs";
 import { makeLineReader } from "../src/cli-io.mjs";
 import { doctorReport, resolveCloakDir, resolveCoreDir } from "../src/doctor.mjs";
 import { agentSystemPrompt, BetterWright, NetworkPolicy } from "../src/index.mjs";
@@ -187,15 +188,6 @@ function formatDuration(ms) {
   return n < 1000 ? `${n}ms` : `${(n / 1000).toFixed(1)}s`;
 }
 
-// The token portion of a run summary, shared by `exec` and the console. Input and
-// output are cumulative across turns; `context` is the final prompt size. The
-// cache read/write breakdown stays in the JSON usage but is kept out of this line.
-//   46,880 in / 1,330 out · context 20,000
-function formatUsage(usage) {
-  const n = (x) => Number(x || 0).toLocaleString();
-  return `${n(usage.inputTokens)} in / ${n(usage.outputTokens)} out · context ${n(usage.context)}`;
-}
-
 // ANSI helpers that no-op when stdout is not a TTY or NO_COLOR is set.
 function styler() {
   const on = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
@@ -358,7 +350,7 @@ async function cmdInteractive(flags) {
         dim(
           `${result.ok ? "done" : "unfinished"} · ${result.steps} step${result.steps === 1 ? "" : "s"} · ` +
             `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"} · ${formatDuration(result.durationMs)} · ` +
-            `${formatUsage(result.usage)}\n`,
+            `${formatAgentUsage(result.usage)}\n`,
         ),
       );
     }
@@ -414,7 +406,7 @@ async function cmdExec(flags) {
   process.stderr.write(
     `  done in ${result.steps} step${result.steps === 1 ? "" : "s"}, ` +
       `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"}, ` +
-      `${formatDuration(result.durationMs)}, ${formatUsage(result.usage)}\n`,
+      `${formatDuration(result.durationMs)}, ${formatAgentUsage(result.usage)}\n`,
   );
   console.log(
     JSON.stringify(

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -23,8 +23,9 @@ betterwright exec "find the top Hacker News story and give me its title and poin
 ```
 
 Progress notes stream to stderr as the loop runs — the last one summarizes the
-run's cost (`done in 6 steps, 7 tool calls, 11.4s, 46,880 in / 1,330 out · context
-20,000`) — and the final result is one JSON object on stdout:
+run's cost (`done in 6 steps, 7 tool calls, 11.4s, 6,880 in / 1,330 out · 40,000
+cache read · context 20,000`) — and the final result is one JSON object on
+stdout:
 
 ```json
 {
@@ -34,7 +35,7 @@ run's cost (`done in 6 steps, 7 tool calls, 11.4s, 46,880 in / 1,330 out · cont
   "reason": "done",
   "toolCalls": 7,
   "usage": {
-    "inputTokens": 46880,
+    "inputTokens": 6880,
     "outputTokens": 1330,
     "cacheReadTokens": 40000,
     "cacheWriteTokens": 0,
@@ -48,16 +49,18 @@ run's cost (`done in 6 steps, 7 tool calls, 11.4s, 46,880 in / 1,330 out · cont
 `toolCalls` counts the `browser`/`login`/`ask`/`done` calls the model issued (it
 can exceed `steps` when a turn batches several). `usage` sums the token counts the
 model adapter reported across turns (a field is `0` when the provider returned no
-usage block); `inputTokens` is the full prompt size, cached tokens included.
+usage block); `inputTokens` is fresh input only: each turn's provider input total
+minus the portion served from cache.
 `cacheReadTokens` and `cacheWriteTokens` come straight from the provider's usage
 block — the Responses API's `input_tokens_details.cached_tokens` /
 `cache_write_tokens`, the Chat Completions `prompt_tokens_details` equivalents, or
-Anthropic's `cache_read_input_tokens` / `cache_creation_input_tokens`. (The codex
-ChatGPT backend reports cache reads but always returns `0` for cache writes, so
-cache is kept in this JSON but left out of the one-line summary.) `context` is the
-prompt size at the **end** of the task — the last turn's input, i.e. how much
-context the model was holding when it finished. `durationMs` is the task
-wall-clock (it excludes tearing down a browser the loop created for itself).
+Anthropic's `cache_read_input_tokens` / `cache_creation_input_tokens`. The CLI
+always shows cache reads; it shows cache writes only when the run has a positive,
+provider-reported count. It never derives writes from fresh input. `context` is
+the full prompt size at the **end** of the task — the last turn's provider input
+total, i.e. how much context the model was holding when it finished. `durationMs`
+is the task wall-clock (it excludes tearing down a browser the loop created for
+itself).
 
 Flags:
 
@@ -90,7 +93,7 @@ Type a task and press Enter. /help for commands, /exit or Ctrl-D to quit.
 
 The page title is "Example Domain."
 proof: /…/proof-….png
-done · 2 steps · 2 tool calls · 2.1s · 4,961 in / 120 out · context 4,961
+done · 2 steps · 2 tool calls · 2.1s · 1,889 in / 120 out · 3,072 cache read · context 4,961
 
 ▸
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.8.2",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.8.2",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.8.2",
+  "version": "0.8.5",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/agent-usage.mjs
+++ b/src/agent-usage.mjs
@@ -1,0 +1,25 @@
+function tokenCount(value) {
+  const count = Number(value);
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}
+
+// Providers report cached reads as a subset of their total prompt input. The
+// user-facing input figure is the portion that was not served from that cache.
+export function uncachedInputTokens(totalInputTokens, cacheReadTokens) {
+  return Math.max(0, tokenCount(totalInputTokens) - tokenCount(cacheReadTokens));
+}
+
+// Shared by `exec` and the interactive console so both CLI surfaces describe
+// cost the same way. Cache writes are useful only when a provider reports a real
+// positive count; an omitted/zero field should not imply that every fresh input
+// token was written to cache.
+export function formatAgentUsage(usage = {}) {
+  const n = (value) => tokenCount(value).toLocaleString();
+  const parts = [
+    `${n(usage.inputTokens)} in / ${n(usage.outputTokens)} out`,
+    `${n(usage.cacheReadTokens)} cache read`,
+  ];
+  if (tokenCount(usage.cacheWriteTokens) > 0) parts.push(`${n(usage.cacheWriteTokens)} cache write`);
+  parts.push(`context ${n(usage.context)}`);
+  return parts.join(" · ");
+}

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -23,6 +23,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { uncachedInputTokens } from "./agent-usage.mjs";
 import { codexAccessToken, codexHome, grokAccessToken, loadCodexAuth, loadGrokAuth } from "./auth.mjs";
 import { BetterWright, NetworkPolicy } from "./client.mjs";
 import { agentSystemPrompt } from "./prompt.mjs";
@@ -296,7 +297,10 @@ export async function runAgentTask(options = {}) {
       const response = await model.complete({ system, messages, tools });
       const toolCalls = Array.isArray(response.toolCalls) ? response.toolCalls : [];
       if (response.usage) {
-        inputTokens += response.usage.inputTokens || 0;
+        // Provider input totals include cached reads. Keep the full last-turn
+        // value for context, but report only the portion that was not read from
+        // cache as the run's user-facing input cost.
+        inputTokens += uncachedInputTokens(response.usage.inputTokens, response.usage.cacheReadTokens);
         outputTokens += response.usage.outputTokens || 0;
         cacheReadTokens += response.usage.cacheReadTokens || 0;
         cacheWriteTokens += response.usage.cacheWriteTokens || 0;
@@ -389,13 +393,14 @@ export async function runAgentTask(options = {}) {
     reason,
     // How many tool calls the model issued (browser/login/done) — can exceed
     // `steps` when a turn batches several — and the token usage the adapters
-    // reported (null fields when the provider didn't return a usage block).
+    // reported. `inputTokens` excludes the cached-read portion so it reflects
+    // fresh input work; `context` below retains the full final prompt size.
     toolCalls: toolCallCount,
     usage: {
       inputTokens,
       outputTokens,
-      // Cached-input breakdown (subsets of the input total, summed across turns)
-      // and `context` = the prompt size at the end of the task (last turn's input).
+      // Cached-input counts summed across turns, and `context` = the full prompt
+      // size at the end of the task (last turn's provider input total).
       cacheReadTokens,
       cacheWriteTokens,
       context: contextTokens,

--- a/tests/node/agent.test.mjs
+++ b/tests/node/agent.test.mjs
@@ -12,6 +12,7 @@ import {
   resolveModel,
   runAgentTask,
 } from "../../src/agent.mjs";
+import { formatAgentUsage, uncachedInputTokens } from "../../src/agent-usage.mjs";
 
 function base64url(buffer) {
   return buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
@@ -83,7 +84,7 @@ test("runAgentTask drives browser then finishes on done", async () => {
   assert.match(toolTurn.results[0].content, /"result":"HN"/);
 });
 
-test("runAgentTask sums token usage and counts every tool call", async () => {
+test("runAgentTask reports uncached input, cache usage, and full final context", async () => {
   const browser = fakeBrowser({
     runs: [
       { ok: true, result: "a", artifacts: [], durationMs: 1 },
@@ -112,15 +113,44 @@ test("runAgentTask sums token usage and counts every tool call", async () => {
 
   // 2 browser + 1 done = 3 tool calls across 2 steps.
   assert.equal(result.toolCalls, 3);
-  assert.equal(result.usage.inputTokens, 150);
+  // User-facing input excludes cache reads per turn: (100 - 60) + (50 - 30).
+  assert.equal(result.usage.inputTokens, 60);
   assert.equal(result.usage.outputTokens, 30);
-  // Cache read/write sum across turns; context is the LAST turn's input size.
+  // Cache read/write sum across turns; context is the LAST turn's full input size.
   assert.equal(result.usage.cacheReadTokens, 90);
   assert.equal(result.usage.cacheWriteTokens, 40);
   assert.equal(result.usage.context, 50);
   // Wall-clock is reported as a non-negative number of milliseconds.
   assert.equal(typeof result.durationMs, "number");
   assert.ok(result.durationMs >= 0);
+});
+
+test("cache-aware usage formatting is shared by every CLI summary", () => {
+  assert.equal(
+    formatAgentUsage({
+      inputTokens: 6880,
+      outputTokens: 1330,
+      cacheReadTokens: 40000,
+      cacheWriteTokens: 2000,
+      context: 20000,
+    }),
+    "6,880 in / 1,330 out · 40,000 cache read · 2,000 cache write · context 20,000",
+  );
+  assert.equal(
+    formatAgentUsage({
+      inputTokens: 6880,
+      outputTokens: 1330,
+      cacheReadTokens: 40000,
+      cacheWriteTokens: 0,
+      context: 20000,
+    }),
+    "6,880 in / 1,330 out · 40,000 cache read · context 20,000",
+  );
+});
+
+test("uncached input cannot become negative when provider usage is inconsistent", () => {
+  assert.equal(uncachedInputTokens(50, 60), 0);
+  assert.equal(uncachedInputTokens(50, 30), 20);
 });
 
 test("runAgentTask reports zeroed usage when the model omits a usage block", async () => {
@@ -532,7 +562,7 @@ test("responsesModel parses batched function_call items from the SSE stream and 
     'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"fc_1","name":"browser","arguments":"{\\"code\\":\\"return 1\\"}"}}',
     'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"fc_2","name":"browser","arguments":"{\\"code\\":\\"return 2\\"}"}}',
     'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"fc_1","name":"browser","arguments":"{\\"code\\":\\"return 1\\"}"}}',
-    'data: {"type":"response.completed","response":{"status":"completed"}}',
+    'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":100,"output_tokens":20,"input_tokens_details":{"cached_tokens":64,"cache_write_tokens":16}}}}',
   ].join("\n\n");
   const fetchImpl = async (url, init) => {
     captured = { url, body: JSON.parse(init.body) };
@@ -549,6 +579,12 @@ test("responsesModel parses batched function_call items from the SSE stream and 
   assert.deepEqual(out.toolCalls.map((c) => c.id), ["fc_1", "fc_2"]);
   assert.deepEqual(out.toolCalls[0].input, { code: "return 1" });
   assert.equal(out.stopReason, "completed");
+  assert.deepEqual(out.usage, {
+    inputTokens: 100,
+    outputTokens: 20,
+    cacheReadTokens: 64,
+    cacheWriteTokens: 16,
+  });
   // Batched tool calls are enabled on the request.
   assert.equal(captured.body.parallel_tool_calls, true);
   assert.match(captured.url, /\/responses$/);

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -94,12 +94,12 @@ export interface AgentResult {
   toolCalls: number;
   /**
    * Token usage summed across turns (fields are 0 when unavailable).
-   * `inputTokens` is the full prompt size (cached tokens included);
-   * `cacheReadTokens` is the part served from cache and `cacheWriteTokens` the
-   * fresh input processed/written to the cache (`inputTokens = cacheRead +
-   * cacheWrite` on OpenAI-style backends). `context` is the prompt size at the
-   * end of the task (the last turn's input) — how much context the model was
-   * holding when it finished.
+   * `inputTokens` excludes the portion served from cache; `cacheReadTokens` is
+   * that cached portion. `cacheWriteTokens` is reported only from a provider's
+   * real cache-write field (0 when unavailable), and can overlap fresh input.
+   * `context` is the full prompt size at the end of the task (the last turn's
+   * provider input total) — how much context the model was holding when it
+   * finished.
    */
   usage: {
     inputTokens: number;


### PR DESCRIPTION
## What changed

- report `usage.inputTokens` as provider input minus cache reads on each turn
- preserve the full final prompt size in `usage.context`
- show cache reads in both `betterwright exec` and interactive CLI summaries
- show cache writes only when a provider reports a positive real count
- add provider-normalization and CLI-formatting coverage
- prepare release `0.8.5`

## Why

Provider input totals include tokens served from prompt cache, which made BetterWright's displayed input cost look substantially higher than the fresh input actually processed. Cache writes also cannot be inferred safely from non-cached input.

## Validation

- `npm run release:check`
- `BETTERWRIGHT_REQUIRE_BROWSER=1 npm test` (204 tests, 199 passed, 5 explicit opt-in/skipped)
- `xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 node --test tests/node/cloak.test.mjs` (4/4)
- real Codex CLI smoke: cache read shown in stderr and JSON
- real Grok CLI smoke: cache read shown in stderr and JSON


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cache-aware usage reporting for agent runs.
  - Usage summaries now show fresh input tokens, output tokens, cache reads, and context size.
  - Cache writes appear only when the provider reports a positive value.
  - JSON results continue to include provider-reported cache read and write totals.

- **Documentation**
  - Updated CLI examples and usage definitions to clarify token and cache accounting.
  - Documented the revised usage fields and context-size semantics.

- **Chores**
  - Released version 0.8.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->