### PR TITLE
fix headed browser command-line warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Removed Chromium's `--host-resolver-rules` launch argument and marked the
+  managed browser as a test-type process so Cloak/Playwright's required root and
+  container arguments no longer produce persistent command-line warning bars.
+  The transport proxy and `NetworkPolicy` continue to enforce metadata blocking.
+
 ## [0.8.5] — 2026-07-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.6] — 2026-07-18
 
 ### Fixed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,17 +75,14 @@ actually relied upon are below it, at the browser and network layer.
 
 The controls that hold even if a snippet found a way around the JS facades:
 
-1. **Browser resolver rules.** The Chromium-derived managed browser is launched
-   with `--host-resolver-rules` mapping
-   cloud-metadata hostnames and link-local ranges to `NOTFOUND`. WebRTC is
-   pinned to the proxy path so it can't send UDP around it.
-2. **A mandatory transport proxy.** All traffic — including localhost — is
+1. **A mandatory transport proxy.** All traffic — including localhost — is
    forced through a loopback SOCKS proxy the worker runs (`bypass: <-loopback>`).
    The proxy authorizes the connect target *and re-authorizes every IP the
    hostname resolved to*, then connects to those exact literals. This closes
    DNS-rebinding and redirect-hop bypasses: Chromium never does a second,
-   unguarded lookup.
-3. **The policy, failing closed.** `NetworkPolicy` answers every `guard`. If it
+   unguarded lookup. WebRTC is pinned to the proxy path so it can't send UDP
+   around it.
+2. **The policy, failing closed.** `NetworkPolicy` answers every `guard`. If it
    errors, the request is denied. Metadata endpoints can't be allowlisted.
 
 These are independent of the sandbox and of each other. See

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -91,21 +91,18 @@ A server-side agent usually runs on a cloud instance whose metadata service
 (`169.254.169.254` and friends) hands out the machine's credentials to anything
 that can make an HTTP request from the box. A prompt-injected page trying to
 read those is one of the sharpest risks in agent browsing. So the block is not
-just a policy default — it is enforced at three independent layers:
+just a policy default — it is enforced at two independent layers:
 
-1. **Chromium resolver rules.** The browser is launched with
-   `--host-resolver-rules` that map every metadata hostname and link-local range
-   to `NOTFOUND` before any page loads.
-2. **The transport guard.** All traffic is forced through the worker's own
+1. **The transport guard.** All traffic is forced through the worker's own
    loopback SOCKS proxy (Chromium cannot bypass it, even for localhost). The
    proxy validates the connect target *and* re-validates every IP the hostname
    resolved to, so a hostname that passes cannot be swapped for a metadata
    address by DNS rebinding.
-3. **The policy.** `NetworkPolicy` refuses metadata hosts and refuses to honor
+2. **The policy.** `NetworkPolicy` refuses metadata hosts and refuses to honor
    an `allowHosts` entry or a `custom` allow that names one.
 
-Any one of these would stop the common case; together they close the redirect
-and rebinding variants too.
+Either layer stops the common case; together they close the redirect and
+rebinding variants too.
 
 ## Failure is closed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/cloak.mjs
+++ b/src/cloak.mjs
@@ -55,6 +55,22 @@ export function managedCloakViewport(binaryInfo, headless) {
   return undefined;
 }
 
+/** Build the explicit Chromium arguments used by the managed Cloak browser. */
+export function managedCloakArgs(fingerprintSeed) {
+  return [
+    // Chromium suppresses bad-flag infobars for automated test browsers when
+    // this recognized switch is present. Cloak/Playwright must retain
+    // --no-sandbox for root and container runtimes, where sandboxed Chromium
+    // cannot launch.
+    "--test-type",
+    // WebRTC is not represented by Playwright request routing and can
+    // otherwise send STUN/data-channel UDP directly around a TCP proxy.
+    // Force it onto the configured proxy/TCP path instead.
+    "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+    `--fingerprint=${fingerprintSeed}`,
+  ];
+}
+
 function cloakEntrypoint() {
   const override = (process.env.BETTERWRIGHT_CLOAKBROWSER_PATH || "").trim();
   if (!override) return "cloakbrowser";

--- a/src/policy.mjs
+++ b/src/policy.mjs
@@ -2,10 +2,9 @@
 //
 // Every request the worker makes is answered by `NetworkPolicy.check`; the
 // conformance vectors in tests/fixtures/policy-vectors.json pin every
-// decision. Two lower layers do not depend on this policy:
-// Chromium's `--host-resolver-rules` NXDOMAIN the metadata hostnames, and all
-// traffic is forced through the worker's loopback SOCKS proxy so even localhost
-// reaches this check.
+// decision. A lower layer does not depend on this policy: all traffic is forced
+// through the worker's loopback SOCKS proxy so even localhost reaches this
+// check.
 
 import net from "node:net";
 

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -5,8 +5,8 @@
 // The model writes normal Playwright JavaScript, but it never receives Node's
 // process, module loader, filesystem, or the route APIs that protect the host's
 // network policy.  This is defense in depth, not a claim that node:vm is a
-// security boundary.  The non-removable metadata endpoint floor is installed
-// on Chromium's command line before any model code can run.
+// security boundary.  The non-removable metadata endpoint floor is enforced by
+// the transport guard and NetworkPolicy before model code can reach the network.
 
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -38,6 +38,7 @@ import {
   assertProfileNotNewer,
   cloakBinaryInfo,
   launchCloakPersistentContext,
+  managedCloakArgs,
   managedCloakViewport,
 } from "./cloak.mjs";
 import {
@@ -75,9 +76,11 @@ const DEFAULT_SCREENSHOT_PIXEL_LIMIT = 40_000_000;
 const SAFE_SYNC_VM_TIMEOUT_MS = 1_000;
 const MAX_ACTIVE_SECRETS = 200;
 
-// Chromium applies these mappings below page/network routing.  They remain in
-// force even if evaluated code finds a way around the best-effort JS facades.
-// Current Chromium spells the resolver failure sentinel "^NOTFOUND".
+/**
+ * @deprecated Retained for source compatibility. BetterWright no longer passes
+ * `--host-resolver-rules` because Chromium displays a persistent unsupported
+ * command-line warning whenever that flag is present.
+ */
 export const METADATA_RESOLVER_RULES = [
   "MAP metadata.google.internal ^NOTFOUND",
   "MAP metadata.goog ^NOTFOUND",
@@ -1232,13 +1235,9 @@ async function ensureBrowser(config) {
     const transportProxyPort = await guardProxy.ensure();
 
     const headless = launchConfig.headless !== false;
-    const args = [
-      `--host-resolver-rules=${METADATA_RESOLVER_RULES}`,
-      // WebRTC is not represented by Playwright request routing and can
-      // otherwise send STUN/data-channel UDP directly around a TCP proxy.
-      // Force it onto the configured proxy/TCP path instead.
-      "--webrtc-ip-handling-policy=disable_non_proxied_udp",
-    ];
+    const args = managedCloakArgs(
+      fingerprintSeedForProfile(profileLock.profileDir),
+    );
     const proxy = {
       server: `socks5://127.0.0.1:${transportProxyPort}`,
       // Chromium otherwise bypasses the proxy for localhost/link-local
@@ -1253,7 +1252,6 @@ async function ensureBrowser(config) {
     // not appear to change hardware on every restart. Its blanket humanizer is
     // intentionally disabled; BetterWright's frame-safe human helpers remain
     // the only model-facing interaction layer.
-    args.push(`--fingerprint=${fingerprintSeedForProfile(profileLock.profileDir)}`);
     const binaryInfo = await cloakBinaryInfo();
     if (!profileLock.ephemeral) {
       assertProfileNotNewer(profileLock.profileDir, binaryInfo?.version);

--- a/tests/node/cloak.test.mjs
+++ b/tests/node/cloak.test.mjs
@@ -5,11 +5,28 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { assertProfileNotNewer, managedCloakViewport } from "../../src/cloak.mjs";
+import {
+  assertProfileNotNewer,
+  managedCloakArgs,
+  managedCloakViewport,
+} from "../../src/cloak.mjs";
 import { BetterWright, NetworkPolicy } from "../../src/index.mjs";
 
 const enabled = process.env.BETTERWRIGHT_CLOAK_E2E === "1";
 const opts = { skip: enabled ? false : "set BETTERWRIGHT_CLOAK_E2E=1" };
+
+test("managed Cloak arguments omit resolver rules and suppress bad-flag bars", () => {
+  const args = managedCloakArgs("12345");
+  assert.deepEqual(args, [
+    "--test-type",
+    "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+    "--fingerprint=12345",
+  ]);
+  assert.equal(
+    args.some((arg) => arg.startsWith("--host-resolver-rules")),
+    false,
+  );
+});
 
 test("managed Cloak viewports stay coherent on affected builds", () => {
   assert.deepEqual(

--- a/types/worker.d.ts
+++ b/types/worker.d.ts
@@ -1,1 +1,5 @@
+/**
+ * @deprecated BetterWright no longer passes `--host-resolver-rules` because
+ * Chromium displays a persistent unsupported command-line warning for it.
+ */
 export const METADATA_RESOLVER_RULES: string;


### PR DESCRIPTION
## What changed

- remove BetterWright's `--host-resolver-rules` Chromium launch argument
- add Chromium's recognized `--test-type` switch so Cloak/Playwright's required root/container `--no-sandbox` argument does not render a warning bar
- keep the transport proxy and `NetworkPolicy` metadata protections active
- update architecture, network-policy, public type documentation, changelog, and package version to 0.8.6
- add a regression test over the exact managed launch arguments

## Root cause

Chromium classifies `--host-resolver-rules` and `--no-sandbox` as bad flags and renders a persistent infobar unless the process is marked as an automated test browser. Removing only BetterWright's resolver flag exposed Cloak's required `--no-sandbox` warning, so both the launch argument and the automation-process marker are handled.

## Validation

- `npm run release:check` — 163 passed, 5 expected skips; types/package smoke passed
- `BETTERWRIGHT_REQUIRE_BROWSER=1 npm test` — 200 passed, 5 expected live-demo skips
- `xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 node --test tests/node/cloak.test.mjs` — 5/5 passed
- real headed navigation to the exact Framework configurator — clean browser chrome, no command-line warning, `navigator.webdriver === false`
- live metadata endpoint block remained green after resolver-flag removal