### PR TITLE
fix: await in-flight worker shutdown

### DIFF
--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -104,7 +104,7 @@ const STEALTH_WARNING =
   "world, so page-defined main-world globals (e.g. window.__NEXT_DATA__) read " +
   "as undefined. DOM access, clicks, and typing are unaffected.";
 let useSetContentCompatibility = false;
-let shuttingDown = false;
+let shutdownPromise = null;
 let activeExecutionSession = null;
 let downloadCdpSession = null;
 let downloadGuardReady = false;
@@ -3391,9 +3391,12 @@ async function execute(message) {
   }
 }
 
-async function shutdown() {
-  if (shuttingDown) return;
-  shuttingDown = true;
+function shutdown() {
+  shutdownPromise ??= performShutdown();
+  return shutdownPromise;
+}
+
+async function performShutdown() {
   // Chromium can emit BrowserContext.close before its process finishes the
   // final profile writes. Preserve the temporary path so shutdown performs a
   // second removal after close() has fully resolved, even if the close event

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -3412,7 +3412,11 @@ async function performShutdown() {
   }
   browserContext = null;
   releaseProfileLock();
-  await guardProxy.close();
+  try {
+    await guardProxy.close();
+  } catch {
+    /* parent/process exit */
+  }
   if (ephemeralProfileDir) {
     try {
       fs.rmSync(ephemeralProfileDir, { recursive: true, force: true });

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -844,6 +844,61 @@ test("timed-out challenge runs report that the page must be reopened", opts, asy
   }
 });
 
+test("timeout restart flushes recent persistent-profile changes", opts, async () => {
+  const server = await listen((_req, res) => {
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end("<title>Profile flush</title><h1>Profile flush</h1>");
+  });
+  const home = tempHome();
+  const seed = new BetterWright({ home, headless: true });
+  try {
+    const stored = await seed.run(`
+      await page.goto(${JSON.stringify(server.origin)});
+      return page.evaluate(() => {
+        document.cookie = 'seeded=alive; Max-Age=3600; Path=/; SameSite=Lax';
+        return document.cookie;
+      });
+    `);
+    assert.equal(stored.ok, true, stored.error);
+    assert.match(stored.result, /seeded=alive/);
+  } finally {
+    await seed.close();
+  }
+
+  const bw = new BetterWright({ home, headless: true });
+  try {
+    const stored = await bw.run(`
+      await page.goto(${JSON.stringify(server.origin)});
+      return page.evaluate(() => {
+        document.cookie = 'recent=alive; Max-Age=3600; Path=/; SameSite=Lax';
+        return document.cookie;
+      });
+    `);
+    assert.equal(stored.ok, true, stored.error);
+    assert.equal(stored.profileMode, "persistent");
+    assert.match(stored.result, /seeded=alive/);
+    assert.match(stored.result, /recent=alive/);
+
+    const timedOut = await bw.run("await new Promise(() => {})", {
+      timeout: 5,
+    });
+    assert.equal(timedOut.ok, false);
+    assert.match(timedOut.error, /timed out/i);
+
+    const restarted = await bw.run(`
+      await page.goto(${JSON.stringify(server.origin)});
+      return page.evaluate(() => document.cookie);
+    `);
+    assert.equal(restarted.ok, true, restarted.error);
+    assert.equal(restarted.profileMode, "persistent");
+    assert.match(restarted.result, /seeded=alive/);
+    assert.match(restarted.result, /recent=alive/);
+  } finally {
+    await bw.close();
+    await server.close();
+  }
+});
+
 test("captcha.click activates a checkbox-style challenge and returns a fresh snapshot", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/browser.test.mjs
+++ b/tests/node/browser.test.mjs
@@ -850,51 +850,54 @@ test("timeout restart flushes recent persistent-profile changes", opts, async ()
     res.end("<title>Profile flush</title><h1>Profile flush</h1>");
   });
   const home = tempHome();
-  const seed = new BetterWright({ home, headless: true });
   try {
-    const stored = await seed.run(`
-      await page.goto(${JSON.stringify(server.origin)});
-      return page.evaluate(() => {
-        document.cookie = 'seeded=alive; Max-Age=3600; Path=/; SameSite=Lax';
-        return document.cookie;
+    const seed = new BetterWright({ home, headless: true });
+    try {
+      const stored = await seed.run(`
+        await page.goto(${JSON.stringify(server.origin)});
+        return page.evaluate(() => {
+          document.cookie = 'seeded=alive; Max-Age=3600; Path=/; SameSite=Lax';
+          return document.cookie;
+        });
+      `);
+      assert.equal(stored.ok, true, stored.error);
+      assert.match(stored.result, /seeded=alive/);
+    } finally {
+      await seed.close();
+    }
+
+    const bw = new BetterWright({ home, headless: true });
+    try {
+      const stored = await bw.run(`
+        await page.goto(${JSON.stringify(server.origin)});
+        return page.evaluate(() => {
+          document.cookie = 'recent=alive; Max-Age=3600; Path=/; SameSite=Lax';
+          return document.cookie;
+        });
+      `);
+      assert.equal(stored.ok, true, stored.error);
+      assert.equal(stored.profileMode, "persistent");
+      assert.match(stored.result, /seeded=alive/);
+      assert.match(stored.result, /recent=alive/);
+
+      const timedOut = await bw.run("await new Promise(() => {})", {
+        timeout: 5,
       });
-    `);
-    assert.equal(stored.ok, true, stored.error);
-    assert.match(stored.result, /seeded=alive/);
+      assert.equal(timedOut.ok, false);
+      assert.match(timedOut.error, /timed out/i);
+
+      const restarted = await bw.run(`
+        await page.goto(${JSON.stringify(server.origin)});
+        return page.evaluate(() => document.cookie);
+      `);
+      assert.equal(restarted.ok, true, restarted.error);
+      assert.equal(restarted.profileMode, "persistent");
+      assert.match(restarted.result, /seeded=alive/);
+      assert.match(restarted.result, /recent=alive/);
+    } finally {
+      await bw.close();
+    }
   } finally {
-    await seed.close();
-  }
-
-  const bw = new BetterWright({ home, headless: true });
-  try {
-    const stored = await bw.run(`
-      await page.goto(${JSON.stringify(server.origin)});
-      return page.evaluate(() => {
-        document.cookie = 'recent=alive; Max-Age=3600; Path=/; SameSite=Lax';
-        return document.cookie;
-      });
-    `);
-    assert.equal(stored.ok, true, stored.error);
-    assert.equal(stored.profileMode, "persistent");
-    assert.match(stored.result, /seeded=alive/);
-    assert.match(stored.result, /recent=alive/);
-
-    const timedOut = await bw.run("await new Promise(() => {})", {
-      timeout: 5,
-    });
-    assert.equal(timedOut.ok, false);
-    assert.match(timedOut.error, /timed out/i);
-
-    const restarted = await bw.run(`
-      await page.goto(${JSON.stringify(server.origin)});
-      return page.evaluate(() => document.cookie);
-    `);
-    assert.equal(restarted.ok, true, restarted.error);
-    assert.equal(restarted.profileMode, "persistent");
-    assert.match(restarted.result, /seeded=alive/);
-    assert.match(restarted.result, /recent=alive/);
-  } finally {
-    await bw.close();
     await server.close();
   }
 });


### PR DESCRIPTION
## Summary

- make worker shutdown re-entrant by returning one shared in-flight shutdown promise
- add a browser regression test proving recent persistent-profile state survives a timeout-triggered worker restart

## Root cause

On `BW_TIMEOUT`, the worker sends `restartWorker: true` and schedules its own `shutdown().finally(process.exit(1))`. The client receives that result and calls `close()`, which ends worker stdin. The worker's stdin `close` handler then calls `shutdown().finally(process.exit(0))` a second time.

Previously, `shutdown()` guarded re-entry with a boolean and returned immediately for the second caller. That returned promise settled before the first shutdown finished, allowing the second `process.exit()` to terminate the worker before `browserContext.close()` flushed recent profile writes.

A trace of the failing path showed the stdin-close exit occurring before the first shutdown reached `browserContext.close()`.

## Regression test

The new test:

1. creates a persistent cookie and flushes it through a normal close;
2. reopens the same profile and creates a second persistent cookie;
3. forces `BW_TIMEOUT` with a pending promise;
4. verifies the replacement worker sees both the previously flushed cookie and the recent cookie.

On current `main`, only the previously flushed cookie survives. With this patch, both survive.

## Validation

- new regression test passes in 3 consecutive runs
- `tests/node/browser.test.mjs`: 40/40 pass
- TypeScript package tests: pass
- Biome checks for the changed files: pass
- LSP diagnostics for the changed files: clean
