### PR TITLE
guard-proxy: back off repeated failing CONNECTs to stop retry storms

### DIFF
--- a/src/guard-proxy.mjs
+++ b/src/guard-proxy.mjs
@@ -15,6 +15,17 @@ const SOCKS_HANDSHAKE_TIMEOUT_MS = 15_000;
 const SOCKS_CONNECT_TIMEOUT_MS = 10_000;
 const MAX_SOCKS_HANDSHAKE_BYTES = 8_192;
 
+// Repeated identical CONNECT failures back off before the SOCKS failure
+// reply. Browsers retry immediately on a failure reply, so an instant reject
+// (~1 ms for ENETUNREACH literals or DNS misses) lets a single unreachable
+// target spin the worker at thousands of connections per second and peg a
+// core. Delaying only *repeated* failures caps that loop at a harmless rate
+// while leaving first attempts and reachable targets untouched.
+const FAILURE_BACKOFF_INITIAL_MS = 250;
+const FAILURE_BACKOFF_MAX_MS = 5_000;
+const FAILURE_BACKOFF_FORGET_MS = 30_000;
+const FAILURE_BACKOFF_MAX_KEYS = 1_024;
+
 function transportUrl(host, port) {
   const scheme = port === 80 ? "http:" : "https:";
   const urlHost = net.isIP(host) === 6 ? `[${host}]` : host;
@@ -42,6 +53,54 @@ export function createGuardProxy({ guardUrl, executeId }) {
   let guardProxyServer = null;
   let guardProxyPort = null;
   const guardProxySockets = new Set();
+  const connectFailures = new Map();
+
+  // Returns how long to hold the failure reply for this target. Entries decay
+  // after FAILURE_BACKOFF_FORGET_MS so a recovered target is retried for real,
+  // and the map is bounded because a hostile page can spray distinct targets.
+  function noteConnectFailure(host, port) {
+    const key = `${host}|${port}`;
+    const now = Date.now();
+    const entry = connectFailures.get(key);
+    const count =
+      entry && now - entry.last <= FAILURE_BACKOFF_FORGET_MS
+        ? entry.count + 1
+        : 1;
+    connectFailures.delete(key);
+    connectFailures.set(key, { count, last: now });
+    if (connectFailures.size > FAILURE_BACKOFF_MAX_KEYS) {
+      for (const [staleKey, stale] of connectFailures)
+        if (now - stale.last > FAILURE_BACKOFF_FORGET_MS)
+          connectFailures.delete(staleKey);
+      // Still over the cap: insertion order approximates least-recently-failed
+      // because every update re-inserts, so evict from the front.
+      while (connectFailures.size > FAILURE_BACKOFF_MAX_KEYS)
+        connectFailures.delete(connectFailures.keys().next().value);
+    }
+    if (count < 2) return 0;
+    return Math.min(
+      FAILURE_BACKOFF_INITIAL_MS * 2 ** (count - 2),
+      FAILURE_BACKOFF_MAX_MS,
+    );
+  }
+
+  function clearConnectFailure(host, port) {
+    connectFailures.delete(`${host}|${port}`);
+  }
+
+  // Abortable hold: resolves early if the client goes away mid-delay so a
+  // closed socket never pins a timer for seconds.
+  function holdReply(socket, ms) {
+    return new Promise((resolve) => {
+      const done = () => {
+        clearTimeout(timer);
+        socket.off("close", done);
+        resolve();
+      };
+      const timer = setTimeout(done, ms);
+      socket.once("close", done);
+    });
+  }
 
   async function guardedTransportAddresses(host, port) {
     const attribution = executeId();
@@ -224,6 +283,7 @@ export function createGuardProxy({ guardUrl, executeId }) {
           client.off("data", onData);
           try {
             const upstream = await connectGuardedTarget(host, port);
+            clearConnectFailure(host, port);
             if (client.destroyed) {
               upstream.destroy();
               return;
@@ -234,6 +294,14 @@ export function createGuardProxy({ guardUrl, executeId }) {
             client.pipe(upstream).pipe(client);
             client.resume();
           } catch (error) {
+            // Policy denials stay instant: they are deliberate decisions, not
+            // transient network failures, and pages routinely re-request
+            // blocked resources during normal use.
+            if (error?.code !== "BW_PROXY_BLOCKED") {
+              const delayMs = noteConnectFailure(host, port);
+              if (delayMs && !client.destroyed)
+                await holdReply(client, delayMs);
+            }
             reject(
               error?.code === "BW_PROXY_BLOCKED"
                 ? 2
@@ -284,6 +352,7 @@ export function createGuardProxy({ guardUrl, executeId }) {
     const server = guardProxyServer;
     guardProxyServer = null;
     guardProxyPort = null;
+    connectFailures.clear();
     for (const socket of guardProxySockets) socket.destroy();
     guardProxySockets.clear();
     if (!server) return;

--- a/tests/node/guard-proxy.test.mjs
+++ b/tests/node/guard-proxy.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import { test } from "node:test";
+
+import { createGuardProxy } from "../../src/guard-proxy.mjs";
+
+// Drive the proxy as a real SOCKS5 client: greeting, CONNECT to `host:port`
+// (hostname form), resolve with the reply code once it arrives.
+function socksConnect(proxyPort, host, port) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port: proxyPort });
+    let greeted = false;
+    socket.on("connect", () => socket.write(Buffer.from([5, 1, 0])));
+    socket.on("data", (data) => {
+      if (!greeted) {
+        greeted = true;
+        const request = Buffer.alloc(7 + host.length);
+        request.set([5, 1, 0, 3, host.length]);
+        request.write(host, 5);
+        request.writeUInt16BE(port, 5 + host.length);
+        socket.write(request);
+        return;
+      }
+      socket.destroy();
+      resolve(data[1]);
+    });
+    socket.on("error", reject);
+  });
+}
+
+async function withProxy(guardUrl, run) {
+  const proxy = createGuardProxy({
+    guardUrl,
+    executeId: () => "test",
+  });
+  const port = await proxy.ensure();
+  try {
+    return await run(port);
+  } finally {
+    await proxy.close();
+  }
+}
+
+const allowAll = async () => ({ allowed: true });
+
+// A listener that immediately refuses nothing but is closed before use gives a
+// deterministic local connection failure (ECONNREFUSED) with no network access.
+async function refusedPort() {
+  const server = net.createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+test("repeated failing CONNECTs to one target back off", async () => {
+  const port = await refusedPort();
+  await withProxy(allowAll, async (proxyPort) => {
+    const start = Date.now();
+    const codes = [];
+    for (let i = 0; i < 4; i++)
+      codes.push(await socksConnect(proxyPort, "127.0.0.1", port));
+    const elapsed = Date.now() - start;
+    assert.deepEqual(codes, [5, 5, 5, 5]);
+    // Delays: 0 + 250 + 500 + 1000 ms; allow generous scheduling slack.
+    assert.ok(elapsed >= 1500, `expected backoff, elapsed ${elapsed}ms`);
+  });
+});
+
+test("first failure replies fast and distinct targets are independent", async () => {
+  const portA = await refusedPort();
+  const portB = await refusedPort();
+  await withProxy(allowAll, async (proxyPort) => {
+    // Prime target A with repeated failures.
+    for (let i = 0; i < 3; i++)
+      await socksConnect(proxyPort, "127.0.0.1", portA);
+    // Target B's first failure must not inherit A's backoff.
+    const start = Date.now();
+    assert.equal(await socksConnect(proxyPort, "127.0.0.1", portB), 5);
+    assert.ok(Date.now() - start < 200, "first failure should be instant");
+  });
+});
+
+test("DNS failures back off too", async () => {
+  await withProxy(allowAll, async (proxyPort) => {
+    const host = "bw-guard-proxy-test.invalid";
+    const start = Date.now();
+    const codes = [];
+    for (let i = 0; i < 3; i++)
+      codes.push(await socksConnect(proxyPort, host, 443));
+    const elapsed = Date.now() - start;
+    assert.deepEqual(codes, [4, 4, 4]);
+    // Delays: 0 + 250 + 500 ms.
+    assert.ok(elapsed >= 600, `expected backoff, elapsed ${elapsed}ms`);
+  });
+});
+
+test("policy denials stay instant", async () => {
+  const deny = async () => ({ allowed: false, reason: "test" });
+  await withProxy(deny, async (proxyPort) => {
+    const start = Date.now();
+    for (let i = 0; i < 5; i++)
+      assert.equal(await socksConnect(proxyPort, "127.0.0.1", 9), 2);
+    assert.ok(Date.now() - start < 500, "blocked replies must not back off");
+  });
+});
+
+test("a successful connect clears the failure state", async () => {
+  const server = net.createServer((socket) => socket.end());
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  // Fail twice against the closed port, then reopen it and connect for real.
+  await withProxy(allowAll, async (proxyPort) => {
+    await socksConnect(proxyPort, "127.0.0.1", port);
+    await socksConnect(proxyPort, "127.0.0.1", port);
+    const revived = net.createServer((socket) => socket.end());
+    await new Promise((resolve) => revived.listen(port, "127.0.0.1", resolve));
+    try {
+      assert.equal(await socksConnect(proxyPort, "127.0.0.1", port), 0);
+      // Close it again: the next failure must be treated as a first failure.
+      await new Promise((resolve) => revived.close(resolve));
+      const start = Date.now();
+      assert.equal(await socksConnect(proxyPort, "127.0.0.1", port), 5);
+      assert.ok(Date.now() - start < 200, "failure state should have reset");
+    } finally {
+      await new Promise((resolve) => revived.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
Fixes #29.

## Problem

Browsers retry immediately when a SOCKS CONNECT fails. The guard proxy replies to failures instantly (~1 ms), so a target that fails fast lets the retry loop spin at thousands of connections per second and peg the worker's core. Two real-world variants (details in #29, both triggered by Cloudflare Turnstile):

1. **IPv6 literal without a v6 route** — Chromium hands the proxy a v6 literal; `net.isIP()` short-circuits to a single candidate (no cross-family fallback), `connect()` fails `ENETUNREACH` in ~1 ms. Observed ~1300–2600 connects/sec, all failing.
2. **AAAA-only hostname with IPv6 disabled** — Turnstile's IPv6 probe (`brunhild.challenges.cloudflare.com`, no A records) fails `dns.lookup` → instant SOCKS deny. Observed ~3800 accepts/sec, zero upstream connects.

The retry driver is external (the browser reacting to the failure reply), so caching failures alone would only make rejects faster. The load-bearing observation: the existing 10 s connect-*timeout* path never storms — a delay before the failure reply is what breaks the loop.

## Change

Hold the SOCKS failure reply with an escalating per-`(host, port)` delay on repeated identical failures:

- first failure replies instantly (normal pages hit dead hosts occasionally);
- subsequent failures within 30 s: 250 ms doubling to a 5 s cap;
- a successful connect or 30 s of quiet resets the target;
- the failure map is bounded (1024 keys; expired entries evicted first, then oldest);
- the delay aborts early if the client disconnects, so closed sockets never pin timers;
- policy denials (`BW_PROXY_BLOCKED`) intentionally stay instant — they are deliberate decisions, not transient network failures.

This covers both variants and anything else a page can invent, since it keys on the observable behavior (repeated identical failures) rather than a specific root cause. No config knobs.

## Numbers

Failure-reply throughput, sequential SOCKS client hammering one unreachable target (Linux, Node 24):

| scenario | before | after |
|---|---|---|
| IPv6 literal, no v6 route | ~14,000 replies/sec | ~1/sec |
| AAAA-only hostname | ~3,900 replies/sec | ~1/sec |

End-to-end with the originally affected Cloudflare-fronted site open: worker previously sat at 40–100% CPU indefinitely (strace over 3 s: ~54k `epoll_pwait`, ~12k `socket`/`connect`/`close`, all connects failing); with this patch the worker idles at <1% CPU with a near-empty strace, tested with IPv6 both enabled and disabled.

## Tests

`tests/node/guard-proxy.test.mjs` — offline-deterministic (closed local ports, `.invalid` hostname): backoff timing on repeated failures, per-target independence, DNS-failure backoff, policy denials stay instant, reset after a successful connect. `npm run lint` and `npm test` pass (one pre-existing env-dependent failure in `agent.test.mjs` — codex credentials present on the machine — also fails on clean `main`).