### PR TITLE
Fix guard proxy connection storms

### DIFF
--- a/src/guard-proxy.mjs
+++ b/src/guard-proxy.mjs
@@ -14,6 +14,13 @@ import net from "node:net";
 const SOCKS_HANDSHAKE_TIMEOUT_MS = 15_000;
 const SOCKS_CONNECT_TIMEOUT_MS = 10_000;
 const MAX_SOCKS_HANDSHAKE_BYTES = 8_192;
+const FAMILY_UNREACHABLE_TTL_MS = 30_000;
+const FAILURE_BACKOFF_BASE_MS = 25;
+const FAILURE_BACKOFF_MAX_MS = 1_000;
+const FAILURE_BACKOFF_RESET_MS = 30_000;
+const FAILURE_COOLDOWN_MS = 1_000;
+const MAX_FAILURE_TARGETS = 256;
+const FAMILY_UNREACHABLE_CODES = new Set(["ENETUNREACH", "EAFNOSUPPORT"]);
 
 function transportUrl(host, port) {
   const scheme = port === 80 ? "http:" : "https:";
@@ -31,6 +38,15 @@ function socksReply(code) {
   return Buffer.from([5, code, 0, 1, 0, 0, 0, 0, 0, 0]);
 }
 
+function socksReplyCode(error) {
+  if (error?.code === "BW_PROXY_BLOCKED") return 2;
+  if (error?.code === "ENETUNREACH") return 3;
+  if (["BW_PROXY_DNS", "EHOSTUNREACH"].includes(error?.code)) return 4;
+  if (error?.code === "ECONNREFUSED") return 5;
+  if (error?.code === "EAFNOSUPPORT") return 8;
+  return 1;
+}
+
 function ipv6FromBytes(value) {
   const groups = [];
   for (let offset = 0; offset < 16; offset += 2)
@@ -38,28 +54,204 @@ function ipv6FromBytes(value) {
   return groups.join(":");
 }
 
-export function createGuardProxy({ guardUrl, executeId }) {
+function positiveInteger(value, fallback) {
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function waitFor(delayMs) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
+}
+
+export function createGuardProxy({ guardUrl, executeId, transport = {} }) {
   let guardProxyServer = null;
   let guardProxyPort = null;
   const guardProxySockets = new Set();
+  const unavailableFamilies = new Map();
+  const targetFailures = new Map();
+  const pendingFailureDelays = new Set();
+  let stateGeneration = 0;
+  // Hooks make transport failures deterministic in tests without depending on
+  // the host's IPv6 configuration. Production uses Node's DNS, TCP, and clock.
+  const lookup =
+    typeof transport.lookup === "function" ? transport.lookup : dns.lookup;
+  const dial = typeof transport.connect === "function" ? transport.connect : null;
+  const now = typeof transport.now === "function" ? transport.now : Date.now;
+  const delay = typeof transport.delay === "function" ? transport.delay : waitFor;
+  const familyUnreachableTtlMs = positiveInteger(
+    transport.familyUnreachableTtlMs,
+    FAMILY_UNREACHABLE_TTL_MS,
+  );
+  const failureBackoffBaseMs = positiveInteger(
+    transport.failureBackoffBaseMs,
+    FAILURE_BACKOFF_BASE_MS,
+  );
+  const failureBackoffMaxMs = Math.max(
+    failureBackoffBaseMs,
+    positiveInteger(transport.failureBackoffMaxMs, FAILURE_BACKOFF_MAX_MS),
+  );
+  const failureBackoffResetMs = positiveInteger(
+    transport.failureBackoffResetMs,
+    FAILURE_BACKOFF_RESET_MS,
+  );
+  const failureCooldownMs = positiveInteger(
+    transport.failureCooldownMs,
+    FAILURE_COOLDOWN_MS,
+  );
+  const maxFailureTargets = positiveInteger(
+    transport.maxFailureTargets,
+    MAX_FAILURE_TARGETS,
+  );
 
-  async function guardedTransportAddresses(host, port) {
-    const attribution = executeId();
-    const target = transportUrl(host, port);
+  function targetKey(host, port) {
+    const normalized = String(host).toLowerCase();
+    return `${net.isIP(normalized) === 6 ? `[${normalized}]` : normalized}:${port}`;
+  }
+
+  function unavailableFamilyError(family) {
+    const cached = unavailableFamilies.get(family);
+    if (!cached) return null;
+    if (cached.expiresAt <= now()) {
+      unavailableFamilies.delete(family);
+      return null;
+    }
+    const error = new Error("Browser transport address family is temporarily unreachable");
+    error.code = cached.code;
+    return error;
+  }
+
+  function rememberUnavailableFamily(family, error) {
+    if (![4, 6].includes(family) || !FAMILY_UNREACHABLE_CODES.has(error?.code))
+      return;
+    unavailableFamilies.delete(family);
+    unavailableFamilies.set(family, {
+      code: error.code,
+      expiresAt: now() + familyUnreachableTtlMs,
+    });
+  }
+
+  function trimTargetFailures() {
+    while (targetFailures.size > maxFailureTargets) {
+      let candidate = null;
+      for (const [key, state] of targetFailures) {
+        candidate ??= key;
+        if (!state.probing) {
+          candidate = key;
+          break;
+        }
+      }
+      targetFailures.delete(candidate);
+    }
+  }
+
+  function beginTargetAttempt(key, generation) {
+    if (generation !== stateGeneration) return { stale: true };
+    const state = targetFailures.get(key);
+    if (!state) return { state: null };
+    targetFailures.delete(key);
+    targetFailures.set(key, state);
+    if (state.retryAt > now() || state.probing) return { suppressed: true, state };
+    state.probing = true;
+    return { state };
+  }
+
+  function rememberTargetFailure(
+    key,
+    error,
+    previous,
+    generation,
+    { probeCompleted = false } = {},
+  ) {
+    if (generation !== stateGeneration) return null;
+    const timestamp = now();
+    const current = targetFailures.get(key) || previous;
+    const failures =
+      current && timestamp - current.at < failureBackoffResetMs
+        ? current.failures + 1
+        : 1;
+    const exponent = Math.min(failures - 1, 30);
+    const delayMs = Math.min(
+      failureBackoffMaxMs,
+      failureBackoffBaseMs * 2 ** exponent,
+    );
+    targetFailures.delete(key);
+    targetFailures.set(key, {
+      at: timestamp,
+      code: error?.code || "BW_PROXY_CONNECT",
+      delayMs,
+      failures,
+      probing: probeCompleted ? false : Boolean(current?.probing),
+      retryAt: timestamp + failureCooldownMs,
+    });
+    trimTargetFailures();
+    return delayMs;
+  }
+
+  async function waitForFailureDelay(delayMs, generation) {
+    if (!delayMs || generation !== stateGeneration) return;
+    let cancel;
+    const cancelled = new Promise((resolve) => {
+      cancel = resolve;
+      pendingFailureDelays.add(resolve);
+    });
+    const scheduled = Promise.resolve()
+      .then(() => delay(delayMs))
+      .catch(() => {});
+    try {
+      await Promise.race([scheduled, cancelled]);
+    } finally {
+      pendingFailureDelays.delete(cancel);
+    }
+  }
+
+  function cachedTargetError(state) {
+    const error = new Error("Browser transport target is temporarily unavailable");
+    error.code = state?.code || "BW_PROXY_CONNECT";
+    return error;
+  }
+
+  async function rejectCachedTarget(state, generation) {
+    await waitForFailureDelay(state.delayMs, generation);
+    throw cachedTargetError(state);
+  }
+
+  async function rejectTargetFailure(
+    key,
+    error,
+    previous,
+    generation,
+    options,
+  ) {
+    const delayMs = rememberTargetFailure(
+      key,
+      error,
+      previous,
+      generation,
+      options,
+    );
+    await waitForFailureDelay(delayMs, generation);
+    throw error;
+  }
+
+  async function guardTransportTarget(host, port, attribution) {
     const targetDecision = await guardUrl(
-      target,
+      transportUrl(host, port),
       { method: "CONNECT", resourceType: "transport" },
       attribution,
     );
     if (!targetDecision?.allowed)
       throw proxyBlockedError(targetDecision?.reason);
+  }
 
+  async function guardedTransportAddresses(host, port, attribution) {
     let addresses;
     const family = net.isIP(host);
     if (family) addresses = [{ address: host, family }];
     else {
       try {
-        addresses = await dns.lookup(host, { all: true, verbatim: false });
+        addresses = await lookup(host, { all: true, verbatim: false });
       } catch {
         const error = new Error("Browser transport DNS resolution failed");
         error.code = "BW_PROXY_DNS";
@@ -99,7 +291,11 @@ export function createGuardProxy({ guardUrl, executeId }) {
     return socket;
   }
 
-  function connectAddress(address, port) {
+  function connectSocket(address, port) {
+    if (dial)
+      return Promise.resolve(
+        dial({ host: address.address, port, family: address.family }),
+      );
     return new Promise((resolve, reject) => {
       const socket = trackProxySocket(
         net.createConnection({
@@ -126,19 +322,65 @@ export function createGuardProxy({ guardUrl, executeId }) {
     });
   }
 
-  async function connectGuardedTarget(host, port) {
-    const addresses = await guardedTransportAddresses(host, port);
-    let lastError = null;
-    for (const address of addresses) {
-      try {
-        return await connectAddress(address, port);
-      } catch (error) {
-        lastError = error;
+  async function connectAddress(address, port, generation) {
+    if (generation !== stateGeneration) throw cachedTargetError();
+    const suppressed = unavailableFamilyError(address.family);
+    if (suppressed) throw suppressed;
+    try {
+      const socket = await connectSocket(address, port);
+      if (generation !== stateGeneration) {
+        socket.destroy();
+        throw cachedTargetError();
       }
+      unavailableFamilies.delete(address.family);
+      return dial ? trackProxySocket(socket) : socket;
+    } catch (error) {
+      if (generation === stateGeneration)
+        rememberUnavailableFamily(address.family, error);
+      throw error;
     }
-    const error = new Error("Browser transport could not reach the target");
-    error.code = lastError?.code || "BW_PROXY_CONNECT";
-    throw error;
+  }
+
+  async function connectGuardedTarget(host, port) {
+    const key = targetKey(host, port);
+    const generation = stateGeneration;
+    const attribution = executeId();
+    try {
+      await guardTransportTarget(host, port, attribution);
+    } catch (error) {
+      return rejectTargetFailure(
+        key,
+        error,
+        targetFailures.get(key),
+        generation,
+      );
+    }
+
+    const attempt = beginTargetAttempt(key, generation);
+    if (attempt.stale) throw cachedTargetError();
+    if (attempt.suppressed)
+      return rejectCachedTarget(attempt.state, generation);
+
+    try {
+      const addresses = await guardedTransportAddresses(host, port, attribution);
+      let lastError = null;
+      for (const address of addresses) {
+        try {
+          const socket = await connectAddress(address, port, generation);
+          if (generation === stateGeneration) targetFailures.delete(key);
+          return socket;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      const error = new Error("Browser transport could not reach the target");
+      error.code = lastError?.code || "BW_PROXY_CONNECT";
+      throw error;
+    } catch (error) {
+      return rejectTargetFailure(key, error, attempt.state, generation, {
+        probeCompleted: true,
+      });
+    }
   }
 
   function handleGuardProxyClient(client) {
@@ -234,13 +476,7 @@ export function createGuardProxy({ guardUrl, executeId }) {
             client.pipe(upstream).pipe(client);
             client.resume();
           } catch (error) {
-            reject(
-              error?.code === "BW_PROXY_BLOCKED"
-                ? 2
-                : error?.code === "BW_PROXY_DNS"
-                  ? 4
-                  : 5,
-            );
+            reject(socksReplyCode(error));
           }
           return;
         }
@@ -284,6 +520,11 @@ export function createGuardProxy({ guardUrl, executeId }) {
     const server = guardProxyServer;
     guardProxyServer = null;
     guardProxyPort = null;
+    stateGeneration += 1;
+    unavailableFamilies.clear();
+    targetFailures.clear();
+    for (const cancel of pendingFailureDelays) cancel();
+    pendingFailureDelays.clear();
     for (const socket of guardProxySockets) socket.destroy();
     guardProxySockets.clear();
     if (!server) return;

--- a/tests/node/guard-proxy.test.mjs
+++ b/tests/node/guard-proxy.test.mjs
@@ -1,0 +1,567 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import net from "node:net";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+
+import { createGuardProxy } from "../../src/guard-proxy.mjs";
+
+const IPV6_ONE = "2001:db8:0:0:0:0:0:1";
+const IPV6_TWO = "2001:db8:0:0:0:0:0:2";
+
+function codedError(code) {
+  const error = new Error(`test transport error: ${code}`);
+  error.code = code;
+  return error;
+}
+
+function requestBytes(host, port = 443) {
+  let address;
+  let addressType;
+  const family = net.isIP(host);
+  if (family === 4) {
+    addressType = 1;
+    address = Buffer.from(host.split(".").map(Number));
+  } else if (family === 6) {
+    addressType = 4;
+    const groups = host.split(":");
+    assert.equal(groups.length, 8, "test IPv6 literals must be fully expanded");
+    address = Buffer.alloc(16);
+    for (let index = 0; index < groups.length; index += 1)
+      address.writeUInt16BE(Number.parseInt(groups[index], 16), index * 2);
+  } else {
+    const encoded = Buffer.from(host);
+    assert.ok(encoded.length > 0 && encoded.length <= 255);
+    addressType = 3;
+    address = Buffer.concat([Buffer.from([encoded.length]), encoded]);
+  }
+  const encodedPort = Buffer.alloc(2);
+  encodedPort.writeUInt16BE(port);
+  return Buffer.concat([Buffer.from([5, 1, 0, addressType]), address, encodedPort]);
+}
+
+function readBytes(socket, minimum) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let length = 0;
+    const timer = setTimeout(() => finish(new Error("timed out reading SOCKS reply")), 2_000);
+    const finish = (error, value) => {
+      clearTimeout(timer);
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      if (error) reject(error);
+      else resolve(value);
+    };
+    const onData = (chunk) => {
+      chunks.push(chunk);
+      length += chunk.length;
+      if (length >= minimum)
+        finish(null, Buffer.concat(chunks, length).subarray(0, minimum));
+    };
+    const onError = (error) => finish(error);
+    const onClose = () => finish(new Error("SOCKS socket closed before its reply"));
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+async function socksConnect(proxyPort, host, port = 443) {
+  const client = net.createConnection({ host: "127.0.0.1", port: proxyPort });
+  try {
+    await once(client, "connect");
+    client.write(Buffer.from([5, 1, 0]));
+    assert.deepEqual(await readBytes(client, 2), Buffer.from([5, 0]));
+    client.write(requestBytes(host, port));
+    const reply = await readBytes(client, 10);
+    return reply[1];
+  } finally {
+    client.destroy();
+  }
+}
+
+function proxyOptions(transport = {}, guardUrl = async () => ({ allowed: true })) {
+  return {
+    guardUrl,
+    executeId: () => "guard-proxy-test",
+    transport,
+  };
+}
+
+async function waitUntil(predicate) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error("condition was not reached");
+}
+
+function timedDelay(delays, paddingMs = 25) {
+  return (milliseconds) =>
+    new Promise((resolve) => {
+      delays.push(milliseconds);
+      setTimeout(resolve, milliseconds + paddingMs);
+    });
+}
+
+test("family unreachability suppresses new dials without skipping guard checks", async () => {
+  let dialCount = 0;
+  const guardCalls = [];
+  const proxy = createGuardProxy(
+    proxyOptions(
+      {
+        connect: async () => {
+          dialCount += 1;
+          throw codedError("ENETUNREACH");
+        },
+        delay: async () => {},
+        familyUnreachableTtlMs: 100,
+      },
+      async (url, details) => {
+        guardCalls.push({ url, details });
+        return { allowed: true };
+      },
+    ),
+  );
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, IPV6_ONE), 3);
+    assert.equal(await socksConnect(port, IPV6_TWO), 3);
+    assert.equal(dialCount, 1);
+    assert.equal(guardCalls.length, 4);
+    assert.ok(guardCalls.every(({ details }) => details.method === "CONNECT"));
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("family suppression expires at its bounded TTL", async () => {
+  let clock = 1_000;
+  let dialCount = 0;
+  const proxy = createGuardProxy(
+    proxyOptions({
+      connect: async () => {
+        dialCount += 1;
+        throw codedError("EAFNOSUPPORT");
+      },
+      delay: async () => {},
+      now: () => clock,
+      familyUnreachableTtlMs: 100,
+      failureBackoffBaseMs: 5,
+      failureCooldownMs: 5,
+    }),
+  );
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, IPV6_ONE), 8);
+    clock += 5;
+    assert.equal(await socksConnect(port, IPV6_ONE), 8);
+    assert.equal(dialCount, 1);
+    clock = 1_100;
+    assert.equal(await socksConnect(port, IPV6_ONE), 8);
+    assert.equal(dialCount, 2);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("open target cooldown suppresses DNS and connect work", async (t) => {
+  await t.test("DNS failure", async () => {
+    let lookupCount = 0;
+    let topLevelChecks = 0;
+    const delays = [];
+    const proxy = createGuardProxy(
+      proxyOptions(
+        {
+          lookup: async () => {
+            lookupCount += 1;
+            throw codedError("ENOTFOUND");
+          },
+          delay: timedDelay(delays),
+          failureBackoffBaseMs: 5,
+          failureBackoffMaxMs: 20,
+          failureCooldownMs: 250,
+        },
+        async (_url, details) => {
+          if (details.resourceType === "transport") topLevelChecks += 1;
+          return { allowed: true };
+        },
+      ),
+    );
+    try {
+      const port = await proxy.ensure();
+      assert.equal(await socksConnect(port, "missing.test"), 4);
+      assert.equal(await socksConnect(port, "missing.test"), 4);
+      assert.equal(lookupCount, 1);
+      assert.equal(topLevelChecks, 2);
+      assert.deepEqual(delays, [5, 5]);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  await t.test("fast connection failure", async () => {
+    let lookupCount = 0;
+    let dialCount = 0;
+    let topLevelChecks = 0;
+    let addressChecks = 0;
+    const delays = [];
+    const proxy = createGuardProxy(
+      proxyOptions(
+        {
+          lookup: async () => {
+            lookupCount += 1;
+            return [{ address: "192.0.2.20", family: 4 }];
+          },
+          connect: async () => {
+            dialCount += 1;
+            throw codedError("ECONNREFUSED");
+          },
+          delay: timedDelay(delays),
+          failureBackoffBaseMs: 5,
+          failureBackoffMaxMs: 20,
+          failureCooldownMs: 250,
+        },
+        async (_url, details) => {
+          if (details.resourceType === "transport") topLevelChecks += 1;
+          else addressChecks += 1;
+          return { allowed: true };
+        },
+      ),
+    );
+    try {
+      const port = await proxy.ensure();
+      assert.equal(await socksConnect(port, "refused.test"), 5);
+      assert.equal(await socksConnect(port, "refused.test"), 5);
+      assert.equal(lookupCount, 1);
+      assert.equal(dialCount, 1);
+      assert.equal(topLevelChecks, 2);
+      assert.equal(addressChecks, 1);
+      assert.deepEqual(delays, [5, 5]);
+    } finally {
+      await proxy.close();
+    }
+  });
+});
+
+test("guard failures use bounded exponential delay without bypassing policy", async () => {
+  let guardCount = 0;
+  let lookupCount = 0;
+  let dialCount = 0;
+  const delays = [];
+  const proxy = createGuardProxy(
+    proxyOptions(
+      {
+        lookup: async () => {
+          lookupCount += 1;
+          return [{ address: "192.0.2.21", family: 4 }];
+        },
+        connect: async () => {
+          dialCount += 1;
+          throw codedError("ECONNREFUSED");
+        },
+        delay: async (milliseconds) => delays.push(milliseconds),
+        now: () => 1_000,
+        failureBackoffBaseMs: 5,
+        failureBackoffMaxMs: 20,
+        failureCooldownMs: 250,
+      },
+      async () => {
+        guardCount += 1;
+        return { allowed: false, reason: "test policy" };
+      },
+    ),
+  );
+  try {
+    const port = await proxy.ensure();
+    for (let attempt = 0; attempt < 4; attempt += 1)
+      assert.equal(await socksConnect(port, "blocked.test"), 2);
+    assert.equal(guardCount, 4);
+    assert.equal(lookupCount, 0);
+    assert.equal(dialCount, 0);
+    assert.deepEqual(delays, [5, 10, 20, 20]);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("an expired cooldown admits only one half-open DNS probe", async () => {
+  let clock = 1_000;
+  let lookupCount = 0;
+  let topLevelChecks = 0;
+  let denyNextTarget = false;
+  let rejectProbe;
+  const proxy = createGuardProxy(
+    proxyOptions(
+      {
+        lookup: async () => {
+          lookupCount += 1;
+          if (lookupCount === 1) throw codedError("ENOTFOUND");
+          if (lookupCount === 2)
+            return new Promise((_resolve, reject) => {
+              rejectProbe = reject;
+            });
+          throw codedError("ENOTFOUND");
+        },
+        delay: async () => {},
+        now: () => clock,
+        failureBackoffBaseMs: 5,
+        failureCooldownMs: 20,
+      },
+      async (_url, details) => {
+        if (details.resourceType === "transport") {
+          topLevelChecks += 1;
+          if (denyNextTarget) {
+            denyNextTarget = false;
+            return { allowed: false, reason: "test policy" };
+          }
+        }
+        return { allowed: true };
+      },
+    ),
+  );
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "probe.test"), 4);
+
+    clock += 20;
+    const probe = socksConnect(port, "probe.test");
+    await waitUntil(() => typeof rejectProbe === "function");
+    denyNextTarget = true;
+    assert.equal(await socksConnect(port, "probe.test"), 2);
+
+    clock += 20;
+    assert.equal(await socksConnect(port, "probe.test"), 2);
+    assert.equal(lookupCount, 2);
+    assert.equal(topLevelChecks, 4);
+
+    rejectProbe(codedError("ENOTFOUND"));
+    assert.equal(await probe, 4);
+    assert.equal(lookupCount, 2);
+  } finally {
+    rejectProbe?.(codedError("test cleanup"));
+    await proxy.close();
+  }
+});
+
+test("per-target backoff is asynchronous, exponential, and capped on suppressed dials", async () => {
+  let clock = 1_000;
+  let dialCount = 0;
+  const pendingDelays = [];
+  const proxy = createGuardProxy(
+    proxyOptions({
+      connect: async () => {
+        dialCount += 1;
+        throw codedError("EAFNOSUPPORT");
+      },
+      delay: (milliseconds) =>
+        new Promise((resolve) => pendingDelays.push({ milliseconds, resolve })),
+      now: () => clock,
+      failureBackoffBaseMs: 5,
+      failureBackoffMaxMs: 20,
+      failureCooldownMs: 20,
+      familyUnreachableTtlMs: 1_000,
+    }),
+  );
+  try {
+    const port = await proxy.ensure();
+    for (const [timestamp, expectedDelay] of [
+      [1_000, 5],
+      [1_005, 5],
+      [1_020, 10],
+      [1_030, 10],
+      [1_040, 20],
+      [1_060, 20],
+      [1_065, 20],
+    ]) {
+      clock = timestamp;
+      let settled = false;
+      const request = socksConnect(port, IPV6_ONE).then((reply) => {
+        settled = true;
+        return reply;
+      });
+      await waitUntil(() => pendingDelays.length > 0);
+      const pending = pendingDelays.shift();
+      assert.equal(pending.milliseconds, expectedDelay);
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(settled, false);
+      pending.resolve();
+      assert.equal(await request, 8);
+    }
+    assert.equal(dialCount, 1);
+  } finally {
+    for (const pending of pendingDelays) pending.resolve();
+    await proxy.close();
+  }
+});
+
+test("target failure history is bounded and cleared by close", async () => {
+  let clock = 1_000;
+  const delays = [];
+  const proxy = createGuardProxy(
+    proxyOptions({
+      connect: async () => {
+        throw codedError("ECONNREFUSED");
+      },
+      delay: async (milliseconds) => delays.push(milliseconds),
+      now: () => clock,
+      failureBackoffBaseMs: 5,
+      failureBackoffMaxMs: 100,
+      failureCooldownMs: 5,
+      maxFailureTargets: 2,
+    }),
+  );
+  try {
+    let port = await proxy.ensure();
+    for (const host of [
+      "192.0.2.1",
+      "192.0.2.2",
+      "192.0.2.3",
+    ])
+      assert.equal(await socksConnect(port, host), 5);
+    clock += 5;
+    for (const host of ["192.0.2.2", "192.0.2.1"])
+      assert.equal(await socksConnect(port, host), 5);
+    assert.deepEqual(delays, [5, 5, 5, 10, 5]);
+
+    await proxy.close();
+    port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "192.0.2.2"), 5);
+    assert.equal(delays.at(-1), 5);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a successful connection resets target failure backoff", async () => {
+  let clock = 1_000;
+  const delays = [];
+  let attempt = 0;
+  const proxy = createGuardProxy(
+    proxyOptions({
+      connect: async () => {
+        attempt += 1;
+        if (attempt === 2) return new PassThrough();
+        throw codedError("ECONNREFUSED");
+      },
+      delay: async (milliseconds) => delays.push(milliseconds),
+      now: () => clock,
+      failureBackoffBaseMs: 5,
+      failureBackoffMaxMs: 100,
+      failureCooldownMs: 5,
+    }),
+  );
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "192.0.2.9"), 5);
+    clock += 5;
+    assert.equal(await socksConnect(port, "192.0.2.9"), 0);
+    assert.equal(await socksConnect(port, "192.0.2.9"), 5);
+    assert.deepEqual(delays, [5, 5]);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("close cancels delayed replies and resets target cooldown", async () => {
+  const pendingDelays = [];
+  const proxy = createGuardProxy(
+    proxyOptions({
+      connect: async () => {
+        throw codedError("ECONNREFUSED");
+      },
+      delay: (milliseconds) =>
+        new Promise((resolve) => pendingDelays.push({ milliseconds, resolve })),
+      failureBackoffBaseMs: 5,
+      failureBackoffMaxMs: 100,
+    }),
+  );
+  try {
+    let port = await proxy.ensure();
+    const firstRequest = socksConnect(port, "192.0.2.30").then(
+      (value) => ({ value }),
+      (error) => ({ error }),
+    );
+    await waitUntil(() => pendingDelays.length === 1);
+    assert.equal(pendingDelays[0].milliseconds, 5);
+
+    await proxy.close();
+    const firstOutcome = await firstRequest;
+    assert.ok(firstOutcome.error instanceof Error);
+    pendingDelays[0].resolve();
+
+    port = await proxy.ensure();
+    const secondRequest = socksConnect(port, "192.0.2.30");
+    await waitUntil(() => pendingDelays.length === 2);
+    assert.equal(pendingDelays[1].milliseconds, 5);
+    pendingDelays[1].resolve();
+    assert.equal(await secondRequest, 5);
+  } finally {
+    for (const pending of pendingDelays) pending.resolve();
+    await proxy.close();
+  }
+});
+
+test("the default transport still completes a SOCKS5 connection", async () => {
+  const upstream = net.createServer();
+  upstream.listen({ host: "127.0.0.1", port: 0 });
+  await once(upstream, "listening");
+  const accepted = once(upstream, "connection");
+  const proxy = createGuardProxy(proxyOptions());
+  try {
+    const proxyPort = await proxy.ensure();
+    const upstreamPort = upstream.address().port;
+    assert.equal(await socksConnect(proxyPort, "127.0.0.1", upstreamPort), 0);
+    const [socket] = await accepted;
+    socket.destroy();
+  } finally {
+    await proxy.close();
+    await new Promise((resolve) => upstream.close(resolve));
+  }
+});
+
+test("SOCKS5 replies preserve policy, reachability, and address errors", async (t) => {
+  const cases = [
+    {
+      name: "blocked by policy",
+      expected: 2,
+      guardUrl: async () => ({ allowed: false, reason: "test policy" }),
+    },
+    {
+      name: "DNS failure",
+      expected: 4,
+      host: "missing.test",
+      transport: { lookup: async () => { throw codedError("ENOTFOUND"); } },
+    },
+    { name: "network unreachable", expected: 3, errorCode: "ENETUNREACH" },
+    { name: "host unreachable", expected: 4, errorCode: "EHOSTUNREACH" },
+    { name: "connection refused", expected: 5, errorCode: "ECONNREFUSED" },
+    { name: "address family unsupported", expected: 8, errorCode: "EAFNOSUPPORT" },
+    { name: "general connect failure", expected: 1, errorCode: "BW_PROXY_CONNECT" },
+    { name: "success", expected: 0, success: true },
+  ];
+
+  for (const item of cases) {
+    await t.test(item.name, async () => {
+      const transport = {
+        delay: async () => {},
+        ...item.transport,
+      };
+      if (item.errorCode)
+        transport.connect = async () => {
+          throw codedError(item.errorCode);
+        };
+      if (item.success) transport.connect = async () => new PassThrough();
+      const proxy = createGuardProxy(
+        proxyOptions(transport, item.guardUrl || (async () => ({ allowed: true }))),
+      );
+      try {
+        const port = await proxy.ensure();
+        assert.equal(await socksConnect(port, item.host || "192.0.2.10"), item.expected);
+      } finally {
+        await proxy.close();
+      }
+    });
+  }
+});


### PR DESCRIPTION
Fixes #29.

## Summary
- cache temporarily unreachable address families to avoid repeated doomed socket syscalls
- add bounded per-target circuit breaking with asynchronous exponential reply delays and one half-open probe
- preserve the top-level policy check on every CONNECT and clear/cancel state on proxy close
- return precise RFC 1928 SOCKS5 failure codes

## Research and design
Chromium SOCKS5 resolves hostnames through the proxy already, so this targets the reported literal-IPv6 fast-failure path rather than changing DNS semantics. The implementation uses the existing Node DNS/net stack with no new dependency and follows a closed/open/half-open circuit-breaker model.

## Validation
- `npm test`: 247 tests, 242 passed, 5 expected live/headed skips
- `npm run release:check`: 207 tests, 202 passed, 5 expected skips; lint, types, version, and package smoke passed
- focused guard-proxy tests: 21/21
- focused coverage: 91.50% lines, 80.49% branches, 84.44% functions
- `npm audit --omit=dev`: 0 vulnerabilities
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SOCKS5 connection reliability with address validation, retry backoff, and temporary suppression of unavailable connection paths.
  * Added more accurate SOCKS5 error responses for policy, DNS, reachability, and connection failures.
  * Connections now recover cleanly after shutdown, with stale retries and cooldowns reset.

* **Bug Fixes**
  * Prevented repeated connection attempts during temporary failures.
  * Ensured successful connections clear prior failure backoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->