### PR TITLE
Release v0.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.9.1",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.9.1",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.9.1",
+  "version": "0.9.5",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",


### PR DESCRIPTION
## Summary

- release the production credential manager and trusted agent integration
- include Pi tool rendering, shutdown lifecycle hardening, and guard proxy backoff
- align package metadata at 0.9.5

## Validation

- `npm ci --ignore-scripts`
- `npm run release:check`
- `BETTERWRIGHT_REQUIRE_BROWSER=1 npm test` (322 passed, 5 opt-in live-demo skips)
- `BETTERWRIGHT_CLOAK_E2E=1 node --test tests/node/cloak.test.mjs` (5 passed)
- `npm audit --omit=dev` (0 vulnerabilities)

Publishing the matching GitHub Release after merge will trigger the existing OIDC trusted-publishing workflow.