### PR TITLE
release 0.9.6: self-healing browser profile lock for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/profile-lock.mjs
+++ b/src/profile-lock.mjs
@@ -1,0 +1,264 @@
+// Cross-process advisory lock for the persistent browser profile.
+//
+// The lock is a sibling directory of the profile (`<profile>.betterwright-lock`)
+// holding an `owner.json` lease. The owning worker refreshes the lease mtime on
+// a heartbeat, so a lock left behind by a hard-killed process expires on its
+// own even when the recorded pid has been recycled — Windows reuses pids
+// aggressively, so "a process with that pid is alive" proves nothing there.
+// Chromium's own profile singleton remains the final authority; this lock only
+// exists to fail over to an ephemeral profile with a useful warning instead of
+// a raw Chromium launch error.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const PROFILE_LOCK_STALE_MS = 60_000;
+export const PROFILE_LOCK_HEARTBEAT_MS = 15_000;
+
+// Codes a sandbox or Windows ACL produces when it refuses a write outside the
+// allowed workspace. These must degrade gracefully, never fail the launch.
+const PERMISSION_CODES = new Set(["EPERM", "EACCES", "EROFS", "ENOTSUP"]);
+
+function processAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function mkdirPrivate(dir) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+export function profileLockDirFor(profileDir) {
+  return `${profileDir}.betterwright-lock`;
+}
+
+function readOwner(ownerFile) {
+  const raw = fs.readFileSync(ownerFile, "utf8");
+  if (raw.length > 4096) throw new Error("oversized profile lock owner file");
+  return JSON.parse(raw);
+}
+
+// Decide whether an existing lock directory may be reclaimed.
+//  - Lease-bearing owner (0.9.6+): reclaimable when its heartbeat went stale,
+//    even if some process now wears the recorded pid (pid reuse), or when the
+//    pid is dead on this host.
+//  - Legacy owner (<= 0.9.5, no lease): reclaimable only when its pid is dead
+//    on this host — a live legacy holder never heartbeats, so age proves nothing.
+//  - Missing/corrupt owner file: reclaimable once the lock directory itself is
+//    old enough that this cannot be a lock another process is mid-creating.
+function inspectExistingLock(lockDir, ownerFile, staleMs) {
+  let owner = null;
+  let ownerMtimeMs = null;
+  try {
+    owner = readOwner(ownerFile);
+    ownerMtimeMs = fs.statSync(ownerFile).mtimeMs;
+  } catch {
+    owner = null;
+  }
+  if (!owner || typeof owner !== "object" || !owner.hostname) {
+    try {
+      const dirMtimeMs = fs.statSync(lockDir).mtimeMs;
+      return { reclaimable: Date.now() - dirMtimeMs >= staleMs, owner: null };
+    } catch {
+      return { reclaimable: true, owner: null };
+    }
+  }
+  const sameHost = owner.hostname === os.hostname();
+  if (sameHost && !processAlive(Number(owner.pid))) {
+    return { reclaimable: true, owner };
+  }
+  const holderHeartbeats = Number.isFinite(Number(owner.leaseMs));
+  const age = ownerMtimeMs === null ? Infinity : Date.now() - ownerMtimeMs;
+  if (holderHeartbeats && age >= staleMs) return { reclaimable: true, owner };
+  return { reclaimable: false, owner };
+}
+
+// Atomic rename means competing recoverers cannot both recursively delete the
+// same directory. Returns null on success (or when another process already
+// recovered it); returns the error when Windows refuses because a handle in
+// the directory is still open — the caller retries or falls back, never crashes.
+function reclaimStaleLock(lockDir) {
+  const staleDir = `${lockDir}.stale-${process.pid}-${crypto.randomBytes(4).toString("hex")}`;
+  try {
+    fs.renameSync(lockDir, staleDir);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    return error;
+  }
+  try {
+    fs.rmSync(staleDir, { recursive: true, force: true });
+  } catch {
+    /* an emptied-later tombstone is inert; never block acquisition on it */
+  }
+  return null;
+}
+
+function ephemeralFallback(runtimeDir, priorOwner, lockDir, blockedReason) {
+  let ephemeral;
+  try {
+    mkdirPrivate(runtimeDir);
+    ephemeral = fs.mkdtempSync(path.join(runtimeDir, "ephemeral-profile-"));
+  } catch (error) {
+    throw new Error(
+      `BetterWright could not create a temporary browser profile under ${runtimeDir} ` +
+        `(${error?.code || error}). If a sandbox restricts file writes, allow ` +
+        "writes to this directory, or close the BetterWright process that owns " +
+        "the persistent profile.",
+    );
+  }
+  try {
+    fs.chmodSync(ephemeral, 0o700);
+  } catch {
+    /* best effort on Windows */
+  }
+  const ownerText = priorOwner
+    ? `pid ${priorOwner.pid || "?"} on ${priorOwner.hostname || "another host"}`
+    : "another BetterWright process";
+  const warning = blockedReason
+    ? `The browser profile lock at ${lockDir} could not be acquired or recovered ` +
+      `(${blockedReason}); using an isolated temporary profile without saved logins. ` +
+      "If no other BetterWright browser is running, delete that directory to " +
+      "restore the saved profile."
+    : `Another BetterWright process owns the persistent browser profile (${ownerText}); ` +
+      "using an isolated temporary profile without saved logins. If that process " +
+      "is a leftover from an earlier session, close it and relaunch to reclaim " +
+      "the saved profile; a lock left by a crashed process expires on its own " +
+      "within about a minute.";
+  return {
+    profileDir: ephemeral,
+    lockDir: null,
+    ownerFile: null,
+    owner: priorOwner,
+    ephemeral: true,
+    warning,
+  };
+}
+
+// Windows sandboxes (and locked-down ACLs) can allow writes inside an existing
+// profile directory while refusing to create new siblings next to it. Losing
+// the advisory lock must not lose the user's saved logins: continue on the
+// persistent profile and let Chromium's own singleton reject true concurrency.
+function unlockedFallback(profileDir, lockDir, error) {
+  try {
+    mkdirPrivate(profileDir);
+  } catch {
+    /* the browser launch surfaces the real error if the profile is unusable */
+  }
+  return {
+    profileDir,
+    lockDir: null,
+    ownerFile: null,
+    owner: null,
+    ephemeral: false,
+    warning:
+      `Could not create the browser profile lock at ${lockDir} ` +
+      `(${error?.code || error}), which usually means a sandbox restricts ` +
+      "writes there. Continuing with the persistent profile; the browser's " +
+      "own profile lock still prevents concurrent use.",
+  };
+}
+
+export function acquireProfileLock(profileDir, runtimeDir, options = {}) {
+  const staleMs = Math.max(
+    Number(options.staleMs) || PROFILE_LOCK_STALE_MS,
+    1_000,
+  );
+  const lockDir = profileLockDirFor(profileDir);
+  const ownerFile = path.join(lockDir, "owner.json");
+  const owner = {
+    pid: process.pid,
+    hostname: os.hostname(),
+    startedAt: new Date().toISOString(),
+    token: crypto.randomBytes(16).toString("hex"),
+    leaseMs: staleMs,
+  };
+  try {
+    mkdirPrivate(path.dirname(profileDir));
+  } catch {
+    /* if the parent is truly unusable, the attempts below surface it */
+  }
+
+  let blocked = null;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      fs.mkdirSync(lockDir, { mode: 0o700 });
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        if (PERMISSION_CODES.has(error?.code)) {
+          return unlockedFallback(profileDir, lockDir, error);
+        }
+        throw error;
+      }
+      const existing = inspectExistingLock(lockDir, ownerFile, staleMs);
+      if (!existing.reclaimable) {
+        return ephemeralFallback(runtimeDir, existing.owner, lockDir, null);
+      }
+      blocked = reclaimStaleLock(lockDir);
+      continue;
+    }
+    try {
+      fs.writeFileSync(ownerFile, JSON.stringify(owner), {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      mkdirPrivate(profileDir);
+      return { profileDir, lockDir, ownerFile, owner, ephemeral: false, warning: "" };
+    } catch (error) {
+      try {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+      if (PERMISSION_CODES.has(error?.code)) {
+        return unlockedFallback(profileDir, lockDir, error);
+      }
+      throw error;
+    }
+  }
+  return ephemeralFallback(
+    runtimeDir,
+    null,
+    lockDir,
+    blocked ? `stale lock cleanup failed: ${blocked.code || blocked}` : "lock contention",
+  );
+}
+
+export function profileLockHeldByUs(lock) {
+  if (!lock?.ownerFile || !lock.owner?.token) return false;
+  try {
+    return readOwner(lock.ownerFile)?.token === lock.owner.token;
+  } catch {
+    return false;
+  }
+}
+
+// Refresh the lease so other processes keep seeing a live owner. Returns false
+// once the lock is no longer ours (stolen after a stall, or deleted) so the
+// caller can stop heartbeating a file it no longer owns.
+export function touchProfileLock(lock) {
+  if (!profileLockHeldByUs(lock)) return false;
+  try {
+    const now = new Date();
+    fs.utimesSync(lock.ownerFile, now, now);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function releaseProfileLockDir(lock) {
+  if (!lock?.lockDir) return;
+  if (!profileLockHeldByUs(lock)) return;
+  try {
+    fs.rmSync(lock.lockDir, { recursive: true, force: true });
+  } catch {
+    /* a leftover lock with a dead pid expires on its own */
+  }
+}

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -10,7 +10,6 @@
 
 import crypto from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import vm from "node:vm";
@@ -57,6 +56,12 @@ import {
   scrollWheel,
   typeText,
 } from "./human.mjs";
+import {
+  acquireProfileLock,
+  PROFILE_LOCK_HEARTBEAT_MS,
+  releaseProfileLockDir,
+  touchProfileLock,
+} from "./profile-lock.mjs";
 import {
   compressSnapshot,
   diffSnapshots,
@@ -114,6 +119,7 @@ let browserContext = null;
 let launchPromise = null;
 let launchConfig = null;
 let profileLock = null;
+let profileLockHeartbeat = null;
 let profileMode = "persistent";
 let profileWarning = "";
 // Set by the client via `--import` when stealthRuntimeFix is on: the driver is
@@ -297,83 +303,24 @@ function uniqueName(name) {
   return `${stem}-${Date.now()}-${crypto.randomBytes(3).toString("hex")}${ext}`;
 }
 
-function processAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code === "EPERM";
-  }
+function startProfileLockHeartbeat() {
+  if (!profileLock?.ownerFile || profileLockHeartbeat) return;
+  profileLockHeartbeat = setInterval(() => {
+    // Once the lease is no longer ours (deleted, or reclaimed after a long
+    // stall) stop refreshing so we never extend another process's lock.
+    if (!touchProfileLock(profileLock)) stopProfileLockHeartbeat();
+  }, PROFILE_LOCK_HEARTBEAT_MS);
+  profileLockHeartbeat.unref();
 }
 
-function acquireProfile(profileDir, runtimeDir) {
-  mkdirPrivate(path.dirname(profileDir));
-  const lockDir = `${profileDir}.betterwright-lock`;
-  const ownerFile = path.join(lockDir, "owner.json");
-  const owner = {
-    pid: process.pid,
-    hostname: os.hostname(),
-    startedAt: nowIso(),
-  };
-
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    try {
-      fs.mkdirSync(lockDir, { mode: 0o700 });
-      writePrivate(ownerFile, JSON.stringify(owner));
-      mkdirPrivate(profileDir);
-      return { profileDir, lockDir, owner, ephemeral: false, warning: "" };
-    } catch (error) {
-      if (error?.code !== "EEXIST") throw error;
-      let prior = null;
-      try {
-        prior = JSON.parse(fs.readFileSync(ownerFile, "utf8"));
-      } catch {
-        /* stale/partial */
-      }
-      const sameHost = prior?.hostname === os.hostname();
-      const live = sameHost && processAlive(Number(prior?.pid));
-      if (!live && (sameHost || !prior?.hostname)) {
-        const staleDir = `${lockDir}.stale-${process.pid}-${crypto.randomBytes(4).toString("hex")}`;
-        try {
-          // Atomic rename means competing recoverers cannot both recursively
-          // delete the same directory. Chromium's own profile lock remains the
-          // final authority if ownership changes during crash recovery.
-          fs.renameSync(lockDir, staleDir);
-          fs.rmSync(staleDir, { recursive: true, force: true });
-        } catch (renameError) {
-          if (!["ENOENT", "EEXIST"].includes(renameError?.code))
-            throw renameError;
-        }
-        continue;
-      }
-
-      mkdirPrivate(runtimeDir);
-      const ephemeral = fs.mkdtempSync(
-        path.join(runtimeDir, "ephemeral-profile-"),
-      );
-      try {
-        fs.chmodSync(ephemeral, 0o700);
-      } catch {
-        /* best effort */
-      }
-      const ownerText = prior
-        ? `pid ${prior.pid || "?"} on ${prior.hostname || "another host"}`
-        : "another BetterWright process";
-      return {
-        profileDir: ephemeral,
-        lockDir: null,
-        owner: prior,
-        ephemeral: true,
-        warning: `Another BetterWright process owns the persistent browser profile (${ownerText}); using an isolated temporary profile without saved logins.`,
-      };
-    }
-  }
-
-  throw new Error(`Could not acquire browser profile lock at ${lockDir}`);
+function stopProfileLockHeartbeat() {
+  if (!profileLockHeartbeat) return;
+  clearInterval(profileLockHeartbeat);
+  profileLockHeartbeat = null;
 }
 
 function releaseProfileLock() {
+  stopProfileLockHeartbeat();
   if (!profileLock) return;
   if (profileLock.ephemeral) {
     try {
@@ -381,23 +328,8 @@ function releaseProfileLock() {
     } catch {
       /* process exit */
     }
-    profileLock = null;
-    return;
-  }
-  if (!profileLock.lockDir) return;
-  try {
-    const owner = JSON.parse(
-      fs.readFileSync(path.join(profileLock.lockDir, "owner.json"), "utf8"),
-    );
-    if (Number(owner?.pid) !== process.pid || owner?.hostname !== os.hostname())
-      return;
-  } catch {
-    /* if unreadable, only this worker should own the lock */
-  }
-  try {
-    fs.rmSync(profileLock.lockDir, { recursive: true, force: true });
-  } catch {
-    /* process exit */
+  } else {
+    releaseProfileLockDir(profileLock);
   }
   profileLock = null;
 }
@@ -1325,10 +1257,11 @@ async function ensureBrowser(config) {
     mkdirPrivate(launchConfig.artifactsDir);
 
     mkdirPrivate(launchConfig.runtimeDir);
-    profileLock = acquireProfile(
+    profileLock = acquireProfileLock(
       launchConfig.profileDir,
       launchConfig.runtimeDir,
     );
+    startProfileLockHeartbeat();
     profileMode = profileLock.ephemeral ? "ephemeral" : "persistent";
     profileWarning = profileLock.warning;
     const transportProxyPort = await guardProxy.ensure();

--- a/tests/node/profile-lock.test.mjs
+++ b/tests/node/profile-lock.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  acquireProfileLock,
+  profileLockDirFor,
+  profileLockHeldByUs,
+  releaseProfileLockDir,
+  touchProfileLock,
+} from "../../src/profile-lock.mjs";
+
+function makeRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "bw-profile-lock-"));
+  return {
+    root,
+    profileDir: path.join(root, "profile"),
+    runtimeDir: path.join(root, "runtime"),
+  };
+}
+
+function writeOwner(profileDir, owner, { ageMs = 0 } = {}) {
+  const lockDir = profileLockDirFor(profileDir);
+  fs.mkdirSync(lockDir, { recursive: true, mode: 0o700 });
+  const ownerFile = path.join(lockDir, "owner.json");
+  fs.writeFileSync(ownerFile, JSON.stringify(owner), { mode: 0o600 });
+  if (ageMs > 0) {
+    const then = new Date(Date.now() - ageMs);
+    fs.utimesSync(ownerFile, then, then);
+    fs.utimesSync(lockDir, then, then);
+  }
+  return ownerFile;
+}
+
+async function deadPid() {
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  await once(child, "exit");
+  return child.pid;
+}
+
+test("acquires a fresh lock and releases it", () => {
+  const { profileDir, runtimeDir } = makeRoot();
+  const lock = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(lock.ephemeral, false);
+  assert.equal(lock.profileDir, profileDir);
+  assert.ok(fs.existsSync(lock.ownerFile));
+  const owner = JSON.parse(fs.readFileSync(lock.ownerFile, "utf8"));
+  assert.equal(owner.pid, process.pid);
+  assert.ok(owner.token);
+  assert.ok(Number.isFinite(owner.leaseMs));
+  assert.ok(profileLockHeldByUs(lock));
+  releaseProfileLockDir(lock);
+  assert.equal(fs.existsSync(lock.lockDir), false);
+});
+
+test("falls back to an ephemeral profile while a live owner heartbeats", () => {
+  const { profileDir, runtimeDir } = makeRoot();
+  const first = acquireProfileLock(profileDir, runtimeDir);
+  const second = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(second.ephemeral, true);
+  assert.notEqual(second.profileDir, profileDir);
+  assert.match(second.warning, /pid \d+/);
+  assert.match(second.warning, /reclaim the saved profile/);
+  releaseProfileLockDir(first);
+});
+
+test("reclaims a lock whose owner pid is dead on this host", async () => {
+  const { profileDir, runtimeDir } = makeRoot();
+  writeOwner(profileDir, {
+    pid: await deadPid(),
+    hostname: os.hostname(),
+    startedAt: new Date().toISOString(),
+  });
+  const lock = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(lock.ephemeral, false);
+  assert.equal(lock.profileDir, profileDir);
+  releaseProfileLockDir(lock);
+});
+
+test("reclaims a stale-heartbeat lock even when the pid is alive (pid reuse)", () => {
+  // Windows recycles pids quickly, so a hard-killed worker's pid often points
+  // at an unrelated live process. The heartbeat lease is the tiebreaker.
+  const { profileDir, runtimeDir } = makeRoot();
+  writeOwner(
+    profileDir,
+    {
+      pid: process.pid,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      token: "someone-else",
+      leaseMs: 60_000,
+    },
+    { ageMs: 10 * 60_000 },
+  );
+  const lock = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(lock.ephemeral, false);
+  assert.equal(lock.profileDir, profileDir);
+  releaseProfileLockDir(lock);
+});
+
+test("never steals a legacy-format lock with a live pid, no matter how old", () => {
+  const { profileDir, runtimeDir } = makeRoot();
+  writeOwner(
+    profileDir,
+    {
+      pid: process.pid,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+    },
+    { ageMs: 24 * 60 * 60_000 },
+  );
+  const lock = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(lock.ephemeral, true);
+});
+
+test("keeps a corrupt lock briefly, then reclaims it after the stale window", () => {
+  const { profileDir, runtimeDir } = makeRoot();
+  const lockDir = profileLockDirFor(profileDir);
+  fs.mkdirSync(lockDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(lockDir, "owner.json"), "{not json");
+
+  const young = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(young.ephemeral, true);
+
+  const then = new Date(Date.now() - 10 * 60_000);
+  fs.utimesSync(path.join(lockDir, "owner.json"), then, then);
+  fs.utimesSync(lockDir, then, then);
+  const reclaimed = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(reclaimed.ephemeral, false);
+  releaseProfileLockDir(reclaimed);
+});
+
+test("touchProfileLock refreshes the lease and detects theft", () => {
+  const { profileDir, runtimeDir } = makeRoot();
+  const lock = acquireProfileLock(profileDir, runtimeDir);
+  const then = new Date(Date.now() - 5 * 60_000);
+  fs.utimesSync(lock.ownerFile, then, then);
+  assert.equal(touchProfileLock(lock), true);
+  assert.ok(Date.now() - fs.statSync(lock.ownerFile).mtimeMs < 60_000);
+
+  fs.writeFileSync(
+    lock.ownerFile,
+    JSON.stringify({ ...lock.owner, token: "thief" }),
+  );
+  assert.equal(touchProfileLock(lock), false);
+  assert.equal(profileLockHeldByUs(lock), false);
+  // Releasing must not delete a lock we no longer own.
+  releaseProfileLockDir(lock);
+  assert.equal(fs.existsSync(lock.lockDir), true);
+});
+
+test("degrades to the persistent profile unlocked when the lock cannot be created", (t) => {
+  if (typeof process.geteuid === "function" && process.geteuid() === 0) {
+    t.skip("permission simulation is a no-op for root");
+    return;
+  }
+  const { root, profileDir, runtimeDir } = makeRoot();
+  fs.mkdirSync(profileDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(root, 0o500);
+  t.after(() => fs.chmodSync(root, 0o700));
+  const lock = acquireProfileLock(profileDir, runtimeDir);
+  assert.equal(lock.ephemeral, false);
+  assert.equal(lock.profileDir, profileDir);
+  assert.equal(lock.lockDir, null);
+  assert.match(lock.warning, /Could not create the browser profile lock/);
+});


### PR DESCRIPTION
## Problem

Windows users reported sessions getting permanently locked (Discord): after a worker was hard-killed, new sessions kept falling back to an ephemeral profile without saved logins and the agent could never reclaim the persistent profile. Separately, a sandboxed Windows environment hit an `EPERM` creating the lock directory outside the workspace, which aborted the launch entirely.

Root causes:

1. **Pid reuse defeats liveness detection.** On Windows a hard kill (`SIGKILL` → `TerminateProcess`) skips `shutdown()`, leaving the lock behind. Windows recycles pids aggressively, so `processAlive(deadOwnerPid)` soon returns `true` for an unrelated process — the stale lock then looks live forever.
2. **Permission errors were fatal.** `mkdirSync(lockDir)` failing with `EPERM` (sandbox/ACL) propagated and failed the launch; `EPERM`/`EBUSY` during stale-lock cleanup (open handles, antivirus) crashed acquisition too.

## Fix

The lock moves to `src/profile-lock.mjs` and gains a heartbeat lease, mirroring the vault lock's design:

- The owner writes `leaseMs` + a random `token` into `owner.json` and refreshes its mtime every 15s (`utimesSync`, ownership-checked so a stolen lock is never extended).
- A lease-bearing lock whose heartbeat is ≥60s stale is reclaimed even if its recorded pid appears alive. Legacy locks (≤0.9.5, no lease) keep pid-only semantics, so a live old-version holder is never robbed.
- Missing/corrupt `owner.json` is reclaimed only after the stale window, so a lock mid-creation can't be stolen.
- `EPERM`/`EACCES` creating the lock degrades to the persistent profile *unlocked* with a warning — Chromium's own profile singleton stays the final authority — instead of failing the launch.
- Windows rename/delete failures during stale-lock recovery fall back to an ephemeral profile with an actionable warning instead of throwing.
- The occupied-profile warning now tells the agent which pid holds the profile, how to reclaim it, and that crashed-process locks expire on their own (~1 min).
- `releaseProfileLock` verifies ownership by token and no longer deletes a lock another process took over.

## Testing

- New unit suite `tests/node/profile-lock.test.mjs` (8 tests): fresh acquire/release, live-owner ephemeral fallback, dead-pid reclaim, **stale-heartbeat reclaim with a live pid (the Windows pid-reuse case)**, legacy-lock preservation, corrupt-lock grace window, heartbeat refresh + theft detection, permission-degradation fallback.
- Full browser integration suite passes locally (41/41, real Cloak launch).
- Verified live: a running worker refreshes the lease every 15s and removes the lock on close.
- `npm run release:check` green (versions, lint, unit, types, package smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved browser profile safety when multiple processes access the same persistent profile.
  - Automatically detects and recovers stale profile locks.
  - Uses an isolated temporary profile when a profile is actively in use.
  - Continues gracefully with the persistent profile when lock creation is unavailable, with a warning.
  - Maintains active locks automatically and prevents accidental removal after ownership changes.

- **Chores**
  - Updated the package version to 0.9.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->