### PR TITLE
fix flaky worker-exit credential test: kill abruptly instead of SIGTERM

### DIFF
--- a/tests/node/credential-fill.test.mjs
+++ b/tests/node/credential-fill.test.mjs
@@ -629,7 +629,11 @@ test("semantic credential detection and pending credential plumbing", opts, asyn
           const worker = bw?._process;
           if (worker) {
             const exited = once(worker, "exit");
-            worker.kill("SIGTERM");
+            // SIGKILL, not SIGTERM: this simulates the worker dying mid-RPC,
+            // and a graceful SIGTERM shutdown closes Chromium first — slow
+            // enough on a loaded runner to race the client's execute timeout
+            // and fail the test with the timeout error instead of exit.
+            worker.kill("SIGKILL");
             await exited;
           }
         }


### PR DESCRIPTION
The "recovers pending metadata when the worker exits after generation
RPC" test SIGTERMed the worker and awaited its exit while the client's
35s execute timer was running. SIGTERM triggers a graceful shutdown
that closes Chromium first, which on a loaded CI runner can take
longer than the timer, so the client reported "Execution timed out"
instead of "worker exited unexpectedly" (and the leftover pending id
then failed the next subtest). Seen once on the v0.9.6 publish run.

SIGKILL matches what the test simulates — the worker dying mid-RPC —
and makes the exit immediate, removing the race. It also leaves the
profile lock behind, so the restart now exercises dead-pid lock
reclaim against a real browser.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
