### PR TITLE
Release v0.9.10

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+# Keep experimental / non-product paths out of the published tarball.
+src/cdpfree/
+artifacts/
+.tmp/
+tmp/
+*.tmp.mjs

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 
 # BetterWright
 
-**A persistent, policy-guarded Playwright browser for AI agents.**
+**The token-efficient browser for AI agents.**
 
 [![npm](https://img.shields.io/npm/v/betterwright?color=cb3837&logo=npm)](https://www.npmjs.com/package/betterwright)
 [![CI](https://github.com/CuriosityOS/betterwright/actions/workflows/ci.yml/badge.svg)](https://github.com/CuriosityOS/betterwright/actions/workflows/ci.yml)
 [![node](https://img.shields.io/node/v/betterwright?color=339933&logo=node.js&logoColor=white)](package.json)
 [![license](https://img.shields.io/npm/l/betterwright)](LICENSE)
 
-One long-lived browser your agent returns to, turn after turn — with a network
-policy on every request, an encrypted credential vault whose secrets are filled
-without being returned, proof screenshots, human-shaped input, and native
-CAPTCHA helpers.
+One persistent, policy-guarded browser your agent returns to turn after turn —
+engineered so every observation costs the fewest tokens possible.
 
 </div>
 
@@ -25,38 +23,53 @@ betterwright run -c "await page.goto('https://example.com'); return page.title()
 # {"ok": true, "result": "Example Domain", ...}
 ```
 
-![BetterWright — a browser path ending at a verified checkpoint](https://raw.githubusercontent.com/CuriosityOS/betterwright/main/docs/assets/hero.png)
-
 ---
 
-## Why not just use Playwright directly?
+## Tokens are the bottleneck
 
-Playwright is built for tests: a trusted script that knows exactly what it will
-click, running to completion and tearing the browser down. An agent is the
-opposite — it decides its next step from what it sees, its code is untrusted
-model output, and the same browser has to still be there on the next turn.
-That difference is where the work is:
+An agent's browser loop is *observe → decide → act*, and the observe step is
+where context windows go to die. Raw HTML dumps, full accessibility trees, and
+screenshot-only loops burn thousands of tokens per turn — so tasks hit context
+limits, costs climb, and the model drowns in markup it never needed.
+
+BetterWright's whole observation stack is built around that problem:
+
+| Mechanism | Token effect |
+| --- | --- |
+| **Compressed agent snapshots** | A distilled accessibility tree — not raw HTML — measuring **30–75% fewer tokens** than standard tree output, with `[ref=eN]` markers the model acts on directly instead of re-deriving selectors |
+| **Diff mode** | After an action, return **only what changed** — not the page again |
+| **Interactive-only filter** | Drop static text nodes; keep what the agent can click, fill, or read |
+| **Scoped truncation** | Hints about *where* to look next instead of a silently clipped wall |
+| **Single-call finish** | Read-only tasks complete in **one model turn** — the code returns `{finalAnswer}` and the loop ends, no confirmation round-trip |
+| **Persistent session** | One long-lived browser: no re-login, no re-navigation, no re-paying the token cost of getting back to where you were |
+
+Measured end-to-end against another agent scaffold driving the same model at
+the same effort ([benchmark](benchmarks/exec-headtohead/REPORT.md), 15 tasks,
+3 rounds): **14/15 correct vs 12/15**, faster median (10.2s vs 14.7s), and a
+login → cart → checkout flow in **5 model turns vs 13** — because cheap
+observations mean fewer turns to reach the same answer.
+
+## Why not just Playwright?
+
+Playwright is built for tests: trusted scripts, known selectors, teardown at
+the end. An agent is the opposite — untrusted model output deciding its next
+step from what it sees, in a browser that must still be there next turn:
 
 |  | Playwright | BetterWright |
 | --- | --- | --- |
-| **Session** | Browser per script, torn down at the end | One persistent managed browser with a real profile — logins survive across turns, invocations, and days |
-| **Trust** | The script gets the full API | Model code runs in a sandbox with file, process, and network-routing APIs removed |
-| **Network** | Any URL the code names | Every request checked against policy (DNS-rebinding-proof); cloud metadata endpoints always blocked |
-| **Secrets** | Passwords in your script or env | Built-in AES-256-GCM vault; metadata is searchable, forms are detected, and agent-facing APIs never return the password |
-| **Evidence** | You assert; nobody looks | `screenshot({kind: 'proof'})` — tagged artifacts the agent cites as proof of work |
-| **Snapshots** | Raw accessibility tree | Compressed agent-ready tree, 30–75% fewer tokens, `[ref=eN]` markers the agent acts on directly |
-| **CAPTCHAs** | Out of scope | Local `captcha.solve()` — checkbox, Turnstile, slider; vision handoff for image grids. No third-party services |
-
-Writing a test? Use Playwright. Handing a browser to an agent that must stay
-safe and accountable? That's what this is for.
-
----
+| **Observations** | Raw accessibility tree or DIY HTML | Compressed, diffable, redacted snapshots priced for a context window |
+| **Session** | Browser per script | One persistent managed browser — logins survive turns, days, restarts |
+| **Trust** | Full API access | Model code runs sandboxed: no file, process, or network-routing APIs |
+| **Network** | Any URL | Every request policy-checked (DNS-rebinding-proof); cloud metadata endpoints always blocked |
+| **Secrets** | Passwords in the script | AES-256-GCM vault; forms are detected and filled without the secret ever entering the conversation |
+| **Evidence** | Assertions | `screenshot({kind: 'proof'})` — tagged artifacts the agent cites as proof of work |
+| **CAPTCHAs** | Out of scope | Local `captcha.solve()` — checkbox, Turnstile, slider; vision handoff for image grids |
 
 ## Quick start
 
-Requires **Node.js 22+**. Setup downloads CloakBrowser's signed binary (~200 MB,
-once) from its official release source — never as a hidden npm lifecycle side
-effect, so installs stay predictable and work with `--ignore-scripts`.
+Requires **Node.js 22+**. Setup downloads the managed browser (~200 MB, once)
+from its official release source — never as an npm lifecycle side effect, so
+installs stay predictable and work with `--ignore-scripts`.
 
 ```bash
 npm install -g betterwright
@@ -64,124 +77,55 @@ betterwright setup     # fetch + verify the managed browser (once)
 betterwright doctor    # confirm everything resolves
 ```
 
-Then drive it:
-
 ```bash
-# one action — one JSON result, ~1s including launch and clean shutdown
+# one action — one JSON result, ~1s including launch
 betterwright run -c "await page.goto('https://example.com'); return page.title()"
 
 # multi-step work — blank-line-separated snippets against one live session
 betterwright repl < steps.txt
 ```
 
-Logins, cookies, the profile, and encrypted vault items persist across every
-invocation; open tabs and in-memory `state` persist within a `repl` session.
-
----
-
 ## Give it to your agent
 
 Any agent that can run a shell command can drive the browser.
-`betterwright skill` prints the instructions that teach it how — CLI usage plus
-operator guidance (act decisively, verify with proof screenshots, never touch
-secrets). No server, no SDK, no glue code.
-
-<details open>
-<summary><b>Claude Code</b></summary>
+`betterwright skill` prints the instructions that teach it how — CLI usage
+plus operator guidance. No server, no SDK, no glue code.
 
 ```bash
+# Claude Code
 mkdir -p ~/.claude/skills/browser
 betterwright skill --claude > ~/.claude/skills/browser/SKILL.md
-```
 
-Use `.claude/skills/browser/SKILL.md` inside a repo for a project-scoped skill.
+# Codex
+betterwright skill >> ~/.codex/AGENTS.md
 
-</details>
-
-<details>
-<summary><b>Codex</b></summary>
-
-```bash
-betterwright skill >> ~/.codex/AGENTS.md      # global, or >> AGENTS.md per-repo
-```
-
-</details>
-
-<details>
-<summary><b>Pi Coding Agent (native package)</b></summary>
-
-BetterWright's manifest loads a persistent `browser` tool, trusted
-`browser_login` (fills saved or generated credentials without the secret ever
-entering the conversation), approval-gated `browser_download`, vision
-screenshots, and the operator prompt — no skill file or MCP hop:
-
-```bash
-pi install npm:betterwright
-npx -y betterwright setup
-pi
-```
-
-See the [Pi guide](SETUP.md#2--pi-coding-agent) and the reproducible
-[Online-Mind2Web benchmark](benchmarks/online-mind2web).
-
-</details>
-
-<details>
-<summary><b>MCP</b></summary>
-
-A stdio server with `browser`, `browser_login`, `browser_download`, and
-`browser_doctor` tools:
-
-```bash
+# MCP (stdio server: browser, browser_login, browser_download, browser_doctor)
 npm install -g betterwright @modelcontextprotocol/sdk
 claude mcp add betterwright -- npx betterwright mcp
+
+# Pi Coding Agent (native persistent tools, trusted login, approval-gated downloads)
+pi install npm:betterwright
 ```
 
-</details>
-
-<details>
-<summary><b>Any custom agent</b></summary>
-
-Append `betterwright skill` output to the agent's system prompt; its shell tool
-does the rest. **[SETUP.md](SETUP.md)** is the full integration guide, written
-to be followed by an AI agent — point your coding agent at it and it can wire
-any host end to end.
-
-</details>
+**[SETUP.md](SETUP.md)** is the full integration guide, written to be followed
+by an AI agent — point your coding agent at it and it wires any host end to end.
 
 ### Or let it drive itself
 
-BetterWright ships its own browser-tuned agent loop — hand it a task and a
-model:
+BetterWright ships its own browser-tuned agent loop:
 
 ```bash
 betterwright auth --login codex     # OAuth sign-in, no API key to paste
 betterwright exec "find the top Hacker News story and give me its title and points" --model codex
 ```
 
-`--model claude|codex|grok`, or a bare model id (`--model gpt-5.6-sol`) and the
-backend is inferred from the prefix. The loop observes with `snapshot`, acts,
-verifies, captures a proof screenshot, and reports what the run cost in tokens
-and tool calls — see [docs/agent.md](docs/agent.md).
-
-Run **`betterwright`** with no arguments for the interactive console: type
-tasks, watch each step stream, keep one browser session across tasks, and
-answer the agent's `ask` when it genuinely needs you (an MFA code, a
-consequential choice):
-
-```console
-$ betterwright --model codex
-▸ find the top Hacker News story and give me its title and points
-```
-
----
+`--model claude|codex|grok`, or a bare model id and the backend is inferred.
+The loop observes with snapshots, acts, verifies, captures proof, and reports
+what the run cost in tokens and tool calls — [docs/agent.md](docs/agent.md).
+Run **`betterwright`** bare for the interactive console: one browser session
+across tasks, steps streaming as they happen.
 
 ## The JavaScript API
-
-For a JS/TS host, embed the client in-process. `run()` takes a string of async
-Playwright JavaScript; inside it the agent has a small set of globals — `page`,
-`snapshot`, `screenshot`, `human`, `credentials`, and friends
-([docs/browser-api.md](docs/browser-api.md)):
 
 ```js
 import { BetterWright } from "betterwright";
@@ -193,35 +137,35 @@ console.log(title.result);
 await bw.close();
 ```
 
-Every call returns the worker's result envelope (`ok`, `result`, `error`,
-`artifacts`, `console`, `pages`, `challenges`, `warnings`, `durationMs`).
-Full API: [docs/javascript.md](docs/javascript.md).
-
----
+`run()` takes a string of async Playwright JavaScript with sandboxed globals —
+`page`, `snapshot`, `screenshot`, `human`, `credentials`, and friends. Every
+call returns one result envelope (`ok`, `result`, `error`, `artifacts`,
+`console`, `pages`, `challenges`, `warnings`, `durationMs`).
+Full API: [docs/javascript.md](docs/javascript.md) ·
+[docs/browser-api.md](docs/browser-api.md).
 
 ## What each piece does
 
 | Piece | What it gives you |
 | --- | --- |
-| [**Network policy**](docs/network-policy.md) | Every navigation, subresource, WebSocket, and raw TCP connection checked. Metadata endpoints and secret-bearing URLs always blocked; private networks and loopback open by default so dev servers just work. Harden with `blockHosts`, `allowPrivateNetwork: false`, or a `custom` hook. |
-| [**Credential vault**](docs/credentials.md) | Built in and AES-256-GCM encrypted outside the browser profile. PSL-backed site matching, selector-free login/signup detection, metadata-only account choice, pending generated passwords committed only after success, and external-manager overrides. |
-| [**Agent snapshots**](docs/browser-api.md#reading-the-page) | A compressed accessibility tree with actionable `[ref=eN]` markers, interactive-only and diff modes, password values redacted, and scoping hints instead of silent truncation. |
-| [**Proof artifacts**](docs/browser-api.md#screenshots-and-artifacts) | Screenshots tagged `proof`, `question`, or `debug`, returned as paths a host UI can render. |
-| [**CAPTCHA helpers**](docs/captcha.md) | Local `captcha.solve()`: checkbox, Turnstile, managed-challenge, and slider stages; image grids hand off to the agent's own vision with tile bounds and crops. No third-party solving services. |
-| [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel events — no extra runtime dependency. |
-| [**Managed CloakBrowser**](docs/getting-started.md#managed-cloakbrowser-backend) | The only backend, headed and headless — reduces common fingerprint false positives without silently falling back to Chrome. |
-| [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time, with byte and artifact quotas intact. |
-| [**Operator guidance**](docs/agent-prompt.md) | `agentSystemPrompt()` / `betterwright skill` — makes the model act decisively on authorized tasks instead of hedging, with guardrail options for confirmation, spending caps, or hard prohibitions. |
+| [**Agent snapshots**](docs/browser-api.md#reading-the-page) | The token-efficiency core: compressed tree, `[ref=eN]` actions, diff and interactive-only modes, password redaction |
+| [**Credential vault**](docs/credentials.md) | AES-256-GCM outside the profile; PSL site matching, selector-free login detection, metadata-only account choice |
+| [**Network policy**](docs/network-policy.md) | Every navigation, subresource, WebSocket, and raw TCP connection checked; metadata endpoints always blocked |
+| [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
+| [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel — no extra dependency |
+| [**Cloaking V2**](docs/cloaking-v2.md) | Coherent native fingerprint: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; live reCAPTCHA v3 returns 0.9 headed and headless |
+| [**Native Chromium fork**](docs/chromium-fork.md) | Optional BetterWright-built Chromium: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. Auto-detected at `~/.betterwright/chromium/`; platforms without an artifact (Windows) stay on managed CloakBrowser |
+| [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time |
+| [**Operator guidance**](docs/agent-prompt.md) | `betterwright skill` / `agentSystemPrompt()` — decisive action on authorized tasks, with optional confirmation/spending guardrails |
 
 ## How it works
 
-The CLI (or your JS host) owns one long-lived Node worker. The worker holds a
-persistent browser context and exposes sandboxed globals to the model's code;
-it calls back to the host to authorize each request and resolve site-matched
-credentials without putting their values in a result.
-CDP and raw browser handles stay worker-internal. The security model — what
-the sandbox removes, why the metadata floor cannot be lifted, and where it
-does *not* claim to be a boundary — is written up in
+The CLI (or your JS host) owns one long-lived Node worker. The worker holds
+the persistent browser context and exposes sandboxed globals to model code; it
+calls back to the host to authorize requests and resolve credentials without
+putting secrets in results. CDP and raw browser handles stay worker-internal.
+The security model — what the sandbox removes, why the metadata floor cannot
+be lifted, and where it does *not* claim to be a boundary — is in
 [docs/architecture.md](docs/architecture.md).
 
 ## Scope and responsible use

--- a/SETUP.md
+++ b/SETUP.md
@@ -197,8 +197,10 @@ servers) and confirm a `browser` tool appears. Then do **§5**.
 The server keeps one browser alive for its lifetime, so pages and logins persist
 across tool calls.
 
-Managed launches use CloakBrowser exclusively in headed and headless modes to
-reduce common automation false positives. This is not a guarantee of
+Managed launches use CloakBrowser in headed and headless modes to reduce
+common automation false positives; hosts with the native Chromium fork
+artifact installed (`~/.betterwright/chromium/`) run that instead — see
+[docs/chromium-fork.md](docs/chromium-fork.md). This is not a guarantee of
 undetectability.
 
 Broad discovery should use the host's web-search tool, then open selected

--- a/benchmarks/stealth-bench/README.md
+++ b/benchmarks/stealth-bench/README.md
@@ -1,0 +1,28 @@
+# Stealth Bench V1
+
+This runner applies Browser Use's encrypted Stealth Bench task set to
+BetterWright without copying or publishing its plaintext tasks. It decrypts the
+tasks in memory, launches an isolated browser profile for each attempt, stores
+only task metadata and verdicts, and never writes screenshots or model traces.
+
+The pinned public dataset currently contains 80 tasks and has SHA-256
+`d9a842e6cf924929b25b39d1d96b6aa9eb89e05fe942598dfda85bf468d7cfda`.
+That differs from the original 71-task blog post, so reports must retain the
+dataset hash.
+
+```bash
+node benchmarks/stealth-bench/runner.mjs \
+  --dataset /path/to/browser-use-benchmark/Stealth_Bench_V1.enc \
+  --mode headless \
+  --task-ids 1,2,3 \
+  --output /tmp/betterwright-stealth-headless.json
+```
+
+Use `--binary /path/to/Chromium` to test a local fork build and
+`--upstream-proxy socks5://...` for an IP-matched proxy run. The runner treats
+CAPTCHAs and anti-bot interstitials as blocked; it explicitly does not solve
+them, because the measurement is clean access rather than solver performance.
+
+The upstream benchmark repository does not publish a repository-wide license.
+Keep its encrypted dataset in the external checkout and do not vendor it here.
+

--- a/benchmarks/stealth-bench/runner.mjs
+++ b/benchmarks/stealth-bench/runner.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BetterWright, codexModel, runAgentTask } from "../../src/index.mjs";
+
+export const DATASET_NAME = "Stealth_Bench_V1";
+export const PINNED_DATASET_SHA256 =
+  "d9a842e6cf924929b25b39d1d96b6aa9eb89e05fe942598dfda85bf468d7cfda";
+
+const BLOCK_PATTERN =
+  /\b(?:access denied|are you human|automated queries|bot detected|captcha|challenge-platform|checking your browser|cloudflare ray id|datadome|enable javascript and cookies|just a moment|perimeterx|press and hold|request blocked|security check|temporarily blocked|verify you are human|verify your identity|unusual traffic)\b/i;
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function decodedFernetToken(encryptedText) {
+  const outer = Buffer.from(String(encryptedText).trim(), "base64");
+  const token = Buffer.from(outer.toString("ascii"), "base64url");
+  if (token.length < 73 || token[0] !== 0x80) {
+    throw new Error("Stealth Bench task file is not a valid Fernet token.");
+  }
+  return token;
+}
+
+export function decryptTaskPayload(encryptedText, passphrase = DATASET_NAME) {
+  const key = crypto.createHash("sha256").update(passphrase).digest();
+  const token = decodedFernetToken(encryptedText);
+  const signed = token.subarray(0, -32);
+  const signature = token.subarray(-32);
+  const expected = crypto
+    .createHmac("sha256", key.subarray(0, 16))
+    .update(signed)
+    .digest();
+  if (!crypto.timingSafeEqual(signature, expected)) {
+    throw new Error("Stealth Bench task file failed authentication.");
+  }
+  const decipher = crypto.createDecipheriv(
+    "aes-128-cbc",
+    key.subarray(16),
+    token.subarray(9, 25),
+  );
+  return Buffer.concat([
+    decipher.update(token.subarray(25, -32)),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+export function normalizeTask(input) {
+  const taskId = String(input?.task_id ?? "").trim();
+  const instruction = String(input?.confirmed_task ?? "").trim();
+  const category = String(input?.category ?? "").trim();
+  const website = new URL(String(input?.website ?? "").trim());
+  if (!/^\d+$/.test(taskId)) throw new TypeError(`Invalid Stealth Bench task ID: ${taskId}`);
+  if (!instruction) throw new TypeError(`Stealth Bench task ${taskId} has no instruction.`);
+  if (!category) throw new TypeError(`Stealth Bench task ${taskId} has no category.`);
+  if (!new Set(["http:", "https:"]).has(website.protocol)) {
+    throw new TypeError(`Stealth Bench task ${taskId} must use HTTP or HTTPS.`);
+  }
+  return { taskId, instruction, category, website: website.href };
+}
+
+export async function loadStealthTasks(filename, options = {}) {
+  const encrypted = await fs.readFile(filename);
+  const digest = sha256(encrypted);
+  if (!options.allowUnpinned && digest !== PINNED_DATASET_SHA256) {
+    throw new Error(
+      `Unknown Stealth Bench dataset ${digest}; pass --allow-unpinned to run it intentionally.`,
+    );
+  }
+  const parsed = JSON.parse(decryptTaskPayload(encrypted.toString("utf8")));
+  if (!Array.isArray(parsed)) throw new TypeError("Stealth Bench task payload must be an array.");
+  const tasks = parsed.map(normalizeTask);
+  if (new Set(tasks.map((task) => task.taskId)).size !== tasks.length) {
+    throw new TypeError("Stealth Bench task payload contains duplicate task IDs.");
+  }
+  const categories = Object.fromEntries(
+    [...Map.groupBy(tasks, (task) => task.category)]
+      .map(([category, rows]) => [category, rows.length])
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return { tasks, metadata: { name: DATASET_NAME, sha256: digest, count: tasks.length, categories } };
+}
+
+export function selectTasks(tasks, options = {}) {
+  let selected = [...tasks];
+  if (options.taskIds) {
+    const ids = new Set(
+      String(options.taskIds)
+        .split(/[\s,]+/)
+        .map((value) => value.trim())
+        .filter(Boolean),
+    );
+    const available = new Set(tasks.map((task) => task.taskId));
+    const missing = [...ids].filter((taskId) => !available.has(taskId));
+    if (missing.length) throw new Error(`Unknown Stealth Bench task IDs: ${missing.join(", ")}`);
+    selected = selected.filter((task) => ids.has(task.taskId));
+  }
+  if (options.category) {
+    const category = String(options.category).toLowerCase();
+    selected = selected.filter((task) => task.category.toLowerCase() === category);
+  }
+  if (options.limit !== undefined) {
+    const limit = Number(options.limit);
+    if (!Number.isInteger(limit) || limit < 1) throw new TypeError("limit must be a positive integer.");
+    selected = selected.slice(0, limit);
+  }
+  if (!selected.length) throw new Error("No Stealth Bench tasks matched the selection.");
+  return selected;
+}
+
+export function buildTaskPrompt(task) {
+  return [
+    `Stealth Bench task ${task.taskId}.`,
+    `Start at ${task.website}`,
+    "",
+    task.instruction,
+    "",
+    "This run measures whether the browser reaches and operates the site without anti-bot intervention.",
+    "Do not call captcha.solve, click a CAPTCHA, or work around an access-denied page.",
+    "Return PASSED only after completing the requested steps without a challenge.",
+    "Return BLOCKED when an anti-bot, CAPTCHA, security check, or access-denied page prevents completion.",
+    "Return FAILED only for a non-anti-bot failure. Keep the final reason brief.",
+  ].join("\n");
+}
+
+function textFromObservation(observation) {
+  return [
+    observation?.title,
+    observation?.bodyText,
+    ...(observation?.warnings || []),
+    ...(observation?.challenges || []).map((item) =>
+      typeof item === "string" ? item : JSON.stringify(item),
+    ),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function classifyAttempt({ answer, observations = [], agentOk = false }) {
+  const normalizedAnswer = String(answer || "").trim();
+  const observationText = observations.map(textFromObservation).join("\n");
+  const challengeCount = observations.reduce(
+    (count, observation) => count + (observation?.challenges?.length || 0),
+    0,
+  );
+  if (/^BLOCKED\b/i.test(normalizedAnswer) || challengeCount || BLOCK_PATTERN.test(observationText)) {
+    return { status: "blocked", challengeCount };
+  }
+  if (agentOk && /^PASSED\b/i.test(normalizedAnswer)) {
+    return { status: "passed", challengeCount: 0 };
+  }
+  return { status: "failed", challengeCount: 0 };
+}
+
+async function finalObservation(browser, session) {
+  const result = await browser.run(
+    `const bodyText = await page.locator("body").innerText({ timeout: 5000 }).catch(() => "");
+return { url: page.url(), title: await page.title(), bodyText: bodyText.slice(0, 4000) };`,
+    { session, note: "Inspect final benchmark state", timeout: 15 },
+  );
+  const returned = result?.value && typeof result.value === "object" ? result.value : {};
+  return {
+    url: returned.url || result?.pages?.find((page) => page.active)?.url || null,
+    title: returned.title || null,
+    bodyText: returned.bodyText || "",
+    challenges: result?.challenges || [],
+    warnings: result?.warnings || [],
+  };
+}
+
+export async function runTask(task, options = {}) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), `betterwright-stealth-${task.taskId}-`));
+  const session = `stealth-${task.taskId}-${crypto.randomUUID()}`;
+  const observations = [];
+  const browser = new BetterWright({
+    home,
+    headless: options.headless,
+    vault: false,
+    credentialCapture: false,
+    downloadPolicy: "deny",
+    stealthRuntimeFix: true,
+    ...(options.upstreamProxy ? { upstreamProxy: options.upstreamProxy, geoip: true } : {}),
+  });
+  const originalRun = browser.run.bind(browser);
+  browser.run = async (...args) => {
+    const result = await originalRun(...args);
+    observations.push({
+      challenges: result?.challenges || [],
+      warnings: result?.warnings || [],
+    });
+    return result;
+  };
+  const startedAt = new Date();
+  try {
+    const result = await runAgentTask({
+      task: buildTaskPrompt(task),
+      browser,
+      session,
+      model: codexModel({ model: options.model || "gpt-5.6-sol", effort: options.effort || "high" }),
+      maxDurationMs: options.timeoutMs,
+      onStep: options.onStep,
+    });
+    observations.push(await finalObservation(browser, session));
+    const verdict = classifyAttempt({
+      answer: result.answer,
+      observations,
+      agentOk: result.ok,
+    });
+    return {
+      task_id: task.taskId,
+      category: task.category,
+      website: task.website,
+      mode: options.headless ? "headless" : "headed",
+      status: verdict.status,
+      challenge_count: verdict.challengeCount,
+      agent_reason: result.reason,
+      answer_sha256: sha256(result.answer || ""),
+      steps: result.steps,
+      tool_calls: result.toolCalls,
+      duration_ms: result.durationMs,
+      started_at: startedAt.toISOString(),
+      finished_at: new Date().toISOString(),
+      final_url: observations.at(-1)?.url || null,
+    };
+  } finally {
+    await browser.close().catch(() => {});
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+function parseCli(argv) {
+  const options = {};
+  const boolean = new Set(["allowUnpinned"]);
+  const args = [...argv];
+  while (args.length) {
+    const token = args.shift();
+    if (!token.startsWith("--")) throw new Error(`Unexpected argument: ${token}`);
+    const key = token.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (boolean.has(key)) options[key] = true;
+    else {
+      if (!args.length) throw new Error(`${token} requires a value.`);
+      options[key] = args.shift();
+    }
+  }
+  return options;
+}
+
+function parseMode(value) {
+  if (value === "headless") return true;
+  if (value === "headed") return false;
+  throw new Error("--mode must be headed or headless.");
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const cli = parseCli(argv);
+  if (!cli.dataset) throw new Error("--dataset is required.");
+  if (!cli.output) throw new Error("--output is required.");
+  const headless = parseMode(cli.mode || "headless");
+  if (cli.binary) process.env.CLOAKBROWSER_BINARY_PATH = path.resolve(cli.binary);
+  const loaded = await loadStealthTasks(path.resolve(cli.dataset), {
+    allowUnpinned: cli.allowUnpinned,
+  });
+  const selected = selectTasks(loaded.tasks, {
+    taskIds: cli.taskIds,
+    category: cli.category,
+    limit: cli.limit,
+  });
+  const timeoutMs = Number(cli.timeoutMinutes || 10) * 60_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("--timeout-minutes must be positive.");
+  }
+  const records = [];
+  for (const [index, task] of selected.entries()) {
+    console.log(`[${index + 1}/${selected.length}] ${task.taskId} ${task.category} ${headless ? "headless" : "headed"}`);
+    const record = await runTask(task, {
+      headless,
+      timeoutMs,
+      upstreamProxy: cli.upstreamProxy,
+      model: cli.model,
+      effort: cli.effort,
+      onStep: ({ step, tool, note }) => console.log(`  step ${step} ${tool}: ${note || ""}`),
+    });
+    records.push(record);
+    console.log(`  ${record.status} (${Math.round(record.duration_ms / 1000)}s)`);
+  }
+  const passed = records.filter((record) => record.status === "passed").length;
+  const output = {
+    benchmark: DATASET_NAME,
+    dataset: loaded.metadata,
+    browser: "BetterWright Chromium fork",
+    binary: cli.binary ? path.resolve(cli.binary) : "managed",
+    mode: headless ? "headless" : "headed",
+    model: cli.model || "gpt-5.6-sol",
+    effort: cli.effort || "high",
+    task_count: records.length,
+    passed,
+    blocked: records.filter((record) => record.status === "blocked").length,
+    failed: records.filter((record) => record.status === "failed").length,
+    pass_rate: records.length ? passed / records.length : null,
+    generated_at: new Date().toISOString(),
+    tasks: records,
+  };
+  const destination = path.resolve(cli.output);
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.writeFile(destination, `${JSON.stringify(output, null, 2)}\n`);
+  console.log(JSON.stringify(output, null, 2));
+}
+
+const invoked = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invoked) {
+  main().catch((error) => {
+    console.error(error?.stack || error);
+    process.exitCode = 1;
+  });
+}
+

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -48,6 +48,23 @@ function collectValues(argv, flag) {
   return values;
 }
 
+// Cloaking V2 flags shared by run/repl/agent. On by default; --no-cloak-v2
+// disables the coherent-identity layer. --upstream-proxy chains an egress
+// proxy through the policy guard (the IP layer); --geoip aligns locale and
+// timezone with the egress IP unless --locale/--timezone pin them explicitly.
+function cloakingFromFlags(flags) {
+  return {
+    cloakV2: !flags.has("--no-cloak-v2"),
+    upstreamProxy: flagValue(process.argv, "--upstream-proxy") || undefined,
+    geoip: flags.has("--geoip"),
+    locale: flagValue(process.argv, "--locale") || undefined,
+    timezone: flagValue(process.argv, "--timezone") || undefined,
+    headedInvisible: flags.has("--headed-invisible"),
+    platform: flagValue(process.argv, "--platform") || undefined,
+    stealthRuntimeFix: flags.has("--stealth") || undefined,
+  };
+}
+
 async function cmdDoctor() {
   const report = await doctorReport();
   for (const [key, value] of Object.entries(report)) console.log(`${key.padEnd(20)} ${value}`);
@@ -92,7 +109,7 @@ async function readSnippet(arg) {
 
 async function cmdRun(arg, flags) {
   const code = await readSnippet(arg);
-  const bw = new BetterWright({ policy: policyFromFlags(flags), headless: !flags.has("--headed"), stealthRuntimeFix: flags.has("--stealth") || undefined });
+  const bw = new BetterWright({ policy: policyFromFlags(flags), headless: !flags.has("--headed"), ...cloakingFromFlags(flags) });
   try {
     const result = await bw.run(code);
     console.log(JSON.stringify(result, null, 2));
@@ -155,7 +172,7 @@ function cmdSkill(flags) {
 }
 
 async function cmdRepl(flags) {
-  const bw = new BetterWright({ policy: policyFromFlags(flags), headless: !flags.has("--headed"), stealthRuntimeFix: flags.has("--stealth") || undefined });
+  const bw = new BetterWright({ policy: policyFromFlags(flags), headless: !flags.has("--headed"), ...cloakingFromFlags(flags) });
   console.log("BetterWright REPL — blank line runs a snippet, Ctrl-D quits.\n");
   const rl = readline.createInterface({ input: process.stdin });
   let buffer = [];
@@ -235,7 +252,7 @@ async function cmdInteractive(flags) {
     new BetterWright({
       policy: policyFromFlags(flags),
       headless,
-      stealthRuntimeFix: flags.has("--stealth") || undefined,
+      ...cloakingFromFlags(flags),
     });
   let browser = newBrowser();
   // The running transcript, so a follow-up task remembers earlier ones. `/new`

--- a/docs/HANDOFF-linux-mac-identity-2026-07-22.md
+++ b/docs/HANDOFF-linux-mac-identity-2026-07-22.md
@@ -1,0 +1,241 @@
+# HANDOFF — Linux→Mac fingerprint (Google `/sorry` still open)
+
+> Date: 2026-07-22  
+> For: Kimi (author of `fork-identity` + `docs/chromium-fork-patches.md`)  
+> From: Cursor agent session that implemented the first binary patch slice and validated on `core`  
+> Goal: headless Linux fork presents as the capture Mac and clears Google search the way Mac already does
+
+---
+
+## 1. Verdict (read this first)
+
+**JS/CDP Mac identity + the first C++ patch slice are coherent on Linux. Google search is still `/sorry` on `core`.**
+
+Same residential egress IP (`103.252.201.200`) as the Mac. Mac headless fork → real SERPs. Linux headless fork with Mac identity → `/sorry` + “unusual traffic”. **Not an IP problem.** Remaining gap is still Linux-native (fonts / TLS / canvas / audio / other network fingerprint) — exactly the surfaces your patches doc called out beyond UA/platform.
+
+---
+
+## 2. What you already shipped (BetterWright repo — no rebuild needed)
+
+In `/Users/core/betterwright` (local Mac; also synced to `core:/root/betterwright-fork-test` for probes):
+
+| Piece | Role |
+|---|---|
+| `src/fork-identity.mjs` | Capture-machine Mac identity (Chrome 150 UA, UA-CH, MacIntel, 1800×1169@2x / availHeight 1049, hw 12, mem 16, M4 WebGL strings as aspirational) |
+| `src/cloak-v2.mjs` | `--fingerprint-platform` always passed; fork defaults `platform: "macos"` regardless of host |
+| `src/worker.mjs` | Fork launch: `--window-size=1800,1169`, `--force-device-scale-factor=2`, context `userAgent`, per-page `Emulation.setUserAgentOverride` + UA metadata |
+| `docs/chromium-fork-patches.md` | Full binary patch spec (still the source of truth for unfinished work) |
+| CLI `--platform=` + typings | Explicit `linux`/`windows` opt-out |
+
+**Important CDP finding before binary patches:** after navigation, CDP left `navigator.userAgent` / UA-CH as macOS but **`navigator.platform` fell back to `Linux x86_64`**. That mismatch alone is a hard tell. Binary `NavigatorBase::platform()` patch was required; CDP is not enough for platform.
+
+---
+
+## 3. What this session added (Chromium fork — **needs your review**)
+
+### Source tree (Mac, uncommitted)
+
+`/Users/core/slave/work/betterwright-chromium/src` — branch `betterwright` @ `150.0.7871.129`
+
+Patched files (gated on `--fingerprint-platform=macos`):
+
+| File | Change |
+|---|---|
+| `content/public/common/content_switches.{h,cc}` | `kFingerprintPlatform` |
+| `content/browser/renderer_host/render_process_host_impl.cc` | Propagate switch to renderer |
+| `components/embedder_support/user_agent_utils.cc` | Force Mac UA string; coerce UA-CH (`macOS` / `26.6.0` / `arm` / `64`) |
+| `third_party/blink/.../navigator_base.cc` | `platform` → `MacIntel`; `hardwareConcurrency` → `12` |
+| `third_party/blink/.../navigator_id.cc` | Same MacIntel gate |
+| `third_party/blink/.../navigator_device_memory.cc` | `deviceMemory` → `16` |
+| `third_party/blink/.../webgl_rendering_context_base.cc` | Unmasked vendor/renderer → Apple M4 Pro strings |
+| `ui/ozone/platform/headless/headless_screen.cc` | Mac display geometry (see gotcha below) |
+| `chrome/browser/headless/headless_mode_init.cc` | Ozone default size when masked |
+
+Mirrored to **`core:/root/bw/src`** (same relative paths).
+
+### Binary on `core`
+
+```
+/root/bw/src/out/LinuxStatic/chrome
+Chromium 150.0.7871.129
+args.gn: is_component_build=false, proprietary_codecs=true, ffmpeg_branding="Chrome", target_cpu="x64"
+```
+
+Rebuild: `bash /root/bw/build-linux.sh` (tmux session name used: `bw-linux-fp`). Incremental ~1–2 min after touch.
+
+BetterWright against it:
+
+```bash
+export BETTERWRIGHT_CHROMIUM_PATH=/root/bw/src/out/LinuxStatic/chrome
+export BETTERWRIGHT_HOME=/tmp/some-fresh-home
+export BETTERWRIGHT_HEADLESS=1
+# code tree with fork-identity: /root/betterwright-fork-test
+```
+
+### Screen geometry gotcha (please keep)
+
+Launcher always passes `--force-device-scale-factor=2`. Ozone/headless sizes are **physical** under that flag:
+
+- Wrong: bounds `1800×1169` + dpr 2 → CSS `900×585`
+- Right: ozone / bounds **`3600×2338`**, insets **`TLBR(78,0,162,0)`**, screen `device_pixel_ratio` left at 1.0 → CSS **`1800×1169` / `availHeight 1049` / `dpr 2`**
+
+Verified with raw chrome:
+
+```text
+{"w":1800,"h":1169,"aw":1800,"ah":1049,"dpr":2,"p":"MacIntel"}
+```
+
+---
+
+## 4. Live probe results (2026-07-22)
+
+### Linux `core` + patched binary + fork-identity — identity OK
+
+```json
+{
+  "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ... Chrome/150.0.0.0 Safari/537.36",
+  "platform": "MacIntel",
+  "webdriver": false,
+  "hw": 12,
+  "mem": 16,
+  "screen": { "w": 1800, "h": 1169, "aw": 1800, "ah": 1049, "dpr": 2 },
+  "uad": { "platform": "macOS", "brands": ["Not;A=Brand","Chromium","Google Chrome"] },
+  "high": { "architecture": "arm", "platformVersion": "26.6.0", "...": "fullVersionList ok" },
+  "webgl": {
+    "unmaskedVendor": "Google Inc. (Apple)",
+    "unmaskedRenderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)"
+  }
+}
+```
+
+Google: still **`https://www.google.com/sorry/...`**, `unusualTraffic: true`.
+
+Probe artifacts: `core:/tmp/bw-fp-verify2/result.json`, screenshot `.../google.png`.
+
+### Mac control (same IP, same query, same day)
+
+```text
+url: https://www.google.com/search?q=playwright+chromium+stealth...
+sorry: false
+platform: MacIntel
+body: ... Search Results AI Overview ...
+```
+
+So Google is discriminating **Linux client vs Mac client**, not the address.
+
+---
+
+## 5. Still NOT done (your patch checklist)
+
+From `docs/chromium-fork-patches.md` — do these next, in likely impact order:
+
+1. **Fonts (§7)** — hardest Linux tell. Bundle Mac-metric set + `FONTCONFIG_FILE` wrapper next to `linux-x64/chrome`. `measureText` widths matter as much as names.
+2. **Canvas noise (§3)** — seeded, **stable across restarts** with same profile (people usually get this wrong with per-session RNG).
+3. **Audio noise (§4)** — ~1e-7, same stability rule.
+4. Retire CDP UA stopgap once source UA path is trusted for service workers too (partially done in `user_agent_utils.cc`; confirm SW requests).
+5. Optional: package a clean `linux-x64/` artifact (not just `out/LinuxStatic`) for BetterWright `BETTERWRIGHT_CHROMIUM_ROOT` layout.
+
+**Not claimed fixed:** TLS/JA3 / HTTP2 fingerprint still scream Linux under a Mac UA. If fonts+canvas+audio aren’t enough, that’s the next research track (outside the current Blink surface list).
+
+---
+
+## 6. Reproduce in 60 seconds
+
+```bash
+ssh core
+export BETTERWRIGHT_CHROMIUM_PATH=/root/bw/src/out/LinuxStatic/chrome
+export BETTERWRIGHT_HEADLESS=1
+export BETTERWRIGHT_HOME=/tmp/bw-kimi-repro
+rm -rf "$BETTERWRIGHT_HOME"
+cd /root/betterwright-fork-test   # or rsync fresh from Mac /Users/core/betterwright
+node /tmp/bw-fp-verify2.mjs      # or re-copy from Mac betterwright/tmp/bw-fp-verify.mjs
+```
+
+Direct binary smoke (no BetterWright):
+
+```bash
+/root/bw/src/out/LinuxStatic/chrome --headless=new --no-sandbox --disable-gpu \
+  --fingerprint-platform=macos --fingerprint=testseed \
+  --window-size=1800,1169 --force-device-scale-factor=2 \
+  --dump-dom 'data:text/html,<script>document.title=JSON.stringify({
+    w:screen.width,h:screen.height,ah:screen.availHeight,dpr:devicePixelRatio,
+    p:navigator.platform,hw:navigator.hardwareConcurrency})</script>'
+```
+
+Expect: `w=1800,h=1169,ah=1049,dpr=2,p=MacIntel,hw=12`.
+
+---
+
+## 7. Paths cheat sheet
+
+| What | Where |
+|---|---|
+| BetterWright (Mac) | `/Users/core/betterwright` |
+| BetterWright (core probe tree) | `core:/root/betterwright-fork-test` |
+| Patch spec | `betterwright/docs/chromium-fork-patches.md` |
+| Fork identity (JS) | `betterwright/src/fork-identity.mjs` |
+| Chromium src (Mac) | `/Users/core/slave/work/betterwright-chromium/src` |
+| Chromium src (core) | `core:/root/bw/src` |
+| Linux binary | `core:/root/bw/src/out/LinuxStatic/chrome` |
+| Build script | `core:/root/bw/build-linux.sh` |
+| depot_tools | `core:/root/depot_tools` |
+| Prior fork handoff | `betterwright-chromium/HANDOFF-2026-07-22.md` |
+| Capture machine | MacBook Pro 14" Mac16,8 / M4 Pro / 12 cores / 24 GB / macOS 26.6 / Chrome 150.0.7871.129 |
+
+---
+
+## 8. Suggested next move for you
+
+1. Diff / review the uncommitted C++ slice above — keep or reshape to your taste; don’t regress the **3600×2338 physical** screen math.
+2. Implement **fonts** first; re-run the Google probe on `core` with a **fresh** `BETTERWRIGHT_HOME` (burned profiles / repeat `/sorry` can muddy signals).
+3. Then canvas + audio with **profile-stable** seed hashing; verify hash identical across two cold starts, different across two seeds.
+4. Only after fonts+canvas+audio still fail: instrument TLS/JA3 vs Mac Chrome 150 on the same IP.
+
+Acceptance target unchanged: headless Linux fork on `core` returns a normal Google SERP for a simple query, matching Mac behavior on the same egress.
+
+---
+
+## 9. Response (Kimi, 2026-07-22) — ACCEPTANCE PASSED
+
+All remaining items implemented, built on `core`, and verified. **Google now
+returns a real SERP from the headless Linux fork.**
+
+### Shipped this round
+
+| Item | Where | Verification |
+|---|---|---|
+| Canvas farbling (toDataURL, toBlob, convertToBlob, getImageData, WebGL readPixels) | `platform/graphics/fingerprint_noise.{h,cc}` + hooks in `image_data_buffer.cc`, `base_rendering_context_2d.cc`, `webgl_rendering_context_base.cc` | Hash identical across 2 cold starts, same seed; distinct across seeds ✓ |
+| Audio farbling | `offline_audio_context.cc FireCompletionEvent()` | Same stability/distinctness ✓ |
+| Fonts | `scripts/assemble-mac-fonts.sh` (36 mac-metric fonts) + `prepareForkFontsConfig` generating `fonts.conf` + `FONTCONFIG_FILE` env at launch | `fc-list` 470 faces; per-family `measureText` widths differ ✓ |
+| Build fix | lambda return type in `fingerprint_noise.cc` | `LINUX_BUILD_EXIT=0` ✓ |
+
+### The actual last blocker: timezone, not TLS
+
+After fonts+canvas+audio, Google still `/sorry`'d. Gap probe vs real Mac
+Chrome showed `Intl` timezone **UTC** (core host) + locale **en-GB** against
+an **SG residential** egress — the Mac control had Asia/Singapore + en-US.
+Re-ran the identical probe with `timezone: "Asia/Singapore"`,
+`locale: "en-US"`:
+
+```json
+{ "sorryUrl": false, "unusualTraffic": false, "resultish": true,
+  "title": "playwright chromium stealth - Google Search" }
+```
+
+**Operational rule going forward:** fork sessions against geo-sensitive
+targets must pin `timezone`/`locale` to the egress geography (or use
+`geoip: true` with `upstreamProxy`, which resolves both automatically).
+TLS/JA3 was never the problem — stock BoringSSL ClientHello matches Mac
+Chrome closely enough.
+
+### Notes
+
+- `speechSynthesis.getVoices()` is `0` in headless on **both** Linux fork
+  and real Mac Chrome — not a discriminator; no patch needed.
+- CDP UA stopgap retained for now; the source UA path in
+  `user_agent_utils.cc` already covers service workers, so it can be
+  retired in a cleanup pass.
+- Chromium tree (`betterwright-chromium/src`, branch `betterwright`) and
+  this repo both hold uncommitted work — commit/reshape at your discretion.
+- Artifact packaging (`linux-x64/` layout with `fonts/`) still open; the
+  probe ran from `out/LinuxStatic` with `fonts/` synced alongside.

--- a/docs/chromium-fork-patches.md
+++ b/docs/chromium-fork-patches.md
@@ -1,0 +1,144 @@
+# Chromium Fork Fingerprint Patch Set
+
+Build-side patches for the pinned BetterWright Chromium 150 fork. The JS
+layer (`src/fork-identity.mjs`) already masks UA, UA-CH, `navigator.platform`,
+and screen geometry via launch flags + CDP emulation. The surfaces below are
+only reachable from Chromium source — patch them so the binary is coherent
+even where CDP cannot reach (service workers, WebGL, canvas, fonts).
+
+All values come from the capture machine: MacBook Pro 14" (Mac16,8), Apple
+M4 Pro, 12 cores / 24 GB, macOS 26.6, display 1800x1169 @2x, running genuine
+Google Chrome 150.0.7871.129. Gate every patch on
+`--fingerprint-platform=macos` (the flag the launcher now passes) and key
+per-profile variation to `--fingerprint=<seed>`.
+
+## 1. Platform identity at source (replaces the CDP stopgap)
+
+Once these land, the CDP `Emulation.setUserAgentOverride` layer can be
+retired for the fork — source is authoritative, and service workers inherit
+it automatically.
+
+**`components/embedder_support/user_agent_utils.cc`**
+
+- `GetUserAgent()`: when masked, force
+  `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/<major>.0.0.0 Safari/537.36`
+  — and never emit the `Headless` marker in `--headless` mode (the stock
+  headless UA is an instant tell).
+- `GetUserAgentMetadata()`: `platform = "macOS"`,
+  `platform_version = "26.6.0"`, `architecture = "arm"`, `model = ""`,
+  `bitness = "64"`, `mobile = false`.
+- Brand list (`GenerateBrandVersionList` / `GetBrandVersionList`): emit the
+  real consumer-Chrome triple —
+  `Not;A=Brand v8(.0.0.0)`, `Chromium v<major>`, `Google Chrome v<full>`.
+
+**`third_party/blink/renderer/core/frame/navigator_id.cc`**
+
+- `NavigatorID::platform()`: return `"MacIntel"` when masked. (Real Apple
+  Silicon Chrome still reports `MacIntel` — do not invent `MacARM`.)
+
+## 2. WebGL
+
+**`third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc`**
+
+In `WebGLRenderingContextBase::getParameter`, intercept
+`UNMASKED_VENDOR_WEBGL` / `UNMASKED_RENDERER_WEBGL` (extension
+`WEBGL_debug_renderer_info`) when masked:
+
+```cpp
+case GLenum(Extensions3D::kUnmaskedVendor):
+  return String("Google Inc. (Apple)");
+case GLenum(Extensions3D::kUnmaskedRenderer):
+  return String("ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, "
+                "Unspecified Version)");
+```
+
+Leave `VENDOR`/`RENDERER` returning `WebKit` / `WebKit WebGL` — that is what
+real Chrome returns for the non-debug parameters. Also patch the WebGL2 path
+(`webgl2_rendering_context_base.cc` shares the base implementation; verify
+the single interception covers both) and GPU process info strings if any
+diagnostic surface exposes the real GL renderer (e.g. `chrome://gpu` is not
+web-visible, but `WEBGL_debug_renderer_info` via WebGL1 contexts is).
+
+## 3. Canvas noise (unique but stable per profile) — IMPLEMENTED 2026-07-22
+
+Goal: a canvas hash that is unique to this profile+seed and **stable across
+restarts** — per-session randomization is itself a detection signal.
+
+Implemented as a shared renderer helper
+(`third_party/blink/renderer/platform/graphics/fingerprint_noise.{h,cc}`):
+FNV-1a over the `--fingerprint` seed + splitmix64 per pixel; ±1 on one color
+channel per pixel, alpha untouched. Hooked at every readback surface:
+
+- `image_data_buffer.cc` — `ImageDataBuffer::FarbleIfEnabled()` copies the
+  readback and re-points `pixmap_` (covers `toDataURL`, `toBlob`,
+  `OffscreenCanvas.convertToBlob`, audits). Never writes into `peekPixels`
+  memory (that is the live canvas backing store).
+- `base_rendering_context_2d.cc` — `getImageData` after a successful
+  `readPixels`.
+- `webgl_rendering_context_base.cc` — WebGL `readPixels` (RGBA/
+  UNSIGNED_BYTE).
+
+Verified on `core`: identical `canvasHash`/`getImageDataHash`/
+`webglReadPixelsHash` across two cold starts with one seed; all three change
+with a different seed.
+
+## 4. Audio — IMPLEMENTED 2026-07-22
+
+`offline_audio_context.cc` — `FireCompletionEvent()` applies
+`ApplyFingerprintAudioNoise` (±5e-7, seed+channel keyed) to every channel of
+the rendered buffer. Verified stable per profile, distinct per seed.
+
+## 5. Hardware surfaces — IMPLEMENTED (first slice)
+
+- `navigator_base.cc`: `hardwareConcurrency` → `12` when masked. (The CDP
+  `Emulation.setHardwareConcurrencyOverride` stopgap covers pages only.)
+- `navigator_device_memory.cc`: `deviceMemory` → `16` — the bucketed value
+  real Chrome reports on the 24 GB capture machine.
+
+## 6. Screen geometry — IMPLEMENTED (first slice)
+
+`ui/ozone/platform/headless/headless_screen.cc`: with the Mac mask, bounds
+**3600×2338 physical** + `TLBR(78,0,162,0)` insets under
+`--force-device-scale-factor=2` → CSS `1800×1169`, `availHeight 1049`,
+`dpr 2`. Do not regress the physical-pixel math (see the handoff doc).
+
+## 7. Fonts (the hardest Linux→Mac tell) — IMPLEMENTED 2026-07-22
+
+- `scripts/assemble-mac-fonts.sh` (run on macOS) copies 36 mac-metric fonts
+  (Helvetica/Helvetica Neue, Arial set, Times NR set, Courier New, Georgia,
+  Verdana, Trebuchet, Menlo, Monaco, SFNS, Palatino, Futura, Avenir Next,
+  Apple Color Emoji…) into `artifacts/linux-x64/fonts/ttf`.
+- The worker generates an absolute-path `fonts.conf` in the profile runtime
+  dir and launches the fork with `FONTCONFIG_FILE` pointing at it
+  (`src/fork-identity.mjs: prepareForkFontsConfig`, gated on the Mac mask).
+- Verified on `core`: `fc-list` enumerates 470 faces; `measureText` widths
+  differ per family (Helvetica Neue 291 / Menlo 247 / Georgia 307 /
+  Palatino 307 / Avenir Next 304) instead of collapsing to one fallback.
+  SF/Helvetica Neue binaries are Apple-licensed: lab artifact only.
+
+## 8. Build flags — DONE
+
+`out/LinuxStatic` builds with `proprietary_codecs=true`,
+`ffmpeg_branding="Chrome"`, `is_component_build=false`, `target_cpu="x64"`.
+
+## Acceptance — PASSED 2026-07-22
+
+Headless Linux fork on `core` + residential egress returns a **real Google
+SERP** (`sorryUrl:false, unusualTraffic:false, resultish:true`) for the same
+query the Mac passes, once **timezone and locale match the egress IP**
+(`timezone: "Asia/Singapore", locale: "en-US"` — or `geoip: true` with an
+upstream proxy). UTC timezone + SG residential IP was the final coherence
+break; everything else was already in place.
+
+## Validation after build
+
+```bash
+BETTERWRIGHT_CHROMIUM_PATH=/path/to/linux-x64/chrome \
+  node scripts/stealth-report.mjs --live
+```
+
+Probe checklist: `navigator.platform` → `MacIntel`; UA/UA-CH macOS in both
+page and service-worker requests; WebGL debug strings as above; canvas hash
+stable across two launches with the same profile, different across two
+profiles; `screen.availHeight` 1049; `fc-list | wc -l` inside the browser
+matches the bundled set; no `Headless` in UA under `--headless`.

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -1,0 +1,121 @@
+# Native Chromium Fork
+
+BetterWright can run the pinned BetterWright Chromium 150 fork while keeping
+its public `run()`, `human.*`, `captcha.*`, snapshot, policy, proxy, and vault
+APIs unchanged. The fork is selected by environment variable or discovered
+automatically; the managed CloakBrowser path is the fallback when no artifact
+is present.
+
+## Runtime Selection
+
+Use an exact executable path:
+
+```bash
+export BETTERWRIGHT_CHROMIUM_PATH=/absolute/path/to/chrome
+betterwright run -c 'return await page.title()'
+```
+
+Or point at the packaged artifact root:
+
+```bash
+export BETTERWRIGHT_CHROMIUM_ROOT=/absolute/path/to/artifacts
+betterwright run -c 'return await page.title()'
+```
+
+The artifact-root layout is fixed:
+
+```text
+artifacts/
+  mac-arm64/Chromium.app/Contents/MacOS/Chromium
+  linux-x64/chrome
+  win-x64/chrome.exe
+```
+
+Only macOS arm64 and Linux x64 are built and runtime-tested. Windows is reserved
+for a future verified artifact.
+
+`BETTERWRIGHT_CHROMIUM_PATH` takes precedence over
+`BETTERWRIGHT_CHROMIUM_ROOT`. Configured paths must be absolute and must exist;
+BetterWright fails closed instead of silently falling back to another browser.
+
+## Zero-Config Discovery and Platform Routing
+
+With neither variable set, BetterWright checks the default root
+`~/.betterwright/chromium/` for the current platform's artifact. Found → the
+fork runs with no configuration at all. Not found (or no artifact shipped for
+the platform, e.g. Windows) → managed CloakBrowser, exactly as before.
+
+```text
+~/.betterwright/chromium/
+  mac-arm64/Chromium.app/Contents/MacOS/Chromium
+  linux-x64/chrome          (+ fonts/ttf/ for the macOS-metric font set)
+```
+
+This makes mixed fleets trivial: drop the artifact on Linux and macOS hosts,
+run `betterwright setup` on Windows hosts, and every machine picks the right
+backend with the same configuration. Set `BETTERWRIGHT_CHROMIUM_ROOT=off` (or
+`BETTERWRIGHT_CHROMIUM_PATH=off`) to force the managed path on a host that has
+the artifact installed.
+
+**Profiles are not interchangeable.** Fork and Cloak share
+`$BETTERWRIGHT_HOME/browser/profile` by default. Prefer a dedicated home for
+fork deployments (e.g. `BETTERWRIGHT_HOME=~/.betterwright-fork`). Switching
+`off` after the fork has upgraded that profile requires deleting
+`browser/profile` first.
+
+**Match timezone/locale to egress** (or enable `geoip` with `upstreamProxy`).
+Nothing in the fork hard-codes Singapore or any other region — pin whatever
+geography the exit IP actually has.
+
+## Control Plane
+
+The fork is launched through stock `playwright-core` over normal CDP. Custom
+behavior lives in Chromium/V8 (deferred inspector console delivery). No
+page-world stealth shim is installed. Patchright/`stealthRuntimeFix` is
+rejected when the fork is configured.
+
+## Identity
+
+| Option | Native behavior |
+| --- | --- |
+| `locale` | `--lang` and `--fingerprint-locale` |
+| `timezone` | `--bw-timezone` (alias `--fingerprint-timezone`) |
+| `platform` | `--fingerprint-platform`; defaults to `macos` (see masking below) |
+| `headless` | Real native headless |
+| `headedInvisible` | Headed window parked off-screen |
+| `upstreamProxy` / `geoip` | Policy-checked egress; locale/tz from egress when enabled |
+
+## Platform Masking (Linux → macOS)
+
+A headless-Linux browser identity is one of the strongest automation signals
+risk engines score, so the fork masks the host platform as a realistic
+consumer Mac by default (`platform: "macos"`; opt out with `platform:
+"linux"` or `"windows"` in the constructor / `--platform=` on the CLI).
+
+The identity is not invented — every value was captured from genuine Google
+Chrome 150.0.7871.129 (the fork's exact pinned version) on an Apple M4 Pro
+MacBook Pro running macOS 26.6: UA and UA-CH (brands, `macOS` 26.6.0,
+`arm`), `navigator.platform = MacIntel`, 1800×1169 @2x screen geometry with
+real menu-bar/Dock `availHeight`, 12 cores, `deviceMemory` 16. See
+`src/fork-identity.mjs`.
+
+Two layers apply it without any page-world JavaScript shims:
+
+1. **Launch layer** — `--fingerprint-platform`, window-size/DPR flags, and a
+   context-level `userAgent` baseline (correct from the first navigation).
+2. **CDP emulation layer** — per-page `Emulation.setUserAgentOverride` with
+   full `UserAgentMetadata` (the DevTools protocol path, invisible to
+   getter/toString probes), plus hardware-concurrency override where the
+   build supports it.
+
+The binary patch set in
+[chromium-fork-patches.md](chromium-fork-patches.md) is implemented and
+verified (2026-07-22): UA/UA-CH at the source, `navigator.platform`, WebGL
+renderer/vendor, deterministic per-profile canvas/audio farbling, screen
+geometry, and a bundled macOS-metric font set loaded through a launch-time
+`FONTCONFIG_FILE`. With timezone/locale matched to egress geography the
+headless Linux fork returns real Google SERPs instead of `/sorry`; see
+[HANDOFF-linux-mac-identity-2026-07-22.md](HANDOFF-linux-mac-identity-2026-07-22.md)
+§9 for the verification record.
+
+Cloaking V2 identity coherence still applies; see [cloaking-v2.md](cloaking-v2.md).

--- a/docs/cloaking-v2.md
+++ b/docs/cloaking-v2.md
@@ -1,0 +1,104 @@
+# Cloaking V2
+
+Cloaking V2 keeps BetterWright's managed browser identity coherent across the
+two layers that sites score. For the opt-in Chromium 150/V8 inspector fork, see
+[chromium-fork.md](chromium-fork.md).
+
+1. **Chromium layer** - CloakBrowser's source-level patches, a stable
+   fingerprint seed, native locale/timezone flags, and binary-specific native
+   geometry handling.
+2. **IP layer** - an optional upstream egress proxy chained through the local
+   policy guard, with locale/timezone resolved to match the egress geography.
+
+The model API is unchanged: snippets, snapshots, `human.*`, `captcha.*`,
+credentials, and proof captures work as before.
+
+## Native surfaces
+
+V2 deliberately does not monkey-patch browser APIs in the page world. The
+managed binary remains authoritative for canvas, WebGL, audio, fonts, plugins,
+hardware, automation markers, and client hints.
+
+| Surface | V2 behavior |
+| --- | --- |
+| Geometry | Native Cloak geometry plus BetterWright's build-specific viewport compatibility |
+| Locale | `--lang`, `--fingerprint-locale`, and Accept-Language |
+| Timezone | `--fingerprint-timezone`, so `Intl` and `Date` agree |
+| GPU, plugins, hardware | CloakBrowser source-level fingerprint patches |
+| JavaScript APIs | Left native; no replacement getters or functions |
+
+That last row is important. Fresh stock Chrome 150 leaves `chrome.runtime`
+unavailable to ordinary web pages and can initially enumerate zero speech
+voices. An earlier V2 init pack forced those values and made a synthetic probe
+look perfect, but live reCAPTCHA checks stalled. Removing the page-world shims
+restored server-verified `0.9` in both true-headless and headed modes.
+
+## Launch modes
+
+- **Headless** (default): a real `--headless` Cloak process with a realistic
+  desktop viewport. This is not an off-screen headed substitute.
+- **Headed** (`--headed`): a normal visible browser window.
+- **Headed-invisible** (`headedInvisible: true` / `--headed-invisible`): a
+  headed window parked off-screen for workflows that explicitly need native
+  window compositing.
+
+## Egress proxy
+
+```js
+const browser = new BetterWright({
+  upstreamProxy: "socks5://user:pass@residential-egress:1080",
+  geoip: true,
+});
+```
+
+- Supports `http://` and `socks5://` upstreams with optional credentials.
+- Every connection is still policy-checked and DNS-validated locally.
+- The guard tunnels to the validated literal IP, preserving DNS-rebinding
+  protection while the target observes the upstream IP.
+- WebRTC is forced onto the proxied path.
+- `geoip: true` resolves locale/timezone through the upstream. Explicit
+  `locale` and `timezone` values always win.
+
+## Verification
+
+```bash
+node scripts/stealth-report.mjs
+node scripts/stealth-report.mjs --live
+node scripts/stealth-report.mjs --live --site recaptcha-v3-score
+```
+
+The local fixture checks roughly 30 browser surfaces against stock-Chrome
+behavior. Live acceptance uses server-verified score endpoints:
+
+| Check | True headless | Headed |
+| --- | --- | --- |
+| Local fixture | stock-Chrome parity | stock-Chrome parity |
+| `antcpt.com/score_detector` | 0.9 | 0.9 |
+| `democaptcha.com` | 0.9 | 0.9 |
+
+`recaptcha-demo.appspot.com` is not an acceptance gate. Its widget currently
+reports that the site exceeded its Enterprise free quota, so an unresolved
+request there does not establish browser detection.
+
+A direct MV3 extension probe and the normal Playwright-backed BetterWright
+runtime both return `0.9` on healthy endpoints. This falsifies the premise that
+merely attaching CDP causes universal refusal. BetterWright therefore retains
+the full `run()` API rather than replacing it with a smaller extension-only
+interpreter.
+
+Interactive CAPTCHA issuance is a separate gate. In the current public-demo
+runs, Turnstile remained at `processing` without a token in both modes, while
+reCAPTCHA v2 escalated to an image grid that requires vision. The report prints
+`tokenIssued` explicitly so those outcomes cannot be mistaken for a pass.
+
+## Configuration
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `cloakV2` | `true` | Native coherent-identity layer. CLI: `--no-cloak-v2` |
+| `upstreamProxy` | - | `http://` / `socks5://` egress proxy. CLI: `--upstream-proxy` |
+| `geoip` | `false` | Locale/timezone from egress IP. CLI: `--geoip` |
+| `locale` | - | Explicit BCP 47 locale. CLI: `--locale` |
+| `timezone` | - | Explicit IANA timezone. CLI: `--timezone` |
+| `headedInvisible` | `false` | Off-screen headed window. CLI: `--headed-invisible` |
+| `stealthRuntimeFix` | `false` | Optional patchright isolated-world execution |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,49 @@ doctor` reports both versions. For a reproducible deployment, set a full
 `CLOAKBROWSER_VERSION`; to keep an already installed build from checking for a
 newer stable build, set `CLOAKBROWSER_AUTO_UPDATE=false`.
 
+### Native Chromium fork (optional)
+
+Deployments that need a fingerprint surface CloakBrowser doesn't cover can run
+BetterWright's own Chromium build instead — per-profile-stable canvas/audio
+farbling, platform masking (a Linux server presents as a consumer Mac), and
+bundled macOS-metric fonts. The npm package is only the JS/runtime; the
+patched Chromium binary is a **separate artifact** you deploy. Details:
+[chromium-fork.md](chromium-fork.md).
+
+Resolution order:
+
+1. `BETTERWRIGHT_CHROMIUM_PATH` (explicit binary) or
+   `BETTERWRIGHT_CHROMIUM_ROOT` (artifact root). A configured-but-missing
+   binary is an error — it fails closed, never silently downgrades.
+2. Zero-config discovery at `~/.betterwright/chromium/<platform>/`: if the
+   artifact for this platform exists there, it is used automatically.
+3. Otherwise the managed CloakBrowser backend. Platforms with no shipped
+   artifact (Windows) always land here.
+
+Force the managed path even with an artifact installed:
+
+```bash
+export BETTERWRIGHT_CHROMIUM_ROOT=off
+```
+
+**Timezone / locale must match egress.** The fork does not hard-code any
+country. Pin `timezone` and `locale` to the geography of the IP sites see
+(constructor options, `--timezone` / `--locale`, or `geoip: true` with
+`upstreamProxy`). A Singapore residential exit with host `UTC` still trips
+geo-sensitive gates (e.g. Google `/sorry`); the same binary with
+`Asia/Singapore` + `en-US` does not.
+
+**Do not share one profile across backends.** Cloak (~146) and the fork
+(150) both write `$BETTERWRIGHT_HOME/browser/profile`. Once the fork has
+opened that directory, falling back to Cloak fails closed
+(`assertProfileNotNewer`). Use a separate `BETTERWRIGHT_HOME` for fork
+hosts, or delete `browser/profile` when switching backends (saved site
+logins in that profile are lost).
+
+A typical split: **Linux and macOS hosts get the fork artifact, Windows hosts
+run `betterwright setup` and stay on CloakBrowser** — one config, no branching
+in your deployment code.
+
 ## Your first run
 
 A snippet is a string of async Playwright JavaScript. The last expression is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.9.7",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.9.7",
+      "version": "0.9.9",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.3",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -202,6 +203,19 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -212,6 +226,176 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chownr": {
@@ -258,6 +442,607 @@
         }
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -279,6 +1064,79 @@
         "node": ">= 18"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/patchright-core": {
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/patchright-core/-/patchright-core-1.61.1.tgz",
@@ -291,6 +1149,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/playwright-core": {
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
@@ -301,6 +1190,264 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/tar": {
@@ -337,6 +1484,49 @@
       "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -351,6 +1541,49 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -358,6 +1591,26 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.9.7",
+  "version": "0.9.9",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",
@@ -66,6 +66,7 @@
     "bin",
     "types",
     "skills",
+    "docs/*.md",
     "examples/javascript",
     "SETUP.md",
     "SECURITY.md",
@@ -135,6 +136,7 @@
   "homepage": "https://github.com/CuriosityOS/betterwright#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/scripts/assemble-mac-fonts.sh
+++ b/scripts/assemble-mac-fonts.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Assemble the macOS-metric font set for the linux-x64 fork artifact.
+#
+# Copies the fonts a real consumer Mac presents (the same families
+# fingerprint scripts probe) from THIS macOS host into the artifact's
+# fonts/ttf directory. Run on macOS, then ship the artifact to Linux:
+#
+#   scripts/assemble-mac-fonts.sh artifacts/linux-x64/fonts/ttf
+#
+# At launch the worker writes a fontconfig file pointing at this directory
+# and starts the fork with FONTCONFIG_FILE set, so font enumeration and
+# measureText metrics match a Mac instead of a bare Linux server.
+#
+# Note: several of these fonts are Apple-licensed. This is an authorized
+# lab artifact for the program's own test VMs — do not redistribute.
+
+set -euo pipefail
+
+OUT="${1:-artifacts/linux-x64/fonts/ttf}"
+SYS="/System/Library/Fonts"
+SUP="$SYS/Supplemental"
+
+mkdir -p "$OUT"
+
+# Family coverage a macOS Chrome exposes to JS font probing.
+FILES=(
+  # Core sans/serif/mono
+  "$SYS/Helvetica.ttc"
+  "$SYS/HelveticaNeue.ttc"
+  "$SUP/Arial.ttf"
+  "$SUP/Arial Bold.ttf"
+  "$SUP/Arial Italic.ttf"
+  "$SUP/Arial Bold Italic.ttf"
+  "$SUP/Arial Narrow.ttf"
+  "$SUP/Arial Black.ttf"
+  "$SUP/Times New Roman.ttf"
+  "$SUP/Times New Roman Bold.ttf"
+  "$SUP/Times New Roman Italic.ttf"
+  "$SUP/Times New Roman Bold Italic.ttf"
+  "$SUP/Courier New.ttf"
+  "$SUP/Courier New Bold.ttf"
+  "$SUP/Courier New Italic.ttf"
+  "$SUP/Georgia.ttf"
+  "$SUP/Georgia Bold.ttf"
+  "$SUP/Verdana.ttf"
+  "$SUP/Verdana Bold.ttf"
+  "$SUP/Trebuchet MS.ttf"
+  "$SUP/Trebuchet MS Bold.ttf"
+  "$SUP/Comic Sans MS.ttf"
+  "$SUP/Impact.ttf"
+  "$SUP/Tahoma.ttf"
+  # macOS staples
+  "$SYS/Menlo.ttc"
+  "$SYS/Monaco.ttf"
+  "$SYS/SFNS.ttf"
+  "$SYS/NewYork.ttf"
+  "$SYS/Geneva.ttf"
+  "$SYS/Apple Color Emoji.ttc"
+  "$SYS/Apple Symbols.ttf"
+  # Common supplemental families
+  "$SYS/Palatino.ttc"
+  "$SUP/Futura.ttc"
+  "$SYS/Avenir Next.ttc"
+  "$SYS/Avenir Next Condensed.ttc"
+  # Optima/Didot/Hoefler Text/American Typewriter are download-on-demand in
+  # recent macOS; add them here if the host has downloaded them.
+  "$SUP/Andale Mono.ttf"
+)
+
+missing=0
+copied=0
+for f in "${FILES[@]}"; do
+  if [[ -f "$f" ]]; then
+    cp "$f" "$OUT/"
+    copied=$((copied + 1))
+  else
+    echo "MISSING: $f" >&2
+    missing=$((missing + 1))
+  fi
+done
+
+echo "copied=$copied missing=$missing -> $OUT"
+[[ $copied -gt 20 ]] || { echo "too few fonts copied; refusing" >&2; exit 1; }

--- a/scripts/stealth-report.mjs
+++ b/scripts/stealth-report.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Cloaking V2 stealth report.
+//
+// Serves tests/fixtures/stealth-probe.html on loopback, launches the managed
+// browser in headless and (when a display exists) headed mode, collects the
+// per-check results, and prints a score table. With --live it also visits
+// public bot-score pages and scrapes their headline verdicts.
+//
+// Usage:
+//   node scripts/stealth-report.mjs [--live] [--headed-only|--headless-only]
+//   node scripts/stealth-report.mjs --json > report.json
+
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BetterWright } from "../src/index.mjs";
+
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const PROBE_PAGE = path.join(ROOT, "tests", "fixtures", "stealth-probe.html");
+const args = process.argv.slice(2);
+const LIVE = args.includes("--live");
+const AS_JSON = args.includes("--json");
+const HEADED_ONLY = args.includes("--headed-only");
+const HEADLESS_ONLY = args.includes("--headless-only");
+const NO_CLOAK_V2 = args.includes("--no-cloak-v2");
+function flagValue(flag) {
+  const index = args.indexOf(flag);
+  return index !== -1 && index + 1 < args.length ? args[index + 1] : null;
+}
+// --upstream socks5://user:pass@host:1080 runs the whole matrix through the
+// egress proxy with geo-matched identity (the IP layer); --geoip-off pins
+// en-US + host timezone instead of resolving from the egress IP.
+const UPSTREAM = flagValue("--upstream");
+const GEOIP = UPSTREAM && !args.includes("--geoip-off");
+const ONLY_SITE = flagValue("--site");
+
+const LIVE_SITES = [
+  { name: "sannysoft", url: "https://bot.sannysoft.com/", wait: 4000 },
+  {
+    name: "incolumitas",
+    url: "https://bot.incolumitas.com/",
+    wait: 16000,
+    hostWait: true,
+    script: `const score = await page.locator("#behavioralScore").textContent();
+     const value = Number.parseFloat(score || "");
+     const behavioralScore = Number.isFinite(value) ? value : null;
+     return { title: await page.title(), text: JSON.stringify({ behavioralScore, classification: behavioralScore == null ? null : behavioralScore >= 0.5 ? "Human" : "Bot" }), failed: [] };`,
+  },
+  {
+    name: "recaptcha-v3-score-democaptcha",
+    url: "https://democaptcha.com/demo-form-eng/recaptcha-3-test-score.html",
+    wait: 25000,
+    hostWait: true,
+    script: `return { title: await page.title(), text: await page.locator("#score").textContent(), failed: [] };`,
+  },
+  {
+    name: "browserscan-bot",
+    url: "https://www.browserscan.net/bot-detection",
+    wait: 8000,
+  },
+  {
+    name: "turnstile-demo",
+    url: "https://2captcha.com/demo/cloudflare-turnstile",
+    wait: 10000,
+    script: `const solve = await captcha.solve({ timeout: 60000, maxStages: 3 });
+     const token = await page.locator('[name="cf-turnstile-response"]').inputValue().catch(() => "");
+     return { title: await page.title(), text: JSON.stringify({ status: solve.status, stage: solve.stage, cleared: solve.cleared, tokenIssued: token.length > 20, tokenLength: token.length }), failed: [] };`,
+  },
+  {
+    name: "recaptcha-v2-checkbox",
+    url: "https://2captcha.com/demo/recaptcha-v2",
+    wait: 6000,
+    // Full solver path: detect, click, and read the token Google issues.
+    script: `const solve = await captcha.solve({ timeout: 60000, maxStages: 3 });
+     const tokenLength = await page.evaluate(() => {
+       const el = document.querySelector("[name=g-recaptcha-response]");
+       return el?.value?.length ?? 0;
+     });
+     return { title: await page.title(), text: JSON.stringify({ status: solve.status, stage: solve.stage, cleared: solve.cleared, tokenIssued: tokenLength > 20, tokenLength }), failed: [] };`,
+  },
+  {
+    name: "recaptcha-v3-score",
+    url: "https://antcpt.com/score_detector/",
+    wait: 25000,
+    hostWait: true,
+    script: `return { title: await page.title(), text: await page.locator(".well .col-md-6 big").textContent(), failed: [] };`,
+  },
+];
+
+function serveProbe() {
+  const html = fs.readFileSync(PROBE_PAGE);
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(html);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+async function collectProbe(browser, url) {
+  const result = await browser.run(
+    `await page.goto(${JSON.stringify(url)}, { waitUntil: "load", timeout: 30000 });
+     await page.waitForFunction(() => window.__PROBE_RESULTS__, null, { timeout: 15000 });
+     return await page.evaluate(() => window.__PROBE_RESULTS__);`,
+    { timeout: 60 },
+  );
+  if (!result?.ok) throw new Error(`probe run failed: ${JSON.stringify(result)?.slice(0, 400)}`);
+  return result.result;
+}
+
+async function collectLive(browser, site) {
+  const body =
+    site.script ||
+    `await page.waitForTimeout(${site.wait});
+     return await page.evaluate(() => {
+       const text = document.body ? document.body.innerText.slice(0, 4000) : "";
+       const failed = [...document.querySelectorAll("td.failed, .failed, .fail, [class*=fail]")]
+         .map((el) => (el.innerText || "").trim()).filter(Boolean).slice(0, 20);
+       return { title: document.title, text, failed };
+     });`;
+  let result;
+  if (site.hostWait) {
+    const navigation = await browser.run(
+      `await page.goto(${JSON.stringify(site.url)}, { waitUntil: "domcontentloaded", timeout: 45000 });
+       return true;`,
+      { timeout: 60 },
+    );
+    if (!navigation?.ok) return { error: JSON.stringify(navigation)?.slice(0, 300) };
+    await new Promise((resolve) => setTimeout(resolve, site.wait));
+    result = await browser.run(body, { timeout: 120 });
+  } else {
+    result = await browser.run(
+      `await page.goto(${JSON.stringify(site.url)}, { waitUntil: "domcontentloaded", timeout: 45000 });
+       ${body}`,
+      { timeout: 120 },
+    );
+  }
+  if (!result?.ok) return { error: JSON.stringify(result)?.slice(0, 300) };
+  return result.result;
+}
+
+function printProbe(mode, data) {
+  console.log(`\n=== ${mode} — score ${data.score}/100 ===`);
+  for (const check of data.checks) {
+    const mark = check.status === "PASS" ? " ✓ " : check.status === "FAIL" ? " ✗ " : " ~ ";
+    console.log(`${mark} ${check.name.padEnd(46)} ${check.value}`);
+  }
+}
+
+async function launchAndProbe({ headless, label }) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-stealth-"));
+  const browser = new BetterWright({
+    home,
+    headless,
+    cloakV2: !NO_CLOAK_V2,
+    defaultTimeout: 60,
+    ...(UPSTREAM ? { upstreamProxy: UPSTREAM, geoip: GEOIP } : {}),
+  });
+  try {
+    const server = await serveProbe();
+    const url = `http://127.0.0.1:${server.address().port}/`;
+    const probe = await collectProbe(browser, url);
+    // Egress identity check: which IP and timezone does the stack present?
+    let egress = null;
+    if (UPSTREAM) {
+      const ipCheck = await browser.run(
+        `const response = await page.goto("http://ip-api.com/json/?fields=query,country,timezone", { timeout: 30000 });
+         const body = await page.evaluate(() => document.body.innerText);
+         const tz = await page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+         return { egress: JSON.parse(body), browserTimezone: tz };`,
+        { timeout: 60 },
+      );
+      egress = ipCheck?.ok ? ipCheck.result : { error: JSON.stringify(ipCheck)?.slice(0, 200) };
+    }
+    const live = [];
+    if (LIVE) {
+      for (const site of LIVE_SITES.filter(
+        (candidate) => !ONLY_SITE || candidate.name === ONLY_SITE,
+      )) {
+        try {
+          live.push({ name: site.name, ...(await collectLive(browser, site)) });
+        } catch (error) {
+          live.push({ name: site.name, error: error.message });
+        }
+      }
+    }
+    server.close();
+    return { label, probe, egress, live };
+  } finally {
+    await browser.close().catch(() => {});
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+const runs = [];
+const modes = [];
+if (!HEADED_ONLY) modes.push({ headless: true, label: "headless" });
+if (!HEADLESS_ONLY && os.platform() === "darwin") modes.push({ headless: false, label: "headed" });
+
+for (const mode of modes) {
+  try {
+    const report = await launchAndProbe(mode);
+    runs.push(report);
+    if (!AS_JSON) {
+      printProbe(report.label, report.probe);
+      if (report.egress) {
+        console.log(`\negress: ${JSON.stringify(report.egress)}`);
+      }
+      for (const site of report.live) {
+        console.log(`\n--- live: ${site.name} ---`);
+        if (site.error) console.log(`error: ${site.error}`);
+        else {
+          console.log(`title: ${site.title}`);
+          if (site.failed?.length) console.log(`failed rows: ${site.failed.join(" | ")}`);
+          else console.log(site.text.slice(0, 600));
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`\n=== ${mode.label} — ERROR: ${error.message} ===`);
+    runs.push({ label: mode.label, error: error.message });
+  }
+}
+
+if (AS_JSON) {
+  console.log(JSON.stringify(runs, null, 2));
+} else {
+  console.log("\n=== summary ===");
+  for (const run of runs) {
+    console.log(
+      run.probe
+        ? `${run.label.padEnd(10)} ${run.probe.score}/100`
+        : `${run.label.padEnd(10)} error: ${run.error}`,
+    );
+  }
+}

--- a/src/chromium-fork.mjs
+++ b/src/chromium-fork.mjs
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const BETTERWRIGHT_CHROMIUM_VERSION = "150.0.7871.129";
+
+// Playwright 1.61.1 defaults that deliberately change normal browser behavior.
+// Keep its lifecycle, profile, proxy, and CDP-pipe arguments, but let the fork
+// run the same web-platform features and foreground/background policies as a
+// user-launched Chromium session.
+const PLAYWRIGHT_BEHAVIORAL_DEFAULT_ARGS = Object.freeze([
+  "--disable-field-trial-config",
+  "--disable-background-networking",
+  "--disable-background-timer-throttling",
+  "--disable-backgrounding-occluded-windows",
+  "--disable-back-forward-cache",
+  "--disable-client-side-phishing-detection",
+  "--disable-component-extensions-with-background-pages",
+  "--disable-component-update",
+  "--disable-default-apps",
+  "--disable-extensions",
+  "--disable-features=AvoidUnnecessaryBeforeUnloadCheckSync,BoundaryEventDispatchTracksNodeRemoval,DestroyProfileOnBrowserClose,DialMediaRouteProvider,GlobalMediaControls,HttpsUpgrades,LensOverlay,MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate,AutoDeElevate,RenderDocument,OptimizationHints,msForceBrowserSignIn,msEdgeUpdateLaunchServicesPreferredVersion",
+  "--disable-hang-monitor",
+  "--disable-ipc-flooding-protection",
+  "--disable-popup-blocking",
+  "--disable-prompt-on-repost",
+  "--disable-renderer-backgrounding",
+  "--force-color-profile=srgb",
+  "--metrics-recording-only",
+  "--no-service-autorun",
+  "--disable-sync",
+]);
+
+/** Preserve native metrics and normal browser behavior around Playwright's CDP pipe. */
+export function chromiumForkContextOptions({
+  platform = process.platform,
+  getuid = process.getuid,
+} = {}) {
+  const runningAsRoot =
+    typeof getuid === "function" && getuid.call(process) === 0;
+  return {
+    viewport: null,
+    ignoreDefaultArgs: [...PLAYWRIGHT_BEHAVIORAL_DEFAULT_ARGS],
+    // Chromium refuses its Linux sandbox as uid 0. Everywhere else, retain the
+    // normal production sandbox rather than Playwright's test-runner default.
+    chromiumSandbox: platform !== "linux" || !runningAsRoot,
+  };
+}
+
+const PLATFORM_LAYOUT = Object.freeze({
+  "darwin-arm64": path.join(
+    "mac-arm64",
+    "Chromium.app",
+    "Contents",
+    "MacOS",
+    "Chromium",
+  ),
+  "linux-x64": path.join("linux-x64", "chrome"),
+  "win32-x64": path.join("win-x64", "chrome.exe"),
+});
+
+function configuredValue(value) {
+  return String(value || "").trim();
+}
+
+/** Where deployments drop the fork artifact for zero-config discovery. */
+export function defaultChromiumForkRoot({ home = os.homedir() } = {}) {
+  return path.join(home, ".betterwright", "chromium");
+}
+
+/**
+ * Resolve the pinned fork binary without changing BetterWright's public API.
+ *
+ * Resolution order:
+ *  1. BETTERWRIGHT_CHROMIUM_PATH / BETTERWRIGHT_CHROMIUM_ROOT (strict: a
+ *     configured-but-missing binary is an error).
+ *  2. The default root (~/.betterwright/chromium) — if the artifact for this
+ *     platform exists there, use it silently. Platforms without a shipped
+ *     artifact (e.g. Windows) fall through to managed CloakBrowser.
+ *  3. Either variable set to "off" forces the managed CloakBrowser path.
+ */
+export function resolveChromiumForkBinary({
+  env = process.env,
+  platform = process.platform,
+  arch = process.arch,
+  home = os.homedir(),
+  existsSync = fs.existsSync,
+} = {}) {
+  const explicit = configuredValue(env.BETTERWRIGHT_CHROMIUM_PATH);
+  let root = configuredValue(env.BETTERWRIGHT_CHROMIUM_ROOT);
+  if (
+    explicit.toLowerCase() === "off" ||
+    root.toLowerCase() === "off"
+  ) {
+    return null;
+  }
+
+  let implicit = false;
+  if (!explicit && !root) {
+    root = defaultChromiumForkRoot({ home });
+    implicit = true;
+  }
+
+  let candidate;
+  if (explicit) {
+    if (!path.isAbsolute(explicit)) {
+      throw new Error("BETTERWRIGHT_CHROMIUM_PATH must be an absolute path.");
+    }
+    candidate = explicit;
+  } else {
+    if (!implicit && !path.isAbsolute(root)) {
+      throw new Error("BETTERWRIGHT_CHROMIUM_ROOT must be an absolute path.");
+    }
+    const layout = PLATFORM_LAYOUT[`${platform}-${arch}`];
+    if (!layout) {
+      if (implicit) return null; // no artifact for this platform: managed path
+      throw new Error(
+        `No BetterWright Chromium artifact layout for ${platform}-${arch}.`,
+      );
+    }
+    candidate = path.join(root, layout);
+  }
+
+  if (!existsSync(candidate)) {
+    if (implicit) return null; // artifact not deployed here: managed path
+    throw new Error(`BetterWright Chromium binary not found: ${candidate}`);
+  }
+  return candidate;
+}

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -85,7 +85,9 @@ function assertManagedCloakOnly(options) {
   }
   if (String(options.executablePath || "").trim()) {
     throw new TypeError(
-      "executablePath is not supported. Use CLOAKBROWSER_BINARY_PATH to select an official CloakBrowser binary.",
+      "executablePath is not supported. Use BETTERWRIGHT_CHROMIUM_PATH / " +
+        "BETTERWRIGHT_CHROMIUM_ROOT for the native fork, or " +
+        "CLOAKBROWSER_BINARY_PATH for an official CloakBrowser binary.",
     );
   }
   const cdp = String(
@@ -265,6 +267,27 @@ export class BetterWright {
    *   longer read page-defined main-world globals (e.g. `window.__NEXT_DATA__`);
    *   DOM access and clicks are unaffected. Requires the optional
    *   `patchright-core` dependency to be installed.
+   * @param {boolean} [options.cloakV2=true] Cloaking V2: coherent desktop
+   *   identity for the managed browser using native CloakBrowser flags and
+   *   binary-specific viewport handling. No page-world API shims are installed.
+   * @param {string} [options.upstreamProxy] http:// or socks5:// egress proxy
+   *   chained through the local policy guard (the IP layer): targets observe
+   *   the upstream IP while policy and DNS-rebinding checks stay local.
+   *   Optional inline credentials: `socks5://user:pass@host:1080`.
+   * @param {boolean} [options.geoip=false] resolve locale/timezone from the
+   *   upstream egress IP so JS-layer identity matches network-layer geography.
+   *   Requires `upstreamProxy`; explicit `locale`/`timezone` always win.
+   * @param {string} [options.locale] browser locale (e.g. "en-US") applied to
+   *   the fingerprint flags, Accept-Language, and JS locale surfaces.
+   * @param {string} [options.timezone] IANA timezone (e.g. "Europe/Berlin")
+   *   applied at the Chromium layer.
+   * @param {boolean} [options.headedInvisible=false] run a real headed window
+   *   parked off-screen, retaining headed compositing without occupying the
+   *   visible desktop.
+   * @param {"macos"|"windows"|"linux"} [options.platform] identity platform
+   *   presented to sites. The native Chromium fork defaults to "macos" (a
+   *   realistic consumer-Mac fingerprint captured from real Chrome on Apple
+   *   Silicon); the managed CloakBrowser path defaults to the host platform.
    */
   constructor(options = {}) {
     this.home = options.home || defaultHome();
@@ -290,6 +313,22 @@ export class BetterWright {
     this.publicSearchPolicy = resolvePublicSearchPolicy(options.publicSearchPolicy);
     this.downloadPolicy = normalizeDownloadPolicy(options.downloadPolicy);
     this.stealthRuntimeFix = resolveStealthRuntimeFix(options.stealthRuntimeFix);
+    this.cloakV2 = options.cloakV2 !== false;
+    this.upstreamProxy = options.upstreamProxy || null;
+    this.geoip = options.geoip === true;
+    this.locale = options.locale || null;
+    this.timezone = options.timezone || null;
+    this.headedInvisible = options.headedInvisible === true;
+    if (this.headedInvisible) this.headless = false;
+    if (
+      options.platform != null &&
+      !["macos", "windows", "linux"].includes(options.platform)
+    ) {
+      throw new TypeError(
+        'platform must be "macos", "windows", or "linux".',
+      );
+    }
+    this.platform = options.platform || null;
     this.defaultTimeout = Math.max(Number(options.defaultTimeout) || DEFAULT_TIMEOUT_SECONDS, 5);
 
     this._process = null;
@@ -322,6 +361,13 @@ export class BetterWright {
       downloadsDir: downloads,
       browserFlavor: this.browserFlavor,
       stealthRuntimeFix: this.stealthRuntimeFix,
+      cloakV2: this.cloakV2,
+      upstreamProxy: this.upstreamProxy,
+      geoip: this.geoip,
+      locale: this.locale,
+      timezone: this.timezone,
+      headedInvisible: this.headedInvisible,
+      platform: this.platform,
       headless: this.headless,
       credentialCapture: this.credentialCapture,
       searchMinIntervalMs: this.searchMinIntervalMs,
@@ -361,6 +407,16 @@ export class BetterWright {
     // any driver import runs. `--import` must precede the worker script.
     const execArgv = [];
     if (this.stealthRuntimeFix) {
+      const nativeForkConfigured = Boolean(
+        String(process.env.BETTERWRIGHT_CHROMIUM_PATH || "").trim() ||
+          String(process.env.BETTERWRIGHT_CHROMIUM_ROOT || "").trim(),
+      );
+      if (nativeForkConfigured) {
+        throw new BrowserError(
+          "stealthRuntimeFix cannot be combined with BetterWright Chromium; " +
+            "the native fork requires the pinned stock playwright-core driver.",
+        );
+      }
       if (!stealthDriverAvailable()) {
         throw new BrowserError(
           "stealthRuntimeFix is enabled but the optional 'patchright-core' " +

--- a/src/cloak-v2.mjs
+++ b/src/cloak-v2.mjs
@@ -1,0 +1,144 @@
+// Cloaking V2 — launch profile builder.
+//
+// Implements the two-layer doctrine for the managed browser:
+//
+//   1. Chromium layer: the CloakBrowser fork carries the source-level patches
+//      and this module feeds it a coherent identity (fingerprint seed, locale,
+//      timezone) without monkey-patching browser APIs in JavaScript.
+//   2. IP layer: an optional upstream proxy chained through the local guard
+//      proxy (policy still enforced per connection), with timezone/locale
+//      resolved to match the egress IP so the network layer and the JS layer
+//      tell the same story.
+//
+// Headless parity comes from the patched binary plus BetterWright's existing
+// binary-specific viewport compatibility layer.
+// Page-world shims are intentionally avoided: live reCAPTCHA verification
+// showed that the old init pack made Cloak easier, not harder, to detect.
+
+/** Window sizes used only when parking a headed browser off-screen. */
+const HEADED_WINDOW_SIZES = Object.freeze({
+  macos: Object.freeze({
+    width: 1920,
+    height: 1015,
+  }),
+  windows: Object.freeze({
+    width: 1920,
+    height: 1040,
+  }),
+});
+
+const COUNTRY_LOCALE = Object.freeze({
+  US: "en-US", GB: "en-GB", CA: "en-CA", AU: "en-AU", NZ: "en-NZ", IE: "en-IE",
+  DE: "de-DE", AT: "de-AT", CH: "de-CH", FR: "fr-FR", BE: "fr-BE", ES: "es-ES",
+  MX: "es-MX", AR: "es-AR", IT: "it-IT", NL: "nl-NL", PT: "pt-PT", BR: "pt-BR",
+  PL: "pl-PL", SE: "sv-SE", NO: "nb-NO", DK: "da-DK", FI: "fi-FI", JP: "ja-JP",
+  KR: "ko-KR", SG: "en-SG", HK: "zh-HK", TW: "zh-TW", IN: "en-IN", IL: "he-IL",
+  ZA: "en-ZA", AE: "ar-AE", TR: "tr-TR", RU: "ru-RU", UA: "uk-UA", CZ: "cs-CZ",
+});
+
+/** Chromium args V2 adds on top of the base managed set. */
+export function v2LaunchArgs({
+  locale,
+  timezone,
+  platform = "macos",
+  headedInvisible = false,
+  nativeFork = false,
+} = {}) {
+  const args = [];
+  if (locale) {
+    args.push(`--lang=${locale}`, `--fingerprint-locale=${locale}`);
+  }
+  if (timezone) {
+    args.push(
+      nativeFork
+        ? `--bw-timezone=${timezone}`
+        : `--fingerprint-timezone=${timezone}`,
+    );
+  }
+  if (platform) {
+    // The fork shares the --fingerprint-* flag namespace: platform masking is
+    // honored by fork builds carrying the platform patch set
+    // (docs/chromium-fork-patches.md) and is harmless on builds without it.
+    args.push(`--fingerprint-platform=${platform}`);
+  }
+  if (headedInvisible) {
+    // Headed-but-invisible: a real window with headed compositing parked off
+    // the visible desktop.
+    const size = HEADED_WINDOW_SIZES[platform] || HEADED_WINDOW_SIZES.macos;
+    args.push(
+      `--window-size=${size.width},${size.height}`,
+      "--window-position=32000,32000",
+    );
+  }
+  return args;
+}
+
+/**
+ * Resolve the egress-IP identity through the upstream proxy. The JS layer must
+ * not disagree with the network layer: a Frankfurt exit paired with an
+ * America/New_York timezone creates an avoidable inconsistency.
+ *
+ * `fetchJson(url)` is injectable for tests; production uses a plain HTTP GET
+ * through the upstream proxy. Any failure falls back to the caller's explicit
+ * values (or no spoof) — a missed geo lookup must never block a launch.
+ */
+export async function resolveGeoIdentity({
+  geoip = false,
+  locale,
+  timezone,
+  lookupUrl = "http://ip-api.com/json/?fields=status,countryCode,timezone",
+  fetchJson,
+} = {}) {
+  const result = { locale: locale || null, timezone: timezone || null, source: "explicit" };
+  if (!geoip || (locale && timezone)) return result;
+  if (typeof fetchJson !== "function") return result;
+  try {
+    const data = await fetchJson(lookupUrl);
+    if (data?.status !== "success") return result;
+    if (!timezone && typeof data.timezone === "string" && data.timezone) {
+      result.timezone = data.timezone;
+    }
+    if (!locale && typeof data.countryCode === "string") {
+      result.locale = COUNTRY_LOCALE[data.countryCode.toUpperCase()] || "en-US";
+    }
+    result.source = "geoip";
+    return result;
+  } catch {
+    return result;
+  }
+}
+
+/**
+ * Full V2 launch plan for the worker. Viewport selection remains in cloak.mjs,
+ * where it can be gated to the exact managed binary build.
+ */
+export function buildV2LaunchPlan({
+  platform,
+  locale = "en-US",
+  timezone,
+  headedInvisible = false,
+  nativeFork = false,
+} = {}) {
+  // The native fork masks the host platform as a consumer Mac by default: a
+  // headless-Linux identity is a strong automation signal. The managed
+  // CloakBrowser path keeps its host-derived coherent identity.
+  const resolvedPlatform =
+    platform ||
+    (nativeFork
+      ? "macos"
+      : process.platform === "darwin"
+        ? "macos"
+        : process.platform === "win32"
+          ? "windows"
+          : "linux");
+  return {
+    args: v2LaunchArgs({
+      locale,
+      timezone,
+      platform: resolvedPlatform,
+      headedInvisible,
+      nativeFork,
+    }),
+    identity: { locale, timezone: timezone || null, platform: resolvedPlatform },
+  };
+}

--- a/src/cloak.mjs
+++ b/src/cloak.mjs
@@ -71,6 +71,14 @@ export function managedCloakArgs(fingerprintSeed) {
   ];
 }
 
+/** Native fork arguments: WebRTC proxy boundary plus optional fingerprint seed. */
+export function managedChromiumForkArgs(fingerprintSeed) {
+  return [
+    "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+    ...(fingerprintSeed ? [`--fingerprint=${fingerprintSeed}`] : []),
+  ];
+}
+
 function cloakEntrypoint() {
   const override = (process.env.BETTERWRIGHT_CLOAKBROWSER_PATH || "").trim();
   if (!override) return "cloakbrowser";

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -9,6 +9,12 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import {
+  BETTERWRIGHT_CHROMIUM_VERSION,
+  resolveChromiumForkBinary,
+} from "./chromium-fork.mjs";
+import { forkFontsDir } from "./fork-identity.mjs";
+
 const require = createRequire(import.meta.url);
 
 export const PINNED_PLAYWRIGHT_VERSION = "1.61.1";
@@ -88,6 +94,24 @@ export async function doctorReport() {
   const workerOk = fs.existsSync(worker);
   const cloakOk = cloak.version === PINNED_CLOAKBROWSER_VERSION && cloak.installed;
   const stealth = stealthDriverVersion();
+  let chromiumFork = null;
+  let chromiumForkError = null;
+  try {
+    chromiumFork = resolveChromiumForkBinary();
+  } catch (error) {
+    chromiumForkError = error instanceof Error ? error.message : String(error);
+  }
+  const browser = chromiumFork ? "chromium-fork" : "cloak";
+  const chromiumForkFonts = chromiumFork ? forkFontsDir(chromiumFork) : null;
+  const chromiumForkFontsWarning =
+    chromiumFork && !chromiumForkFonts
+      ? "fork binary has no fonts/ttf beside it; host fontconfig will leak (Linux tell). Deploy the macOS-metric font bundle next to chrome."
+      : null;
+  const ready =
+    workerOk &&
+    version === PINNED_PLAYWRIGHT_VERSION &&
+    (chromiumFork ? true : cloakOk) &&
+    !chromiumForkError;
   return {
     node: process.execPath,
     worker,
@@ -102,9 +126,14 @@ export async function doctorReport() {
     cloakbrowser_binary_tier: cloak.tier,
     cloakbrowser_binary: cloak.binary,
     cloakbrowser_ok: cloakOk,
+    chromium_fork: chromiumFork,
+    chromium_fork_version: chromiumFork ? BETTERWRIGHT_CHROMIUM_VERSION : null,
+    chromium_fork_error: chromiumForkError,
+    chromium_fork_fonts: chromiumForkFonts,
+    chromium_fork_fonts_warning: chromiumForkFontsWarning,
     stealth_driver: stealth,
     stealth_available: Boolean(stealth),
-    browser: "cloak",
-    ready: workerOk && version === PINNED_PLAYWRIGHT_VERSION && cloakOk,
+    browser,
+    ready,
   };
 }

--- a/src/fork-identity.mjs
+++ b/src/fork-identity.mjs
@@ -1,0 +1,183 @@
+// Fork identity: a realistic consumer macOS fingerprint for the native
+// Chromium fork, replacing the host identity (typically a headless Linux
+// server, which abuse-score engines weight heavily).
+
+import fs from "node:fs";
+import path from "node:path";
+//
+// Every value below was captured from a real MacBook Pro 14" (Mac16,8,
+// Apple M4 Pro, 12 cores, 24 GB, macOS 26.6, 1800x1169@2x scaled display)
+// running genuine Google Chrome 150.0.7871.129 — the exact version the fork
+// pins. Values are version-parameterized so a future version bump only
+// changes BETTERWRIGHT_CHROMIUM_VERSION.
+//
+// Application is two-layer:
+//   1. Chromium layer: launch flags (--fingerprint-platform, window
+//      geometry, device scale factor) plus the baseline context userAgent.
+//   2. CDP emulation layer: Emulation.setUserAgentOverride with full
+//      UserAgentMetadata per page. This is the DevTools emulation protocol —
+//      no page-world JavaScript shims, so nothing is observable via getter
+//      inspection or Function.prototype.toString probes.
+//
+// Surfaces CDP cannot reach (WebGL renderer, canvas/audio, hardware
+// concurrency on some builds, fonts) are binary patches in the fork tree —
+// see docs/chromium-fork-patches.md.
+
+/**
+ * Build the macOS identity for a Chromium version.
+ * @param {string} chromiumVersion e.g. "150.0.7871.129"
+ */
+export function forkMacIdentity(chromiumVersion) {
+  const version = String(chromiumVersion || "").trim();
+  const major = version.split(".")[0];
+  return {
+    platform: "macos",
+
+    // Headed consumer-Chrome UA (real headless inserts "HeadlessChrome";
+    // masked here and by the binary patch).
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+      `(KHTML, like Gecko) Chrome/${major}.0.0.0 Safari/537.36`,
+
+    // navigator.platform — set through Emulation.setUserAgentOverride's
+    // platform parameter, no JS patch required.
+    navigatorPlatform: "MacIntel",
+    acceptLanguage: "en-US,en",
+
+    // Sec-CH-UA* request headers and navigator.userAgentData, exactly as
+    // emitted by real Google Chrome 150 on macOS 26.6 (Apple Silicon).
+    userAgentMetadata: {
+      brands: [
+        { brand: "Not;A=Brand", version: "8" },
+        { brand: "Chromium", version: major },
+        { brand: "Google Chrome", version: major },
+      ],
+      fullVersionList: [
+        { brand: "Not;A=Brand", version: "8.0.0.0" },
+        { brand: "Chromium", version },
+        { brand: "Google Chrome", version },
+      ],
+      fullVersion: version,
+      platform: "macOS",
+      platformVersion: "26.6.0",
+      architecture: "arm",
+      model: "",
+      mobile: false,
+      bitness: "64",
+      wow64: false,
+    },
+
+    // M4 Pro: 12 logical cores; deviceMemory is Chrome's bucketed value as
+    // reported on the real 24 GB machine.
+    hardwareConcurrency: 12,
+    deviceMemory: 16,
+
+    // 14" MacBook Pro at the 1800x1169 "More Space" scaled resolution, DPR
+    // 2. availHeight 1049 = 1169 - 39px menu bar - 81px visible Dock, the
+    // real NSScreen.visibleFrame on the capture machine.
+    screen: {
+      width: 1800,
+      height: 1169,
+      availWidth: 1800,
+      availHeight: 1049,
+      colorDepth: 24,
+      pixelDepth: 24,
+      devicePixelRatio: 2,
+    },
+
+    // Only patchable in the binary (docs/chromium-fork-patches.md). Captured
+    // from the real machine's WebGL2 context.
+    webgl: {
+      unmaskedVendor: "Google Inc. (Apple)",
+      unmaskedRenderer:
+        "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    },
+  };
+}
+
+/**
+ * Apply the identity to one page over CDP. Best-effort per command: an
+ * unrecognized emulation command on an older fork build must not break
+ * page setup.
+ */
+async function applyForkIdentityToPage(cdp, identity) {
+  await cdp.send("Emulation.setUserAgentOverride", {
+    userAgent: identity.userAgent,
+    acceptLanguage: identity.acceptLanguage,
+    platform: identity.navigatorPlatform,
+    userAgentMetadata: identity.userAgentMetadata,
+  });
+  try {
+    await cdp.send("Emulation.setHardwareConcurrencyOverride", {
+      hardwareConcurrency: identity.hardwareConcurrency,
+    });
+  } catch {
+    // Not available on all Chromium builds; the binary patch covers it.
+  }
+}
+
+/** Absolute path to the artifact's `fonts/ttf` directory, or null if absent. */
+export function forkFontsDir(forkBinary) {
+  if (!forkBinary) return null;
+  const fontsDir = path.join(path.dirname(forkBinary), "fonts", "ttf");
+  try {
+    return fs.statSync(fontsDir).isDirectory() ? fontsDir : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Point the fork's fontconfig at the bundled macOS-metric font set
+ * (scripts/assemble-mac-fonts.sh; ships as <artifact>/fonts/ttf next to the
+ * binary). The conf is generated at launch so absolute paths follow wherever
+ * the artifact is deployed. Returns null when no font bundle is present —
+ * the fork then exposes the host fontconfig, which is a known Linux tell.
+ */
+export function prepareForkFontsConfig({ forkBinary, runtimeDir }) {
+  const fontsDir = forkFontsDir(forkBinary);
+  if (!fontsDir) return null;
+  const cacheDir = path.join(runtimeDir, "fontconfig-cache");
+  fs.mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+  const confPath = path.join(runtimeDir, "fonts.conf");
+  fs.writeFileSync(
+    confPath,
+    `<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <dir>${fontsDir}</dir>
+  <cachedir>${cacheDir}</cachedir>
+  <match target="pattern"><test name="family"><string>sans-serif</string></test><edit name="family" mode="prepend" binding="strong"><string>Helvetica Neue</string></edit></match>
+  <match target="pattern"><test name="family"><string>serif</string></test><edit name="family" mode="prepend" binding="strong"><string>Times New Roman</string></edit></match>
+  <match target="pattern"><test name="family"><string>monospace</string></test><edit name="family" mode="prepend" binding="strong"><string>Menlo</string></edit></match>
+</fontconfig>
+`,
+    { mode: 0o600 },
+  );
+  return { confPath, cacheDir, fontsDir };
+}
+
+/**
+ * Install the identity on a persistent context: all existing pages plus
+ * every page created later. Pair with the context-level `userAgent`
+ * baseline so the first navigation of a brand-new page still sends the
+ * right User-Agent before its CDP session attaches.
+ *
+ * Known gaps (binary patch territory): service-worker requests and
+ * WebGL/canvas/audio/hardware surfaces.
+ */
+export async function installForkIdentityEmulation(context, identity) {
+  const applyTo = async (page) => {
+    try {
+      const cdp = await context.newCDPSession(page);
+      await applyForkIdentityToPage(cdp, identity);
+    } catch {
+      // Page closed mid-attach or session refused; identity for that page
+      // still carries the context-level userAgent baseline.
+    }
+  };
+  context.on("page", (page) => {
+    void applyTo(page);
+  });
+  await Promise.all(context.pages().map((page) => applyTo(page)));
+}

--- a/src/guard-proxy.mjs
+++ b/src/guard-proxy.mjs
@@ -21,6 +21,36 @@ const FAILURE_BACKOFF_RESET_MS = 30_000;
 const FAILURE_COOLDOWN_MS = 1_000;
 const MAX_FAILURE_TARGETS = 256;
 const FAMILY_UNREACHABLE_CODES = new Set(["ENETUNREACH", "EAFNOSUPPORT"]);
+const UPSTREAM_HANDSHAKE_TIMEOUT_MS = 15_000;
+const MAX_UPSTREAM_RESPONSE_BYTES = 65_536;
+
+/**
+ * Parse an upstream proxy URL for Cloaking V2 egress chaining.
+ * Supports http:// and socks5:// with optional inline credentials.
+ * Returns null for anything else — the caller decides whether to fail.
+ */
+export function parseUpstreamProxy(value) {
+  if (!value) return null;
+  let url;
+  try {
+    url = new URL(String(value));
+  } catch {
+    return null;
+  }
+  const protocol = url.protocol.replace(/:$/, "").toLowerCase();
+  if (!["http", "socks5", "socks5h"].includes(protocol)) return null;
+  const port = Number(url.port) || (protocol === "http" ? 8080 : 1080);
+  if (!Number.isSafeInteger(port) || port <= 0 || port > 65535) return null;
+  const host = url.hostname;
+  if (!host) return null;
+  return {
+    protocol: protocol === "http" ? "http" : "socks5",
+    host,
+    port,
+    username: decodeURIComponent(url.username || ""),
+    password: decodeURIComponent(url.password || ""),
+  };
+}
 
 function transportUrl(host, port) {
   const scheme = port === 80 ? "http:" : "https:";
@@ -54,6 +84,189 @@ function ipv6FromBytes(value) {
   return groups.join(":");
 }
 
+function ipv6ToBuffer(host) {
+  const bytes = Buffer.alloc(16);
+  const [head, tail] = host.split("::");
+  const headGroups = head ? head.split(":").filter(Boolean) : [];
+  const tailGroups = tail ? tail.split(":").filter(Boolean) : [];
+  const zeroCount = 8 - headGroups.length - tailGroups.length;
+  const groups = [
+    ...headGroups,
+    ...Array(Math.max(zeroCount, 0)).fill("0"),
+    ...tailGroups,
+  ];
+  for (let index = 0; index < 8; index += 1) {
+    bytes.writeUInt16BE(parseInt(groups[index] || "0", 16) || 0, index * 2);
+  }
+  return bytes;
+}
+
+function completeSocks5Reply(buffer) {
+  if (buffer.length < 4) return null;
+  let addressLength;
+  if (buffer[3] === 1) addressLength = 4;
+  else if (buffer[3] === 4) addressLength = 16;
+  else if (buffer[3] === 3) {
+    if (buffer.length < 5) return null;
+    addressLength = 1 + buffer[4];
+  } else {
+    return buffer[1];
+  }
+  return buffer.length >= 4 + addressLength + 2 ? buffer[1] : null;
+}
+
+/**
+ * Minimal plain-HTTP GET tunneled through an upstream egress proxy. Used by
+ * Cloaking V2 geo-identity resolution: the lookup must originate from the
+ * egress IP or it returns the client's own geography. HTTP only (geo lookup
+ * endpoints are plain HTTP); responses must fit in memory and use
+ * content-length or connection-close framing. Returns {status, body}.
+ */
+export async function httpGetViaProxy(upstream, targetUrl, { timeoutMs = 10_000 } = {}) {
+  if (!upstream) throw new Error("httpGetViaProxy requires an upstream proxy");
+  const url = new URL(String(targetUrl));
+  if (url.protocol !== "http:") {
+    throw new Error("httpGetViaProxy supports plain HTTP targets only");
+  }
+  const port = Number(url.port) || 80;
+  const socket = net.createConnection({ host: upstream.host, port: upstream.port });
+  const fail = (error) => {
+    socket.destroy();
+    throw error;
+  };
+  try {
+    await new Promise((resolve, reject) => {
+      socket.setTimeout(timeoutMs, () => {
+        const error = new Error("Upstream proxy geo lookup timed out");
+        error.code = "BW_PROXY_UPSTREAM";
+        reject(error);
+      });
+      socket.once("error", reject);
+      socket.once("connect", () => {
+        socket.off("error", reject);
+        resolve();
+      });
+    });
+    const authority = `${url.hostname}:${port}`;
+    let buffer = Buffer.alloc(0);
+    const readProxyReply = (until) =>
+      new Promise((resolve, reject) => {
+        const cleanup = () => {
+          socket.off("data", onData);
+          socket.off("error", onError);
+        };
+        const onData = (chunk) => {
+          buffer = Buffer.concat([buffer, chunk]);
+          if (buffer.length > MAX_UPSTREAM_RESPONSE_BYTES) {
+            cleanup();
+            reject(new Error("Upstream proxy reply exceeded limit"));
+            return;
+          }
+          const value = until(buffer);
+          if (value === null || value === undefined) return;
+          cleanup();
+          buffer = Buffer.alloc(0);
+          resolve(value);
+        };
+        const onError = (error) => {
+          cleanup();
+          reject(error);
+        };
+        socket.on("data", onData);
+        socket.once("error", onError);
+      }).catch((error) => fail(error));
+
+    if (upstream.protocol === "socks5") {
+      const wantsAuth = Boolean(upstream.username || upstream.password);
+      socket.write(wantsAuth ? Buffer.from([5, 2, 0, 2]) : Buffer.from([5, 1, 0]));
+      const method = await readProxyReply((reply) =>
+        reply.length >= 2 ? reply[1] : null,
+      );
+      if (method === 2) {
+        const username = Buffer.from(upstream.username, "utf8");
+        const password = Buffer.from(upstream.password, "utf8");
+        if (username.length > 255 || password.length > 255) {
+          fail(new Error("Upstream proxy credentials too long"));
+        }
+        socket.write(
+          Buffer.concat([
+            Buffer.from([1, username.length]),
+            username,
+            Buffer.from([password.length]),
+            password,
+          ]),
+        );
+        const authStatus = await readProxyReply((reply) =>
+          reply.length >= 2 ? reply[1] : null,
+        );
+        if (authStatus !== 0) {
+          fail(new Error("Upstream proxy authentication failed"));
+        }
+      } else if (method !== 0) {
+        fail(new Error("Upstream proxy offered no usable authentication method"));
+      }
+      const host = Buffer.from(url.hostname, "utf8");
+      if (host.length > 255) fail(new Error("Geo lookup hostname is too long"));
+      const portBytes = Buffer.alloc(2);
+      portBytes.writeUInt16BE(port);
+      socket.write(
+        Buffer.concat([
+          Buffer.from([5, 1, 0, 3, host.length]),
+          host,
+          portBytes,
+        ]),
+      );
+      const replyStatus = await readProxyReply(completeSocks5Reply);
+      if (replyStatus !== 0) {
+        fail(new Error(`Upstream proxy refused geo CONNECT (reply ${replyStatus})`));
+      }
+    } else {
+      const headers = [`CONNECT ${authority} HTTP/1.1`, `Host: ${authority}`];
+      if (upstream.username || upstream.password) {
+        headers.push(
+          `Proxy-Authorization: Basic ${Buffer.from(
+            `${upstream.username}:${upstream.password}`,
+          ).toString("base64")}`,
+        );
+      }
+      socket.write(`${headers.join("\r\n")}\r\n\r\n`);
+      const connectStatus = await readProxyReply((reply) => {
+        const end = reply.indexOf("\r\n\r\n");
+        return end === -1
+          ? null
+          : reply.subarray(0, reply.indexOf("\r\n")).toString("latin1");
+      });
+      if (!/^HTTP\/\d(?:\.\d)?\s+200/i.test(connectStatus)) {
+        fail(new Error(`Upstream proxy refused geo CONNECT: ${connectStatus}`));
+      }
+    }
+    const path = `${url.pathname || "/"}${url.search || ""}`;
+    socket.write(
+      `GET ${path} HTTP/1.1\r\nHost: ${authority}\r\nAccept: application/json\r\nConnection: close\r\n\r\n`,
+    );
+    let raw = buffer;
+    buffer = Buffer.alloc(0);
+    const response = await new Promise((resolve, reject) => {
+      socket.on("data", (chunk) => {
+        raw = Buffer.concat([raw, chunk]);
+        if (raw.length > MAX_UPSTREAM_RESPONSE_BYTES * 4) {
+          reject(new Error("Upstream geo response exceeded limit"));
+        }
+      });
+      socket.once("close", () => resolve(raw));
+      socket.once("error", reject);
+    }).catch((error) => fail(error));
+    const headerEnd = response.indexOf("\r\n\r\n");
+    if (headerEnd === -1) fail(new Error("Upstream geo response had no header block"));
+    const headerText = response.subarray(0, headerEnd).toString("latin1");
+    const statusMatch = /^HTTP\/\d(?:\.\d)?\s+(\d{3})/i.exec(headerText);
+    const status = statusMatch ? Number(statusMatch[1]) : 0;
+    return { status, body: response.subarray(headerEnd + 4).toString("utf8") };
+  } finally {
+    socket.destroy();
+  }
+}
+
 function positiveInteger(value, fallback) {
   return Number.isSafeInteger(value) && value > 0 ? value : fallback;
 }
@@ -65,9 +278,14 @@ function waitFor(delayMs) {
   });
 }
 
-export function createGuardProxy({ guardUrl, executeId, transport = {} }) {
+export function createGuardProxy({ guardUrl, executeId, transport = {}, upstreamProxy = null }) {
   let guardProxyServer = null;
   let guardProxyPort = null;
+  // Cloaking V2 IP layer: when set, every policy-approved connection tunnels
+  // to its validated literal IP through this upstream egress proxy, so the
+  // target sees the upstream's IP while the guard still enforces policy and
+  // DNS-rebinding protection locally (the upstream never resolves names).
+  let upstream = upstreamProxy || null;
   const guardProxySockets = new Set();
   const unavailableFamilies = new Map();
   const targetFailures = new Map();
@@ -341,6 +559,185 @@ export function createGuardProxy({ guardUrl, executeId, transport = {} }) {
     }
   }
 
+  // --- Cloaking V2 upstream egress tunneling ---------------------------------
+
+  function connectUpstreamSocket() {
+    return new Promise((resolve, reject) => {
+      const socket = trackProxySocket(
+        net.createConnection({ host: upstream.host, port: upstream.port }),
+      );
+      const fail = (error) => {
+        socket.destroy();
+        reject(error);
+      };
+      socket.setTimeout(UPSTREAM_HANDSHAKE_TIMEOUT_MS, () => {
+        const error = new Error("Upstream egress proxy handshake timed out");
+        error.code = "BW_PROXY_UPSTREAM";
+        fail(error);
+      });
+      socket.once("error", fail);
+      socket.once("connect", () => {
+        socket.off("error", fail);
+        resolve(socket);
+      });
+    });
+  }
+
+  function readUpstreamReply(socket, until) {
+    return new Promise((resolve, reject) => {
+      let buffer = Buffer.alloc(0);
+      const onData = (chunk) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        if (buffer.length > MAX_UPSTREAM_RESPONSE_BYTES) {
+          cleanup();
+          const error = new Error("Upstream egress proxy reply exceeded limit");
+          error.code = "BW_PROXY_UPSTREAM";
+          reject(error);
+          return;
+        }
+        const result = until(buffer);
+        // `until` returns null/undefined while more bytes are needed; any
+        // other value — including the SOCKS success byte 0 — completes.
+        if (result !== null && result !== undefined) {
+          cleanup();
+          resolve(result);
+        }
+      };
+      const onError = (error) => {
+        cleanup();
+        reject(error);
+      };
+      const cleanup = () => {
+        socket.off("data", onData);
+        socket.off("error", onError);
+      };
+      socket.on("data", onData);
+      socket.on("error", onError);
+    });
+  }
+
+  async function tunnelHttpUpstream(socket, host, port) {
+    const authority = `${net.isIP(host) === 6 ? `[${host}]` : host}:${port}`;
+    const headers = [`CONNECT ${authority} HTTP/1.1`, `Host: ${authority}`];
+    if (upstream.username || upstream.password) {
+      const credentials = Buffer.from(
+        `${upstream.username}:${upstream.password}`,
+      ).toString("base64");
+      headers.push(`Proxy-Authorization: Basic ${credentials}`);
+    }
+    socket.write(`${headers.join("\r\n")}\r\n\r\n`);
+    // One buffered read for the whole header block: the status line and the
+    // terminating CRLF can arrive in any fragmentation, and bytes past the
+    // header terminator (already TLS traffic) must stay on the socket.
+    const status = await readUpstreamReply(socket, (buffer) => {
+      const end = buffer.indexOf("\r\n\r\n");
+      if (end === -1) return null;
+      return buffer.subarray(0, buffer.indexOf("\r\n")).toString("latin1");
+    });
+    const match = /^HTTP\/\d(?:\.\d)?\s+(\d{3})/i.exec(status);
+    if (match?.[1] !== "200") {
+      const error = new Error(`Upstream egress proxy refused CONNECT: ${status}`);
+      error.code = "BW_PROXY_UPSTREAM";
+      throw error;
+    }
+    return socket;
+  }
+
+  async function tunnelSocks5Upstream(socket, host, port) {
+    const wantsAuth = Boolean(upstream.username || upstream.password);
+    socket.write(
+      wantsAuth ? Buffer.from([5, 2, 0, 2]) : Buffer.from([5, 1, 0]),
+    );
+    const method = await readUpstreamReply(socket, (buffer) =>
+      buffer.length >= 2 ? buffer[1] : null,
+    );
+    if (method === 2) {
+      const username = Buffer.from(upstream.username, "utf8");
+      const password = Buffer.from(upstream.password, "utf8");
+      if (username.length > 255 || password.length > 255) {
+        const error = new Error("Upstream egress proxy credentials too long");
+        error.code = "BW_PROXY_UPSTREAM";
+        throw error;
+      }
+      socket.write(
+        Buffer.concat([
+          Buffer.from([1, username.length]),
+          username,
+          Buffer.from([password.length]),
+          password,
+        ]),
+      );
+      const authStatus = await readUpstreamReply(socket, (buffer) =>
+        buffer.length >= 2 ? buffer[1] : null,
+      );
+      if (authStatus !== 0) {
+        const error = new Error("Upstream egress proxy authentication failed");
+        error.code = "BW_PROXY_UPSTREAM";
+        throw error;
+      }
+    } else if (method !== 0) {
+      const error = new Error("Upstream egress proxy offered no usable auth method");
+      error.code = "BW_PROXY_UPSTREAM";
+      throw error;
+    }
+    // CONNECT to the validated literal IP — the upstream never resolves names,
+    // so the local DNS-rebinding validation stays authoritative.
+    const family = net.isIP(host);
+    let addressPart;
+    if (family === 4) {
+      addressPart = Buffer.concat([
+        Buffer.from([1]),
+        Buffer.from(host.split(".").map((octet) => Number(octet))),
+      ]);
+    } else if (family === 6) {
+      addressPart = Buffer.concat([Buffer.from([4]), ipv6ToBuffer(host)]);
+    } else {
+      const encoded = Buffer.from(host, "utf8");
+      addressPart = Buffer.concat([
+        Buffer.from([3, encoded.length]),
+        encoded,
+      ]);
+    }
+    const portBytes = Buffer.alloc(2);
+    portBytes.writeUInt16BE(port, 0);
+    socket.write(
+      Buffer.concat([Buffer.from([5, 1, 0]), addressPart, portBytes]),
+    );
+    const reply = await readUpstreamReply(socket, completeSocks5Reply);
+    if (reply !== 0) {
+      const error = new Error(`Upstream egress proxy CONNECT failed (reply ${reply})`);
+      error.code = "BW_PROXY_UPSTREAM";
+      throw error;
+    }
+    return socket;
+  }
+
+  async function connectViaUpstream(address, port, generation) {
+    if (generation !== stateGeneration) throw cachedTargetError();
+    const socket = await connectUpstreamSocket();
+    try {
+      if (upstream.protocol === "http") {
+        await tunnelHttpUpstream(socket, address.address, port);
+      } else {
+        await tunnelSocks5Upstream(socket, address.address, port);
+      }
+      socket.setTimeout(0);
+      if (generation !== stateGeneration) {
+        socket.destroy();
+        throw cachedTargetError();
+      }
+      return socket;
+    } catch (error) {
+      socket.destroy();
+      throw error;
+    }
+  }
+
+  /** Switch the upstream egress proxy; applies to new connections only. */
+  function setUpstream(next) {
+    upstream = next || null;
+  }
+
   async function connectGuardedTarget(host, port) {
     const key = targetKey(host, port);
     const generation = stateGeneration;
@@ -366,7 +763,9 @@ export function createGuardProxy({ guardUrl, executeId, transport = {} }) {
       let lastError = null;
       for (const address of addresses) {
         try {
-          const socket = await connectAddress(address, port, generation);
+          const socket = upstream
+            ? await connectViaUpstream(address, port, generation)
+            : await connectAddress(address, port, generation);
           if (generation === stateGeneration) targetFailures.delete(key);
           return socket;
         } catch (error) {
@@ -537,5 +936,5 @@ export function createGuardProxy({ guardUrl, executeId, transport = {} }) {
     });
   }
 
-  return { ensure, close };
+  return { ensure, close, setUpstream };
 }

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -34,12 +34,19 @@ import {
   PUBLIC_SEARCH_BLOCK_ADVICE,
 } from "./challenges.mjs";
 import {
+  BETTERWRIGHT_CHROMIUM_VERSION,
+  chromiumForkContextOptions,
+  resolveChromiumForkBinary,
+} from "./chromium-fork.mjs";
+import {
   assertProfileNotNewer,
   cloakBinaryInfo,
   launchCloakPersistentContext,
+  managedChromiumForkArgs,
   managedCloakArgs,
   managedCloakViewport,
 } from "./cloak.mjs";
+import { buildV2LaunchPlan, resolveGeoIdentity } from "./cloak-v2.mjs";
 import {
   collectCredentialFrameDetections,
   disposeCredentialFrameDetections,
@@ -48,7 +55,16 @@ import {
   downloadBehaviorParams,
   normalizeDownloadPolicy,
 } from "./downloads.mjs";
-import { createGuardProxy } from "./guard-proxy.mjs";
+import {
+  forkMacIdentity,
+  installForkIdentityEmulation,
+  prepareForkFontsConfig,
+} from "./fork-identity.mjs";
+import {
+  createGuardProxy,
+  httpGetViaProxy,
+  parseUpstreamProxy,
+} from "./guard-proxy.mjs";
 import {
   movePointer,
   pointInside,
@@ -1252,26 +1268,11 @@ async function installContextGuard(context) {
       await route.abort("blockedbyclient").catch(() => {});
     }
   });
-  await context.routeWebSocket("**/*", async (webSocket) => {
-    const executeId = transportExecuteId();
-    try {
-      const decision = await guardUrl(
-        webSocket.url(),
-        { method: "GET", resourceType: "websocket" },
-        executeId,
-      );
-      if (decision?.allowed) webSocket.connectToServer();
-      else
-        await webSocket.close({
-          code: 1008,
-          reason: "Blocked by browser policy",
-        });
-    } catch {
-      await webSocket
-        .close({ code: 1011, reason: "Browser policy unavailable" })
-        .catch(() => {});
-    }
-  });
+  // Do not install Playwright's WebSocket interception. It changes the
+  // browser's WebSocket path observably enough for commercial bot defenses to
+  // challenge an otherwise identical session. WebSocket connections still
+  // cannot bypass policy: Chromium sends every TCP target through the SOCKS
+  // guard, which authorizes the host and each resolved address before dialing.
 }
 
 async function ensureBrowser(config) {
@@ -1288,7 +1289,9 @@ async function ensureBrowser(config) {
   }
   if (String(config.executablePath || "").trim()) {
     throw new Error(
-      "Custom executables are disabled; use CLOAKBROWSER_BINARY_PATH for an official CloakBrowser binary.",
+      "Custom executables are disabled; use BETTERWRIGHT_CHROMIUM_PATH / " +
+        "BETTERWRIGHT_CHROMIUM_ROOT for the native fork, or " +
+        "CLOAKBROWSER_BINARY_PATH for an official CloakBrowser binary.",
     );
   }
   const publicSearchPolicy = String(config.publicSearchPolicy || "block")
@@ -1318,9 +1321,93 @@ async function ensureBrowser(config) {
     const transportProxyPort = await guardProxy.ensure();
 
     const headless = launchConfig.headless !== false;
-    const args = managedCloakArgs(
-      fingerprintSeedForProfile(profileLock.profileDir),
-    );
+    const forkBinary = resolveChromiumForkBinary();
+    const args = forkBinary
+      ? managedChromiumForkArgs(
+          fingerprintSeedForProfile(profileLock.profileDir),
+        )
+      : managedCloakArgs(fingerprintSeedForProfile(profileLock.profileDir));
+
+    // Upstream egress proxy (the IP layer). Every connection still passes
+    // policy + DNS-rebinding validation here; the upstream only changes which
+    // IP the target observes. Applies independently of cloakV2 — a configured
+    // proxy is never silently ignored.
+    let upstream = null;
+    if (launchConfig.upstreamProxy) {
+      upstream = parseUpstreamProxy(launchConfig.upstreamProxy);
+      if (!upstream) {
+        throw new Error(
+          "upstreamProxy must be an http:// or socks5:// URL (optional user:pass@).",
+        );
+      }
+    }
+    guardProxy.setUpstream(upstream);
+
+    // Cloaking V2: one coherent identity across the Chromium and network
+    // layers. geoip resolves the locale/timezone to match the egress
+    // geography so the JS layer and the network layer tell the same story.
+    let v2Plan = null;
+    if (launchConfig.cloakV2 !== false) {
+      const identity = await resolveGeoIdentity({
+        geoip: launchConfig.geoip === true && Boolean(upstream),
+        locale: launchConfig.locale,
+        timezone: launchConfig.timezone,
+        fetchJson: upstream
+          ? async (url) => {
+              const response = await httpGetViaProxy(upstream, url);
+              try {
+                return JSON.parse(response.body);
+              } catch {
+                return null;
+              }
+            }
+          : undefined,
+      });
+      v2Plan = buildV2LaunchPlan({
+        locale: identity.locale || "en-US",
+        timezone: identity.timezone || undefined,
+        platform: launchConfig.platform || undefined,
+        headedInvisible: launchConfig.headedInvisible === true,
+        nativeFork: Boolean(forkBinary),
+      });
+      args.push(...v2Plan.args);
+    }
+
+    // Native fork platform masking: present a real consumer-Mac identity
+    // (captured from genuine Chrome on an M4 Pro MacBook; see
+    // src/fork-identity.mjs) instead of the host Linux identity. Window
+    // geometry + DPR flags make screen.* coherent in headless; the UA/UA-CH/
+    // navigator.platform layer is applied per page over CDP after launch.
+    let forkIdentity = null;
+    if (
+      forkBinary &&
+      v2Plan &&
+      v2Plan.identity.platform === "macos" &&
+      launchConfig.platform !== "linux" &&
+      launchConfig.platform !== "windows"
+    ) {
+      forkIdentity = forkMacIdentity(BETTERWRIGHT_CHROMIUM_VERSION);
+      if (launchConfig.headedInvisible !== true) {
+        args.push(
+          `--window-size=${forkIdentity.screen.width},${forkIdentity.screen.height}`,
+        );
+      }
+      args.push(
+        `--force-device-scale-factor=${forkIdentity.screen.devicePixelRatio}`,
+      );
+    }
+
+    // Bundled macOS-metric fonts (scripts/assemble-mac-fonts.sh) ride the
+    // artifact next to the binary; generated conf keeps paths absolute to
+    // the deployment location. Absent bundle: host fontconfig, a known tell.
+    let forkEnv = null;
+    if (forkIdentity) {
+      const fonts = prepareForkFontsConfig({
+        forkBinary,
+        runtimeDir: launchConfig.runtimeDir,
+      });
+      if (fonts) forkEnv = { ...process.env, FONTCONFIG_FILE: fonts.confPath };
+    }
     const proxy = {
       server: `socks5://127.0.0.1:${transportProxyPort}`,
       // Chromium otherwise bypasses the proxy for localhost/link-local
@@ -1329,36 +1416,67 @@ async function ensureBrowser(config) {
       bypass: "<-loopback>",
     };
 
-    // Cloak's wrapper supplies its source-level fingerprint flags, coherent
-    // viewport defaults, and automation-safe Chromium arguments. BetterWright
-    // pins one random seed to the persistent profile so the same identity does
-    // not appear to change hardware on every restart. Its blanket humanizer is
-    // intentionally disabled; BetterWright's frame-safe human helpers remain
-    // the only model-facing interaction layer.
-    const binaryInfo = await cloakBinaryInfo();
-    if (!profileLock.ephemeral) {
-      assertProfileNotNewer(profileLock.profileDir, binaryInfo?.version);
+    if (forkBinary) {
+      if (!profileLock.ephemeral) {
+        assertProfileNotNewer(
+          profileLock.profileDir,
+          BETTERWRIGHT_CHROMIUM_VERSION,
+        );
+      }
+      useSetContentCompatibility = false;
+      const { chromium } = await import("playwright-core");
+      browserContext = await chromium.launchPersistentContext(
+        profileLock.profileDir,
+        {
+          executablePath: forkBinary,
+          headless,
+          ...chromiumForkContextOptions(),
+          proxy,
+          args,
+          // Context-level UA baseline: correct User-Agent from the very first
+          // navigation, before per-page CDP emulation attaches.
+          ...(forkIdentity ? { userAgent: forkIdentity.userAgent } : {}),
+          ...(forkEnv ? { env: forkEnv } : {}),
+          acceptDownloads: true,
+          serviceWorkers: "allow",
+          downloadsPath: launchConfig.downloadsDir,
+        },
+      );
+      if (forkIdentity) {
+        await installForkIdentityEmulation(browserContext, forkIdentity);
+      }
+    } else {
+      // Cloak's wrapper supplies its source-level fingerprint flags, coherent
+      // viewport defaults, and automation-safe Chromium arguments. BetterWright
+      // pins one random seed to the persistent profile so the same identity does
+      // not appear to change hardware on every restart. Its blanket humanizer is
+      // intentionally disabled; BetterWright's frame-safe human helpers remain
+      // the only model-facing interaction layer.
+      const binaryInfo = await cloakBinaryInfo();
+      if (!profileLock.ephemeral) {
+        assertProfileNotNewer(profileLock.profileDir, binaryInfo?.version);
+      }
+      // Patched Cloak builds can report stale lifecycle events to Playwright's
+      // protocol-level setContent implementation. The document-write fallback
+      // below preserves Page/Frame setContent semantics across Cloak versions.
+      useSetContentCompatibility = true;
+      const viewport = managedCloakViewport(binaryInfo, headless);
+      browserContext = await launchCloakPersistentContext({
+        userDataDir: profileLock.profileDir,
+        headless,
+        humanize: false,
+        ...(viewport ? { viewport } : {}),
+        proxy,
+        args,
+        contextOptions: {
+          acceptDownloads: true,
+          serviceWorkers: "block",
+        },
+        launchOptions: {
+          downloadsPath: launchConfig.downloadsDir,
+        },
+      });
     }
-    // Patched Cloak builds can report stale lifecycle events to Playwright's
-    // protocol-level setContent implementation. The document-write fallback
-    // below preserves Page/Frame setContent semantics across Cloak versions.
-    useSetContentCompatibility = true;
-    const viewport = managedCloakViewport(binaryInfo, headless);
-    browserContext = await launchCloakPersistentContext({
-      userDataDir: profileLock.profileDir,
-      headless,
-      humanize: false,
-      ...(viewport ? { viewport } : {}),
-      proxy,
-      args,
-      contextOptions: {
-        acceptDownloads: true,
-        serviceWorkers: "block",
-      },
-      launchOptions: {
-        downloadsPath: launchConfig.downloadsDir,
-      },
-    });
     const launchedContext = browserContext;
     launchedContext.on("close", () => {
       if (browserContext === launchedContext) browserContext = null;

--- a/tests/fixtures/stealth-probe.html
+++ b/tests/fixtures/stealth-probe.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>BetterWright Stealth Probe</title>
+<style>
+  body { font-family: -apple-system, "SF Pro Text", Helvetica, Arial, sans-serif; margin: 2rem; color: #1a1a1a; }
+  h1 { font-size: 1.3rem; }
+  table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+  th, td { border: 1px solid #ccc; padding: 4px 10px; text-align: left; font-size: 0.85rem; }
+  th { background: #f0f0f0; }
+  td.pass { background: #dcf5dc; }
+  td.fail { background: #fae0e0; }
+  td.warn { background: #fdf3d7; }
+  #score { font-size: 1.6rem; font-weight: 700; margin-top: 1rem; }
+  .mono { font-family: ui-monospace, Menlo, monospace; font-size: 0.78rem; }
+</style>
+</head>
+<body>
+<h1>BetterWright Cloaking V2 — stealth probe</h1>
+<div id="score">computing…</div>
+<table id="results">
+  <thead><tr><th>Check</th><th>Result</th><th>Value</th></tr></thead>
+  <tbody></tbody>
+</table>
+<script>
+"use strict";
+const checks = [];
+function record(name, status, value) {
+  checks.push({ name, status, value: String(value).slice(0, 300) });
+}
+function pass(name, value) { record(name, "PASS", value); }
+function fail(name, value) { record(name, "FAIL", value); }
+function warn(name, value) { record(name, "WARN", value); }
+
+async function run() {
+  // --- automation signals ---------------------------------------------------
+  navigator.webdriver === undefined || navigator.webdriver === false
+    ? pass("navigator.webdriver", navigator.webdriver)
+    : fail("navigator.webdriver", navigator.webdriver);
+
+  /HeadlessChrome/.test(navigator.userAgent)
+    ? fail("userAgent headless marker", navigator.userAgent)
+    : pass("userAgent headless marker", "absent");
+
+  const cdcKeys = Object.getOwnPropertyNames(window).filter((k) => /cdc_|\$cdc/i.test(k));
+  cdcKeys.length === 0
+    ? pass("driver injection markers", "none")
+    : fail("driver injection markers", cdcKeys.join(","));
+
+  // --- chrome object --------------------------------------------------------
+  if (window.chrome && typeof window.chrome === "object") {
+    pass("window.chrome", "present");
+    // A fresh stock Chrome 150 page does not expose chrome.runtime. Adding a
+    // page-world shim here is an over-spoof, not a stealth improvement.
+    typeof window.chrome.runtime === "undefined"
+      ? pass("chrome.runtime web-page exposure", "absent (stock parity)")
+      : warn("chrome.runtime web-page exposure", "present");
+    typeof window.chrome.app === "object"
+      ? pass("chrome.app", "present")
+      : fail("chrome.app", "missing");
+  } else {
+    fail("window.chrome", typeof window.chrome);
+  }
+
+  // --- iframe coherence -----------------------------------------------------
+  try {
+    const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    document.body.appendChild(iframe);
+    iframe.contentWindow.chrome
+      ? pass("iframe contentWindow.chrome", "present")
+      : fail("iframe contentWindow.chrome", "missing");
+    iframe.remove();
+  } catch (error) {
+    warn("iframe contentWindow.chrome", error.message);
+  }
+
+  // --- plugins / mimeTypes --------------------------------------------------
+  navigator.plugins && navigator.plugins.length >= 3
+    ? pass("navigator.plugins", `${navigator.plugins.length} entries`)
+    : fail("navigator.plugins", navigator.plugins ? `${navigator.plugins.length} entries` : "missing");
+  navigator.mimeTypes && navigator.mimeTypes.length >= 1
+    ? pass("navigator.mimeTypes", `${navigator.mimeTypes.length} entries`)
+    : fail("navigator.mimeTypes", "empty");
+
+  // --- languages ------------------------------------------------------------
+  Array.isArray(navigator.languages) && navigator.languages.length >= 1
+    ? pass("navigator.languages", navigator.languages.join(","))
+    : fail("navigator.languages", "missing");
+
+  // --- geometry coherence ---------------------------------------------------
+  const geo = {
+    screenW: screen.width, screenH: screen.height,
+    availW: screen.availWidth, availH: screen.availHeight,
+    innerW: window.innerWidth, innerH: window.innerHeight,
+    outerW: window.outerWidth, outerH: window.outerHeight,
+    dpr: window.devicePixelRatio,
+  };
+  // Headless tell: screen == inner == outer with zero window chrome.
+  if (geo.screenH > geo.innerH && geo.outerH >= geo.innerH && geo.outerW > 0 && geo.outerH > 0) {
+    pass("geometry coherence", JSON.stringify(geo));
+  } else if (geo.outerH === geo.innerH && geo.screenH === geo.innerH) {
+    fail("geometry coherence (headless signature)", JSON.stringify(geo));
+  } else {
+    warn("geometry coherence", JSON.stringify(geo));
+  }
+  geo.screenW >= geo.availW && geo.screenH >= geo.availH
+    ? pass("screen/avail coherence", `${geo.availW}x${geo.availH} of ${geo.screenW}x${geo.screenH}`)
+    : fail("screen/avail coherence", JSON.stringify(geo));
+  Number.isInteger(geo.dpr) || geo.dpr > 0
+    ? pass("devicePixelRatio", geo.dpr)
+    : fail("devicePixelRatio", geo.dpr);
+  screen.colorDepth === 24
+    ? pass("screen.colorDepth", screen.colorDepth)
+    : warn("screen.colorDepth", screen.colorDepth);
+
+  // --- permissions coherence -------------------------------------------------
+  try {
+    if (typeof Notification === "undefined") {
+      fail("Notification API", "missing");
+    } else {
+      const perm = Notification.permission;
+      const query = await navigator.permissions.query({ name: "notifications" });
+      const coherent =
+        (perm === "default" && query.state === "prompt") ||
+        (perm === "granted" && query.state === "granted") ||
+        (perm === "denied" && query.state === "denied");
+      coherent
+        ? pass("Notification/permissions coherence", `${perm}/${query.state}`)
+        : fail("Notification/permissions coherence", `${perm}/${query.state}`);
+    }
+  } catch (error) {
+    warn("Notification/permissions coherence", error.message);
+  }
+
+  // --- hardware -------------------------------------------------------------
+  navigator.hardwareConcurrency >= 2
+    ? pass("hardwareConcurrency", navigator.hardwareConcurrency)
+    : fail("hardwareConcurrency", navigator.hardwareConcurrency);
+  !("deviceMemory" in navigator) || navigator.deviceMemory >= 2
+    ? pass("deviceMemory", "deviceMemory" in navigator ? navigator.deviceMemory : "n/a")
+    : fail("deviceMemory", navigator.deviceMemory);
+  navigator.maxTouchPoints === 0
+    ? pass("maxTouchPoints (desktop)", 0)
+    : warn("maxTouchPoints (desktop)", navigator.maxTouchPoints);
+
+  // --- WebGL -----------------------------------------------------------------
+  try {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+    if (gl) {
+      const ext = gl.getExtension("WEBGL_debug_renderer_info");
+      const vendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR);
+      const renderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+      /swiftshader|software|llvmpipe|angle \(google/i.test(renderer)
+        ? fail("WebGL renderer", renderer)
+        : pass("WebGL renderer", renderer);
+      pass("WebGL vendor", vendor);
+    } else {
+      fail("WebGL", "context unavailable");
+    }
+  } catch (error) {
+    warn("WebGL", error.message);
+  }
+
+  // --- media devices ----------------------------------------------------------
+  try {
+    if (navigator.mediaDevices?.enumerateDevices) {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      devices.length > 0
+        ? pass("mediaDevices", `${devices.length} devices`)
+        : warn("mediaDevices", "0 devices");
+    }
+  } catch (error) {
+    warn("mediaDevices", error.message);
+  }
+
+  // --- speech synthesis voices (headless often has none) ---------------------
+  try {
+    const voices = speechSynthesis.getVoices();
+    voices.length > 0
+      ? pass("speechSynthesis voices", voices.length)
+      : warn("speechSynthesis voices", 0);
+  } catch (error) {
+    warn("speechSynthesis voices", error.message);
+  }
+
+  // --- misc APIs ---------------------------------------------------------------
+  "connection" in navigator && navigator.connection
+    ? pass("navigator.connection", navigator.connection.effectiveType || "present")
+    : warn("navigator.connection", "missing");
+  navigator.pdfViewerEnabled === true
+    ? pass("pdfViewerEnabled", true)
+    : warn("pdfViewerEnabled", navigator.pdfViewerEnabled);
+
+  // --- client hints ------------------------------------------------------------
+  try {
+    if (navigator.userAgentData) {
+      const data = await navigator.userAgentData.getHighEntropyValues(["platform", "platformVersion", "model", "uaFullVersion"]);
+      const headlessBrand = /headless/i.test(JSON.stringify(data.brands || [])) || /headless/i.test(navigator.userAgent);
+      headlessBrand
+        ? fail("client hints", JSON.stringify(data))
+        : pass("client hints", `${data.platform} ${data.uaFullVersion || ""}`);
+      data.mobile === false ? pass("client hints mobile=false", "ok") : fail("client hints mobile=false", data.mobile);
+    } else {
+      warn("client hints", "userAgentData missing");
+    }
+  } catch (error) {
+    warn("client hints", error.message);
+  }
+
+  // --- toString hygiene on patched surfaces -------------------------------------
+  function isNative(fn) {
+    try {
+      return /\{\s*\[native code\]\s*\}/.test(Function.prototype.toString.call(fn));
+    } catch {
+      return false;
+    }
+  }
+  const toStringTargets = {
+    "permissions.query": navigator.permissions?.query,
+    "plugins getter": navigator.__lookupGetter__ ? null : Object.getOwnPropertyDescriptor(Navigator.prototype, "plugins")?.get,
+    "webdriver getter": Object.getOwnPropertyDescriptor(Navigator.prototype, "webdriver")?.get,
+  };
+  for (const [label, fn] of Object.entries(toStringTargets)) {
+    if (typeof fn !== "function") continue;
+    isNative(fn) ? pass(`toString hygiene: ${label}`, "native") : fail(`toString hygiene: ${label}`, "non-native");
+  }
+  isNative(Function.prototype.toString)
+    ? pass("toString hygiene: Function.prototype.toString", "native")
+    : fail("toString hygiene: Function.prototype.toString", "tampered");
+
+  // --- timezone / intl ----------------------------------------------------------
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    tz ? pass("Intl timezone", tz) : fail("Intl timezone", "missing");
+  } catch (error) {
+    warn("Intl timezone", error.message);
+  }
+
+  // --- error stack cleanliness ----------------------------------------------------
+  try {
+    const stack = new Error().stack || "";
+    /cdp|devtools|playwright|__playwright/i.test(stack)
+      ? fail("error stack artifacts", stack.split("\n")[1] || stack.slice(0, 120))
+      : pass("error stack artifacts", "clean");
+  } catch {
+    /* ignore */
+  }
+  window.__playwright || window.__pw_manual || window.__PW_inspect
+    ? fail("playwright globals", "present")
+    : pass("playwright globals", "absent");
+
+  // --- score ----------------------------------------------------------------------
+  const scored = checks.filter((c) => c.status !== "WARN");
+  const passed = scored.filter((c) => c.status === "PASS").length;
+  const score = Math.round((passed / scored.length) * 100);
+  window.__PROBE_RESULTS__ = { score, checks, userAgent: navigator.userAgent };
+
+  // render
+  document.getElementById("score").textContent = `Stealth score: ${score}/100 (${passed}/${scored.length} checks passed)`;
+  const tbody = document.querySelector("#results tbody");
+  for (const check of checks) {
+    const row = document.createElement("tr");
+    const cls = check.status === "PASS" ? "pass" : check.status === "FAIL" ? "fail" : "warn";
+    row.innerHTML = `<td>${check.name}</td><td class="${cls}">${check.status}</td><td class="mono"></td>`;
+    row.children[2].textContent = check.value;
+    tbody.appendChild(row);
+  }
+  document.title = `probe:${score}`;
+}
+run();
+</script>
+</body>
+</html>

--- a/tests/node/chromium-fork.test.mjs
+++ b/tests/node/chromium-fork.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  BETTERWRIGHT_CHROMIUM_VERSION,
+  chromiumForkContextOptions,
+  resolveChromiumForkBinary,
+} from "../../src/chromium-fork.mjs";
+
+const present = () => true;
+const ROOT = path.dirname(
+  path.dirname(path.dirname(fileURLToPath(import.meta.url))),
+);
+
+const NO_FORK_HOME = path.join(ROOT, "tests", "fixtures", "no-such-home");
+
+test("Chromium fork stays disabled when no runtime path is configured", () => {
+  assert.equal(
+    resolveChromiumForkBinary({ env: {}, home: NO_FORK_HOME }),
+    null,
+  );
+  assert.equal(BETTERWRIGHT_CHROMIUM_VERSION, "150.0.7871.129");
+});
+
+test("default root discovers a deployed artifact (zero-config fork)", () => {
+  const home = "/home/deploy";
+  const binary = path.join(home, ".betterwright", "chromium", "linux-x64", "chrome");
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: {},
+      platform: "linux",
+      arch: "x64",
+      home,
+      existsSync: (p) => p === binary,
+    }),
+    binary,
+  );
+});
+
+test("platforms without a deployed artifact fall back to managed CloakBrowser", () => {
+  // Windows: layout exists but no artifact shipped.
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: {},
+      platform: "win32",
+      arch: "x64",
+      home: "C:\\Users\\deploy",
+      existsSync: () => false,
+    }),
+    null,
+  );
+});
+
+test("explicit off forces managed CloakBrowser even with an artifact", () => {
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: { BETTERWRIGHT_CHROMIUM_ROOT: "off" },
+      existsSync: present,
+    }),
+    null,
+  );
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: { BETTERWRIGHT_CHROMIUM_PATH: "OFF" },
+      existsSync: present,
+    }),
+    null,
+  );
+});
+
+test("Chromium fork preserves native metrics and normal browser behavior", () => {
+  const options = chromiumForkContextOptions({
+    platform: "darwin",
+    getuid: () => 501,
+  });
+  assert.equal(options.viewport, null);
+  assert.equal(options.chromiumSandbox, true);
+  assert.ok(options.ignoreDefaultArgs.includes("--disable-extensions"));
+  assert.ok(options.ignoreDefaultArgs.includes("--disable-back-forward-cache"));
+  assert.ok(
+    options.ignoreDefaultArgs.some((arg) =>
+      arg.includes("ThirdPartyStoragePartitioning"),
+    ),
+  );
+  assert.equal(
+    options.ignoreDefaultArgs.includes("--remote-debugging-pipe"),
+    false,
+  );
+});
+
+test("managed worker avoids detectable WebSocket interception", () => {
+  const workerSource = fs.readFileSync(
+    path.join(ROOT, "src", "worker.mjs"),
+    "utf8",
+  );
+  assert.doesNotMatch(workerSource, /\.routeWebSocket\s*\(/);
+  assert.match(workerSource, /createGuardProxy\s*\(/);
+});
+
+test("Chromium fork disables the Linux sandbox only for uid zero", () => {
+  assert.equal(
+    chromiumForkContextOptions({ platform: "linux", getuid: () => 0 })
+      .chromiumSandbox,
+    false,
+  );
+  assert.equal(
+    chromiumForkContextOptions({ platform: "linux", getuid: () => 1000 })
+      .chromiumSandbox,
+    true,
+  );
+});
+
+test("explicit Chromium fork path wins and must be absolute", () => {
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: {
+        BETTERWRIGHT_CHROMIUM_PATH: "/opt/betterwright/chrome",
+        BETTERWRIGHT_CHROMIUM_ROOT: "/ignored",
+      },
+      existsSync: present,
+    }),
+    "/opt/betterwright/chrome",
+  );
+  assert.throws(
+    () =>
+      resolveChromiumForkBinary({
+        env: { BETTERWRIGHT_CHROMIUM_PATH: "relative/chrome" },
+        existsSync: present,
+      }),
+    /absolute path/,
+  );
+});
+
+test("artifact root resolves native macOS and Linux layouts", () => {
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: { BETTERWRIGHT_CHROMIUM_ROOT: "/opt/betterwright" },
+      platform: "darwin",
+      arch: "arm64",
+      existsSync: present,
+    }),
+    path.join(
+      "/opt/betterwright",
+      "mac-arm64",
+      "Chromium.app",
+      "Contents",
+      "MacOS",
+      "Chromium",
+    ),
+  );
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: { BETTERWRIGHT_CHROMIUM_ROOT: "/opt/betterwright" },
+      platform: "linux",
+      arch: "x64",
+      existsSync: present,
+    }),
+    path.join("/opt/betterwright", "linux-x64", "chrome"),
+  );
+});
+
+test("configured fork paths fail closed when missing or unsupported", () => {
+  assert.throws(
+    () =>
+      resolveChromiumForkBinary({
+        env: { BETTERWRIGHT_CHROMIUM_PATH: "/missing/chrome" },
+        existsSync: () => false,
+      }),
+    /not found/,
+  );
+  assert.throws(
+    () =>
+      resolveChromiumForkBinary({
+        env: { BETTERWRIGHT_CHROMIUM_ROOT: "/opt/betterwright" },
+        platform: "linux",
+        arch: "riscv64",
+        existsSync: present,
+      }),
+    /No BetterWright Chromium artifact layout/,
+  );
+});

--- a/tests/node/client.test.mjs
+++ b/tests/node/client.test.mjs
@@ -74,6 +74,45 @@ test("CloakBrowser is the managed default", async () => {
   }
 });
 
+test("Cloaking V2 options reach the worker and headedInvisible forces headed mode", async () => {
+  const defaults = new BetterWright();
+  const configured = new BetterWright({
+    cloakV2: false,
+    upstreamProxy: "socks5://proxy.example:1080",
+    geoip: true,
+    locale: "de-DE",
+    timezone: "Europe/Berlin",
+    headless: true,
+    headedInvisible: true,
+  });
+  try {
+    assert.equal(defaults.cloakV2, true);
+    assert.equal(defaults._workerConfig().cloakV2, true);
+    assert.equal(configured.headless, false);
+    assert.deepEqual(
+      {
+        cloakV2: configured._workerConfig().cloakV2,
+        upstreamProxy: configured._workerConfig().upstreamProxy,
+        geoip: configured._workerConfig().geoip,
+        locale: configured._workerConfig().locale,
+        timezone: configured._workerConfig().timezone,
+        headedInvisible: configured._workerConfig().headedInvisible,
+      },
+      {
+        cloakV2: false,
+        upstreamProxy: "socks5://proxy.example:1080",
+        geoip: true,
+        locale: "de-DE",
+        timezone: "Europe/Berlin",
+        headedInvisible: true,
+      },
+    );
+  } finally {
+    await defaults.close();
+    await configured.close();
+  }
+});
+
 test("headed and headless modes use the same managed Cloak profile", async () => {
   const headed = new BetterWright({ headless: false });
   const headless = new BetterWright({ headless: true });

--- a/tests/node/cloak-v2.test.mjs
+++ b/tests/node/cloak-v2.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildV2LaunchPlan,
+  resolveGeoIdentity,
+  v2LaunchArgs,
+} from "../../src/cloak-v2.mjs";
+
+test("v2LaunchArgs renders locale/timezone/platform flags", () => {
+  const args = v2LaunchArgs({
+    locale: "de-DE",
+    timezone: "Europe/Berlin",
+    platform: "macos",
+  });
+  assert.ok(args.includes("--lang=de-DE"));
+  assert.ok(args.includes("--fingerprint-locale=de-DE"));
+  assert.ok(args.includes("--fingerprint-timezone=Europe/Berlin"));
+  assert.ok(args.includes("--fingerprint-platform=macos"));
+});
+
+test("v2LaunchArgs uses native fork timezone switch and passes platform farbling", () => {
+  const args = v2LaunchArgs({
+    locale: "de-DE",
+    timezone: "Europe/Berlin",
+    platform: "macos",
+    nativeFork: true,
+  });
+  assert.ok(args.includes("--bw-timezone=Europe/Berlin"));
+  assert.equal(args.includes("--fingerprint-timezone=Europe/Berlin"), false);
+  assert.ok(args.includes("--fingerprint-platform=macos"));
+});
+
+test("native fork defaults platform identity to macos mask", () => {
+  const plan = buildV2LaunchPlan({ nativeFork: true });
+  assert.equal(plan.identity.platform, "macos");
+  assert.ok(plan.args.includes("--fingerprint-platform=macos"));
+});
+
+test("explicit platform wins over the fork macos default", () => {
+  const plan = buildV2LaunchPlan({ nativeFork: true, platform: "windows" });
+  assert.equal(plan.identity.platform, "windows");
+  assert.ok(plan.args.includes("--fingerprint-platform=windows"));
+});
+
+test("headedInvisible parks a real window off-screen at preset size", () => {
+  const args = v2LaunchArgs({ platform: "macos", headedInvisible: true });
+  assert.ok(args.includes("--window-size=1920,1015"));
+  assert.ok(args.includes("--window-position=32000,32000"));
+});
+
+test("geo identity: explicit values win, no lookup performed", async () => {
+  let called = false;
+  const result = await resolveGeoIdentity({
+    geoip: true,
+    locale: "en-US",
+    timezone: "America/New_York",
+    fetchJson: async () => {
+      called = true;
+      return null;
+    },
+  });
+  assert.equal(called, false);
+  assert.equal(result.locale, "en-US");
+  assert.equal(result.timezone, "America/New_York");
+});
+
+test("geo identity: lookup fills missing values from egress geography", async () => {
+  const result = await resolveGeoIdentity({
+    geoip: true,
+    fetchJson: async () => ({ status: "success", countryCode: "DE", timezone: "Europe/Berlin" }),
+  });
+  assert.equal(result.locale, "de-DE");
+  assert.equal(result.timezone, "Europe/Berlin");
+  assert.equal(result.source, "geoip");
+});
+
+test("geo identity: lookup failure falls back without throwing", async () => {
+  const result = await resolveGeoIdentity({
+    geoip: true,
+    fetchJson: async () => {
+      throw new Error("upstream down");
+    },
+  });
+  assert.equal(result.locale, null);
+  assert.equal(result.timezone, null);
+});
+
+test("geo identity: unknown country falls back to en-US", async () => {
+  const result = await resolveGeoIdentity({
+    geoip: true,
+    fetchJson: async () => ({ status: "success", countryCode: "AQ", timezone: "Antarctica/Troll" }),
+  });
+  assert.equal(result.locale, "en-US");
+  assert.equal(result.timezone, "Antarctica/Troll");
+});
+
+test("launch plan contains only native flags and identity", () => {
+  const plan = buildV2LaunchPlan({ locale: "ja-JP", timezone: "Asia/Tokyo" });
+  assert.ok(plan.args.includes("--lang=ja-JP"));
+  assert.equal("viewport" in plan, false);
+  assert.equal("initScript" in plan, false);
+  assert.equal(plan.identity.timezone, "Asia/Tokyo");
+});

--- a/tests/node/fork-identity.test.mjs
+++ b/tests/node/fork-identity.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  forkFontsDir,
+  forkMacIdentity,
+  prepareForkFontsConfig,
+} from "../../src/fork-identity.mjs";
+
+test("fork mac identity carries no linux or headless markers", () => {
+  const id = forkMacIdentity("150.0.7871.129");
+  assert.match(id.userAgent, /Macintosh; Intel Mac OS X 10_15_7/);
+  assert.match(id.userAgent, /Chrome\/150\.0\.0\.0 Safari\/537\.36$/);
+  assert.doesNotMatch(id.userAgent, /Linux|X11|Headless/);
+  assert.equal(id.navigatorPlatform, "MacIntel");
+  assert.equal(id.userAgentMetadata.platform, "macOS");
+  assert.equal(id.userAgentMetadata.architecture, "arm");
+  assert.equal(id.userAgentMetadata.mobile, false);
+});
+
+test("fork mac identity tracks the pinned chromium version", () => {
+  const id = forkMacIdentity("151.1.2.3");
+  const brands = id.userAgentMetadata.fullVersionList;
+  assert.deepEqual(
+    brands.find((b) => b.brand === "Chromium"),
+    { brand: "Chromium", version: "151.1.2.3" },
+  );
+  assert.deepEqual(
+    brands.find((b) => b.brand === "Google Chrome"),
+    { brand: "Google Chrome", version: "151.1.2.3" },
+  );
+  assert.ok(
+    id.userAgentMetadata.brands.some(
+      (b) => b.brand === "Google Chrome" && b.version === "151",
+    ),
+  );
+  assert.match(id.userAgent, /Chrome\/151\.0\.0\.0/);
+});
+
+test("fork mac identity matches real consumer hardware", () => {
+  const id = forkMacIdentity("150.0.7871.129");
+  assert.equal(id.hardwareConcurrency, 12);
+  assert.equal(id.deviceMemory, 16);
+  assert.equal(id.screen.devicePixelRatio, 2);
+  assert.ok(id.screen.availHeight < id.screen.height); // menu bar + dock
+  assert.match(id.webgl.unmaskedRenderer, /ANGLE Metal Renderer: Apple M4 Pro/);
+  assert.equal(id.webgl.unmaskedVendor, "Google Inc. (Apple)");
+});
+
+test("fonts config is generated next to the binary's font bundle", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "bw-fonts-"));
+  const binDir = path.join(root, "linux-x64");
+  const fontsDir = path.join(binDir, "fonts", "ttf");
+  fs.mkdirSync(fontsDir, { recursive: true });
+  const runtimeDir = path.join(root, "runtime");
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  const result = prepareForkFontsConfig({
+    forkBinary: path.join(binDir, "chrome"),
+    runtimeDir,
+  });
+  assert.ok(result);
+  const conf = fs.readFileSync(result.confPath, "utf8");
+  assert.ok(conf.includes(`<dir>${fontsDir}</dir>`));
+  assert.ok(conf.includes("Helvetica Neue"));
+  assert.ok(fs.statSync(result.cacheDir).isDirectory());
+});
+
+test("fonts config is null without a bundle (host fontconfig fallback)", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "bw-fonts-none-"));
+  const result = prepareForkFontsConfig({
+    forkBinary: path.join(root, "chrome"),
+    runtimeDir: root,
+  });
+  assert.equal(result, null);
+  assert.equal(forkFontsDir(path.join(root, "chrome")), null);
+});
+
+test("forkFontsDir finds fonts/ttf next to the binary", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "bw-fonts-dir-"));
+  const fontsDir = path.join(root, "fonts", "ttf");
+  fs.mkdirSync(fontsDir, { recursive: true });
+  assert.equal(forkFontsDir(path.join(root, "chrome")), fontsDir);
+});

--- a/tests/node/guard-proxy-upstream.test.mjs
+++ b/tests/node/guard-proxy-upstream.test.mjs
@@ -1,0 +1,364 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import net from "node:net";
+import test from "node:test";
+
+import {
+  createGuardProxy,
+  httpGetViaProxy,
+  parseUpstreamProxy,
+} from "../../src/guard-proxy.mjs";
+
+function socksGreeting(client) {
+  client.write(Buffer.from([5, 1, 0]));
+  return readExact(client, 2);
+}
+
+function readExact(socket, minimum) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let length = 0;
+    const timer = setTimeout(() => finish(new Error("timed out reading socket")), 3_000);
+    const finish = (error, value) => {
+      clearTimeout(timer);
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      if (error) reject(error);
+      else resolve(value);
+    };
+    const onData = (chunk) => {
+      chunks.push(chunk);
+      length += chunk.length;
+      if (length >= minimum) finish(null, Buffer.concat(chunks, length).subarray(0, minimum));
+    };
+    const onError = (error) => finish(error);
+    const onClose = () => finish(new Error("socket closed early"));
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+async function socksRequest(client, host, port = 443) {
+  const encoded = Buffer.from(host, "utf8");
+  const portBytes = Buffer.alloc(2);
+  portBytes.writeUInt16BE(port);
+  client.write(
+    Buffer.concat([Buffer.from([5, 1, 0, 3, encoded.length]), encoded, portBytes]),
+  );
+  const reply = await readExact(client, 10);
+  return reply[1];
+}
+
+function guardOptions(overrides = {}) {
+  return {
+    guardUrl: async () => ({ allowed: true }),
+    executeId: () => "upstream-test",
+    transport: {},
+    ...overrides,
+  };
+}
+
+/** Mock HTTP CONNECT upstream; records the CONNECT authority it received. */
+async function startHttpUpstream({
+  accept = true,
+  requireAuth = null,
+  responseBody = null,
+} = {}) {
+  const received = [];
+  const server = net.createServer((socket) => {
+    let buffer = Buffer.alloc(0);
+    let established = false;
+    socket.on("data", (chunk) => {
+      if (established) {
+        if (responseBody == null) {
+          // Echo server: anything the browser sends comes straight back.
+          socket.write(chunk);
+        } else {
+          socket.end(
+            `HTTP/1.1 200 OK\r\nContent-Length: ${Buffer.byteLength(responseBody)}\r\nConnection: close\r\n\r\n${responseBody}`,
+          );
+        }
+        return;
+      }
+      buffer = Buffer.concat([buffer, chunk]);
+      const end = buffer.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const head = buffer.subarray(0, end).toString("latin1");
+      const [requestLine, ...headerLines] = head.split("\r\n");
+      const authority = requestLine.split(" ")[1];
+      const authHeader = headerLines.find((line) =>
+        line.toLowerCase().startsWith("proxy-authorization:"),
+      );
+      received.push({ authority, authHeader: authHeader || null });
+      const rest = buffer.subarray(end + 4);
+      buffer = Buffer.alloc(0);
+      if (requireAuth) {
+        const expected = `Proxy-Authorization: Basic ${Buffer.from(requireAuth).toString("base64")}`;
+        if (authHeader !== expected) {
+          socket.end("HTTP/1.1 407 Proxy Authentication Required\r\n\r\n");
+          return;
+        }
+      }
+      if (!accept) {
+        socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
+        return;
+      }
+      established = true;
+      socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (rest.length) socket.write(rest);
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { server, received, port: server.address().port };
+}
+
+/** Mock SOCKS5 upstream with optional username/password auth. */
+async function startSocks5Upstream({
+  username = null,
+  password = null,
+  responseBody = null,
+} = {}) {
+  const received = [];
+  const server = net.createServer((socket) => {
+    let stage = "greeting";
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      if (stage === "relay") {
+        if (responseBody == null) {
+          socket.write(chunk);
+        } else {
+          socket.end(
+            `HTTP/1.1 200 OK\r\nContent-Length: ${Buffer.byteLength(responseBody)}\r\nConnection: close\r\n\r\n${responseBody}`,
+          );
+        }
+        return;
+      }
+      buffer = Buffer.concat([buffer, chunk]);
+      if (stage === "greeting") {
+        if (buffer.length < 2 || buffer.length < 2 + buffer[1]) return;
+        const wantsAuth = Boolean(username);
+        socket.write(Buffer.from([5, wantsAuth ? 2 : 0]));
+        buffer = buffer.subarray(2 + buffer[1]);
+        stage = wantsAuth ? "auth" : "request";
+        if (wantsAuth && buffer.length === 0) return;
+      }
+      if (stage === "auth") {
+        if (buffer.length < 2) return;
+        const ulen = buffer[1];
+        if (buffer.length < 2 + ulen + 1) return;
+        const user = buffer.subarray(2, 2 + ulen).toString("utf8");
+        const plen = buffer[2 + ulen];
+        if (buffer.length < 2 + ulen + 1 + plen) return;
+        const pass = buffer.subarray(3 + ulen, 3 + ulen + plen).toString("utf8");
+        socket.write(
+          Buffer.from([1, user === username && pass === password ? 0 : 1]),
+        );
+        buffer = buffer.subarray(3 + ulen + plen);
+        stage = "request";
+        if (buffer.length === 0) return;
+      }
+      if (stage === "request") {
+        if (buffer.length < 10) return;
+        const atyp = buffer[3];
+        let host;
+        if (atyp === 1) host = buffer.subarray(4, 8).join(".");
+        else if (atyp === 3) host = buffer.subarray(5, 5 + buffer[4]).toString("utf8");
+        else host = "ipv6";
+        const port = buffer.readUInt16BE(atyp === 3 ? 7 + buffer[4] - 2 : 8);
+        received.push({ host, port, atyp });
+        socket.write(Buffer.from([5, 0, 0, 1, 0, 0, 0, 0, 0, 0]));
+        buffer = Buffer.alloc(0);
+        stage = "relay";
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { server, received, port: server.address().port };
+}
+
+test("parseUpstreamProxy parses http/socks5 with auth", () => {
+  assert.deepEqual(parseUpstreamProxy("http://proxy.local:8080"), {
+    protocol: "http",
+    host: "proxy.local",
+    port: 8080,
+    username: "",
+    password: "",
+  });
+  assert.deepEqual(parseUpstreamProxy("socks5://user:p%40ss@10.0.0.9:1080"), {
+    protocol: "socks5",
+    host: "10.0.0.9",
+    port: 1080,
+    username: "user",
+    password: "p@ss",
+  });
+  assert.equal(parseUpstreamProxy("socks5h://proxy.local")?.port, 1080);
+  assert.equal(parseUpstreamProxy("ftp://nope"), null);
+  assert.equal(parseUpstreamProxy("not a url"), null);
+  assert.equal(parseUpstreamProxy(null), null);
+});
+
+test("geo lookup tunnels through an HTTP upstream", async () => {
+  const body = JSON.stringify({ status: "success", countryCode: "SG" });
+  const upstream = await startHttpUpstream({ responseBody: body });
+  try {
+    const response = await httpGetViaProxy(
+      parseUpstreamProxy(`http://127.0.0.1:${upstream.port}`),
+      "http://geo.example/lookup",
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.body, body);
+    assert.equal(upstream.received[0].authority, "geo.example:80");
+  } finally {
+    upstream.server.close();
+  }
+});
+
+test("geo lookup uses the SOCKS5 handshake and credentials", async () => {
+  const body = JSON.stringify({ status: "success", countryCode: "DE" });
+  const upstream = await startSocks5Upstream({
+    username: "geo",
+    password: "secret",
+    responseBody: body,
+  });
+  try {
+    const response = await httpGetViaProxy(
+      parseUpstreamProxy(`socks5://geo:secret@127.0.0.1:${upstream.port}`),
+      "http://geo.example/lookup",
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.body, body);
+    assert.deepEqual(upstream.received[0], {
+      host: "geo.example",
+      port: 80,
+      atyp: 3,
+    });
+  } finally {
+    upstream.server.close();
+  }
+});
+
+test("guard tunnels through an HTTP upstream to the validated literal IP", async () => {
+  const upstream = await startHttpUpstream();
+  const guard = createGuardProxy(
+    guardOptions({
+      transport: {
+        lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+      },
+      upstreamProxy: parseUpstreamProxy(`http://127.0.0.1:${upstream.port}`),
+    }),
+  );
+  try {
+    const port = await guard.ensure();
+    const client = net.createConnection({ host: "127.0.0.1", port });
+    await once(client, "connect");
+    await socksGreeting(client);
+    const code = await socksRequest(client, "example.com", 443);
+    assert.equal(code, 0, "guard reports success");
+    client.write("ping-through-upstream");
+    const echoed = await readExact(client, 21);
+    assert.equal(echoed.toString(), "ping-through-upstream");
+    client.destroy();
+    // The upstream saw CONNECT to the validated literal — never the hostname.
+    assert.equal(upstream.received[0].authority, "93.184.216.34:443");
+  } finally {
+    await guard.close();
+    upstream.server.close();
+  }
+});
+
+test("HTTP upstream forwards proxy credentials", async () => {
+  const upstream = await startHttpUpstream({ requireAuth: "alice:s3cret" });
+  const guard = createGuardProxy(
+    guardOptions({
+      transport: { lookup: async () => [{ address: "93.184.216.34", family: 4 }] },
+      upstreamProxy: parseUpstreamProxy(
+        `http://alice:s3cret@127.0.0.1:${upstream.port}`,
+      ),
+    }),
+  );
+  try {
+    const port = await guard.ensure();
+    const client = net.createConnection({ host: "127.0.0.1", port });
+    await once(client, "connect");
+    await socksGreeting(client);
+    assert.equal(await socksRequest(client, "example.com"), 0);
+    assert.match(upstream.received[0].authHeader, /^Proxy-Authorization: Basic /);
+    client.destroy();
+  } finally {
+    await guard.close();
+    upstream.server.close();
+  }
+});
+
+test("SOCKS5 upstream with auth tunnels to the literal IP", async () => {
+  const upstream = await startSocks5Upstream({ username: "bob", password: "hunter2" });
+  const guard = createGuardProxy(
+    guardOptions({
+      transport: { lookup: async () => [{ address: "93.184.216.34", family: 4 }] },
+      upstreamProxy: parseUpstreamProxy(`socks5://bob:hunter2@127.0.0.1:${upstream.port}`),
+    }),
+  );
+  try {
+    const port = await guard.ensure();
+    const client = net.createConnection({ host: "127.0.0.1", port });
+    await once(client, "connect");
+    await socksGreeting(client);
+    assert.equal(await socksRequest(client, "example.com"), 0);
+    client.write("relay-me");
+    assert.equal((await readExact(client, 8)).toString(), "relay-me");
+    assert.equal(upstream.received[0].host, "93.184.216.34");
+    client.destroy();
+  } finally {
+    await guard.close();
+    upstream.server.close();
+  }
+});
+
+test("upstream refusal surfaces as a SOCKS failure to the browser", async () => {
+  const upstream = await startHttpUpstream({ accept: false });
+  const guard = createGuardProxy(
+    guardOptions({
+      transport: { lookup: async () => [{ address: "93.184.216.34", family: 4 }] },
+      upstreamProxy: parseUpstreamProxy(`http://127.0.0.1:${upstream.port}`),
+    }),
+  );
+  try {
+    const port = await guard.ensure();
+    const client = net.createConnection({ host: "127.0.0.1", port });
+    await once(client, "connect");
+    await socksGreeting(client);
+    const code = await socksRequest(client, "example.com");
+    assert.notEqual(code, 0, "guard reports failure");
+    client.destroy();
+  } finally {
+    await guard.close();
+    upstream.server.close();
+  }
+});
+
+test("policy blocks still apply before any upstream connection", async () => {
+  const upstream = await startHttpUpstream();
+  const guard = createGuardProxy(
+    guardOptions({
+      guardUrl: async () => ({ allowed: false, reason: "blocked test host" }),
+      transport: { lookup: async () => [{ address: "93.184.216.34", family: 4 }] },
+      upstreamProxy: parseUpstreamProxy(`http://127.0.0.1:${upstream.port}`),
+    }),
+  );
+  try {
+    const port = await guard.ensure();
+    const client = net.createConnection({ host: "127.0.0.1", port });
+    await once(client, "connect");
+    await socksGreeting(client);
+    assert.equal(await socksRequest(client, "blocked.example"), 2);
+    assert.equal(upstream.received.length, 0, "upstream never contacted");
+    client.destroy();
+  } finally {
+    await guard.close();
+    upstream.server.close();
+  }
+});

--- a/tests/node/stealth-bench.test.mjs
+++ b/tests/node/stealth-bench.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+
+import {
+  buildTaskPrompt,
+  classifyAttempt,
+  decryptTaskPayload,
+  normalizeTask,
+  selectTasks,
+} from "../../benchmarks/stealth-bench/runner.mjs";
+
+function encryptFixture(value, passphrase = "Stealth_Bench_V1") {
+  const key = crypto.createHash("sha256").update(passphrase).digest();
+  const iv = Buffer.from("00112233445566778899aabbccddeeff", "hex");
+  const cipher = crypto.createCipheriv("aes-128-cbc", key.subarray(16), iv);
+  const ciphertext = Buffer.concat([cipher.update(value), cipher.final()]);
+  const header = Buffer.concat([Buffer.from([0x80]), Buffer.alloc(8), iv, ciphertext]);
+  const signature = crypto.createHmac("sha256", key.subarray(0, 16)).update(header).digest();
+  return Buffer.from(Buffer.concat([header, signature]).toString("base64url")).toString("base64");
+}
+
+function task(taskId, category = "Cloudflare") {
+  return {
+    taskId: String(taskId),
+    instruction: `Complete task ${taskId}`,
+    category,
+    website: `https://example.com/${taskId}`,
+  };
+}
+
+test("Stealth Bench Fernet payloads decrypt in memory and reject tampering", () => {
+  const payload = JSON.stringify([{ task_id: 1 }]);
+  const encrypted = encryptFixture(payload);
+  assert.equal(decryptTaskPayload(encrypted), payload);
+
+  const tampered = Buffer.from(encrypted, "base64");
+  tampered[tampered.length - 2] ^= 1;
+  assert.throws(() => decryptTaskPayload(tampered.toString("base64")), /authentication/);
+});
+
+test("Stealth Bench task normalization validates metadata", () => {
+  assert.deepEqual(
+    normalizeTask({
+      task_id: 7,
+      confirmed_task: "Click three controls.",
+      category: "Akamai",
+      website: "https://example.com/start",
+      answer: "unused",
+    }),
+    {
+      taskId: "7",
+      instruction: "Click three controls.",
+      category: "Akamai",
+      website: "https://example.com/start",
+    },
+  );
+  assert.throws(
+    () => normalizeTask({ task_id: 1, confirmed_task: "x", category: "x", website: "file:///tmp/x" }),
+    /HTTP or HTTPS/,
+  );
+});
+
+test("Stealth Bench selection is deterministic and rejects missing IDs", () => {
+  const tasks = [task(1), task(2, "Akamai"), task(3)];
+  assert.deepEqual(selectTasks(tasks, { taskIds: "3,1" }).map((entry) => entry.taskId), ["1", "3"]);
+  assert.deepEqual(selectTasks(tasks, { category: "akamai" }).map((entry) => entry.taskId), ["2"]);
+  assert.throws(() => selectTasks(tasks, { taskIds: "99" }), /Unknown Stealth Bench task IDs/);
+});
+
+test("Stealth Bench prompt forbids CAPTCHA solving and verdicts prioritize block evidence", () => {
+  const prompt = buildTaskPrompt(task(1));
+  assert.match(prompt, /Do not call captcha\.solve/);
+  assert.equal(classifyAttempt({ answer: "PASSED", agentOk: true }).status, "passed");
+  assert.equal(
+    classifyAttempt({
+      answer: "PASSED",
+      agentOk: true,
+      observations: [{ bodyText: "Checking your browser before accessing the site" }],
+    }).status,
+    "blocked",
+  );
+  assert.equal(classifyAttempt({ answer: "FAILED: selector changed", agentOk: true }).status, "failed");
+});
+

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -31,6 +31,13 @@ export class BetterWright {
   publicSearchPolicy: "block" | "allow";
   downloadPolicy: "ask" | "allow" | "deny";
   stealthRuntimeFix: boolean;
+  cloakV2: boolean;
+  upstreamProxy: string | null;
+  geoip: boolean;
+  locale: string | null;
+  timezone: string | null;
+  headedInvisible: boolean;
+  platform: "macos" | "windows" | "linux" | null;
   defaultTimeout: number;
 
   run<T = unknown>(code: string, options?: RunOptions): Promise<RunResult<T>>;

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -47,4 +47,18 @@ export interface BetterWrightOptions {
    * default. Also settable with `BETTERWRIGHT_STEALTH_RUNTIME_FIX=1`.
    */
   stealthRuntimeFix?: boolean;
+  cloakV2?: boolean;
+  upstreamProxy?: string;
+  geoip?: boolean;
+  locale?: string;
+  timezone?: string;
+  headedInvisible?: boolean;
+  /**
+   * Identity platform presented to sites. The native Chromium fork defaults
+   * to "macos" — a realistic consumer-Mac fingerprint (UA, UA-CH,
+   * navigator.platform, screen geometry) captured from genuine Chrome 150 on
+   * an Apple-Silicon MacBook Pro. The managed CloakBrowser path defaults to
+   * the host platform.
+   */
+  platform?: "macos" | "windows" | "linux";
 }


### PR DESCRIPTION
## Summary
- Same contents as the intended 0.9.9 release (native Chromium fork routing, cloaking v2, egress proxy, upgrade-safe docs/doctor)
- Version is **0.9.10** because the protected `v0.9.9` tag was created on the old 0.9.7 commit and cannot be deleted/moved

## Test plan
- [x] `npm run release:check`
- [ ] CI on this PR
- [ ] After merge: `gh release create v0.9.10` → trusted npm publish