### PR TITLE
Release v0.9.11: betterwright update for Chromium fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,12 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - name: Install managed CloakBrowser
-        run: node bin/betterwright.mjs setup
+        run: node bin/betterwright.mjs setup --cloak-only
       # REQUIRE_BROWSER turns the suite's local-dev skip into a CI failure, so a
       # broken Cloak install can never report green by skipping every browser test.
       - run: npm test
         env:
           BETTERWRIGHT_REQUIRE_BROWSER: "1"
+          BETTERWRIGHT_CHROMIUM_ROOT: "off"
       - name: Test managed CloakBrowser headed mode
-        run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 node --test tests/node/cloak.test.mjs
+        run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 BETTERWRIGHT_CHROMIUM_ROOT=off node --test tests/node/cloak.test.mjs

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -51,12 +51,27 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Install managed CloakBrowser
         if: steps.existing.outputs.published != 'true'
-        run: node bin/betterwright.mjs setup
+        run: node bin/betterwright.mjs setup --cloak-only
+      - name: Verify Chromium fork update
+        if: steps.existing.outputs.published != 'true'
+        shell: bash
+        run: |
+          HOME=$(mktemp -d)
+          export HOME
+          node bin/betterwright.mjs update
+          node -e "
+            import { resolveChromiumForkBinary } from './src/chromium-fork.mjs';
+            const binary = resolveChromiumForkBinary({ home: process.env.HOME });
+            if (!binary) throw new Error('update did not install a discoverable fork');
+            console.log('fork ok:', binary);
+          "
       - name: Run browser integration suite
         if: steps.existing.outputs.published != 'true'
         run: npm test
         env:
           BETTERWRIGHT_REQUIRE_BROWSER: "1"
+          # Keep integration/Cloak e2e on Cloak even if a fork exists on the runner.
+          BETTERWRIGHT_CHROMIUM_ROOT: "off"
       - name: Test managed CloakBrowser headed mode
         if: steps.existing.outputs.published != 'true'
         run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 node --test tests/node/cloak.test.mjs

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -74,7 +74,7 @@ jobs:
           BETTERWRIGHT_CHROMIUM_ROOT: "off"
       - name: Test managed CloakBrowser headed mode
         if: steps.existing.outputs.published != 'true'
-        run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 node --test tests/node/cloak.test.mjs
+        run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 BETTERWRIGHT_CHROMIUM_ROOT=off node --test tests/node/cloak.test.mjs
       - name: Publish to npm with provenance
         if: steps.existing.outputs.published != 'true'
         run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ step from what it sees, in a browser that must still be there next turn:
 
 ## Quick start
 
-Requires **Node.js 22+**. Setup downloads the managed browser (~200 MB, once)
-from its official release source — never as an npm lifecycle side effect, so
-installs stay predictable and work with `--ignore-scripts`.
+Requires **Node.js 22+**. Setup downloads the browser (~200 MB, once) — the
+Chromium fork on macOS arm64 / Linux x64, CloakBrowser elsewhere — never as an
+npm lifecycle side effect, so installs stay predictable with `--ignore-scripts`.
 
 ```bash
 npm install -g betterwright
-betterwright setup     # fetch + verify the managed browser (once)
+betterwright setup     # fork (mac/linux) + Cloak fallback
+betterwright update    # refresh / switch to the Chromium fork
 betterwright doctor    # confirm everything resolves
 ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -31,13 +31,15 @@ to its instructions — `betterwright skill` prints both halves ready to paste.
 3. **Download the managed browser** (one-time, ~200 MB):
 
    ```bash
-   betterwright setup
+   betterwright setup     # Chromium fork on mac/linux + Cloak fallback
+   # or: betterwright update   # fork only (switches default away from Cloak)
    ```
 
-   The official CloakBrowser wrapper downloads its signed binary directly from
-   CloakHQ and verifies it before extraction; BetterWright does not redistribute
-   that separately licensed binary. npm installation itself has no hidden
-   browser-download lifecycle script.
+   On macOS arm64 / Linux x64, setup/update fetch the pinned Chromium fork
+   (SHA-256 verified) into `~/.betterwright/chromium/`. Elsewhere (and with
+   `--cloak-only`), the CloakBrowser wrapper downloads its signed binary from
+   CloakHQ. npm installation itself has no hidden browser-download lifecycle
+   script.
 4. **Verify** with `betterwright doctor` — it must print
    `BetterWright is ready.` If it does not, stop and report exactly what
    `doctor` printed.

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -3,7 +3,8 @@
 //
 //   betterwright                  interactive agent console (type tasks, watch
 //                                 progress, answer the agent's questions)
-//   betterwright setup            install the managed Cloak browser
+//   betterwright setup            install Chromium fork (mac/linux) + Cloak fallback
+//   betterwright update           download/refresh the Chromium fork (switches from Cloak)
 //   betterwright doctor           report runtime readiness
 //   betterwright run <file|-|-c>  execute a Playwright snippet
 //   betterwright repl             run blank-line-separated snippets from stdin
@@ -25,6 +26,7 @@ import { pathToFileURL } from "node:url";
 
 import { formatAgentUsage } from "../src/agent-usage.mjs";
 import { makeLineReader } from "../src/cli-io.mjs";
+import { installChromiumFork } from "../src/chromium-fork-install.mjs";
 import { doctorReport, resolveCloakDir, resolveCoreDir } from "../src/doctor.mjs";
 import { agentSystemPrompt, BetterWright, NetworkPolicy } from "../src/index.mjs";
 
@@ -72,13 +74,7 @@ async function cmdDoctor() {
   return report.ready ? 0 : 1;
 }
 
-async function cmdSetup(flags) {
-  if (flags.has("--chromium")) {
-    console.error(
-      "The stock Chromium fallback was removed. BetterWright setup installs only managed CloakBrowser.",
-    );
-    return 1;
-  }
+async function installCloakBrowser() {
   const core = resolveCoreDir();
   if (!core) {
     console.error(
@@ -96,7 +92,67 @@ async function cmdSetup(flags) {
   console.log("Installing the managed CloakBrowser binary ...");
   const binary = await cloak.ensureBinary();
   console.log(`Installed ${binary}`);
+  return 0;
+}
+
+/** Download the Chromium fork so discovery prefers it over Cloak. */
+async function cmdUpdate(flags) {
+  if (flags.has("--cloak-only")) {
+    console.error(
+      "`betterwright update` installs the Chromium fork. Use `betterwright setup --cloak-only` for CloakBrowser alone.",
+    );
+    return 1;
+  }
+  const result = await installChromiumFork({ force: flags.has("--force") });
+  if (result.skipped) {
+    console.log(result.skipped);
+    console.log("On this platform, keep using `betterwright setup` for CloakBrowser.");
+    return 0;
+  }
+  console.log(
+    "\nUpdate complete. BetterWright will use the Chromium fork by default.",
+  );
+  console.log("Run `betterwright doctor` to confirm (browser: chromium-fork).");
+  console.log(
+    "Tip: use a dedicated BETTERWRIGHT_HOME if you still need Cloak on this machine —",
+  );
+  console.log(
+    "fork and Cloak share the default profile and are not interchangeable.",
+  );
+  return 0;
+}
+
+async function cmdSetup(flags) {
+  if (flags.has("--chromium")) {
+    console.error(
+      "The stock Chromium fallback was removed. Use `betterwright update` for the Chromium fork, or `betterwright setup` for managed CloakBrowser.",
+    );
+    return 1;
+  }
+
+  const cloakOnly = flags.has("--cloak-only");
+  if (!cloakOnly) {
+    const result = await installChromiumFork({ force: flags.has("--force") });
+    if (result.skipped) {
+      console.log(result.skipped);
+    } else if (!result.alreadyInstalled) {
+      console.log(
+        "Chromium fork installed. Discovery will prefer it over CloakBrowser.",
+      );
+    }
+  } else {
+    console.log("Skipping Chromium fork (--cloak-only).");
+  }
+
+  const cloakCode = await installCloakBrowser();
+  if (cloakCode !== 0) return cloakCode;
+
   console.log("\nSetup complete. Run `betterwright doctor` to confirm.");
+  if (!cloakOnly) {
+    console.log(
+      "On macOS arm64 / Linux x64, doctor should report browser: chromium-fork after update/setup.",
+    );
+  }
   return 0;
 }
 
@@ -525,7 +581,7 @@ async function main() {
     }
     if (flags.has("--help") || tokens.includes("-h")) {
       console.error(
-        "Usage: betterwright [interactive] | <setup|doctor|run|repl|exec|auth|skill|skills|mcp> [options]\n" +
+        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|auth|skill|skills|mcp> [options]\n" +
           "Run `betterwright` with no arguments for the interactive agent console.",
       );
       return 0;
@@ -538,6 +594,8 @@ async function main() {
   switch (command) {
     case "setup":
       return cmdSetup(flags);
+    case "update":
+      return cmdUpdate(flags);
     case "doctor":
       return cmdDoctor();
     case "run":
@@ -559,7 +617,7 @@ async function main() {
     }
     default:
       console.error(
-        "Usage: betterwright [interactive] | <setup|doctor|run|repl|exec|auth|skill|skills|mcp> [options]\n" +
+        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|auth|skill|skills|mcp> [options]\n" +
           "Run `betterwright` with no arguments for the interactive agent console.",
       );
       return 1;

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -25,8 +25,8 @@ import readline from "node:readline";
 import { pathToFileURL } from "node:url";
 
 import { formatAgentUsage } from "../src/agent-usage.mjs";
-import { makeLineReader } from "../src/cli-io.mjs";
 import { installChromiumFork } from "../src/chromium-fork-install.mjs";
+import { makeLineReader } from "../src/cli-io.mjs";
 import { doctorReport, resolveCloakDir, resolveCoreDir } from "../src/doctor.mjs";
 import { agentSystemPrompt, BetterWright, NetworkPolicy } from "../src/index.mjs";
 

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -2,9 +2,24 @@
 
 BetterWright can run the pinned BetterWright Chromium 150 fork while keeping
 its public `run()`, `human.*`, `captcha.*`, snapshot, policy, proxy, and vault
-APIs unchanged. The fork is selected by environment variable or discovered
-automatically; the managed CloakBrowser path is the fallback when no artifact
-is present.
+APIs unchanged. On macOS arm64 and Linux x64, `betterwright setup` /
+`betterwright update` download the fork into the zero-config discovery root;
+CloakBrowser remains the fallback when no artifact is present (and the only
+path on Windows today).
+
+## Install / update
+
+```bash
+betterwright update          # download fork → ~/.betterwright/chromium/
+betterwright update --force  # re-fetch + re-verify even if already present
+betterwright setup           # fork (when shipped) + CloakBrowser fallback
+betterwright setup --cloak-only
+```
+
+Artifacts come from the GitHub Release tag `chromium-<version>` (see
+`CHROMIUM_FORK_RELEASE_TAG` / `CHROMIUM_FORK_ASSETS` in
+`src/chromium-fork.mjs`). Each zip is SHA-256 pinned in that manifest before
+extract. Apple-licensed fonts are **not** in the public zip.
 
 ## Runtime Selection
 
@@ -51,11 +66,11 @@ the platform, e.g. Windows) → managed CloakBrowser, exactly as before.
   linux-x64/chrome          (+ fonts/ttf/ for the macOS-metric font set)
 ```
 
-This makes mixed fleets trivial: drop the artifact on Linux and macOS hosts,
-run `betterwright setup` on Windows hosts, and every machine picks the right
-backend with the same configuration. Set `BETTERWRIGHT_CHROMIUM_ROOT=off` (or
-`BETTERWRIGHT_CHROMIUM_PATH=off`) to force the managed path on a host that has
-the artifact installed.
+This makes mixed fleets trivial: run `betterwright update` (or `setup`) on
+Linux and macOS hosts, `betterwright setup --cloak-only` on Windows, and every
+machine picks the right backend with the same configuration. Set
+`BETTERWRIGHT_CHROMIUM_ROOT=off` (or `BETTERWRIGHT_CHROMIUM_PATH=off`) to force
+the managed path on a host that has the artifact installed.
 
 **Profiles are not interchangeable.** Fork and Cloak share
 `$BETTERWRIGHT_HOME/browser/profile` by default. Prefer a dedicated home for

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,27 +2,31 @@
 
 ## Install and set up
 
-BetterWright drives a managed CloakBrowser build through Playwright, so it needs
+BetterWright drives a managed browser through Playwright, so it needs
 **Node.js 22+** on your `PATH`. The browser itself is downloaded once by
-`setup`.
+`setup` / `update`.
 
 ```bash
 npm install betterwright
-npx betterwright setup     # downloads the signed managed browser (~200 MB, once)
+npx betterwright setup     # Chromium fork on mac/linux; Cloak everywhere
+npx betterwright update    # download/refresh the fork (switches off Cloak default)
 npx betterwright doctor    # prints what resolved; should end with "BetterWright is ready."
 ```
 
 If `doctor` reports Node missing, install it from <https://nodejs.org> and rerun
-`setup`. If `doctor` reports CloakBrowser missing, rerun
-`npx betterwright setup`.
+`setup`. If `doctor` reports the browser missing, rerun
+`npx betterwright setup` (or `update` for the fork only).
 
-Upgrade with `npm update betterwright` or `npm install betterwright@latest`.
-Package updates are intentional rather than automatic, so application lockfiles
-continue to control when a new BetterWright version is adopted.
+Upgrade the npm package with `npm update betterwright` or
+`npm install betterwright@latest`, then run `betterwright update` so the
+pinned Chromium fork matches that package. Package updates are intentional
+rather than automatic, so application lockfiles continue to control when a
+new BetterWright version is adopted.
 
 ### Managed CloakBrowser backend
 
-Managed launches use CloakBrowser by default. `betterwright setup` asks the
+On platforms without a public fork artifact (Windows today), or when you pass
+`--cloak-only`, launches use CloakBrowser. `betterwright setup` asks the
 pinned official wrapper to fetch the correct binary directly from CloakHQ's
 release source and verify the published checksums with its pinned Ed25519
 signature before extraction. BetterWright ships the wrapper integration, not
@@ -46,14 +50,21 @@ doctor` reports both versions. For a reproducible deployment, set a full
 `CLOAKBROWSER_VERSION`; to keep an already installed build from checking for a
 newer stable build, set `CLOAKBROWSER_AUTO_UPDATE=false`.
 
-### Native Chromium fork (optional)
+### Native Chromium fork (default on macOS arm64 / Linux x64)
 
-Deployments that need a fingerprint surface CloakBrowser doesn't cover can run
-BetterWright's own Chromium build instead — per-profile-stable canvas/audio
-farbling, platform masking (a Linux server presents as a consumer Mac), and
-bundled macOS-metric fonts. The npm package is only the JS/runtime; the
-patched Chromium binary is a **separate artifact** you deploy. Details:
-[chromium-fork.md](chromium-fork.md).
+`betterwright setup` and `betterwright update` download BetterWright's own
+Chromium build into `~/.betterwright/chromium/` (SHA-256 verified from the
+pinned GitHub Release). Discovery then prefers the fork over CloakBrowser —
+per-profile-stable canvas/audio farbling, platform masking (a Linux server
+presents as a consumer Mac), and bundled macOS-metric fonts. The npm package
+is only the JS/runtime; the ~200 MB zip is fetched on demand, never as an
+install lifecycle side effect. Details: [chromium-fork.md](chromium-fork.md).
+
+```bash
+npx betterwright update          # install/refresh fork only
+npx betterwright update --force  # re-download even if present
+npx betterwright setup --cloak-only  # CloakBrowser only (skip fork)
+```
 
 Resolution order:
 
@@ -61,7 +72,8 @@ Resolution order:
    `BETTERWRIGHT_CHROMIUM_ROOT` (artifact root). A configured-but-missing
    binary is an error — it fails closed, never silently downgrades.
 2. Zero-config discovery at `~/.betterwright/chromium/<platform>/`: if the
-   artifact for this platform exists there, it is used automatically.
+   artifact for this platform exists there, it is used automatically
+   (this is what `update` / default `setup` populate).
 3. Otherwise the managed CloakBrowser backend. Platforms with no shipped
    artifact (Windows) always land here.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/chromium-fork-install.mjs
+++ b/src/chromium-fork-install.mjs
@@ -1,0 +1,225 @@
+// Download + install the BetterWright Chromium fork into the zero-config
+// discovery root (~/.betterwright/chromium). Used by `betterwright update`
+// and by default `betterwright setup` on platforms that ship an artifact.
+//
+// Pattern matches Playwright/Cloak: the npm package is the driver; the
+// ~200 MB browser zip is fetched from a pinned GitHub Release and verified
+// with SHA-256 before extract. Apple-licensed fonts are intentionally not
+// in the public zip (see scripts/assemble-mac-fonts.sh).
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+
+import {
+  BETTERWRIGHT_CHROMIUM_VERSION,
+  CHROMIUM_FORK_ASSETS,
+  CHROMIUM_FORK_RELEASE_TAG,
+  PLATFORM_LAYOUT,
+  defaultChromiumForkRoot,
+  resolveChromiumForkBinary,
+} from "./chromium-fork.mjs";
+
+const DEFAULT_REPO = "CuriosityOS/betterwright";
+
+function platformKey(platform = process.platform, arch = process.arch) {
+  return `${platform}-${arch}`;
+}
+
+/** Asset metadata for this host, or null when no public fork is shipped. */
+export function chromiumForkAssetForHost({
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  return CHROMIUM_FORK_ASSETS[platformKey(platform, arch)] || null;
+}
+
+function releaseDownloadUrl(repo, tag, name) {
+  return `https://github.com/${repo}/releases/download/${tag}/${name}`;
+}
+
+function sha256File(filePath) {
+  const hash = createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function downloadToFile(url, destPath, { redirectsLeft = 5 } = {}) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(
+      url,
+      {
+        headers: {
+          "User-Agent": "betterwright-chromium-fork-install",
+          Accept: "application/octet-stream",
+        },
+      },
+      (response) => {
+        const status = response.statusCode || 0;
+        if (
+          status >= 300 &&
+          status < 400 &&
+          response.headers.location &&
+          redirectsLeft > 0
+        ) {
+          response.resume();
+          downloadToFile(response.headers.location, destPath, {
+            redirectsLeft: redirectsLeft - 1,
+          }).then(resolve, reject);
+          return;
+        }
+        if (status !== 200) {
+          response.resume();
+          reject(
+            new Error(
+              `Download failed (${status}) for ${url}. Check that release ` +
+                `${CHROMIUM_FORK_RELEASE_TAG} exists and the asset is public.`,
+            ),
+          );
+          return;
+        }
+        const out = fs.createWriteStream(destPath);
+        pipeline(response, out).then(resolve, reject);
+      },
+    );
+    request.on("error", reject);
+  });
+}
+
+function extractZip(zipPath, destDir) {
+  fs.mkdirSync(destDir, { recursive: true, mode: 0o755 });
+  if (process.platform === "darwin") {
+    // ditto preserves macOS app bundle metadata better than unzip.
+    const result = spawnSync(
+      "ditto",
+      ["-x", "-k", zipPath, destDir],
+      { encoding: "utf8" },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `ditto extract failed: ${result.stderr || result.stdout || "unknown error"}`,
+      );
+    }
+    return;
+  }
+  const result = spawnSync("unzip", ["-oq", zipPath, "-d", destDir], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `unzip failed: ${result.stderr || result.stdout || "unknown error"}`,
+    );
+  }
+}
+
+/**
+ * Install (or refresh) the Chromium fork for this platform into
+ * `~/.betterwright/chromium`. Returns `{ binary, root, skipped }` where
+ * `skipped` is set when this platform has no public artifact (e.g. Windows).
+ *
+ * `download` / `extract` are injectable for unit tests.
+ */
+export async function installChromiumFork({
+  home = os.homedir(),
+  platform = process.platform,
+  arch = process.arch,
+  repo = process.env.BETTERWRIGHT_CHROMIUM_REPO || DEFAULT_REPO,
+  releaseTag = process.env.BETTERWRIGHT_CHROMIUM_RELEASE_TAG ||
+    CHROMIUM_FORK_RELEASE_TAG,
+  force = false,
+  log = console.log,
+  download = downloadToFile,
+  extract = extractZip,
+  existsSync = fs.existsSync,
+  /** Override the public asset manifest (unit tests only). */
+  assets = CHROMIUM_FORK_ASSETS,
+} = {}) {
+  const key = platformKey(platform, arch);
+  const asset = assets[key];
+  if (!asset) {
+    return {
+      binary: null,
+      root: defaultChromiumForkRoot({ home }),
+      skipped: `No public Chromium fork artifact for ${key}; use managed CloakBrowser.`,
+    };
+  }
+
+  const root = defaultChromiumForkRoot({ home });
+  const layout = PLATFORM_LAYOUT[key];
+  const binaryPath = path.join(root, layout);
+
+  if (!force && existsSync(binaryPath)) {
+    const resolved = resolveChromiumForkBinary({
+      env: {},
+      platform,
+      arch,
+      home,
+      existsSync,
+    });
+    if (resolved) {
+      log(`Chromium fork already installed: ${resolved}`);
+      log(
+        `Re-run with --force to re-download ${BETTERWRIGHT_CHROMIUM_VERSION}.`,
+      );
+      return { binary: resolved, root, skipped: null, alreadyInstalled: true };
+    }
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bw-chromium-"));
+  const zipPath = path.join(tmpDir, asset.name);
+  const url = releaseDownloadUrl(repo, releaseTag, asset.name);
+
+  try {
+    log(`Downloading BetterWright Chromium ${BETTERWRIGHT_CHROMIUM_VERSION}...`);
+    log(`  ${url}`);
+    await download(url, zipPath);
+
+    const actual = sha256File(zipPath);
+    if (actual !== asset.sha256) {
+      throw new Error(
+        `SHA-256 mismatch for ${asset.name}: expected ${asset.sha256}, got ${actual}`,
+      );
+    }
+    log(`Checksum OK (${actual.slice(0, 12)}…)`);
+
+    fs.mkdirSync(root, { recursive: true, mode: 0o755 });
+    // Remove prior platform tree so we don't mix old/new files.
+    const platformDir = path.join(root, layout.split(path.sep)[0]);
+    fs.rmSync(platformDir, { recursive: true, force: true });
+
+    log(`Extracting into ${root} ...`);
+    extract(zipPath, root);
+
+    if (!existsSync(binaryPath)) {
+      throw new Error(
+        `Extract succeeded but binary missing at ${binaryPath}. ` +
+          "The release zip layout may not match this BetterWright version.",
+      );
+    }
+    try {
+      fs.chmodSync(binaryPath, 0o755);
+    } catch {
+      /* best-effort */
+    }
+    const sandbox = path.join(path.dirname(binaryPath), "chrome-sandbox");
+    if (existsSync(sandbox) && platform === "linux") {
+      try {
+        fs.chmodSync(sandbox, 0o4755);
+      } catch {
+        log(
+          "Note: could not setuid chrome-sandbox; if launch fails as non-root, run:",
+        );
+        log(`  sudo chmod 4755 ${sandbox}`);
+      }
+    }
+
+    log(`Installed ${binaryPath}`);
+    return { binary: binaryPath, root, skipped: null, alreadyInstalled: false };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/src/chromium-fork-install.mjs
+++ b/src/chromium-fork-install.mjs
@@ -7,8 +7,8 @@
 // with SHA-256 before extract. Apple-licensed fonts are intentionally not
 // in the public zip (see scripts/assemble-mac-fonts.sh).
 
-import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import https from "node:https";
 import os from "node:os";
@@ -19,8 +19,8 @@ import {
   BETTERWRIGHT_CHROMIUM_VERSION,
   CHROMIUM_FORK_ASSETS,
   CHROMIUM_FORK_RELEASE_TAG,
-  PLATFORM_LAYOUT,
   defaultChromiumForkRoot,
+  PLATFORM_LAYOUT,
   resolveChromiumForkBinary,
 } from "./chromium-fork.mjs";
 

--- a/src/chromium-fork.mjs
+++ b/src/chromium-fork.mjs
@@ -47,7 +47,7 @@ export function chromiumForkContextOptions({
   };
 }
 
-const PLATFORM_LAYOUT = Object.freeze({
+export const PLATFORM_LAYOUT = Object.freeze({
   "darwin-arm64": path.join(
     "mac-arm64",
     "Chromium.app",
@@ -57,6 +57,26 @@ const PLATFORM_LAYOUT = Object.freeze({
   ),
   "linux-x64": path.join("linux-x64", "chrome"),
   "win32-x64": path.join("win-x64", "chrome.exe"),
+});
+
+/** GitHub release that hosts the per-platform fork zip artifacts. */
+export const CHROMIUM_FORK_RELEASE_TAG = `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}`;
+
+/**
+ * Public download manifest for `betterwright update` / default `setup`.
+ * SHA-256 pins are of the zip archives on the release, not the nested binary.
+ */
+export const CHROMIUM_FORK_ASSETS = Object.freeze({
+  "darwin-arm64": Object.freeze({
+    name: "betterwright-chromium-mac-arm64.zip",
+    sha256:
+      "074cefbde9a8cf10f2ee15cddb1ac67613ebda3b1549e8948ad9eeafbe522ad6",
+  }),
+  "linux-x64": Object.freeze({
+    name: "betterwright-chromium-linux-x64.zip",
+    sha256:
+      "45ffef258415057d70b71639424dc681284babf533939d32375f99585a136d31",
+  }),
 });
 
 function configuredValue(value) {

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -407,10 +407,11 @@ export class BetterWright {
     // any driver import runs. `--import` must precede the worker script.
     const execArgv = [];
     if (this.stealthRuntimeFix) {
-      const nativeForkConfigured = Boolean(
-        String(process.env.BETTERWRIGHT_CHROMIUM_PATH || "").trim() ||
-          String(process.env.BETTERWRIGHT_CHROMIUM_ROOT || "").trim(),
-      );
+      const pathHint = String(process.env.BETTERWRIGHT_CHROMIUM_PATH || "").trim();
+      const rootHint = String(process.env.BETTERWRIGHT_CHROMIUM_ROOT || "").trim();
+      const nativeForkConfigured =
+        (pathHint && pathHint.toLowerCase() !== "off") ||
+        (rootHint && rootHint.toLowerCase() !== "off");
       if (nativeForkConfigured) {
         throw new BrowserError(
           "stealthRuntimeFix cannot be combined with BetterWright Chromium; " +

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -8,7 +8,8 @@
 // Run it directly (stdio transport):
 //
 //     npm install betterwright @modelcontextprotocol/sdk
-//     npx betterwright setup          # one-time managed browser download
+//     npx betterwright setup          # fork (mac/linux) + Cloak fallback
+//     npx betterwright update         # refresh / switch to Chromium fork
 //     npx betterwright mcp
 //
 // Then register it with your MCP client. For Claude Code:

--- a/tests/node/chromium-fork-install.test.mjs
+++ b/tests/node/chromium-fork-install.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  BETTERWRIGHT_CHROMIUM_VERSION,
+  CHROMIUM_FORK_ASSETS,
+  CHROMIUM_FORK_RELEASE_TAG,
+} from "../../src/chromium-fork.mjs";
+import {
+  chromiumForkAssetForHost,
+  installChromiumFork,
+} from "../../src/chromium-fork-install.mjs";
+
+test("public fork assets are pinned for mac-arm64 and linux-x64", () => {
+  assert.equal(CHROMIUM_FORK_RELEASE_TAG, `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}`);
+  assert.equal(
+    chromiumForkAssetForHost({ platform: "darwin", arch: "arm64" })?.name,
+    "betterwright-chromium-mac-arm64.zip",
+  );
+  assert.equal(
+    chromiumForkAssetForHost({ platform: "linux", arch: "x64" })?.name,
+    "betterwright-chromium-linux-x64.zip",
+  );
+  assert.equal(chromiumForkAssetForHost({ platform: "win32", arch: "x64" }), null);
+  for (const asset of Object.values(CHROMIUM_FORK_ASSETS)) {
+    assert.match(asset.sha256, /^[a-f0-9]{64}$/);
+  }
+});
+
+test("installChromiumFork skips platforms without a public artifact", async () => {
+  const result = await installChromiumFork({
+    platform: "win32",
+    arch: "x64",
+    home: "/tmp/bw-home",
+    log() {},
+  });
+  assert.match(result.skipped, /No public Chromium fork artifact/);
+  assert.equal(result.binary, null);
+});
+
+test("installChromiumFork short-circuits when already installed", async () => {
+  const home = "/home/deploy";
+  const binary = path.join(home, ".betterwright", "chromium", "linux-x64", "chrome");
+  const logs = [];
+  const result = await installChromiumFork({
+    platform: "linux",
+    arch: "x64",
+    home,
+    force: false,
+    existsSync: (p) => p === binary,
+    log: (line) => logs.push(String(line)),
+    download: async () => {
+      throw new Error("should not download");
+    },
+  });
+  assert.equal(result.alreadyInstalled, true);
+  assert.equal(result.binary, binary);
+  assert.match(logs.join("\n"), /already installed/);
+});
+
+test("installChromiumFork downloads, verifies SHA-256, and extracts", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-fork-home-"));
+  const payload = Buffer.from("betterwright-chromium-test-zip");
+  const sha256 = createHash("sha256").update(payload).digest("hex");
+  const assets = {
+    "linux-x64": { name: "test-linux.zip", sha256 },
+  };
+  const binaryRel = path.join("linux-x64", "chrome");
+  let downloadedUrl = null;
+
+  try {
+    const result = await installChromiumFork({
+      platform: "linux",
+      arch: "x64",
+      home,
+      force: true,
+      assets,
+      log() {},
+      download: async (url, dest) => {
+        downloadedUrl = url;
+        fs.writeFileSync(dest, payload);
+      },
+      extract: (zipPath, destDir) => {
+        assert.ok(fs.existsSync(zipPath));
+        const out = path.join(destDir, binaryRel);
+        fs.mkdirSync(path.dirname(out), { recursive: true });
+        fs.writeFileSync(out, "#!/bin/sh\necho chrome\n");
+      },
+    });
+    assert.equal(
+      downloadedUrl,
+      `https://github.com/CuriosityOS/betterwright/releases/download/${CHROMIUM_FORK_RELEASE_TAG}/test-linux.zip`,
+    );
+    assert.equal(result.alreadyInstalled, false);
+    assert.equal(
+      result.binary,
+      path.join(home, ".betterwright", "chromium", "linux-x64", "chrome"),
+    );
+    assert.ok(fs.existsSync(result.binary));
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("installChromiumFork rejects a SHA-256 mismatch", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-fork-bad-"));
+  const assets = {
+    "linux-x64": {
+      name: "bad.zip",
+      sha256: "0".repeat(64),
+    },
+  };
+  try {
+    await assert.rejects(
+      () =>
+        installChromiumFork({
+          platform: "linux",
+          arch: "x64",
+          home,
+          force: true,
+          assets,
+          log() {},
+          download: async (_url, dest) => {
+            fs.writeFileSync(dest, "not-the-expected-bytes");
+          },
+        }),
+      /SHA-256 mismatch/,
+    );
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add `betterwright update` to download/verify/install the pinned Chromium fork into `~/.betterwright/chromium/`, switching the default backend off CloakBrowser on macOS arm64 and Linux x64
- Default `betterwright setup` installs the fork when a public artifact exists, plus Cloak as fallback (`--cloak-only` skips the fork)
- Pin SHA-256 assets against the existing `chromium-150.0.7871.129` GitHub Release

## Test plan
- [x] Unit tests for install/resolve (`chromium-fork-install.test.mjs`)
- [x] Local smoke: `HOME=… betterwright update` downloads, checksums, extracts
- [ ] CI `npm test` + Cloak headed e2e on publish workflow
- [ ] Confirm `npm view betterwright version` is 0.9.11 after release


Made with [Cursor](https://cursor.com)