### PR TITLE
Release v0.9.12 with canonical repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/CuriosityOS/betterwright/main/docs/assets/logo.png" alt="BetterWright" width="96" />
+<img src="https://raw.githubusercontent.com/BetterWright/betterwright/main/docs/assets/logo.png" alt="BetterWright" width="96" />
 
 # BetterWright
 
 **The token-efficient browser for AI agents.**
 
 [![npm](https://img.shields.io/npm/v/betterwright?color=cb3837&logo=npm)](https://www.npmjs.com/package/betterwright)
-[![CI](https://github.com/CuriosityOS/betterwright/actions/workflows/ci.yml/badge.svg)](https://github.com/CuriosityOS/betterwright/actions/workflows/ci.yml)
+[![CI](https://github.com/BetterWright/betterwright/actions/workflows/ci.yml/badge.svg)](https://github.com/BetterWright/betterwright/actions/workflows/ci.yml)
 [![node](https://img.shields.io/node/v/betterwright?color=339933&logo=node.js&logoColor=white)](package.json)
 [![license](https://img.shields.io/npm/l/betterwright)](LICENSE)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",
@@ -129,12 +129,12 @@
   "author": "BetterWright contributors",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CuriosityOS/betterwright.git"
+    "url": "git+https://github.com/BetterWright/betterwright.git"
   },
   "bugs": {
-    "url": "https://github.com/CuriosityOS/betterwright/issues"
+    "url": "https://github.com/BetterWright/betterwright/issues"
   },
-  "homepage": "https://github.com/CuriosityOS/betterwright#readme",
+  "homepage": "https://github.com/BetterWright/betterwright#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/chromium-fork-install.mjs
+++ b/src/chromium-fork-install.mjs
@@ -24,7 +24,7 @@ import {
   resolveChromiumForkBinary,
 } from "./chromium-fork.mjs";
 
-const DEFAULT_REPO = "CuriosityOS/betterwright";
+const DEFAULT_REPO = "BetterWright/betterwright";
 
 function platformKey(platform = process.platform, arch = process.arch) {
   return `${platform}-${arch}`;

--- a/tests/node/chromium-fork-install.test.mjs
+++ b/tests/node/chromium-fork-install.test.mjs
@@ -93,7 +93,7 @@ test("installChromiumFork downloads, verifies SHA-256, and extracts", async () =
     });
     assert.equal(
       downloadedUrl,
-      `https://github.com/CuriosityOS/betterwright/releases/download/${CHROMIUM_FORK_RELEASE_TAG}/test-linux.zip`,
+      `https://github.com/BetterWright/betterwright/releases/download/${CHROMIUM_FORK_RELEASE_TAG}/test-linux.zip`,
     );
     assert.equal(result.alreadyInstalled, false);
     assert.equal(


### PR DESCRIPTION
Updates npm, README, and Chromium download metadata to the new `BetterWright/betterwright` canonical repository.

Verified with the version check, Chromium installer tests, and `npm pack --dry-run`.