### PR TITLE
Release v1.1.1: persistent session daemon for run, repl, and exec

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -19,13 +19,17 @@ The command prints one JSON object:
 `artifacts` lists files written during the run; screenshots appear there with a
 `path` — open that image to actually see the page.
 
-Multi-step task — pipe blank-line-separated snippets into one long-lived session
-so open tabs and in-memory `state` persist between steps:
+Invocations share one persistent browser session held by a background daemon:
+open tabs, page state, and the in-memory `state` object all survive between
+`run` calls, and logins/cookies persist through the on-disk profile. So act in
+small steps — one `run` per action-and-observe — and simply call `run` again to
+continue where the last call left off. The session auto-closes after ~15 idle
+minutes; run `betterwright close` when you finish a task to end it sooner.
+Need isolation for parallel work? Give each worker its own `--session <name>`.
 
-    printf '%s\n\n%s\n' "await page.goto('https://site.example')" "return page.title()" | betterwright repl
-
-Logins and cookies persist across every invocation through the on-disk profile;
-open tabs and `state` persist only within a single `repl` session.
+To batch several steps in one process you can also pipe blank-line-separated
+snippets: `printf '%s\n\n%s\n' "snippetA" "snippetB" | betterwright repl`
+(same session, same persistence).
 
 When a result lists `skills`, deeper site or provider knowledge matches the
 open pages — read the named pack with `betterwright skills show <name>` before
@@ -38,10 +42,12 @@ that — start it first, relay its URL to the user verbatim (it embeds the acces
 token), then keep working. From the plain CLI, snippets cannot start the viewer
 (sealed by design); when the user asks for a live view:
 - delegate the whole task to `betterwright exec "<task>" --live-view`, which
-  prints the watch URL as it starts; or
+  prints the watch URL as it starts (repeated execs continue the same session
+  and conversation; `--fresh` starts over); or
 - have the user run `betterwright view` themselves for a hands-on session with
-  the same logged-in profile — but not while a `repl` session is active: the
-  profile has a single holder, and the second process gets a blank ephemeral one.
+  the same logged-in profile — after `betterwright close`: the profile has a
+  single holder (the session daemon), and a second holder gets a blank
+  ephemeral profile.
 Never claim a live view is running unless one of these actually produced a URL.
 
 Network access is policy-guarded. Loopback and the private network are reachable

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -6,9 +6,13 @@
 //   betterwright setup            install Chromium fork (mac/linux) + Cloak fallback
 //   betterwright update           download/refresh the Chromium fork (switches from Cloak)
 //   betterwright doctor           report runtime readiness
-//   betterwright run <file|-|-c>  execute a Playwright snippet
+//   betterwright run <file|-|-c>  execute a Playwright snippet in the
+//                                 persistent session (tabs/state survive calls)
 //   betterwright repl             run blank-line-separated snippets from stdin
 //   betterwright exec <task>      run a task with BetterWright's own agent loop
+//                                 (repeat execs continue the same session)
+//   betterwright sessions         list live sessions in the background daemon
+//   betterwright close [name]     close a session (--all: everything + daemon)
 //   betterwright models           list models from OpenAI-compatible endpoints
 //   betterwright view             live web view of the browser (watch/take over)
 //   betterwright auth --login <p> OAuth sign-in for a model backend (codex|grok)
@@ -22,13 +26,20 @@
 // --block-loopback, --allow-host/--block-host), and --stealth (isolated-world
 // driver that evades main-world automation detection; needs patchright-core).
 // run only: --approve-downloads (one bounded download-enabled run).
+//
+// run/repl/exec share a persistent browser held by a background session
+// daemon (spawned on first use, exits when its last session closes): open
+// tabs, page state, and the repl `state` object survive between invocations,
+// keyed by --session (default "default"). --fresh forgets exec history,
+// --close ends the session after the call, --no-daemon forces the old
+// one-shot behavior.
 
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { formatAgentUsage } from "../src/agent-usage.mjs";
 import { installChromiumFork } from "../src/chromium-fork-install.mjs";
@@ -38,11 +49,24 @@ import {
   makeLineReader,
   readExecTaskFromStdin,
 } from "../src/cli-io.mjs";
+import { defaultDaemonHome, sessionName } from "../src/daemon.mjs";
+import {
+  connectSessionDaemon,
+  createDaemonBrowser,
+  daemonDisabled,
+  execTask,
+} from "../src/daemon-client.mjs";
 import { doctorReport, resolveCloakDir, resolveCoreDir } from "../src/doctor.mjs";
 import { agentSystemPrompt, BetterWright, NetworkPolicy } from "../src/index.mjs";
 import { defaultLiveViewListen, guessLanHost } from "../src/live-view.mjs";
+import {
+  clearTranscript,
+  loadTranscript,
+  saveTranscript,
+} from "../src/session-store.mjs";
 
 const require = createRequire(import.meta.url);
+const CLI_PATH = fileURLToPath(import.meta.url);
 
 /**
  * Live-view options for CLI `--live-view` / `view`.
@@ -274,20 +298,96 @@ async function readSnippet(arg) {
   return fs.readFileSync(arg, "utf8");
 }
 
+// The browser-shaping options for the session daemon, from the same flags the
+// in-process paths use. The daemon builds its NetworkPolicy/BetterWright from
+// this object AND derives the compatibility signature from it, so flags and
+// signature can never disagree.
+function daemonConfigFromFlags(flags) {
+  return {
+    headless: !flags.has("--headed"),
+    policy: {
+      allowLoopback: !flags.has("--block-loopback"),
+      allowPrivateNetwork: !flags.has("--block-private-network"),
+      allowHosts: collectValues(process.argv, "--allow-host"),
+      blockHosts: collectValues(process.argv, "--block-host"),
+    },
+    cloak: cloakingFromFlags(flags),
+  };
+}
+
+/**
+ * Get a browser for run/repl: the session daemon's persistent session when
+ * possible (spawning the daemon on first use), a private in-process
+ * BetterWright otherwise — with a warning explaining why persistence is off.
+ */
+async function acquireRunBrowser(flags) {
+  const session = sessionName(flagValue(process.argv, "--session", "default"));
+  if (!daemonDisabled(flags)) {
+    const outcome = await connectSessionDaemon({
+      cliPath: CLI_PATH,
+      config: daemonConfigFromFlags(flags),
+    });
+    if (outcome.ok) {
+      const { channel } = outcome;
+      return {
+        session,
+        viaDaemon: true,
+        warning: "",
+        browser: createDaemonBrowser(channel, { session }),
+        cleanup: async ({ closeSession = false } = {}) => {
+          try {
+            if (closeSession)
+              await channel.request({ op: "close_session", session }, 60_000);
+          } finally {
+            channel.end();
+          }
+        },
+      };
+    }
+    const bw = new BetterWright({
+      policy: policyFromFlags(flags),
+      headless: !flags.has("--headed"),
+      ...cloakingFromFlags(flags),
+    });
+    return {
+      session,
+      viaDaemon: false,
+      warning: `session persistence unavailable (${outcome.reason}); this browser closes when the command exits`,
+      browser: bw,
+      cleanup: async () => bw.close(),
+    };
+  }
+  const bw = new BetterWright({
+    policy: policyFromFlags(flags),
+    headless: !flags.has("--headed"),
+    ...cloakingFromFlags(flags),
+  });
+  return {
+    session,
+    viaDaemon: false,
+    warning: "",
+    browser: bw,
+    cleanup: async () => bw.close(),
+  };
+}
+
 async function cmdRun(arg, flags) {
   const code = await readSnippet(arg);
-  const bw = new BetterWright({ policy: policyFromFlags(flags), headless: !flags.has("--headed"), ...cloakingFromFlags(flags) });
+  const acquired = await acquireRunBrowser(flags);
   try {
     // One bounded download-enabled run; the skill instructs agents to get
     // explicit user approval before passing this (MCP/Pi elicit instead).
-    const result = await bw.run(
-      code,
-      flags.has("--approve-downloads") ? { approvedDownloads: true } : undefined,
-    );
+    const result = await acquired.browser.run(code, {
+      session: acquired.session,
+      ...(flags.has("--approve-downloads") ? { approvedDownloads: true } : {}),
+    });
+    if (acquired.viaDaemon) result.session = acquired.session;
+    if (acquired.warning)
+      result.warnings = [...(result.warnings || []), acquired.warning];
     console.log(JSON.stringify(result, null, 2));
     return result.ok ? 0 : 1;
   } finally {
-    await bw.close();
+    await acquired.cleanup({ closeSession: flags.has("--close") });
   }
 }
 
@@ -310,13 +410,17 @@ The command prints one JSON object:
 \`artifacts\` lists files written during the run; screenshots appear there with a
 \`path\` — open that image to actually see the page.
 
-Multi-step task — pipe blank-line-separated snippets into one long-lived session
-so open tabs and in-memory \`state\` persist between steps:
+Invocations share one persistent browser session held by a background daemon:
+open tabs, page state, and the in-memory \`state\` object all survive between
+\`run\` calls, and logins/cookies persist through the on-disk profile. So act in
+small steps — one \`run\` per action-and-observe — and simply call \`run\` again to
+continue where the last call left off. The session auto-closes after ~15 idle
+minutes; run \`betterwright close\` when you finish a task to end it sooner.
+Need isolation for parallel work? Give each worker its own \`--session <name>\`.
 
-    printf '%s\\n\\n%s\\n' "await page.goto('https://site.example')" "return page.title()" | betterwright repl
-
-Logins and cookies persist across every invocation through the on-disk profile;
-open tabs and \`state\` persist only within a single \`repl\` session.
+To batch several steps in one process you can also pipe blank-line-separated
+snippets: \`printf '%s\\n\\n%s\\n' "snippetA" "snippetB" | betterwright repl\`
+(same session, same persistence).
 
 When a result lists \`skills\`, deeper site or provider knowledge matches the
 open pages — read the named pack with \`betterwright skills show <name>\` before
@@ -329,10 +433,12 @@ that — start it first, relay its URL to the user verbatim (it embeds the acces
 token), then keep working. From the plain CLI, snippets cannot start the viewer
 (sealed by design); when the user asks for a live view:
 - delegate the whole task to \`betterwright exec "<task>" --live-view\`, which
-  prints the watch URL as it starts; or
+  prints the watch URL as it starts (repeated execs continue the same session
+  and conversation; \`--fresh\` starts over); or
 - have the user run \`betterwright view\` themselves for a hands-on session with
-  the same logged-in profile — but not while a \`repl\` session is active: the
-  profile has a single holder, and the second process gets a blank ephemeral one.
+  the same logged-in profile — after \`betterwright close\`: the profile has a
+  single holder (the session daemon), and a second holder gets a blank
+  ephemeral profile.
 Never claim a live view is running unless one of these actually produced a URL.
 
 Network access is policy-guarded. Loopback and the private network are reachable
@@ -374,8 +480,15 @@ function cmdSkill(flags) {
 }
 
 async function cmdRepl(flags) {
-  const bw = new BetterWright({ policy: policyFromFlags(flags), headless: !flags.has("--headed"), ...cloakingFromFlags(flags) });
-  console.log("BetterWright REPL — blank line runs a snippet, Ctrl-D quits.\n");
+  const acquired = await acquireRunBrowser(flags);
+  const runSnippet = (code) =>
+    acquired.browser.run(code, { session: acquired.session });
+  console.log(
+    acquired.viaDaemon
+      ? `BetterWright REPL — blank line runs a snippet, Ctrl-D quits. Session "${acquired.session}" persists afterwards (betterwright close to end it).\n`
+      : "BetterWright REPL — blank line runs a snippet, Ctrl-D quits.\n",
+  );
+  if (acquired.warning) process.stderr.write(`  ! ${acquired.warning}\n`);
   const rl = readline.createInterface({ input: process.stdin });
   let buffer = [];
   try {
@@ -385,13 +498,13 @@ async function cmdRepl(flags) {
         continue;
       }
       if (!buffer.length) continue;
-      const result = await bw.run(buffer.join("\n"));
+      const result = await runSnippet(buffer.join("\n"));
       buffer = [];
       console.log(JSON.stringify(result, null, 2));
     }
-    if (buffer.length) console.log(JSON.stringify(await bw.run(buffer.join("\n")), null, 2));
+    if (buffer.length) console.log(JSON.stringify(await runSnippet(buffer.join("\n")), null, 2));
   } finally {
-    await bw.close();
+    await acquired.cleanup({ closeSession: flags.has("--close") });
   }
   return 0;
 }
@@ -591,7 +704,11 @@ Shell note: double quotes still expand \`$\`. Use single quotes for literal pric
 
 Options: --stdin --model <id|source/id> --base-url <url> --api-key-env <name>
          --protocol chat|responses --effort <level> --session <name> --headed
-         --live-view`;
+         --live-view --fresh --close --no-daemon
+
+Repeated execs continue the same session: the browser (tabs, logins) stays
+live in a background daemon and the agent remembers the prior conversation.
+--fresh starts the session over; --close ends it after this task.`;
 const MODELS_USAGE =
   "Usage: betterwright models [openrouter|ollama|vllm] [--base-url <url>] [--api-key-env <name>] [--json]";
 
@@ -706,6 +823,18 @@ async function cmdInteractive(flags) {
   console.log(dim("/help for commands, /exit or Ctrl-D to quit.\n"));
 
   try {
+    // The console needs the persistent profile itself: take it back from an
+    // idle session daemon (left by earlier run/exec calls) before launching.
+    const reclaim = await reclaimDaemonProfile();
+    if (reclaim.closedSessions) {
+      console.log(
+        dim(`closed ${reclaim.closedSessions} idle background session(s) to reuse the saved profile`),
+      );
+    } else if (reclaim.busy) {
+      console.log(
+        dim("a background session is mid-task; this console gets a temporary profile (betterwright close --all to reclaim)"),
+      );
+    }
     // The console owns one viewer for the lifetime of this browser session.
     // Start it before accepting the first task; runAgentTask only attaches to
     // the already-running view and therefore cannot churn its URL per message.
@@ -915,7 +1044,6 @@ async function cmdInteractive(flags) {
 // summary) go to stderr; the final {ok, answer, steps, reason, toolCalls,
 // usage, proof} goes to stdout.
 async function cmdExec(flags) {
-  const { runAgentTask } = await import("../src/agent.mjs");
   const argv = process.argv;
   if (flags.has("--help")) {
     console.log(EXEC_USAGE);
@@ -939,43 +1067,101 @@ async function cmdExec(flags) {
     return 1;
   }
   const { model, modelOptions } = modelCliSelection(argv);
+  const session = sessionName(flagValue(argv, "--session", "default"));
+  const fresh = flags.has("--fresh");
+  const home = defaultDaemonHome();
+  const onStep = ({ step, tool, note, url }) => {
+    if (url && (tool === "handoff" || tool === "liveView")) {
+      process.stderr.write(`\n  ▶ ${tool === "handoff" ? "HANDOFF" : "LIVE VIEW"}: ${url}\n`);
+      if (tool === "handoff") process.stderr.write(`    ${note}\n\n`);
+      return;
+    }
+    if (tool === "liveView" && note) {
+      process.stderr.write(`  ! ${note}\n`);
+      return;
+    }
+    process.stderr.write(`  [${step}] ${tool}${note ? `: ${note}` : ""}\n`);
+  };
 
   let result;
-  try {
-    result = await runAgentTask({
-      task,
-      model,
-      modelOptions,
-      session: flagValue(argv, "--session", "default"),
-      policy: policyFromFlags(flags),
-      headless: !flags.has("--headed"),
-      // --live-view starts the viewer at step 0 so the whole run can be
-      // watched; without it the handoff tool still starts one on demand.
-      // Host/port come from --host / env (default 0.0.0.0 + LAN publicHost).
-      liveView: liveViewCliOptions(argv),
-      onStep: ({ step, tool, note, url }) => {
-        if (url && (tool === "handoff" || tool === "liveView")) {
-          process.stderr.write(`\n  ▶ ${tool === "handoff" ? "HANDOFF" : "LIVE VIEW"}: ${url}\n`);
-          if (tool === "handoff") process.stderr.write(`    ${note}\n\n`);
-          return;
-        }
-        if (tool === "liveView" && note) {
-          process.stderr.write(`  ! ${note}\n`);
-          return;
-        }
-        process.stderr.write(`  [${step}] ${tool}${note ? `: ${note}` : ""}\n`);
-      },
+  if (!daemonDisabled(flags)) {
+    const outcome = await connectSessionDaemon({
+      cliPath: CLI_PATH,
+      config: daemonConfigFromFlags(flags),
     });
-  } catch (error) {
-    // Config problems (missing credentials, missing SDK) read better as a plain
-    // line than a stack trace.
-    console.error(error?.message || String(error));
-    return 1;
+    if (outcome.ok) {
+      const { channel } = outcome;
+      try {
+        // The agent loop runs in the daemon, so the conversation and the
+        // browser session both persist for the next exec in this session.
+        result = await execTask(
+          channel,
+          {
+            task,
+            model,
+            modelOptions,
+            session,
+            fresh,
+            // --live-view starts the viewer at step 0 so the whole run can be
+            // watched; without it the handoff tool still starts one on demand.
+            liveView: liveViewCliOptions(argv),
+          },
+          { onStep },
+        );
+        if (flags.has("--close")) {
+          await channel
+            .request({ op: "close_session", session }, 60_000)
+            .catch(() => {});
+        }
+      } catch (error) {
+        // Config problems (missing credentials, missing SDK) read better as a
+        // plain line than a stack trace.
+        console.error(error?.message || String(error));
+        return 1;
+      } finally {
+        channel.end();
+      }
+    } else {
+      process.stderr.write(
+        `  ! session persistence unavailable (${outcome.reason}); running one-shot\n`,
+      );
+    }
+  }
+  if (!result) {
+    // No daemon (disabled or unavailable): one-shot browser, exactly the
+    // pre-daemon behavior — but the transcript still persists on disk, so
+    // the next exec resumes the conversation even without live tabs.
+    const { runAgentTask } = await import("../src/agent.mjs");
+    if (fresh) clearTranscript(home, session);
+    const history = fresh ? [] : loadTranscript(home, session);
+    try {
+      const full = await runAgentTask({
+        task,
+        model,
+        modelOptions,
+        session,
+        history,
+        policy: policyFromFlags(flags),
+        headless: !flags.has("--headed"),
+        liveView: liveViewCliOptions(argv),
+        onStep,
+      });
+      saveTranscript(home, session, full.transcript);
+      const { transcript: _transcript, ...summary } = full;
+      result = { ...summary, session, resumedMessages: history.length };
+    } catch (error) {
+      console.error(error?.message || String(error));
+      return 1;
+    }
   }
   process.stderr.write(
     `  done in ${result.steps} step${result.steps === 1 ? "" : "s"}, ` +
       `${result.toolCalls} tool call${result.toolCalls === 1 ? "" : "s"}, ` +
-      `${formatDuration(result.durationMs)}, ${formatAgentUsage(result.usage)}\n`,
+      `${formatDuration(result.durationMs)}, ${formatAgentUsage(result.usage)}` +
+      (result.resumedMessages
+        ? ` · resumed session "${result.session}" (${result.resumedMessages} prior messages)`
+        : "") +
+      "\n",
   );
   console.log(
     JSON.stringify(
@@ -988,12 +1174,120 @@ async function cmdExec(flags) {
         usage: result.usage,
         durationMs: result.durationMs,
         proof: result.proof,
+        session: result.session,
       },
       null,
       2,
     ),
   );
   return result.ok ? 0 : 1;
+}
+
+// `close [--session <name> | --all]` / `sessions`: manage the session daemon.
+// Management ops talk to whatever daemon is running (any version/config) and
+// never spawn one.
+async function cmdClose(flags, rest) {
+  const outcome = await connectSessionDaemon({
+    cliPath: CLI_PATH,
+    spawnIfNeeded: false,
+    ignoreMismatch: true,
+  });
+  if (!outcome.ok) {
+    console.log("No session daemon is running — nothing to close.");
+    return 0;
+  }
+  const { channel, hello } = outcome;
+  try {
+    if (flags.has("--all")) {
+      const names = (hello.sessions || []).map((entry) => entry.name);
+      for (const name of names) {
+        await channel.request({ op: "close_session", session: name }, 60_000).catch(() => {});
+      }
+      await channel.request({ op: "shutdown" }, 10_000).catch(() => {});
+      console.log(
+        names.length
+          ? `Closed ${names.length} session${names.length === 1 ? "" : "s"} and stopped the browser daemon.`
+          : "Stopped the browser daemon (no sessions were open).",
+      );
+      return 0;
+    }
+    const positional = rest.filter((token) => !token.startsWith("-"));
+    const session = sessionName(
+      flagValue(process.argv, "--session", positional[0] || "default"),
+    );
+    const closed = await channel.request({ op: "close_session", session }, 60_000);
+    console.log(
+      closed?.closed
+        ? `Closed session "${session}"${closed.pagesClosed ? ` (${closed.pagesClosed} tab${closed.pagesClosed === 1 ? "" : "s"})` : ""}.`
+        : `Session "${session}" was not open.`,
+    );
+    return 0;
+  } finally {
+    channel.end();
+  }
+}
+
+async function cmdSessions() {
+  const outcome = await connectSessionDaemon({
+    cliPath: CLI_PATH,
+    spawnIfNeeded: false,
+    ignoreMismatch: true,
+  });
+  if (!outcome.ok) {
+    console.log("No session daemon is running.");
+    return 0;
+  }
+  const { channel, hello } = outcome;
+  channel.end();
+  const { dim } = styler();
+  console.log(
+    dim(
+      `daemon pid ${hello.pid} · v${hello.version} · sessions idle out after ${formatDuration(hello.ttlMs || 0)}`,
+    ),
+  );
+  if (!hello.sessions?.length) {
+    console.log("No open sessions.");
+    return 0;
+  }
+  for (const entry of hello.sessions) {
+    console.log(
+      `${entry.name.padEnd(20)} idle ${formatDuration(entry.idleMs)}${entry.inflight ? ` · ${entry.inflight} call(s) in flight` : ""}`,
+    );
+  }
+  return 0;
+}
+
+/**
+ * Foreground commands that need the persistent profile themselves (the
+ * interactive console, `view`) reclaim it from an idle daemon first; a busy
+ * daemon is left alone and the command falls back to an ephemeral profile
+ * with the worker's usual warning.
+ */
+async function reclaimDaemonProfile() {
+  try {
+    const outcome = await connectSessionDaemon({
+      cliPath: CLI_PATH,
+      spawnIfNeeded: false,
+      ignoreMismatch: true,
+    });
+    if (!outcome.ok) return { reclaimed: true, closedSessions: 0 };
+    const { channel, hello } = outcome;
+    const sessions = Array.isArray(hello.sessions) ? hello.sessions : [];
+    if (sessions.some((entry) => entry.inflight > 0)) {
+      channel.end();
+      return { reclaimed: false, busy: true };
+    }
+    for (const entry of sessions) {
+      await channel
+        .request({ op: "close_session", session: entry.name }, 60_000)
+        .catch(() => {});
+    }
+    await channel.request({ op: "shutdown" }, 10_000).catch(() => {});
+    channel.end();
+    return { reclaimed: true, closedSessions: sessions.length };
+  } catch {
+    return { reclaimed: true, closedSessions: 0 };
+  }
 }
 
 async function cmdModels(flags) {
@@ -1060,6 +1354,12 @@ async function cmdView(flags) {
   const { dim, bold } = styler();
   // Same host resolution as `exec --live-view` so view/exec behave alike.
   const liveOpts = liveViewCliOptions(argv, { required: true });
+  const reclaim = await reclaimDaemonProfile();
+  if (reclaim.busy) {
+    console.log(
+      dim("a background session is mid-task; this view gets a temporary profile (betterwright close --all to reclaim)"),
+    );
+  }
   const browser = new BetterWright({
     policy: policyFromFlags(flags),
     headless: !flags.has("--headed"),
@@ -1195,7 +1495,7 @@ async function main() {
     }
     if (flags.has("--help") || tokens.includes("-h")) {
       console.error(
-        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|models|view|auth|skill|skills|mcp> [options]\n" +
+        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|sessions|close|models|view|auth|skill|skills|mcp> [options]\n" +
           "Run `betterwright` with no arguments for the interactive agent console.",
       );
       return 0;
@@ -1228,14 +1528,22 @@ async function main() {
       return cmdSkill(flags);
     case "skills":
       return cmdSkills(rest);
+    case "close":
+      return cmdClose(flags, rest);
+    case "sessions":
+      return cmdSessions();
     case "mcp": {
       const { runMcpServer } = await import("../src/mcp-server.mjs");
       await runMcpServer();
       return 0;
     }
+    case "__daemon": {
+      const { runSessionDaemon } = await import("../src/daemon.mjs");
+      return runSessionDaemon(process.argv);
+    }
     default:
       console.error(
-        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|models|view|auth|skill|skills|mcp> [options]\n" +
+        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|sessions|close|models|view|auth|skill|skills|mcp> [options]\n" +
           "Run `betterwright` with no arguments for the interactive agent console.",
       );
       return 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -967,6 +967,28 @@ export class BetterWright {
   }
 
   /**
+   * Close one session's pages and forget its state (tabs, `state`, cursor)
+   * without touching the browser, the profile, or other sessions. Resolves
+   * with `{ok, closed, pagesClosed}`; a no-op when the worker is not running
+   * or the session does not exist.
+   * @param {string} [session="default"] session name
+   */
+  closeSession(session) {
+    return this._enqueue(async () => {
+      if (
+        !this._process ||
+        this._process.exitCode !== null ||
+        this._process.signalCode !== null
+      )
+        return { ok: true, closed: false, pagesClosed: 0 };
+      return this._dispatch(
+        { type: "session_close", sessionId: String(session || "default") },
+        30,
+      );
+    });
+  }
+
+  /**
    * Start (or return the already-running) live-view server in the worker: a
    * token-gated local web page that streams the live browser and, when
    * interactive, relays the viewer's mouse and keyboard into it.

--- a/src/daemon-client.mjs
+++ b/src/daemon-client.mjs
@@ -1,0 +1,319 @@
+// Thin client for the BetterWright session daemon (src/daemon.mjs).
+//
+// `acquireDaemonBrowser` is the one call the CLI uses: connect to the daemon
+// for this home (spawning it detached when absent), verify version/config
+// compatibility, and hand back a proxy object with the BetterWright surface
+// the CLI and the exec harness drive (`run`, credential fills, live view,
+// handoff/ask waits). Every proxy method resolves an `{ok:false, error}`
+// envelope on transport failure — the same no-throw contract BetterWright's
+// own methods keep — so callers never need daemon-specific error handling.
+//
+// When the daemon cannot be used (spawn failed, or it is busy with sessions
+// under a different config), the caller falls back to a private in-process
+// BetterWright: exactly the pre-daemon behavior.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import readline from "node:readline";
+
+import {
+  daemonConfigSignature,
+  daemonPackageVersion,
+  daemonSocketPath,
+  defaultDaemonHome,
+  sessionName,
+} from "./daemon.mjs";
+
+const CONNECT_TIMEOUT_MS = 1_000;
+const SPAWN_WAIT_MS = 8_000;
+const HANDSHAKE_TIMEOUT_MS = 10_000;
+
+export function daemonDisabled(flags = new Set()) {
+  if (flags.has("--no-daemon")) return true;
+  return ["1", "true", "yes", "on"].includes(
+    String(process.env.BETTERWRIGHT_NO_DAEMON || "").trim().toLowerCase(),
+  );
+}
+
+function connectOnce(socketPath, timeoutMs = CONNECT_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    const socket = net.connect(socketPath);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(null);
+    }, timeoutMs);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
+}
+
+/** Wrap a connected socket in an id-multiplexed request channel. */
+function createChannel(socket) {
+  let nextId = 1;
+  const pending = new Map();
+  let closed = false;
+  const failAll = (reason) => {
+    closed = true;
+    for (const [, entry] of pending) entry.reject(new Error(reason));
+    pending.clear();
+  };
+  readline
+    .createInterface({ input: socket, crlfDelay: Infinity })
+    // Readline re-emits input-stream errors (e.g. EPIPE after the daemon
+    // died) on itself; without a handler that becomes an uncaught exception.
+    .on("error", () => {})
+    .on("line", (line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+      const entry = pending.get(message?.id);
+      if (!entry) return;
+      // Streamed interim events (exec step notes) keep the request pending;
+      // the final message — the one without `event` — settles it.
+      if (message.event === "step") {
+        try {
+          entry.onEvent?.(message.step);
+        } catch {
+          /* a broken step renderer must not kill the request */
+        }
+        return;
+      }
+      pending.delete(message.id);
+      clearTimeout(entry.timer);
+      entry.resolve(message);
+    });
+  socket.on("close", () => failAll("the session daemon connection closed"));
+  socket.on("error", () => socket.destroy());
+  return {
+    socket,
+    request(payload, timeoutMs = 0, onEvent) {
+      if (closed || socket.destroyed)
+        return Promise.reject(new Error("the session daemon connection closed"));
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        const entry = { resolve, reject, timer: null, onEvent };
+        if (timeoutMs > 0) {
+          entry.timer = setTimeout(() => {
+            pending.delete(id);
+            reject(new Error(`the session daemon did not answer within ${timeoutMs}ms`));
+          }, timeoutMs);
+          entry.timer.unref?.();
+        }
+        pending.set(id, entry);
+        const fail = (error) => {
+          if (!pending.has(id)) return;
+          pending.delete(id);
+          clearTimeout(entry.timer);
+          reject(error);
+        };
+        try {
+          // The callback form keeps a dead socket's EPIPE out of the process
+          // as an uncaught exception — it rejects this request instead.
+          socket.write(`${JSON.stringify({ id, ...payload })}\n`, (error) => {
+            if (error) fail(error);
+          });
+        } catch (error) {
+          fail(error);
+        }
+      });
+    },
+    end() {
+      closed = true;
+      try {
+        socket.end();
+      } catch {
+        /* already gone */
+      }
+      socket.destroy();
+    },
+  };
+}
+
+function spawnDaemon({ home, cliPath, config }) {
+  const payload = Buffer.from(JSON.stringify(config), "utf8").toString("base64url");
+  let logFd;
+  try {
+    fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+    logFd = fs.openSync(path.join(home, "daemon.log"), "a", 0o600);
+  } catch {
+    logFd = "ignore";
+  }
+  const child = spawn(
+    process.execPath,
+    [cliPath, "__daemon", "--config", payload],
+    {
+      detached: true,
+      stdio: ["ignore", "ignore", logFd],
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    },
+  );
+  child.unref();
+  if (typeof logFd === "number") {
+    try {
+      fs.closeSync(logFd);
+    } catch {
+      /* the child holds its own descriptor */
+    }
+  }
+}
+
+async function connectWithSpawn({ home, socketPath, cliPath, config, spawnIfNeeded }) {
+  let socket = await connectOnce(socketPath);
+  if (socket || !spawnIfNeeded) return socket;
+  // A dead daemon can leave its socket file behind; remove it so the fresh
+  // daemon can bind (the daemon double-checks against a live listener itself).
+  if (process.platform !== "win32" && fs.existsSync(socketPath)) {
+    try {
+      fs.rmSync(socketPath, { force: true });
+    } catch {
+      /* the daemon's own EADDRINUSE probe handles this */
+    }
+  }
+  spawnDaemon({ home, cliPath, config });
+  const deadline = Date.now() + SPAWN_WAIT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    socket = await connectOnce(socketPath, 500);
+    if (socket) return socket;
+  }
+  return null;
+}
+
+async function waitForSocketGone(socketPath, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const socket = await connectOnce(socketPath, 300);
+    if (!socket) return true;
+    socket.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+/**
+ * Connect to (or start) the session daemon and complete the hello handshake.
+ *
+ * @returns {Promise<
+ *   | {ok: true, channel: ReturnType<typeof createChannel>, hello: object}
+ *   | {ok: false, reason: string}
+ * >}
+ */
+export async function connectSessionDaemon({
+  home = defaultDaemonHome(),
+  cliPath,
+  config = {},
+  spawnIfNeeded = true,
+  // Management commands (`close`, `sessions`) talk to whatever daemon is
+  // there, regardless of version/config — they only inspect and tear down.
+  ignoreMismatch = false,
+  _retried = false,
+} = {}) {
+  const socketPath = daemonSocketPath(home);
+  const version = daemonPackageVersion();
+  const configSig = daemonConfigSignature(config);
+  const socket = await connectWithSpawn({ home, socketPath, cliPath, config, spawnIfNeeded });
+  if (!socket) {
+    return {
+      ok: false,
+      reason: spawnIfNeeded
+        ? "the session daemon did not start"
+        : "no session daemon is running",
+    };
+  }
+  const channel = createChannel(socket);
+  let hello;
+  try {
+    hello = await channel.request({ op: "hello", version, configSig }, HANDSHAKE_TIMEOUT_MS);
+  } catch (error) {
+    channel.end();
+    return { ok: false, reason: String(error?.message || error) };
+  }
+  if (!hello?.ok) {
+    channel.end();
+    return { ok: false, reason: hello?.error || "the session daemon rejected the handshake" };
+  }
+  if (ignoreMismatch || (hello.version === version && hello.configSig === configSig)) {
+    return { ok: true, channel, hello };
+  }
+  // Mismatched daemon (older package, or different policy/cloaking flags).
+  // Idle: replace it. Holding live sessions: leave it alone and let the
+  // caller fall back to a private one-shot browser.
+  const sessions = Array.isArray(hello.sessions) ? hello.sessions : [];
+  const busy = sessions.length > 0;
+  if (busy || _retried || !spawnIfNeeded) {
+    channel.end();
+    const what = hello.version === version ? "different browser flags" : `version ${hello.version}`;
+    return {
+      ok: false,
+      reason:
+        `a session daemon with ${what} is holding ${sessions.length} live session(s); ` +
+        "using a one-shot browser for this call (close them with `betterwright close --all` to switch)",
+    };
+  }
+  try {
+    await channel.request({ op: "shutdown" }, HANDSHAKE_TIMEOUT_MS);
+  } catch {
+    /* it may exit before answering */
+  }
+  channel.end();
+  await waitForSocketGone(socketPath);
+  return connectSessionDaemon({ home, cliPath, config, spawnIfNeeded, _retried: true });
+}
+
+/**
+ * A minimal BetterWright-shaped proxy over a daemon channel, pinned to one
+ * session — what `betterwright run`/`repl` drive. Snippets run in the
+ * daemon's browser; transport failures resolve as `{ok:false, error}`
+ * envelopes (the same no-throw contract BetterWright.run keeps). `close()`
+ * only disconnects — the session (tabs, state, logins) stays alive.
+ */
+export function createDaemonBrowser(channel, { session = "default" } = {}) {
+  const pinned = sessionName(session);
+  return {
+    session: pinned,
+    run: async (code, options) => {
+      let reply;
+      try {
+        reply = await channel.request({
+          op: "call",
+          method: "run",
+          args: [code, options],
+          session: pinned,
+        });
+      } catch (error) {
+        return { ok: false, error: `session daemon: ${error?.message || error}` };
+      }
+      if (!reply?.ok) return { ok: false, error: reply?.error || "session daemon call failed" };
+      return reply.result;
+    },
+    closeSession: () => channel.request({ op: "close_session", session: pinned }, 60_000),
+    close: async () => channel.end(),
+  };
+}
+
+/**
+ * Run one agent task inside the daemon (the Aside shape: the LLM loop lives
+ * in the daemon, so its transcript and browser session persist across CLI
+ * invocations). Step events stream to `onStep` as they happen; resolves with
+ * the run summary (no transcript — that stays with the daemon).
+ */
+export async function execTask(channel, payload, { onStep } = {}) {
+  const reply = await channel.request(
+    { op: "exec", ...payload },
+    0,
+    typeof onStep === "function" ? onStep : undefined,
+  );
+  if (!reply?.ok) throw new Error(reply?.error || "the session daemon exec failed");
+  return reply.result;
+}

--- a/src/daemon.mjs
+++ b/src/daemon.mjs
@@ -1,0 +1,572 @@
+// The BetterWright session daemon.
+//
+// One background process per BETTERWRIGHT_HOME owns a single BetterWright
+// instance — policy guard, stealth hooks, vault, worker, browser — and serves
+// thin CLI clients over a local socket. This is what makes `betterwright run`
+// and `betterwright exec` persistent: open tabs, in-page state, and the repl
+// `state` object live here between invocations, keyed by `--session` name,
+// until the session is closed explicitly or idles out. The Playwright layer
+// (network-policy routes, stealth hooks, credential capture) never tears down
+// between calls, so there is no unguarded window and nothing to rewire.
+//
+// Protocol: newline-delimited JSON over a unix domain socket (win32: a named
+// pipe). Requests are `{id, op, ...}`; responses `{id, ok, ...}`. Ops:
+//   hello         {version, configSig}     -> {ok, pid, version, configSig,
+//                                              withVault, sessions}
+//   call          {method, args, session}  -> {ok, result} for a whitelisted
+//                                             BetterWright method; the daemon
+//                                             pins `session` into the options
+//   exec          {task, model, modelOptions, session, fresh?, liveView?}
+//                                          -> streamed `{id, ok, event:"step",
+//                                             step}` lines while the agent
+//                                             works, then a final `{id, ok,
+//                                             result}` summary. The agent loop
+//                                             (src/agent.mjs) runs HERE, in
+//                                             the daemon — the Aside shape —
+//                                             so its conversation history and
+//                                             browser session both live across
+//                                             CLI invocations; history is also
+//                                             persisted (elided) to disk via
+//                                             src/session-store.mjs so resume
+//                                             survives a daemon restart.
+//   close_session {session}                -> {ok, closed, pagesClosed}
+//   status        {}                       -> same payload as hello
+//   shutdown      {}                       -> {ok}, then the daemon exits
+//
+// Auth model: filesystem permissions (socket 0600 inside the 0700 home), the
+// ssh-agent shape — same-user processes only. Sessions are collaboration
+// scopes, not a security boundary.
+//
+// Lifecycle: sessions idle out after BETTERWRIGHT_SESSION_TTL_SECONDS
+// (default 900); the daemon exits on its own once no sessions remain.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+
+import { BetterWright, NetworkPolicy } from "./client.mjs";
+
+const require = createRequire(import.meta.url);
+
+export const DAEMON_PROTOCOL = 1;
+export const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
+const MIN_SESSION_TTL_MS = 30_000;
+const EMPTY_GRACE_MS = 60_000;
+const REAP_INTERVAL_MS = 15_000;
+
+export function daemonPackageVersion() {
+  try {
+    return String(require("../package.json").version || "0");
+  } catch {
+    return "0";
+  }
+}
+
+export function defaultDaemonHome() {
+  const configured = (process.env.BETTERWRIGHT_HOME || "").trim();
+  return configured || path.join(os.homedir(), ".betterwright");
+}
+
+export function daemonSocketPath(home = defaultDaemonHome()) {
+  if (process.platform === "win32") {
+    const hash = crypto
+      .createHash("sha256")
+      .update(path.resolve(home))
+      .digest("hex")
+      .slice(0, 16);
+    return `\\\\.\\pipe\\betterwright-${hash}`;
+  }
+  return path.join(home, "daemon.sock");
+}
+
+export function daemonInfoPath(home = defaultDaemonHome()) {
+  return path.join(home, "daemon.json");
+}
+
+export function sessionTtlMs() {
+  const raw = Number(process.env.BETTERWRIGHT_SESSION_TTL_SECONDS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_SESSION_TTL_MS;
+  return Math.max(raw * 1000, MIN_SESSION_TTL_MS);
+}
+
+/**
+ * Canonicalize the browser-shaping options a daemon is launched with, so a
+ * client can tell whether a running daemon matches its flags. The signature is
+ * the JSON of this canonical form — build both the signature and the actual
+ * BetterWright construction from the same object and they can never drift.
+ */
+export function normalizeDaemonConfig(config = {}) {
+  const policy = config.policy && typeof config.policy === "object" ? config.policy : {};
+  const cloak = config.cloak && typeof config.cloak === "object" ? config.cloak : {};
+  const hosts = (list) =>
+    [...new Set((Array.isArray(list) ? list : []).map((h) => String(h).trim().toLowerCase()).filter(Boolean))].sort();
+  return {
+    protocol: DAEMON_PROTOCOL,
+    headless: config.headless !== false,
+    policy: {
+      allowLoopback: policy.allowLoopback !== false,
+      allowPrivateNetwork: policy.allowPrivateNetwork !== false,
+      allowHosts: hosts(policy.allowHosts),
+      blockHosts: hosts(policy.blockHosts),
+    },
+    cloak: {
+      cloakV2: cloak.cloakV2 !== false,
+      upstreamProxy: cloak.upstreamProxy ? String(cloak.upstreamProxy) : null,
+      geoip: cloak.geoip === true,
+      locale: cloak.locale ? String(cloak.locale) : null,
+      timezone: cloak.timezone ? String(cloak.timezone) : null,
+      headedInvisible: cloak.headedInvisible === true,
+      platform: cloak.platform ? String(cloak.platform) : null,
+      stealthRuntimeFix: cloak.stealthRuntimeFix === true,
+    },
+  };
+}
+
+export function daemonConfigSignature(config) {
+  return JSON.stringify(normalizeDaemonConfig(config));
+}
+
+export function createBrowserFromDaemonConfig(config) {
+  const normalized = normalizeDaemonConfig(config);
+  return new BetterWright({
+    policy: new NetworkPolicy(normalized.policy),
+    headless: normalized.headless,
+    cloakV2: normalized.cloak.cloakV2,
+    upstreamProxy: normalized.cloak.upstreamProxy || undefined,
+    geoip: normalized.cloak.geoip,
+    locale: normalized.cloak.locale || undefined,
+    timezone: normalized.cloak.timezone || undefined,
+    headedInvisible: normalized.cloak.headedInvisible,
+    platform: normalized.cloak.platform || undefined,
+    stealthRuntimeFix: normalized.cloak.stealthRuntimeFix || undefined,
+  });
+}
+
+// BetterWright methods a client may invoke, and where the session name pins
+// into their arguments. `run(code, options)` is special-cased.
+const SESSION_OPTION_METHODS = new Set([
+  "fillCredential",
+  "generateAndFillCredential",
+  "commitGeneratedCredential",
+  "discardGeneratedCredential",
+  "listPendingCredentials",
+  "startLiveView",
+  "waitForHandoff",
+  "waitForAsk",
+]);
+const PLAIN_METHODS = new Set([
+  "stopLiveView",
+  "liveViewStatus",
+  "liveViewPostChat",
+  "liveViewDrainChat",
+]);
+
+export function sessionName(value) {
+  const name = String(value ?? "default").trim();
+  return name || "default";
+}
+
+/**
+ * Start the session daemon. Everything is injectable for tests; production
+ * callers pass only `{home, config}` (see `runSessionDaemon`).
+ *
+ * @returns {Promise<{socketPath: string, close: () => Promise<void>}>}
+ */
+export async function startSessionDaemon(options = {}) {
+  const home = options.home || defaultDaemonHome();
+  const socketPath = options.socketPath || daemonSocketPath(home);
+  const config = normalizeDaemonConfig(options.config);
+  const configSig = JSON.stringify(config);
+  const version = options.version || daemonPackageVersion();
+  const ttlMs = Math.max(Number(options.ttlMs) || sessionTtlMs(), 1_000);
+  const emptyGraceMs = Math.max(Number(options.emptyGraceMs) || EMPTY_GRACE_MS, 250);
+  const reapIntervalMs = Math.max(Number(options.reapIntervalMs) || REAP_INTERVAL_MS, 50);
+  const log =
+    typeof options.log === "function"
+      ? options.log
+      : (line) => process.stderr.write(`${line}\n`);
+  const onExit = typeof options.onExit === "function" ? options.onExit : null;
+
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  const browser =
+    typeof options.createBrowser === "function"
+      ? options.createBrowser(config)
+      : createBrowserFromDaemonConfig(config);
+
+  /** @type {Map<string, {lastUsed: number, inflight: number, createdAt: number}>} */
+  const sessions = new Map();
+  // Per-session exec state: the agent's running transcript (in memory, with
+  // the elided copy on disk), and a promise chain so two execs on the same
+  // session can never interleave their conversations.
+  const execHistories = new Map();
+  const execChains = new Map();
+  const connections = new Set();
+  let lastTouch = Date.now();
+  let shuttingDown = false;
+
+  const touch = (name) => {
+    lastTouch = Date.now();
+    if (name === undefined) return null;
+    const key = sessionName(name);
+    let session = sessions.get(key);
+    if (!session) {
+      session = { lastUsed: Date.now(), inflight: 0, createdAt: Date.now() };
+      sessions.set(key, session);
+    }
+    session.lastUsed = Date.now();
+    return { key, session };
+  };
+
+  const sessionsPayload = () =>
+    [...sessions.entries()].map(([name, session]) => ({
+      name,
+      idleMs: Math.max(0, Date.now() - session.lastUsed),
+      inflight: session.inflight,
+    }));
+
+  const statusPayload = () => ({
+    pid: process.pid,
+    version,
+    protocol: DAEMON_PROTOCOL,
+    configSig,
+    withVault: Boolean(browser.vault),
+    ttlMs,
+    sessions: sessionsPayload(),
+  });
+
+  async function closeOneSession(name) {
+    const key = sessionName(name);
+    const existed = sessions.delete(key);
+    // The elided transcript stays on disk (like cookies do), so a later exec
+    // in a re-created session still remembers past work; `exec --fresh` is
+    // the explicit forget. The memory copy mirrors disk, so just drop it.
+    execHistories.delete(key);
+    let result = { ok: true, closed: false, pagesClosed: 0 };
+    try {
+      result = await browser.closeSession(key);
+    } catch (error) {
+      log(`session close failed for ${key}: ${error?.message || error}`);
+    }
+    return { ok: true, closed: Boolean(result?.closed) || existed, pagesClosed: result?.pagesClosed || 0 };
+  }
+
+  // One exec at a time per session; different sessions run concurrently.
+  function runExecOp(message, emitStep) {
+    const key = sessionName(message.session ?? "default");
+    const prior = execChains.get(key) || Promise.resolve();
+    const next = prior.then(() => execOne(key, message, emitStep));
+    execChains.set(
+      key,
+      next.then(
+        () => {},
+        () => {},
+      ),
+    );
+    return next;
+  }
+
+  async function execOne(key, message, emitStep) {
+    const tracked = touch(key);
+    tracked.session.inflight += 1;
+    try {
+      // Lazy imports keep daemon startup light and avoid a module cycle with
+      // session-store (which imports this file's path helpers). `runTask` is
+      // injectable so tests can drive exec without a model or a browser.
+      const runAgentTask =
+        typeof options.runTask === "function"
+          ? options.runTask
+          : (await import("./agent.mjs")).runAgentTask;
+      const store = await import("./session-store.mjs");
+      if (message.fresh) {
+        execHistories.delete(key);
+        store.clearTranscript(home, key);
+      }
+      const history = message.fresh
+        ? []
+        : (execHistories.get(key) ?? store.loadTranscript(home, key));
+      const result = await runAgentTask({
+        task: String(message.task || ""),
+        browser,
+        session: key,
+        history,
+        model: message.model,
+        modelOptions:
+          message.modelOptions && typeof message.modelOptions === "object"
+            ? message.modelOptions
+            : {},
+        ...(message.liveView !== undefined ? { liveView: message.liveView } : {}),
+        onStep: (event) => {
+          try {
+            emitStep(event);
+          } catch {
+            /* a vanished viewer must never break the task */
+          }
+        },
+      });
+      execHistories.set(key, result.transcript);
+      try {
+        store.saveTranscript(home, key, result.transcript);
+      } catch (error) {
+        log(`transcript save failed for ${key}: ${error?.message || error}`);
+      }
+      const { transcript: _transcript, ...summary } = result;
+      return { ...summary, session: key, resumedMessages: history.length };
+    } finally {
+      tracked.session.inflight = Math.max(0, tracked.session.inflight - 1);
+      tracked.session.lastUsed = Date.now();
+      lastTouch = Date.now();
+    }
+  }
+
+  async function handleCall(message) {
+    const method = String(message.method || "");
+    const args = Array.isArray(message.args) ? message.args : [];
+    const tracked = touch(message.session ?? "default");
+    tracked.session.inflight += 1;
+    try {
+      if (method === "run") {
+        const [code, runOptions] = args;
+        return await browser.run(String(code ?? ""), {
+          ...(runOptions && typeof runOptions === "object" ? runOptions : {}),
+          session: tracked.key,
+        });
+      }
+      if (SESSION_OPTION_METHODS.has(method)) {
+        const [callOptions] = args;
+        return await browser[method]({
+          ...(callOptions && typeof callOptions === "object" ? callOptions : {}),
+          session: tracked.key,
+        });
+      }
+      if (PLAIN_METHODS.has(method)) {
+        return await browser[method](...args.slice(0, 1));
+      }
+      throw new Error(`Unknown or disallowed method: ${method}`);
+    } finally {
+      tracked.session.inflight = Math.max(0, tracked.session.inflight - 1);
+      tracked.session.lastUsed = Date.now();
+      lastTouch = Date.now();
+    }
+  }
+
+  let server;
+  let reaper;
+
+  async function shutdown(code = 0) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    clearInterval(reaper);
+    try {
+      server?.close();
+    } catch {
+      /* already closed */
+    }
+    for (const socket of connections) socket.destroy();
+    try {
+      await browser.close();
+    } catch {
+      /* browser teardown is best effort */
+    }
+    for (const file of [socketPath, daemonInfoPath(home)]) {
+      if (process.platform === "win32" && file === socketPath) continue;
+      try {
+        fs.rmSync(file, { force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+    if (onExit) onExit(code);
+    else process.exit(code);
+  }
+
+  function maybeShutdownWhenEmpty() {
+    if (shuttingDown) return;
+    const inflight = [...sessions.values()].some((s) => s.inflight > 0);
+    if (inflight) return;
+    if (sessions.size === 0 && Date.now() - lastTouch >= emptyGraceMs) {
+      void shutdown(0);
+    }
+  }
+
+  async function reap() {
+    const cutoff = Date.now() - ttlMs;
+    for (const [name, session] of sessions) {
+      if (session.inflight > 0 || session.lastUsed >= cutoff) continue;
+      await closeOneSession(name);
+    }
+    maybeShutdownWhenEmpty();
+  }
+
+  function handleConnection(socket) {
+    connections.add(socket);
+    socket.on("close", () => connections.delete(socket));
+    socket.on("error", () => socket.destroy());
+    const lines = readline.createInterface({ input: socket, crlfDelay: Infinity });
+    // Readline re-emits input-stream errors on itself; a vanished client must
+    // not take the daemon down with an uncaught exception.
+    lines.on("error", () => {});
+    const respond = (payload) => {
+      if (socket.destroyed) return;
+      try {
+        // Callback form so a client that vanished mid-stream surfaces as a
+        // swallowed write error, not an uncaught EPIPE in the daemon.
+        socket.write(`${JSON.stringify(payload)}\n`, () => {});
+      } catch {
+        /* client went away */
+      }
+    };
+    lines.on("line", (line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+      const id = message?.id;
+      void (async () => {
+        try {
+          const op = String(message.op || "");
+          if (op === "hello" || op === "status") {
+            touch();
+            respond({ id, ok: true, ...statusPayload() });
+            return;
+          }
+          if (op === "call") {
+            const result = await handleCall(message);
+            respond({ id, ok: true, result });
+            return;
+          }
+          if (op === "exec") {
+            const result = await runExecOp(message, (step) =>
+              respond({ id, ok: true, event: "step", step }),
+            );
+            respond({ id, ok: true, result });
+            return;
+          }
+          if (op === "close_session") {
+            touch();
+            const outcome = await closeOneSession(message.session);
+            respond({ id, ok: true, ...outcome });
+            // The last explicit close ends the daemon promptly rather than
+            // holding the profile (and a Chromium) for the empty-grace window.
+            if (sessions.size === 0) {
+              lastTouch = Date.now() - emptyGraceMs;
+              setTimeout(() => maybeShutdownWhenEmpty(), 25).unref?.();
+            }
+            return;
+          }
+          if (op === "shutdown") {
+            respond({ id, ok: true });
+            setTimeout(() => void shutdown(0), 10);
+            return;
+          }
+          respond({ id, ok: false, error: `Unknown daemon op: ${op}` });
+        } catch (error) {
+          respond({ id, ok: false, error: String(error?.message || error) });
+        }
+      })();
+    });
+  }
+
+  server = net.createServer(handleConnection);
+  await new Promise((resolve, reject) => {
+    const tryListen = (retried) => {
+      server.once("error", (error) => {
+        if (error?.code !== "EADDRINUSE" || retried) {
+          reject(error);
+          return;
+        }
+        // Either another daemon is alive (we lost the spawn race — defer to
+        // it) or a previous daemon died without unlinking its socket.
+        const probe = net.connect(socketPath);
+        probe.once("connect", () => {
+          probe.destroy();
+          reject(Object.assign(new Error("another session daemon is already running"), { code: "ALREADY_RUNNING" }));
+        });
+        probe.once("error", () => {
+          probe.destroy();
+          if (process.platform !== "win32") {
+            try {
+              fs.rmSync(socketPath, { force: true });
+            } catch {
+              /* fall through to the retry */
+            }
+          }
+          tryListen(true);
+        });
+      });
+      server.listen(socketPath, () => resolve());
+    };
+    tryListen(false);
+  });
+  if (process.platform !== "win32") {
+    try {
+      fs.chmodSync(socketPath, 0o600);
+    } catch {
+      /* the 0700 home directory is the outer gate */
+    }
+  }
+  try {
+    fs.writeFileSync(
+      daemonInfoPath(home),
+      JSON.stringify({
+        pid: process.pid,
+        socket: socketPath,
+        version,
+        configSig,
+        startedAt: new Date().toISOString(),
+      }),
+      { encoding: "utf8", mode: 0o600 },
+    );
+  } catch {
+    /* informational only */
+  }
+
+  reaper = setInterval(() => void reap(), reapIntervalMs);
+  reaper.unref?.();
+
+  return {
+    socketPath,
+    close: () => shutdown(0),
+  };
+}
+
+/**
+ * Entry point for the hidden `betterwright __daemon` command: parse the
+ * base64 config from argv, start the daemon, and stay alive until the empty
+ * reaper or a signal ends the process.
+ */
+export async function runSessionDaemon(argv = process.argv) {
+  process.title = "betterwright-daemon";
+  const flagIndex = argv.indexOf("--config");
+  let config = {};
+  if (flagIndex !== -1 && argv[flagIndex + 1]) {
+    try {
+      config = JSON.parse(Buffer.from(argv[flagIndex + 1], "base64url").toString("utf8"));
+    } catch {
+      process.stderr.write("Invalid --config payload; starting with defaults.\n");
+    }
+  }
+  let daemon;
+  try {
+    daemon = await startSessionDaemon({ config });
+  } catch (error) {
+    if (error?.code === "ALREADY_RUNNING") return 0;
+    process.stderr.write(`${error?.stack || error}\n`);
+    return 1;
+  }
+  const stop = () => void daemon.close();
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
+  process.on("uncaughtException", (error) => {
+    process.stderr.write(`daemon uncaught: ${error?.stack || error}\n`);
+    void daemon.close();
+  });
+  // Stay alive until shutdown() calls process.exit.
+  await new Promise(() => {});
+  return 0;
+}

--- a/src/session-store.mjs
+++ b/src/session-store.mjs
@@ -1,0 +1,137 @@
+// On-disk transcript persistence for `betterwright exec` sessions.
+//
+// Each `--session` name gets `<home>/sessions/<name>/transcript.json`. The
+// next exec in the same session loads it as `history`, so the agent genuinely
+// remembers earlier tasks — the resume half of session persistence (the
+// daemon holds the browser half).
+//
+// Saved transcripts are elided, not summarized: stale browser observations
+// (page snapshots, by far the bulk of a browsing transcript) are replaced
+// with a one-line stub, because the live page — still open in the session
+// daemon — is the source of truth. Actions, reasoning, answers, and small
+// results are kept verbatim. The result is O(actions), not O(observations),
+// and byte-identical across loads, which is the ideal prompt-caching shape.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { defaultDaemonHome, sessionName } from "./daemon.mjs";
+
+const STORE_VERSION = 1;
+const KEEP_RECENT_BROWSER_RESULTS = 2;
+const ELIDE_OVER_CHARS = 600;
+const DEFAULT_MAX_SAVED_CHARS = 150_000;
+export const ELIDED_OBSERVATION =
+  "[stale browser output elided from the resumed session — the session's browser is still live; take a fresh snapshot instead of trusting this]";
+
+const ROLES = new Set(["user", "assistant", "tool"]);
+
+function storeDir(home, session) {
+  const name = sessionName(session);
+  const safe = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)
+    ? name
+    : `h-${crypto.createHash("sha256").update(name).digest("hex").slice(0, 16)}`;
+  return path.join(home || defaultDaemonHome(), "sessions", safe);
+}
+
+export function transcriptPath(home, session) {
+  return path.join(storeDir(home, session), "transcript.json");
+}
+
+function validMessage(message) {
+  return (
+    message &&
+    typeof message === "object" &&
+    !Array.isArray(message) &&
+    ROLES.has(message.role)
+  );
+}
+
+/**
+ * Elide stale browser observations and cap total size. Pure — returns a new
+ * array, never mutates the input.
+ *
+ * Rules:
+ *  - The most recent `keepRecentBrowser` browser-tool results stay verbatim
+ *    (they describe the state the session's live pages are still in).
+ *  - Older browser results longer than `elideOverChars` become the stub.
+ *  - If the serialized whole still exceeds `maxChars`, whole messages drop
+ *    from the front — never splitting an assistant/tool pair, and always
+ *    leaving a `user` message first so every model adapter accepts the shape.
+ */
+export function elideTranscript(messages, options = {}) {
+  const keepRecent = options.keepRecentBrowser ?? KEEP_RECENT_BROWSER_RESULTS;
+  const elideOver = options.elideOverChars ?? ELIDE_OVER_CHARS;
+  const maxChars = options.maxChars ?? DEFAULT_MAX_SAVED_CHARS;
+  const input = (Array.isArray(messages) ? messages : []).filter(validMessage);
+
+  // Walk backwards so the last N browser results are identified first.
+  let seenBrowserResults = 0;
+  const elided = [...input]
+    .reverse()
+    .map((message) => {
+      if (message.role !== "tool" || !Array.isArray(message.results)) return message;
+      let changed = false;
+      const results = [...message.results]
+        .reverse()
+        .map((result) => {
+          if (result?.name !== "browser") return result;
+          seenBrowserResults += 1;
+          const content = String(result.content ?? "");
+          if (seenBrowserResults <= keepRecent || content.length <= elideOver)
+            return result;
+          changed = true;
+          return { ...result, content: ELIDED_OBSERVATION };
+        })
+        .reverse();
+      return changed ? { ...message, results } : message;
+    })
+    .reverse();
+
+  while (elided.length && JSON.stringify(elided).length > maxChars) {
+    elided.shift();
+    while (elided.length && elided[0].role !== "user") elided.shift();
+  }
+  while (elided.length && elided[0].role !== "user") elided.shift();
+  return elided;
+}
+
+/** Load the saved transcript for a session, or [] when absent/invalid. */
+export function loadTranscript(home, session) {
+  try {
+    const raw = fs.readFileSync(transcriptPath(home, session), "utf8");
+    const parsed = JSON.parse(raw);
+    const messages = Array.isArray(parsed) ? parsed : parsed?.messages;
+    if (!Array.isArray(messages)) return [];
+    return messages.filter(validMessage);
+  } catch {
+    return [];
+  }
+}
+
+/** Elide and persist a transcript (atomic write, private permissions). */
+export function saveTranscript(home, session, messages, options = {}) {
+  const dir = storeDir(home, session);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const file = transcriptPath(home, session);
+  const payload = JSON.stringify({
+    version: STORE_VERSION,
+    session: sessionName(session),
+    savedAt: new Date().toISOString(),
+    messages: elideTranscript(messages, options),
+  });
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, payload, { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(tmp, file);
+  return file;
+}
+
+/** Forget a session's saved transcript (used by `exec --fresh`). */
+export function clearTranscript(home, session) {
+  try {
+    fs.rmSync(transcriptPath(home, session), { force: true });
+  } catch {
+    /* best effort */
+  }
+}

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -4900,6 +4900,30 @@ async function performShutdown() {
   }
 }
 
+// Explicitly close one session: close its pages and forget it, exactly like
+// the idle reaper would. Used by `betterwright close` (via the session daemon)
+// so an agent can end a persistent session before the TTL does.
+async function sessionClose(message) {
+  const sessionId = String(message.sessionId || "default");
+  const session = sessions.get(sessionId);
+  let pagesClosed = 0;
+  if (session) {
+    for (const page of session.pages.values()) {
+      if (page.isClosed()) continue;
+      pagesClosed += 1;
+      void page.close().catch(() => {});
+    }
+    sessions.delete(sessionId);
+  }
+  sendResult({
+    type: "result",
+    id: message.id,
+    ok: true,
+    closed: Boolean(session),
+    pagesClosed,
+  });
+}
+
 const input = readline.createInterface({
   input: process.stdin,
   crlfDelay: Infinity,
@@ -4945,6 +4969,14 @@ input.on("line", (line) => {
     executeQueue = executeQueue.then(
       () => credentialPending(message),
       () => credentialPending(message),
+    );
+  }
+  // Session teardown rides the executeQueue so pages never close under an
+  // in-flight execute on the same session.
+  if (message.type === "session_close") {
+    executeQueue = executeQueue.then(
+      () => sessionClose(message),
+      () => sessionClose(message),
     );
   }
   // Live-view control runs outside the executeQueue: viewers attach and

--- a/tests/node/daemon.test.mjs
+++ b/tests/node/daemon.test.mjs
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+import test from "node:test";
+import {
+  daemonConfigSignature,
+  daemonPackageVersion,
+  daemonSocketPath,
+  normalizeDaemonConfig,
+  startSessionDaemon,
+} from "../../src/daemon.mjs";
+import {
+  connectSessionDaemon,
+  createDaemonBrowser,
+  execTask,
+} from "../../src/daemon-client.mjs";
+
+function stubBrowser() {
+  const calls = [];
+  return {
+    calls,
+    vault: {},
+    closed: false,
+    run: async (code, options) => {
+      calls.push(["run", code, options]);
+      return { ok: true, result: `ran:${code}`, session: options.session };
+    },
+    closeSession: async (session) => {
+      calls.push(["closeSession", session]);
+      return { ok: true, closed: true, pagesClosed: 2 };
+    },
+    close: async function closeBrowser() {
+      this.closed = true;
+    },
+  };
+}
+
+async function startTestDaemon(overrides = {}) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-d-"));
+  const browser = overrides.browser || stubBrowser();
+  const exits = [];
+  const daemon = await startSessionDaemon({
+    home,
+    config: overrides.config || {},
+    createBrowser: () => browser,
+    onExit: (code) => exits.push(code),
+    ttlMs: overrides.ttlMs,
+    emptyGraceMs: overrides.emptyGraceMs || 60_000,
+    reapIntervalMs: overrides.reapIntervalMs,
+    runTask: overrides.runTask,
+    log: () => {},
+  });
+  const cleanup = async () => {
+    await daemon.close().catch(() => {});
+    fs.rmSync(home, { recursive: true, force: true });
+  };
+  return { home, browser, daemon, exits, cleanup };
+}
+
+function rawChannel(socketPath) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(socketPath);
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      let id = 0;
+      const pending = new Map();
+      readline.createInterface({ input: socket }).on("line", (line) => {
+        const message = JSON.parse(line);
+        if (message.event === "step") return;
+        pending.get(message.id)?.(message);
+        pending.delete(message.id);
+      });
+      resolve({
+        socket,
+        request: (payload) =>
+          new Promise((res) => {
+            id += 1;
+            pending.set(id, res);
+            socket.write(`${JSON.stringify({ id, ...payload })}\n`);
+          }),
+        end: () => socket.destroy(),
+      });
+    });
+  });
+}
+
+test("hello reports identity; call run pins the session; sessions are tracked", async () => {
+  const { home, browser, cleanup } = await startTestDaemon();
+  try {
+    const channel = await rawChannel(daemonSocketPath(home));
+    const hello = await channel.request({ op: "hello", version: "x", configSig: "y" });
+    assert.equal(hello.ok, true);
+    assert.equal(hello.version, daemonPackageVersion());
+    assert.equal(hello.configSig, daemonConfigSignature({}));
+    assert.equal(hello.withVault, true);
+    assert.deepEqual(hello.sessions, []);
+
+    const reply = await channel.request({
+      op: "call",
+      method: "run",
+      args: ["1+1", { session: "spoofed" }],
+      session: "mine",
+    });
+    assert.equal(reply.ok, true);
+    assert.equal(reply.result.result, "ran:1+1");
+    // The daemon pins the request's session over anything inside args.
+    assert.equal(browser.calls.at(-1)[2].session, "mine");
+
+    const status = await channel.request({ op: "status" });
+    assert.deepEqual(
+      status.sessions.map((s) => s.name),
+      ["mine"],
+    );
+    channel.end();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("disallowed methods are rejected", async () => {
+  const { home, cleanup } = await startTestDaemon();
+  try {
+    const channel = await rawChannel(daemonSocketPath(home));
+    const reply = await channel.request({ op: "call", method: "constructor", args: [] });
+    assert.equal(reply.ok, false);
+    assert.match(reply.error, /disallowed/i);
+    const unknown = await channel.request({ op: "wat" });
+    assert.equal(unknown.ok, false);
+    channel.end();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("close_session closes worker pages and the last close shuts the daemon down", async () => {
+  const { home, browser, exits, cleanup } = await startTestDaemon({ emptyGraceMs: 300 });
+  try {
+    const channel = await rawChannel(daemonSocketPath(home));
+    await channel.request({ op: "call", method: "run", args: ["a"], session: "one" });
+    const closed = await channel.request({ op: "close_session", session: "one" });
+    assert.equal(closed.closed, true);
+    assert.equal(closed.pagesClosed, 2);
+    assert.deepEqual(browser.calls.at(-1), ["closeSession", "one"]);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.deepEqual(exits, [0]);
+    assert.equal(browser.closed, true);
+    channel.end();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("idle sessions are reaped after the TTL and the empty daemon exits", async () => {
+  const { home, browser, exits, cleanup } = await startTestDaemon({
+    ttlMs: 1_000,
+    reapIntervalMs: 60,
+    emptyGraceMs: 300,
+  });
+  try {
+    const channel = await rawChannel(daemonSocketPath(home));
+    await channel.request({ op: "call", method: "run", args: ["a"], session: "idle-me" });
+    channel.end();
+    await new Promise((resolve) => setTimeout(resolve, 1_800));
+    assert.ok(
+      browser.calls.some(([kind, name]) => kind === "closeSession" && name === "idle-me"),
+      "TTL reaper closes the idle session",
+    );
+    assert.deepEqual(exits, [0]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("exec runs in the daemon, streams steps, and resumes the transcript next time", async () => {
+  const seen = [];
+  const runTask = async (options) => {
+    seen.push({ history: options.history, task: options.task, session: options.session });
+    options.onStep({ step: 1, tool: "browser", note: `working on ${options.task}` });
+    return {
+      ok: true,
+      answer: `answer:${options.task}`,
+      steps: 1,
+      reason: "done",
+      toolCalls: 1,
+      usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, context: 2 },
+      durationMs: 5,
+      transcript: [
+        ...options.history,
+        { role: "user", text: options.task },
+        { role: "assistant", text: `answer:${options.task}`, toolCalls: [] },
+      ],
+      proof: null,
+    };
+  };
+  const { home, cleanup } = await startTestDaemon({ runTask });
+  try {
+    const outcome = await connectSessionDaemon({ home, spawnIfNeeded: false });
+    assert.equal(outcome.ok, true);
+    const steps = [];
+    const first = await execTask(
+      outcome.channel,
+      { task: "task-1", session: "default", model: "stub" },
+      { onStep: (step) => steps.push(step) },
+    );
+    assert.equal(first.ok, true);
+    assert.equal(first.answer, "answer:task-1");
+    assert.equal(first.resumedMessages, 0);
+    assert.equal(first.transcript, undefined, "transcript stays in the daemon");
+    assert.deepEqual(steps, [{ step: 1, tool: "browser", note: "working on task-1" }]);
+
+    const second = await execTask(outcome.channel, {
+      task: "task-2",
+      session: "default",
+      model: "stub",
+    });
+    assert.equal(second.resumedMessages, 2, "second exec resumes the first conversation");
+    assert.equal(seen[1].history.at(-1).text, "answer:task-1");
+
+    // --fresh forgets the conversation.
+    const third = await execTask(outcome.channel, {
+      task: "task-3",
+      session: "default",
+      model: "stub",
+      fresh: true,
+    });
+    assert.equal(third.resumedMessages, 0);
+    outcome.channel.end();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("exec transcript survives a daemon restart via the on-disk store", async () => {
+  const runTask = async (options) => ({
+    ok: true,
+    answer: "done",
+    steps: 1,
+    reason: "done",
+    toolCalls: 0,
+    usage: {},
+    durationMs: 1,
+    transcript: [
+      ...options.history,
+      { role: "user", text: options.task },
+      { role: "assistant", text: "done", toolCalls: [] },
+    ],
+    proof: null,
+  });
+  const first = await startTestDaemon({ runTask });
+  let home;
+  try {
+    home = first.home;
+    const outcome = await connectSessionDaemon({ home, spawnIfNeeded: false });
+    await execTask(outcome.channel, { task: "remember me", session: "default" });
+    outcome.channel.end();
+  } finally {
+    await first.daemon.close().catch(() => {});
+  }
+  // New daemon, same home: history reloads from disk.
+  const browser = stubBrowser();
+  const daemon = await startSessionDaemon({
+    home,
+    config: {},
+    createBrowser: () => browser,
+    onExit: () => {},
+    runTask,
+    log: () => {},
+  });
+  try {
+    const outcome = await connectSessionDaemon({ home, spawnIfNeeded: false });
+    const result = await execTask(outcome.channel, { task: "next", session: "default" });
+    assert.equal(result.resumedMessages, 2);
+    outcome.channel.end();
+  } finally {
+    await daemon.close().catch(() => {});
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("createDaemonBrowser proxies run and survives daemon death with an envelope", async () => {
+  const { home, daemon, cleanup } = await startTestDaemon();
+  try {
+    const outcome = await connectSessionDaemon({ home, spawnIfNeeded: false });
+    const proxy = createDaemonBrowser(outcome.channel, { session: "p" });
+    const result = await proxy.run("2+2", {});
+    assert.equal(result.result, "ran:2+2");
+    await daemon.close();
+    const dead = await proxy.run("3+3", {});
+    assert.equal(dead.ok, false);
+    assert.match(dead.error, /session daemon/);
+    await proxy.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("config mismatch on a busy daemon falls back; ignoreMismatch connects anyway", async () => {
+  const { home, cleanup } = await startTestDaemon({
+    config: { policy: { blockHosts: ["x.example"] } },
+  });
+  try {
+    // Open a session so the daemon counts as busy.
+    const seed = await connectSessionDaemon({
+      home,
+      spawnIfNeeded: false,
+      config: { policy: { blockHosts: ["x.example"] } },
+    });
+    assert.equal(seed.ok, true);
+    await seed.channel.request({ op: "call", method: "run", args: ["a"], session: "default" });
+
+    const mismatched = await connectSessionDaemon({ home, spawnIfNeeded: false, config: {} });
+    assert.equal(mismatched.ok, false);
+    assert.match(mismatched.reason, /different browser flags/);
+
+    const forced = await connectSessionDaemon({
+      home,
+      spawnIfNeeded: false,
+      config: {},
+      ignoreMismatch: true,
+    });
+    assert.equal(forced.ok, true);
+    forced.channel.end();
+    seed.channel.end();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("normalizeDaemonConfig is order-insensitive and default-stable", () => {
+  const a = daemonConfigSignature({
+    policy: { allowHosts: ["B.com", "a.com"], blockHosts: [] },
+    cloak: { cloakV2: true },
+    headless: true,
+  });
+  const b = daemonConfigSignature({
+    headless: true,
+    cloak: {},
+    policy: { allowHosts: ["a.com", "b.com", "a.com"] },
+  });
+  assert.equal(a, b);
+  assert.notEqual(a, daemonConfigSignature({ headless: false }));
+  assert.equal(
+    normalizeDaemonConfig({}).cloak.stealthRuntimeFix,
+    false,
+  );
+});

--- a/tests/node/session-store.test.mjs
+++ b/tests/node/session-store.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  clearTranscript,
+  ELIDED_OBSERVATION,
+  elideTranscript,
+  loadTranscript,
+  saveTranscript,
+  transcriptPath,
+} from "../../src/session-store.mjs";
+
+function browserTurn(content, note = "") {
+  return [
+    { role: "assistant", text: note, toolCalls: [{ id: "t1", name: "browser", input: {} }] },
+    { role: "tool", results: [{ id: "t1", name: "browser", content }] },
+  ];
+}
+
+test("elideTranscript keeps the last two browser observations and stubs older large ones", () => {
+  const big = (label) => `${label}:${"x".repeat(2_000)}`;
+  const messages = [
+    { role: "user", text: "task one" },
+    ...browserTurn(big("first")),
+    ...browserTurn("small result"),
+    ...browserTurn(big("third")),
+    ...browserTurn(big("fourth")),
+  ];
+  const elided = elideTranscript(messages);
+  const contents = elided
+    .filter((m) => m.role === "tool")
+    .map((m) => m.results[0].content);
+  assert.equal(contents[0], ELIDED_OBSERVATION); // old + large → stub
+  assert.equal(contents[1], "small result"); // old + small → kept
+  assert.ok(contents[2].startsWith("third:")); // last two kept verbatim
+  assert.ok(contents[3].startsWith("fourth:"));
+  // Pure: input untouched.
+  assert.ok(messages[2].results[0].content.startsWith("first:"));
+});
+
+test("elideTranscript caps total size by dropping whole leading turns, never orphaning tool results", () => {
+  const messages = [{ role: "user", text: "the original task" }];
+  for (let i = 0; i < 50; i += 1) {
+    messages.push({ role: "user", text: `follow-up ${i}: ${"y".repeat(400)}` });
+    messages.push(...browserTurn("z".repeat(400)));
+  }
+  const elided = elideTranscript(messages, { maxChars: 8_000, elideOverChars: 100_000 });
+  assert.ok(JSON.stringify(elided).length <= 8_000);
+  assert.ok(elided.length > 0);
+  assert.equal(elided[0].role, "user");
+  for (let i = 0; i < elided.length; i += 1) {
+    if (elided[i].role === "tool")
+      assert.equal(elided[i - 1]?.role, "assistant", "tool result must follow its assistant turn");
+  }
+});
+
+test("elideTranscript drops malformed entries", () => {
+  const elided = elideTranscript([
+    null,
+    "nope",
+    { role: "system", text: "not a transcript role" },
+    { role: "user", text: "keep me" },
+  ]);
+  assert.deepEqual(elided, [{ role: "user", text: "keep me" }]);
+});
+
+test("save/load roundtrip with private permissions; clear forgets", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-store-"));
+  try {
+    const messages = [
+      { role: "user", text: "book the flight" },
+      { role: "assistant", text: "done", toolCalls: [] },
+    ];
+    const file = saveTranscript(home, "default", messages);
+    assert.equal(file, transcriptPath(home, "default"));
+    if (process.platform !== "win32") {
+      assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+    }
+    assert.deepEqual(loadTranscript(home, "default"), messages);
+    clearTranscript(home, "default");
+    assert.deepEqual(loadTranscript(home, "default"), []);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hostile session names cannot escape the sessions directory", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-store-"));
+  try {
+    for (const name of ["../../etc/passwd", "..", "a/b", ".hidden", "x".repeat(200)]) {
+      const file = transcriptPath(home, name);
+      const sessionsRoot = path.join(home, "sessions");
+      assert.ok(
+        path.resolve(file).startsWith(`${path.resolve(sessionsRoot)}${path.sep}`),
+        `${name} must stay under ${sessionsRoot}`,
+      );
+      assert.ok(!path.resolve(file).includes(".."));
+    }
+    // Same hostile name maps to the same file (stable hashing).
+    assert.equal(transcriptPath(home, "a/b"), transcriptPath(home, "a/b"));
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("loadTranscript tolerates a corrupt file", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-store-"));
+  try {
+    const file = transcriptPath(home, "default");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "{not json");
+    assert.deepEqual(loadTranscript(home, "default"), []);
+    fs.writeFileSync(file, JSON.stringify({ messages: "not-an-array" }));
+    assert.deepEqual(loadTranscript(home, "default"), []);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -50,6 +50,13 @@ export class BetterWright {
   liveView: LiveViewOptions;
 
   run<T = unknown>(code: string, options?: RunOptions): Promise<RunResult<T>>;
+  /**
+   * Close one session's pages and forget its state (tabs, `state`, cursor)
+   * without touching the browser, the profile, or other sessions.
+   */
+  closeSession(
+    session?: string,
+  ): Promise<{ ok: boolean; closed: boolean; pagesClosed: number; error?: string }>;
   /** Start (or return the already-running) token-gated live-view server. */
   startLiveView(options?: LiveViewOptions): Promise<LiveViewStatus>;
   /** Stop the live-view server (no-op when not running). */


### PR DESCRIPTION
## Summary
- Adds a per-home **session daemon** (`src/daemon.mjs` + `src/daemon-client.mjs`): a detached background process that owns the single BetterWright/Playwright instance and speaks newline-delimited JSON over a 0600 unix socket (named pipe on Windows). Tabs, page state, logins, and the repl `state` object now survive between CLI invocations instead of dying with each process.
- `betterwright exec` now runs its agent loop **inside the daemon** (Aside-style): step events stream back live, and the LLM transcript persists per session (`src/session-store.mjs` — stale browser observations elided, 150k-char cap, atomic 0600 writes), so consecutive `exec` calls continue one conversation. `--fresh` forgets it; the summary line reports `resumed session "x" (N prior messages)`.
- Sessions default to `default`; `--session <name>` isolates parallel work; idle sessions reap after a 15-minute TTL (`BETTERWRIGHT_SESSION_TTL_SECONDS`); new `betterwright sessions` and `betterwright close [name|--all]` commands inspect/tear down; the daemon exits itself once empty.
- Safety valves: `--no-daemon` / `BETTERWRIGHT_NO_DAEMON` restores one-shot behavior (exec still resumes transcripts from disk); a version/config-signature mismatch replaces an idle daemon but falls back to a private one-shot browser when the daemon holds live sessions; `interactive`/`view` reclaim the profile from an idle daemon.
- Worker/client gain `closeSession()` (closes a session's pages without stopping the browser); SKILL text rewritten around the persistent-session model.

## Testing
- 15 new unit tests (`tests/node/daemon.test.mjs`, `tests/node/session-store.test.mjs`): session pinning, method whitelist, TTL reaping, empty-daemon exit, exec streaming/resume/`--fresh`, transcript survival across daemon restarts, dead-daemon error envelopes, busy-mismatch fallback, config-signature stability, transcript elision/cap invariants, hostile session names, corrupt-file tolerance.
- `npm run release:check` green (versions, biome, unit, types, package smoke — 92 files, new modules included).
- Real-browser E2E in an isolated home: `run` state + DOM mutations persisted across processes; `--session` isolation; repl attached to the same live session; real-model (`gpt-5.6-sol`) `exec` pair proved transcript + tab resume ("PLUM-42" recalled, example.com still open), `--fresh` answered "NONE"; `close --all` shut everything down and removed the socket; daemon.log clean.
- Note: `browser.test.mjs` "human helpers use shaped pointer…" fails on this dev machine on **clean main** too (environmental select-all race, unrelated to this diff); it passes in CI, which gates merge and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)