### PR TITLE
Release v1.1.2: stop blocking secret-shaped URLs in NetworkPolicy

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -312,10 +312,10 @@ using an alternate source or requesting human help.
 
 ## §6 — Safeguards (configure to taste)
 
-By default BetterWright blocks only cloud-metadata endpoints and secret-bearing
-URLs; the public internet, private networks, and loopback are all reachable so
-an agent can drive local dev servers and intranet hosts out of the box. Tighten
-it deliberately. Two independent layers:
+By default BetterWright blocks only cloud-metadata endpoints; the public
+internet, private networks, and loopback are all reachable so an agent can
+drive local dev servers and intranet hosts out of the box. Tighten it
+deliberately. Two independent layers:
 
 **Network — what the browser can reach** (CLI flags, `NetworkPolicy` options,
 or the MCP env vars):

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -156,7 +156,6 @@ new NetworkPolicy({
   allowLoopback: false,
   allowHosts: [],
   blockHosts: [],
-  blockSecretBearingUrls: true,
   custom,                    // (url, details) => decision | null
 });
 ```

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -18,9 +18,6 @@ it with a `NetworkPolicy`.
   can never be allowlisted or disabled; see below.
 - **Blocks non-web schemes** — only `http`, `https`, `ws`, and `wss` are
   routable (`about:blank`, `data:`, and `blob:` are allowed).
-- **Blocks URLs that appear to carry a secret** — a query string or path holding
-  something shaped like an API key or JWT is refused, so a compromised page
-  cannot exfiltrate a token through a URL.
 - **Allows the public internet, private networks, and loopback** — RFC 1918
   ranges, `127.0.0.0/8`, `localhost`, IPv6 loopback/unique-local, link-local,
   carrier-grade NAT, and `*.internal`/`*.local`/`*.lan` hosts are reachable, so
@@ -59,7 +56,6 @@ new BetterWright({ policy });
 | `allowPrivateNetwork` | Permit RFC 1918, link-local, and `*.internal`/`*.local` hosts. Implies loopback. Default `true`; set `false` to block. |
 | `allowHosts` | Always allow these hosts. An entry matches a host exactly or as a parent domain (`example.com` also matches `sub.example.com`); add `:port` to pin a port. |
 | `blockHosts` | Always block these hosts, evaluated before allowlists. |
-| `blockSecretBearingUrls` | Refuse URLs that look like they carry a key/token. Default `true`. |
 | `custom` | A hook, `custom(url, details)`, returning a decision or `null`, evaluated last. |
 
 Evaluation order is: scheme check → `blockHosts` → `allowHosts` → metadata

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/policy.mjs
+++ b/src/policy.mjs
@@ -20,19 +20,6 @@ export const METADATA_ADDRESSES = new Set([
   "fd00:ec2::254",
 ]);
 
-const SECRET_PATTERN =
-  /(sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,})/;
-
-function looksLikeSecret(url) {
-  let decoded = url;
-  try {
-    decoded = decodeURIComponent(url);
-  } catch {
-    /* keep the raw URL */
-  }
-  return SECRET_PATTERN.test(url) || SECRET_PATTERN.test(decoded);
-}
-
 function ipv4ToInt(host) {
   const parts = host.split(".");
   if (parts.length !== 4) return null;
@@ -146,7 +133,6 @@ export class NetworkPolicy {
     this.allowLoopback = options.allowLoopback !== false;
     this.allowHosts = options.allowHosts || [];
     this.blockHosts = options.blockHosts || [];
-    this.blockSecretBearingUrls = options.blockSecretBearingUrls !== false;
     this.custom = typeof options.custom === "function" ? options.custom : null;
   }
 
@@ -196,13 +182,6 @@ export class NetworkPolicy {
     const hostname = parsed.hostname.toLowerCase();
     if (!hostname) return { allowed: false, reason: "URL has no hostname" };
     const port = parsed.port ? Number(parsed.port) : null;
-
-    if (this.blockSecretBearingUrls && looksLikeSecret(url)) {
-      return {
-        allowed: false,
-        reason: "URL contains what appears to be an API key or token",
-      };
-    }
 
     const decision = this.checkHost(hostname, port);
     if (this.custom) {

--- a/tests/fixtures/policy-vectors.json
+++ b/tests/fixtures/policy-vectors.json
@@ -588,51 +588,32 @@
       "allowed": true
     },
     {
-      "name": "openai-style key in url",
+      "name": "openai-style key in url is allowed",
       "url": "https://example.com/?key=sk-abcdefghijklmnopqrstuvwxyz123456",
       "policy": {},
-      "allowed": false,
-      "reason_contains": "API key or token"
-    },
-    {
-      "name": "github token in path",
-      "url": "https://example.com/ghp_ABCDEFGHIJKLMNOPQRSTuvwxyz012345/raw",
-      "policy": {},
-      "allowed": false,
-      "reason_contains": "API key or token"
-    },
-    {
-      "name": "aws access key in query",
-      "url": "https://example.com/?id=AKIAIOSFODNN7EXAMPLE",
-      "policy": {},
-      "allowed": false,
-      "reason_contains": "API key or token"
-    },
-    {
-      "name": "url-encoded secret still caught",
-      "url": "https://example.com/?key=sk%2Dabcdefghijklmnopqrstuvwxyz123456",
-      "policy": {},
-      "allowed": false,
-      "reason_contains": "API key or token"
-    },
-    {
-      "name": "jwt in url blocked",
-      "url": "https://example.com/?t=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0",
-      "policy": {},
-      "allowed": false,
-      "reason_contains": "API key or token"
-    },
-    {
-      "name": "secret check disabled by flag",
-      "url": "https://example.com/?key=sk-abcdefghijklmnopqrstuvwxyz123456",
-      "policy": {
-        "block_secret_bearing_urls": false
-      },
       "allowed": true
     },
     {
-      "name": "short sk prefix is not a secret",
-      "url": "https://example.com/?key=sk-short",
+      "name": "github token in path is allowed",
+      "url": "https://example.com/ghp_ABCDEFGHIJKLMNOPQRSTuvwxyz012345/raw",
+      "policy": {},
+      "allowed": true
+    },
+    {
+      "name": "aws access key in query is allowed",
+      "url": "https://example.com/?id=AKIAIOSFODNN7EXAMPLE",
+      "policy": {},
+      "allowed": true
+    },
+    {
+      "name": "url-encoded key-shaped query is allowed",
+      "url": "https://example.com/?key=sk%2Dabcdefghijklmnopqrstuvwxyz123456",
+      "policy": {},
+      "allowed": true
+    },
+    {
+      "name": "jwt-shaped query is allowed",
+      "url": "https://example.com/?t=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0",
       "policy": {},
       "allowed": true
     }

--- a/tests/node/policy-vectors.test.mjs
+++ b/tests/node/policy-vectors.test.mjs
@@ -23,7 +23,6 @@ function policyFromSnakeCase(options) {
     allowLoopback: options.allow_loopback,
     allowHosts: options.allow_hosts,
     blockHosts: options.block_hosts,
-    blockSecretBearingUrls: options.block_secret_bearing_urls,
   });
 }
 

--- a/tests/node/policy.test.mjs
+++ b/tests/node/policy.test.mjs
@@ -92,9 +92,12 @@ test("allow host honors an explicit port", () => {
   assert.ok(!allow(policy, "http://localhost:4000/"));
 });
 
-test("secret-bearing url blocked", () => {
+test("urls with token-shaped query strings are allowed", () => {
   const policy = new NetworkPolicy();
-  assert.ok(!allow(policy, `https://evil.example.com/?t=ghp_${"a".repeat(36)}`));
+  assert.ok(allow(policy, `https://evil.example.com/?t=ghp_${"a".repeat(36)}`));
+  assert.ok(
+    allow(policy, "https://example.com/?key=sk-abcdefghijklmnopqrstuvwxyz123456"),
+  );
 });
 
 test("unsupported schemes blocked, data/blank allowed", () => {

--- a/types/policy.d.ts
+++ b/types/policy.d.ts
@@ -17,7 +17,6 @@ export interface NetworkPolicyOptions {
   allowLoopback?: boolean;
   allowHosts?: string[];
   blockHosts?: string[];
-  blockSecretBearingUrls?: boolean;
   custom?: NetworkPolicyCustom;
 }
 
@@ -31,7 +30,6 @@ export class NetworkPolicy {
   allowLoopback: boolean;
   allowHosts: string[];
   blockHosts: string[];
-  blockSecretBearingUrls: boolean;
   custom: NetworkPolicyCustom | null;
 
   hostMatches(entry: unknown, hostname: string, port: number | null): boolean;


### PR DESCRIPTION
## Summary
- Bump package version to **1.1.2**.
- Remove `NetworkPolicy` secret-bearing URL blocking (`blockSecretBearingUrls` / `looksLikeSecret` / token-shaped URL denials). Public sites and token-shaped query strings are no longer refused by that heuristic.
- Cloud-metadata endpoints remain unliftable; scheme restrictions and private/loopback / host allow-block options are unchanged.
- Docs, TypeScript types, unit tests, and policy conformance vectors updated to match.

## Testing
- `npm run release:check` green (versions, biome, unit, types, package smoke — `betterwright-1.1.2.tgz`).
- Policy unit + conformance vectors assert token-shaped URLs are **allowed**; metadata denials still covered.