### PR TITLE
Release v1.2.0: managed Live View relay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
       - run: npm run test:unit
       - run: npm run test:types
       - run: npm run check:package
+      - name: Install relay dependencies
+        working-directory: relay
+        run: npm ci --ignore-scripts
+      - name: Type-check relay
+        working-directory: relay
+        run: npm run typecheck
+      - name: Test relay and deployment bundle
+        working-directory: relay
+        run: npm test && npx wrangler deploy --dry-run
 
   node:
     # Keep this display name stable because main branch protection requires it.

--- a/README.md
+++ b/README.md
@@ -178,21 +178,31 @@ BetterWright's whole observation stack is built around that problem:
 
 ## Watch it, coach it, take the wheel
 
-Every run can carry a self-hosted [live view](docs/live-view.md): a web page
+Every run can carry an encrypted [Live View](docs/live-view.md): a web page
 showing the browser in real time, with chat to guide the agent between turns
-and a **handoff** flow for the moments automation shouldn't finish alone —
-MFA, a resistant CAPTCHA, a consequential click. The agent pauses, you take
-the controls, hit **Done**, and it resumes with your note.
+and a **handoff** flow for MFA, a resistant CAPTCHA, or a consequential step.
+The agent pauses, you take control, click **Done**, and it resumes with your
+note.
 
 ```bash
-betterwright exec "…" --live-view          # watch the whole run
-betterwright view --expose tailscale       # drive a headless VPS browser from your laptop
-betterwright view --set-password           # lock every viewer behind a password
+# Managed: account-backed, outbound-only, no ports or host-IP disclosure
+betterwright account set-key              # create the key at betterwright.com/account
+betterwright configure live-view --live-view-mode relay
+betterwright exec "…" --live-view
+
+# Direct alternatives stay available; the no-config default is loopback-only
+betterwright view --expose local
+betterwright view --expose tailscale
+betterwright view --expose lan             # explicit LAN exposure
+betterwright view --set-password           # Direct mode only, salted scrypt
 ```
 
-Hosting is one word (`lan`, `local`, `tailscale`), auth is a capability token
-plus an optional config-stored password, and nothing live-view-related is
-reachable from model code.
+Managed host and viewer traffic goes directly through Cloudflare, not the
+BetterWright website or Azure. The viewer root stays in the URL fragment and
+end-to-end encrypts screen, input, and chat. Each account includes two hours of
+viewer-connected time per ISO week; a waiting host consumes none. Direct mode,
+Tailscale, user-owned tunnels, and experimental Cloudflare Quick Tunnels remain
+available.
 
 ## Why not just Playwright?
 
@@ -218,7 +228,7 @@ step from what it sees, in a browser that must still be there next turn:
 | [**Agent snapshots**](docs/browser-api.md#reading-the-page) | The token-efficiency core: compressed tree, `[ref=eN]` actions, diff and interactive-only modes, password redaction |
 | [**Built-in agent loop**](docs/agent.md) | `betterwright exec` / the interactive console / `runAgentTask()` — model-first selection across Claude, Codex, Grok, OpenRouter, Ollama, vLLM, and any OpenAI-compatible endpoint |
 | [**Credential vault**](docs/credentials.md) | AES-256-GCM outside the profile; PSL site matching, selector-free login detection, metadata-only account choice |
-| [**Live view & handoff**](docs/live-view.md) | Watch and coach the agent live; token + optional password gated; `handoff` pauses for human hands and resumes on Done |
+| [**Live View & handoff**](docs/live-view.md) | Cloudflare-only managed relay with endpoint encryption and account quota, plus loopback, LAN, Tailscale, and user-owned tunnel modes |
 | [**Network policy**](docs/network-policy.md) | Every navigation, subresource, WebSocket, and raw TCP connection checked; metadata endpoints always blocked |
 | [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
 | [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel — no extra dependency |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,39 @@ threat model and the controls that enforce it are documented in
 Please read those sections before deploying BetterWright somewhere it can be
 driven by untrusted input.
 
+## Live View security
+
+Live View is a trusted host capability, not part of the model-authored code
+sandbox. It starts only through an explicit host, agent handoff, or user action
+and remains immutably bound to one BetterWright session.
+
+The no-config Direct viewer listens only on `127.0.0.1`. LAN and Tailscale
+listeners must be selected explicitly. Direct URLs contain a random capability;
+an optional eight-character-minimum password is stored as a salted scrypt
+verifier. Direct HTTP still needs a trusted LAN, tailnet, SSH tunnel, or HTTPS
+tunnel for transport privacy.
+
+The managed relay connects outbound to `live.betterwright.com` and keeps the
+host address out of the viewer. Screen frames, input, and chat are encrypted
+between the BetterWright host and viewer with directional HKDF-derived
+AES-256-GCM keys. The root key stays in the viewer URL fragment and is not sent
+to the relay. Authenticated epochs and sequence numbers reject tampering and
+replay, and an encrypted host challenge gates all viewer input after every
+connection.
+
+Cloudflare can still observe normal service metadata such as account/session
+identifiers, connection timing, peer IP metadata, and ciphertext sizes. D1
+stores HMAC digests for API keys and capabilities, never their plaintext or the
+viewer root. A complete viewer URL grants the access shown by the page, so do
+not log or paste it into model prompts, tickets, or chats. Revoke personal API
+keys at <https://betterwright.com/account> when no longer needed.
+
+The website is an account-management surface only. Managed viewer HTTPS and
+WebSocket traffic goes directly to Cloudflare and does not traverse the Azure
+website origin. See [docs/live-view.md](docs/live-view.md) and the
+[managed relay protocol](https://github.com/BetterWright/betterwright/blob/main/relay/docs/PROTOCOL.md)
+for protocol and operational details.
+
 ## Reporting a vulnerability
 
 Report suspected vulnerabilities privately via GitHub's **Report a

--- a/SETUP.md
+++ b/SETUP.md
@@ -213,6 +213,27 @@ servers) and confirm a `browser` tool appears. Then do **§5**.
 The server keeps one browser alive for its lifetime, so pages and logins persist
 across tool calls.
 
+`browser_handoff` is always present, but remote reachability is a deployer
+choice. With no configuration it uses a Direct loopback-only viewer. For the
+account-backed managed relay, create a personal key at
+<https://betterwright.com/account>, run `betterwright account set-key`, then
+save Relay mode once:
+
+```bash
+betterwright configure live-view --live-view-mode relay
+```
+
+That explicit saved choice applies to the CLI, library, daemon, and MCP server.
+Environment-only deployments can set `BETTERWRIGHT_LIVE_VIEW_TRANSPORT=relay`;
+selecting Relay there is also the authorization, so no redundant second flag is
+required. `BETTERWRIGHT_LIVE_VIEW=1` remains the separate safety opt-in for a
+non-loopback Direct listener. The API key stays in owner-only
+`~/.betterwright/account.json` (or the ephemeral `BETTERWRIGHT_API_KEY`
+environment variable). Managed screen, input,
+and chat traffic is endpoint-encrypted and travels directly through
+`live.betterwright.com`; it does not traverse the BetterWright website. Full
+modes, quota, and threat model: [docs/live-view.md](docs/live-view.md).
+
 Managed launches use CloakBrowser in headed and headless modes to reduce
 common automation false positives; hosts with the native Chromium fork
 artifact installed (`~/.betterwright/chromium/`) run that instead — see
@@ -315,6 +336,26 @@ using an alternate source or requesting human help.
 ---
 
 ## §6 — Safeguards (configure to taste)
+
+**Live View remote access.** The no-config default is Direct mode on
+`127.0.0.1`; nothing is exposed to the LAN or internet. Choose a remote path
+explicitly:
+
+```bash
+# Account-backed, outbound-only managed relay
+betterwright account set-key
+betterwright configure live-view --live-view-mode relay
+
+# Or a Direct network you operate
+betterwright configure live-view --live-view-mode tailscale
+betterwright configure live-view --live-view-mode lan
+```
+
+Managed relay accounts include two viewer-connected hours per ISO week. A
+waiting host is not charged. The complete returned URL is a capability and must
+be treated like a password. Direct LAN mode is plain HTTP; prefer Relay,
+Tailscale, SSH, or an HTTPS tunnel for remote access. See
+[docs/live-view.md](docs/live-view.md).
 
 By default BetterWright blocks only cloud-metadata endpoints; the public
 internet, private networks, and loopback are all reachable so an agent can

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.1.3
+generated_by: betterwright@1.2.0
 ---
 
 # Browser tool: BetterWright

--- a/bin/betterwright.mjs
+++ b/bin/betterwright.mjs
@@ -58,7 +58,6 @@ import {
 } from "../src/daemon-client.mjs";
 import { doctorReport, resolveCloakDir, resolveCoreDir } from "../src/doctor.mjs";
 import { agentSystemPrompt, BetterWright, NetworkPolicy } from "../src/index.mjs";
-import { defaultLiveViewListen, guessLanHost } from "../src/live-view.mjs";
 import {
   clearTranscript,
   loadTranscript,
@@ -77,52 +76,64 @@ const require = createRequire(import.meta.url);
 const CLI_PATH = fileURLToPath(import.meta.url);
 
 /**
- * Live-view options for CLI `--live-view` / `view`.
- * Always defaults to LAN-reachable bind + publicHost (never localhost unless
- * explicitly requested). Override with `--host` / env.
+ * Live-view options for CLI `--live-view` / `view`. Only explicit CLI/env
+ * values are returned, so persisted setup choices remain authoritative. The
+ * library's no-config default is loopback.
  */
 function liveViewCliOptions(argv = process.argv, { required = false } = {}) {
-  const flags = new Set(argv.filter((token) => token.startsWith("--")));
-  if (!required && !flags.has("--live-view")) return undefined;
-  const lan = defaultLiveViewListen();
-  const host = String(
-    flagValue(argv, "--host", process.env.BETTERWRIGHT_LIVE_VIEW_HOST || lan.host),
+  const has = (name) => argv.some((token) => token === name || token.startsWith(`${name}=`));
+  if (!required && !has("--live-view")) return undefined;
+  const out = { interactive: !has("--watch-only") };
+  const hostValue = flagValue(argv, "--host", process.env.BETTERWRIGHT_LIVE_VIEW_HOST);
+  const portValue = flagValue(argv, "--port", process.env.BETTERWRIGHT_LIVE_VIEW_PORT);
+  const publicHostValue = flagValue(
+    argv,
+    "--public-host",
+    process.env.BETTERWRIGHT_LIVE_VIEW_PUBLIC_HOST,
   );
-  const port = Number(
-    flagValue(argv, "--port", process.env.BETTERWRIGHT_LIVE_VIEW_PORT || 0),
-  ) || 0;
-  const loopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
-  const wildcard = host === "0.0.0.0" || host === "::" || host === "";
-  const publicHost = String(
-    flagValue(
-      argv,
-      "--public-host",
-      process.env.BETTERWRIGHT_LIVE_VIEW_PUBLIC_HOST ||
-        (loopback ? host : wildcard ? lan.publicHost || guessLanHost() : host),
-    ),
-  );
-  // One-word hosting presets; an explicit --host wins over --expose (and over
-  // an expose preset stored in config.json, hence the explicit empty string).
   let expose = String(
     flagValue(argv, "--expose", process.env.BETTERWRIGHT_LIVE_VIEW_EXPOSE || ""),
   )
     .trim()
     .toLowerCase();
-  if (expose && flags.has("--host")) {
-    process.stderr.write("--host overrides --expose; ignoring --expose.\n");
+  let mode = String(
+    flagValue(
+      argv,
+      "--live-view-mode",
+      flagValue(argv, "--transport", process.env.BETTERWRIGHT_LIVE_VIEW_TRANSPORT || ""),
+    ),
+  )
+    .trim()
+    .toLowerCase();
+  if (expose === "relay") {
+    mode = "relay";
     expose = "";
   }
-  // The password comes from config.json (`betterwright view --set-password`)
-  // or the env var — never a flag, so it stays out of shell history and ps.
+  if (["local", "lan", "tailscale"].includes(mode)) {
+    expose = mode;
+    mode = "direct";
+  }
+  if (mode && !["direct", "relay"].includes(mode)) {
+    throw new Error(
+      `Unknown live-view mode "${mode}"; use relay, local, lan, tailscale, or direct.`,
+    );
+  }
+  if (hostValue != null && hostValue !== "") {
+    out.host = String(hostValue);
+    if (expose) {
+      process.stderr.write("--host overrides --expose; ignoring --expose.\n");
+      expose = "";
+    }
+    if (!mode) mode = "direct";
+  }
+  if (portValue != null && portValue !== "") out.port = Number(portValue) || 0;
+  if (publicHostValue != null && publicHostValue !== "") out.publicHost = String(publicHostValue);
+  if (expose) out.expose = expose;
+  if (mode) out.transport = mode;
+  // The password comes from config.json or env, never a flag.
   const password = String(process.env.BETTERWRIGHT_LIVE_VIEW_PASSWORD || "");
-  return {
-    host,
-    port,
-    publicHost,
-    interactive: !flags.has("--watch-only"),
-    ...(expose || flags.has("--host") ? { expose } : {}),
-    ...(password ? { password } : {}),
-  };
+  if (password) out.password = password;
+  return out;
 }
 
 /** Prompt on the TTY with echo suppressed (for --set-password). */
@@ -145,6 +156,169 @@ async function promptHidden(question) {
   });
 }
 
+async function promptLine(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(String(answer || "").trim());
+    });
+  });
+}
+
+const LIVE_VIEW_SETUP_MODES = new Set(["relay", "local", "lan", "tailscale"]);
+
+async function configureLiveView(flags, { allowUnconfigured = false } = {}) {
+  const { saveLiveViewSettings } = await import("../src/live-view-config.mjs");
+  const {
+    BETTERWRIGHT_ACCOUNT_URL,
+    loadAccountConfig,
+    saveAccountApiKey,
+    verifyBetterWrightApiKey,
+  } = await import("../src/account-config.mjs");
+  const argv = process.argv;
+  let mode = String(
+    flagValue(
+      argv,
+      "--live-view-mode",
+      flagValue(argv, "--transport", process.env.BETTERWRIGHT_LIVE_VIEW_TRANSPORT || ""),
+    ),
+  )
+    .trim()
+    .toLowerCase();
+  if (mode === "direct") {
+    mode = String(
+      flagValue(argv, "--expose", process.env.BETTERWRIGHT_LIVE_VIEW_EXPOSE || "local"),
+    )
+      .trim()
+      .toLowerCase();
+  }
+  const canPrompt = process.stdin.isTTY && process.stdout.isTTY && !flags.has("--non-interactive");
+  if (!mode && canPrompt) {
+    console.log("\nLive View sharing");
+    console.log("  1  BetterWright Relay  recommended · works anywhere · hides your host IP");
+    console.log("  2  This computer only  loopback, nothing shared");
+    console.log("  3  Local network       reachable on the same LAN/Wi-Fi");
+    console.log("  4  Tailscale network   private to your tailnet");
+    console.log("  5  Decide later        keep the safe loopback default");
+    const answer = await promptLine("Choose [1]: ");
+    mode = ({ "": "relay", "1": "relay", "2": "local", "3": "lan", "4": "tailscale", "5": "local" })[answer] || answer;
+  }
+  if (!mode) return { ok: true, configured: false };
+  if (!LIVE_VIEW_SETUP_MODES.has(mode)) {
+    return {
+      ok: false,
+      error: `Unknown live-view mode "${mode}"; use relay, local, lan, or tailscale.`,
+    };
+  }
+  if (mode === "relay") {
+    const account = loadAccountConfig();
+    let apiKey = account.apiKey || "";
+    let persistApiKey = false;
+    if (!apiKey && flags.has("--api-key-stdin")) {
+      apiKey = fs.readFileSync(0, "utf8").trim();
+      persistApiKey = true;
+    }
+    if (!apiKey && canPrompt) {
+      console.log(`\nCreate a personal API key at ${BETTERWRIGHT_ACCOUNT_URL}`);
+      console.log("The key is stored only in ~/.betterwright/account.json with mode 0600.");
+      apiKey = String(await promptHidden("Paste BetterWright API key: ")).trim();
+      persistApiKey = Boolean(apiKey);
+    }
+    if (!apiKey) {
+      const error =
+        `Managed relay requires a BetterWright account API key. Create one at ${BETTERWRIGHT_ACCOUNT_URL}, then run \`betterwright account set-key\`.`;
+      return allowUnconfigured
+        ? { ok: true, configured: false, mode: "local", warning: `${error} Keeping the safe local default.` }
+        : { ok: false, configured: false, error };
+    }
+    const checked = await verifyBetterWrightApiKey(apiKey, { relayUrl: account.relayUrl });
+    if (!checked.ok) {
+      if (allowUnconfigured) {
+        return {
+          ok: true,
+          configured: false,
+          warning:
+            `${checked.error} Browser setup completed and Live View settings were left unchanged; ` +
+            "the safe no-config default is local-only.",
+        };
+      }
+      return checked;
+    }
+    // A key supplied through BETTERWRIGHT_API_KEY remains environment-only;
+    // only a value explicitly pasted/piped here is persisted.
+    if (persistApiKey) saveAccountApiKey(apiKey, { relayUrl: account.relayUrl });
+    const file = saveLiveViewSettings({ transport: "relay", expose: "local" });
+    return { ok: true, configured: true, mode, file, quota: checked.quota };
+  }
+  const file = saveLiveViewSettings({ transport: "direct", expose: mode });
+  return { ok: true, configured: true, mode, file };
+}
+
+async function cmdAccount(rest, flags) {
+  const {
+    BETTERWRIGHT_ACCOUNT_URL,
+    accountConfigPath,
+    clearAccountConfig,
+    loadAccountConfig,
+    maskBetterWrightApiKey,
+    saveAccountApiKey,
+    verifyBetterWrightApiKey,
+  } = await import("../src/account-config.mjs");
+  const action = firstPositional(rest) || "status";
+  if (action === "logout" || action === "clear") {
+    const file = clearAccountConfig();
+    console.log(`BetterWright account API key removed (${file}).`);
+    return 0;
+  }
+  if (action === "set-key" || action === "login") {
+    let apiKey = String(process.env.BETTERWRIGHT_API_KEY || "").trim();
+    if (!apiKey && flags.has("--api-key-stdin")) apiKey = fs.readFileSync(0, "utf8").trim();
+    if (!apiKey && process.stdin.isTTY) {
+      console.log(`Create a personal key at ${BETTERWRIGHT_ACCOUNT_URL}`);
+      apiKey = String(await promptHidden("Paste BetterWright API key: ")).trim();
+    }
+    if (!apiKey) {
+      console.error("No API key provided. Set BETTERWRIGHT_API_KEY or use --api-key-stdin.");
+      return 1;
+    }
+    const account = loadAccountConfig();
+    const checked = await verifyBetterWrightApiKey(apiKey, { relayUrl: account.relayUrl });
+    if (!checked.ok) {
+      console.error(checked.error);
+      return 1;
+    }
+    const file = saveAccountApiKey(apiKey, { relayUrl: account.relayUrl });
+    console.log(`BetterWright account connected (${file}).`);
+    if (checked.quota) {
+      console.log(`Managed relay: ${Math.floor(Number(checked.quota.remainingSeconds || 0) / 60)} minutes remaining this week.`);
+    }
+    return 0;
+  }
+  if (action !== "status") {
+    console.error("Usage: betterwright account [status | set-key | logout]");
+    return 1;
+  }
+  const account = loadAccountConfig();
+  if (!account.apiKey) {
+    console.log(`Not connected. Create a key at ${BETTERWRIGHT_ACCOUNT_URL}`);
+    return 1;
+  }
+  console.log(`Stored key: ${maskBetterWrightApiKey(account.apiKey)} (${account.source})`);
+  console.log(`Credential file: ${accountConfigPath()}`);
+  const checked = await verifyBetterWrightApiKey(account.apiKey, { relayUrl: account.relayUrl });
+  if (!checked.ok) {
+    console.error(checked.error);
+    return 1;
+  }
+  console.log("Relay authentication: valid");
+  if (checked.quota) {
+    const remaining = Math.max(0, Number(checked.quota.remainingSeconds || 0));
+    console.log(`Weekly allowance: ${Math.floor(remaining / 60)} minutes remaining · resets ${checked.quota.resetAt || "next Monday UTC"}`);
+  }
+  return 0;
+}
+
 /** `view --set-password` / `--clear-password`: manage the stored password hash. */
 async function cmdViewPassword(flags) {
   const { saveLiveViewPassword, liveViewConfigPath } = await import("../src/live-view-config.mjs");
@@ -159,8 +333,8 @@ async function cmdViewPassword(flags) {
     return 1;
   }
   const first = await promptHidden("New live-view password: ");
-  if (first.length < 4) {
-    console.error("Password must be at least 4 characters.");
+  if (first.length < 8) {
+    console.error("Password must be at least 8 characters.");
     return 1;
   }
   const second = await promptHidden("Repeat it: ");
@@ -170,7 +344,7 @@ async function cmdViewPassword(flags) {
   }
   const file = saveLiveViewPassword(first);
   console.log(`Live-view password saved (hashed) to ${file}.`);
-  console.log(dim("Every live view (view, exec --live-view, MCP handoffs) now requires it."));
+  console.log(dim("Direct live views now require it. Managed relay links use their private URL capability instead."));
   console.log(dim(`Config path: ${liveViewConfigPath()} — remove with \`betterwright view --clear-password\`.`));
   return 0;
 }
@@ -322,6 +496,16 @@ async function cmdSetup(flags) {
 
   const cloakCode = await installCloakBrowser();
   if (cloakCode !== 0) return cloakCode;
+
+  const liveViewSetup = await configureLiveView(flags, { allowUnconfigured: true });
+  if (!liveViewSetup.ok) {
+    console.error(`\nLive View setup failed: ${liveViewSetup.error}`);
+    return 1;
+  }
+  if (liveViewSetup.configured) {
+    console.log(`\nLive View mode: ${liveViewSetup.mode || "relay"}`);
+  }
+  if (liveViewSetup.warning) console.log(`\n${liveViewSetup.warning}`);
 
   console.log("\nSetup complete. Run `betterwright doctor` to confirm.");
   if (!cloakOnly) {
@@ -567,6 +751,7 @@ const VALUE_FLAGS = new Set([
   "--endpoint",
   "--expose",
   "--host",
+  "--live-view-mode",
   "--locale",
   "--model",
   "--model-id",
@@ -578,6 +763,7 @@ const VALUE_FLAGS = new Set([
   "--reasoning",
   "--session",
   "--timezone",
+  "--transport",
   "--upstream-proxy",
 ]);
 
@@ -1416,6 +1602,24 @@ function printLiveViewBanner(view, { dim, bold, attached = false } = {}) {
   if (attached) {
     console.log(dim("attached to the session daemon (same tabs as run/exec)"));
   }
+  if (view.transport === "relay" || view.expose === "relay") {
+    const remaining = Number(view.quota?.remainingSeconds);
+    console.log(
+      dim(
+        `who can open it: anyone with the encrypted capability link · ${view.interactive ? "interactive" : "watch-only"} · host IP hidden`,
+      ),
+    );
+    if (Number.isFinite(remaining)) {
+      console.log(
+        dim(
+          `managed allowance: ${Math.max(0, Math.ceil(remaining / 60))} minutes left this week` +
+            (view.quota?.resetAt ? ` · resets ${view.quota.resetAt}` : ""),
+        ),
+      );
+    }
+    console.log(dim("The # fragment holds the encryption key and is never sent to the relay. Treat the whole link like a password."));
+    return;
+  }
   const reach =
     view.expose === "tailscale"
       ? "devices on your tailnet (Tailscale)"
@@ -1524,7 +1728,10 @@ async function cmdView(flags) {
       console.error(view.error || "The live view failed to start.");
       return 1;
     }
-    await browser.run("if (page.url() === 'about:blank') await page.goto('about:blank'); 'ready'");
+    await browser.run(
+      "if (page.url() === 'about:blank') await page.goto('about:blank'); 'ready'",
+      { session },
+    );
     printLiveViewBanner(view, { dim, bold, attached: false });
     await new Promise((resolve) => {
       process.once("SIGINT", resolve);
@@ -1612,6 +1819,26 @@ async function cmdSkills(rest) {
   return 1;
 }
 
+async function cmdConfigure(rest, flags) {
+  const target = firstPositional(rest);
+  if (target !== "live-view") {
+    console.error("Usage: betterwright configure live-view [--live-view-mode relay|local|lan|tailscale]");
+    return 1;
+  }
+  const outcome = await configureLiveView(flags);
+  if (!outcome.ok) {
+    console.error(outcome.error);
+    return 1;
+  }
+  if (!outcome.configured) {
+    console.error("No mode selected. Pass --live-view-mode in a non-interactive shell.");
+    return 1;
+  }
+  console.log(`Live View mode saved: ${outcome.mode || "relay"}`);
+  if (outcome.warning) console.log(outcome.warning);
+  return 0;
+}
+
 async function main() {
   const tokens = process.argv.slice(2);
   const flags = new Set(tokens.filter((token) => token.startsWith("--")));
@@ -1625,7 +1852,7 @@ async function main() {
     }
     if (flags.has("--help") || tokens.includes("-h")) {
       console.error(
-        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|sessions|close|models|view|auth|skill|skills|mcp> [options]\n" +
+        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|sessions|close|models|view|account|configure|auth|skill|skills|mcp> [options]\n" +
           "Run `betterwright` with no arguments for the interactive agent console.",
       );
       return 0;
@@ -1652,6 +1879,10 @@ async function main() {
       return cmdModels(flags);
     case "view":
       return cmdView(flags);
+    case "account":
+      return cmdAccount(rest, flags);
+    case "configure":
+      return cmdConfigure(rest, flags);
     case "auth":
       return cmdAuth(rest);
     case "skill":
@@ -1673,7 +1904,7 @@ async function main() {
     }
     default:
       console.error(
-        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|sessions|close|models|view|auth|skill|skills|mcp> [options]\n" +
+        "Usage: betterwright [interactive] | <setup|update|doctor|run|repl|exec|sessions|close|models|view|account|configure|auth|skill|skills|mcp> [options]\n" +
           "Run `betterwright` with no arguments for the interactive agent console.",
       );
       return 1;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,12 +89,27 @@ These are independent of the sandbox and of each other. See
 [network-policy.md](network-policy.md) for the metadata-endpoint rationale in
 full.
 
-The worker's loopback SOCKS proxy is its only always-on listener. One opt-in
-second listener exists: the [live-view server](live-view.md) (off by default,
-`127.0.0.1` + capability token, started only by an explicit host message),
-which streams CDP screencast frames to a human viewer and relays their input.
-It runs in the worker because that is where the CDP sessions live; it is not
-reachable from the model sandbox.
+The worker's loopback SOCKS proxy is its only always-on listener. Live View is
+off by default and starts only after an explicit trusted-host message. Direct
+mode creates a token-gated listener on `127.0.0.1`; LAN or Tailscale binds must
+be selected explicitly.
+
+Managed mode keeps that browser-facing server hidden on loopback and adds a
+host bridge that connects outbound over WSS to `live.betterwright.com`. The
+viewer also connects outbound to Cloudflare. A hibernating Durable Object
+forwards authenticated binary envelopes but never receives the 256-bit root
+key, which exists only in the host-created URL fragment. Direction-separated
+HKDF keys, AES-256-GCM sequence envelopes, replay rejection, and a host-issued
+root-key challenge protect screen, input, and chat end to end. The relay never
+opens a port on the host, exposes its IP to the viewer, or sends browser traffic
+through the Azure-hosted website.
+
+Each capability is immutably bound to one BetterWright daemon session. The
+worker clears the local server, relay bridge, and binding together on explicit
+stop, terminal relay events, browser-context loss, and session closure. Worker
+restarts preserve only opaque reconnect state; final shutdown waits for relay
+DELETE within a bounded grace period. See [live-view.md](live-view.md) for the
+protocol, quota, and operator model.
 
 ### Secrets
 
@@ -125,6 +140,8 @@ Everything lives under `$BETTERWRIGHT_HOME` (default `~/.betterwright`):
 
 ```
 ~/.betterwright/
+├── account.json       owner-only managed-relay API key (optional)
+├── config.json        non-secret Live View and runtime settings
 ├── browser/
 │   ├── profile/        persistent browser profile (cookies, logins)
 │   └── runtime/        ephemeral profiles when the main one is locked

--- a/docs/live-view.md
+++ b/docs/live-view.md
@@ -1,229 +1,340 @@
-# Live view, chat & human handoff
+# Live View, chat, and human handoff
 
-Watch — coach — and when needed, drive — BetterWright's browser from an
-ordinary web page. This is BetterWright's self-hosted answer to cloud "session
-viewer / human-in-the-loop" products: the agent keeps its persistent,
-policy-guarded session, and a human can watch it live, message it, take the
-controls, or complete a step the agent cannot (MFA, a resistant CAPTCHA, a
-consequential click) — then hand control straight back.
+Live View lets a person watch BetterWright's browser, chat with the agent,
+answer an `ask`, or take control for a handoff without moving the browser to a
+cloud VM.
 
-Three surfaces, one server:
+BetterWright has two first-class transports:
 
-| Surface | What it does |
+- **Managed relay**: an account-backed, encrypted link at
+  `https://live.betterwright.com`. Both host and viewer connect outbound to
+  Cloudflare. No port forwarding, public listener, SSH tunnel, or host IP in
+  the viewer is required.
+- **Direct**: a self-hosted listener on this machine. It is loopback-only by
+  default. LAN and Tailscale exposure are explicit choices.
+
+The Live View data plane does not pass through the BetterWright website. The
+website is only for sign-in and API-key management.
+
+## Where Live View appears
+
+| Surface | How to start it |
 | --- | --- |
-| `betterwright exec "<task>" --live-view` | starts the viewer at step 0 and prints the URL, so you watch the whole run while the agent works |
-| interactive console `--live-view` or `/live` | `--live-view` starts a viewer before the first prompt; **`/live` opens one anytime mid-session**; `/live stop` closes it; `/new`, `/headed`, and `/headless` re-open the viewer when live is enabled |
-| the session dock (chat / ask / handoff) | always-on chat to guide the agent; `ask` questions appear as chips + a reply box; `handoff` elevates the dock with **Done** / **Cancel** and force-enables browser control |
-| agent `live_view` tool | mid-task watch without pausing: the model can open the viewer whenever the user asks, relay the URL, and keep working (`handoff` still pauses for human hands) |
-| MCP `browser_handoff` | `action: "start"` anytime during an MCP session (watch or handoff) |
-| `betterwright view` | attaches to the **session daemon** when one is running (same tabs as `run`/`exec`/`skill` agents) and holds the viewer until Ctrl-C; if no daemon, starts a private browser for warm-up / remote-desktop |
+| One CLI task | `betterwright exec "<task>" --live-view` |
+| Interactive console | start with `--live-view`, or use `/live` at any time |
+| Existing daemon session | `betterwright view --session <name>` |
+| Built-in agent | the `live_view` tool watches without pausing; `handoff` pauses for the person |
+| MCP | `browser_handoff` with `action: "start"` |
+| JavaScript API | `startLiveView()`, `stopLiveView()`, and `liveViewStatus()` |
 
-Library equivalents: `browser.startLiveView()`, `browser.stopLiveView()`,
-`browser.liveViewStatus()`, `browser.waitForHandoff()`, `browser.waitForAsk()`,
-`browser.liveViewPostChat()`, `browser.liveViewDrainChat()`, and
-`runAgentTask({liveView: true})` (or omit the flag and call the agent
-`live_view` / `handoff` tools mid-task). MCP clients get a `browser_handoff` tool.
+The viewer follows exactly one daemon session. Once a capability is created,
+it cannot silently retarget to a different session. Chat, ask, handoff, status,
+and teardown are checked against that same session.
 
-**Live view is invocable anytime** — not only at process or task start. The
-code sandbox still cannot start it (sealed); host surfaces above can.
+Ordinary progress messages never start a listener or managed session. Only an
+explicit Live View, ask, or handoff action activates it.
 
-## How it works
+## Managed relay quick start
 
-The viewer server runs inside the browser worker (the only process holding
-CDP). Frames are CDP `Page.startScreencast` JPEGs pushed over a WebSocket to a
-single self-contained HTML page; your mouse and keyboard travel back as CDP
-`Input.dispatch*` events on the same page. The stream is damage-driven — an
-idle page costs ~nothing; a busy one is roughly screen-share bandwidth
-(~25–80 KB per frame). Several things keep that budget honest:
+1. Sign in at <https://betterwright.com/account> and create a personal Live
+   View API key.
+2. Store and verify it without putting it in shell history:
 
-- the screencast resolution adapts to the largest connected viewer window
-  (bucketed, debounced), so a small laptop window never streams 1440px frames;
-- a viewer whose browser tab is hidden stops receiving frames entirely and
-  repaints from the latest frame the moment it returns;
-- the latest frame is replayed to newly connected viewers, so joining never
-  shows a black canvas waiting for page damage;
-- tab-strip thumbnails travel as per-tab deltas, sent only when the thumbnail
-  actually changed — never re-broadcast wholesale.
+   ```bash
+   betterwright account set-key
+   betterwright account status
+   ```
 
-While the agent is driving, the viewer defaults to watching; **Take control**
-enables your input with a visible warning that agent and human inputs can
-race. The bottom **session dock** is always available:
+   In a non-interactive environment, pipe it on standard input:
 
-- **Chat** — type freeform guidance ("use the work account", "skip that").
-  Messages are queued and delivered to the agent at the next turn boundary
-  (never mid-`browser` step), so the agent incorporates them safely. Over MCP
-  the boundary is each tool call: your messages arrive appended to the next
-  `browser` tool result (and in `browser_handoff` status), and the agent's
-  per-step notes are mirrored into this chat.
-- **Ask** — when the model calls `ask`, the dock elevates with the question and
-  optional choice chips; your reply (chip or text) unblocks the agent.
-- **Handoff** — when the model calls `handoff`, input is force-enabled and the
-  dock shows the reason plus **Done** / **Cancel**. An optional note (the chat
-  field) returns to the model verbatim.
+   ```bash
+   printf '%s' "$BETTERWRIGHT_API_KEY" | betterwright account set-key --api-key-stdin
+   ```
 
-Agent step notes (`browser`, `login`, …) and the final answer are mirrored into
-the same chat log so watching the run feels alive.
+3. Save managed relay as the default and start a view:
 
-Human browser input goes through every existing guard: the SOCKS policy proxy,
-download limits, and credential capture treat takeover navigation exactly like
-model-driven navigation. **Takeover does not bypass network policy.** Chat is
-allowed even in watch-only mode (watch-only only blocks mouse/keyboard into the
-page).
+   ```bash
+   betterwright configure live-view --live-view-mode relay
+   betterwright view
+   ```
 
-## Hosting: pick who can open it
-
-You shouldn't need to know what a bind host is. One word says who can reach
-the viewer, and one flag locks it:
+Use it for one invocation without changing the saved default:
 
 ```bash
-betterwright view                          # devices on your local network (default)
-betterwright view --expose tailscale       # your tailnet only — auto-detects the Tailscale IP
-betterwright view --expose local           # only this machine — pair with your own tunnel
-betterwright view --set-password           # prompt once; every live view now needs it
+betterwright exec "check the production dashboard" --live-view --transport relay
+betterwright view --transport relay --session default
 ```
 
-The same words work everywhere: `exec "<task>" --live-view --expose tailscale`,
-`BETTERWRIGHT_LIVE_VIEW_EXPOSE=tailscale` (CLI and MCP), and
-`startLiveView({expose: "tailscale"})` in the library. Settings you want
-permanent go in `~/.betterwright/config.json` (see below) and apply to all
-three surfaces. What each preset does:
+`betterwright setup` also offers this choice interactively. In a
+non-interactive shell, setup does not change the Live View mode unless
+`--live-view-mode` is provided.
 
-- **`lan`** (default) — binds all interfaces and prints a URL with your
-  machine's private LAN IP, so a phone or laptop on the same network opens it
-  directly.
-- **`tailscale`** — binds *only* your Tailscale address (detected from the
-  100.64.0.0/10 interface; fails with a clear error if Tailscale isn't up).
-  Nothing on the LAN or internet can reach it, traffic is end-to-end
-  encrypted by the tailnet, and the printed URL works from any of your
-  tailnet devices. This is the recommended way to watch a remote VPS.
-- **`local`** — loopback only, for bringing your own tunnel. The CLI prints
-  copy-paste commands for the two common ones:
+### Upgrading from 1.1.x
 
-  ```bash
-  ssh -L PORT:127.0.0.1:PORT <host>                  # then open the printed URL locally
-  cloudflared tunnel --url http://127.0.0.1:PORT     # gives you an https URL to share
-  ```
+Version 1.2.0 deliberately removes implicit network exposure. If an older
+workflow relied on `betterwright view` being LAN-reachable, choose that risk
+explicitly once with `betterwright configure live-view --live-view-mode lan`;
+otherwise it now stays on loopback. Tailscale, user-owned HTTPS tunnels, and
+experimental Quick Tunnels still work as Direct alternatives.
 
-An explicit `--host` still overrides everything for advanced setups.
+Managed Relay is new in 1.2.0 and requires a BetterWright account, a personal
+API key, and an explicit saved, environment, CLI, or API transport choice. A
+saved Relay choice applies to MCP too, so it does not need a redundant
+`BETTERWRIGHT_LIVE_VIEW=1`; that variable remains the safety opt-in for
+non-loopback Direct MCP listeners. New Direct passwords require at least eight
+characters and are stored as salted scrypt verifiers. Existing legacy SHA-256
+verifiers remain readable for a non-breaking upgrade.
 
-### Persistent settings & password
+### Account credentials
 
-`~/.betterwright/config.json` (or `$BETTERWRIGHT_HOME/config.json`) holds
-live-view settings you set once and forget. The CLI, the library and the MCP
-server all read it; flags and env vars override it per run:
+The API key is stored in `~/.betterwright/account.json` with owner-only
+permissions. It is separate from ordinary `config.json`, is masked in status
+output, and is never accepted as a normal command-line value. Revoke a key from
+the account page or remove the local copy with:
+
+```bash
+betterwright account logout
+```
+
+`BETTERWRIGHT_API_KEY` overrides the stored key for an ephemeral process and is
+not persisted automatically. `BETTERWRIGHT_RELAY_URL` can point to a compatible
+self-hosted relay; it must be HTTPS, except for explicit loopback tests. An
+invalid custom relay URL fails closed rather than falling back to the hosted
+service.
+
+## Managed quota and availability
+
+Each account receives **7,200 viewer-connected seconds per ISO week**, which is
+two hours. The week begins Monday at 00:00 UTC.
+
+- Time starts only after an authorized viewer WebSocket is accepted.
+- A waiting host, an idle session with no viewer, and session creation do not
+  consume the allowance.
+- Disconnecting stops the clock. Usage is reconciled against a bounded
+  15-minute lease so a dropped connection cannot run indefinitely.
+- Only one viewer lease can be active for an account at a time.
+- There is no byte-transfer allowance to manage. The time allowance is the
+  user-facing quota.
+
+The account page and `betterwright account status` show the remaining time and
+reset date. Admission also fails closed if quota, budget, or service control
+state cannot be verified.
+
+## Cloudflare-only data path
+
+For managed mode, the host sends an outbound WSS connection directly to
+`live.betterwright.com`. The viewer loads the shell and opens its own WSS
+connection to the same Cloudflare Worker. A per-session Durable Object pairs
+one host and one viewer. D1 stores account, API-key digest, session, and quota
+metadata.
+
+```text
+BetterWright host  -- outbound WSS -->  Cloudflare Durable Object
+                                              ^
+Viewer browser     -- HTTPS + WSS ------------|
+```
+
+The relay path does not traverse Azure or the marketing website. It never
+needs an inbound port on the host and does not give the viewer the host's IP
+address.
+
+### End-to-end encryption
+
+The complete viewer link looks like:
+
+```text
+https://live.betterwright.com/s/<session-id>#k=<root-key>
+```
+
+The `#k=` fragment stays in the viewer browser and is not sent in HTTP requests.
+BetterWright creates the session ID and 32-byte root locally, sends only a
+session-bound proof to the relay, and appends the root to the returned viewer
+URL after validating the response origin and path.
+
+The root derives separate host-to-viewer and viewer-to-host AES-256-GCM keys
+with HKDF-SHA-256. Each direction uses a fresh 16-byte epoch and monotonic
+64-bit sequence numbers. The authenticated header binds protocol version,
+direction, epoch, and sequence; tampering, replay, wrong-direction frames, and
+mid-connection epoch changes are rejected.
+
+On every viewer connection, BetterWright sends an encrypted random challenge.
+The viewer must return the exact encrypted response before mouse, keyboard,
+paste, chat, tab switching, or handoff messages are accepted. The Durable
+Object forwards opaque ciphertext and control events only.
+
+The relay can observe account/session metadata, connection timing, IP
+metadata available to Cloudflare, and ciphertext sizes. It cannot decrypt the
+screen, input, or chat. Anyone who has the complete viewer link can access the
+session, so treat the whole link like a password.
+
+## Direct and user-owned networking
+
+Without saved configuration, Direct mode binds to `127.0.0.1`:
+
+```bash
+betterwright view                         # safe loopback default
+betterwright view --expose local          # explicit loopback
+betterwright view --expose lan            # explicit same-network listener
+betterwright view --expose tailscale      # explicit tailnet-only listener
+```
+
+The presets mean:
+
+- `local`: loopback only. Use an SSH tunnel or a tunnel you own when needed.
+- `lan`: bind all interfaces and print the private LAN address.
+- `tailscale`: bind only the detected Tailscale address. It fails clearly if
+  Tailscale is unavailable.
+
+For a user-owned tunnel, keep BetterWright on loopback:
+
+```bash
+ssh -L PORT:127.0.0.1:PORT <host>
+cloudflared tunnel --url http://127.0.0.1:PORT
+```
+
+Cloudflare Quick Tunnels are an experimental convenience here, not the managed
+production relay. Their URL and availability are controlled by Cloudflare's
+Quick Tunnel service.
+
+### Direct-view password
+
+A direct capability URL is always required. Add a separate password gate with:
+
+```bash
+betterwright view --set-password
+betterwright view --clear-password
+```
+
+Passwords must be at least eight characters. New stored verifiers use salted
+scrypt in `~/.betterwright/config.json`; legacy SHA-256 verifiers remain
+readable for upgrade compatibility. The plaintext is not stored or accepted as
+a CLI flag. A direct password does not apply to managed links, which use the
+fragment capability and endpoint encryption.
+
+Direct viewing is plain HTTP unless the surrounding LAN, tailnet, SSH tunnel,
+or user-owned tunnel supplies transport protection.
+
+## Persistent configuration and precedence
+
+Saved settings live under the `liveView` section of
+`~/.betterwright/config.json`:
 
 ```json
 {
   "liveView": {
-    "expose": "tailscale",
-    "passwordHash": "sha256:…"
+    "transport": "relay",
+    "expose": "local"
   }
 }
 ```
 
-**Password.** `betterwright view --set-password` prompts (hidden input,
-confirmed twice) and stores a SHA-256 hash in that file with `0600`
-permissions — the plaintext never touches a flag, your shell history, or
-`ps`. From then on every live view — `view`, `exec --live-view`, and
-MCP-started handoffs — shows a branded login screen in front of the viewer,
-on top of the capability token that's already in the URL: the token gets
-someone to the door, the password gets them in. Remove it with
-`betterwright view --clear-password`. (Library callers can also pass
-`startLiveView({password})` per start; MCP deployments that prefer env can
-set `BETTERWRIGHT_LIVE_VIEW_PASSWORD`.)
+The API key is never placed in that file. Configuration is resolved in this
+order:
 
-## Security model
+1. explicit per-call API options or CLI flags;
+2. explicit constructor options and surface environment variables;
+3. `account.json` and the `liveView` section of `config.json`;
+4. safe built-ins: Direct transport on `127.0.0.1` with an ephemeral port.
 
-Unlike cloud debug URLs, the self-hosted viewer is authenticated by default:
+Files are re-read on every start, so changing the mode, deleting a saved
+setting, or revoking/removing a local key takes effect in an already-running
+daemon. Choosing an explicit host or exposure preset selects Direct mode; a
+saved Relay choice cannot silently turn that listener into a remote relay.
 
-- **Capability token.** Every server start generates a fresh
-  `?t=<random-192-bit>` token required on the page, every HTTP request, and
-  the WebSocket upgrade (constant-time compare, 404 otherwise). The URL *is*
-  the credential — treat it like a password; don't paste it into chats or
-  ticket systems.
-- **LAN by default.** Live view binds `0.0.0.0` and prints a URL with the
-  machine's private LAN IP (e.g. `http://192.168.0.2:PORT/?t=…`) so another
-  device on the network can open it directly. Loopback only if you ask:
+Useful environment variables:
 
-  ```bash
-  betterwright exec "…" --live-view --host 127.0.0.1
-  # or
-  BETTERWRIGHT_LIVE_VIEW_HOST=127.0.0.1 betterwright exec "…" --live-view
-  ```
+| Variable | Purpose |
+| --- | --- |
+| `BETTERWRIGHT_API_KEY` | ephemeral account API key |
+| `BETTERWRIGHT_RELAY_URL` | managed or compatible self-hosted relay origin |
+| `BETTERWRIGHT_LIVE_VIEW_TRANSPORT` | `direct` or `relay` |
+| `BETTERWRIGHT_LIVE_VIEW_EXPOSE` | Direct preset: `local`, `lan`, or `tailscale` |
+| `BETTERWRIGHT_LIVE_VIEW_HOST` | explicit Direct bind host |
+| `BETTERWRIGHT_LIVE_VIEW_PORT` | explicit Direct bind port |
+| `BETTERWRIGHT_LIVE_VIEW_PUBLIC_HOST` | host printed for a wildcard Direct bind |
+| `BETTERWRIGHT_LIVE_VIEW_PASSWORD` | ephemeral Direct-view password |
+| `BETTERWRIGHT_LIVE_VIEW=1` | MCP deployer opt-in for non-loopback Direct access; an explicit saved/environment Relay selection authorizes Relay itself |
 
-  Pin the printed host with `--public-host` / `BETTERWRIGHT_LIVE_VIEW_PUBLIC_HOST`.
-  Over MCP, a non-loopback host still requires `BETTERWRIGHT_LIVE_VIEW=1` —
-  the deployer, not the model, opts in.
-- **Optional password gate.** With a password set (`betterwright view
-  --set-password`), the token only reaches a login page; the viewer (and the
-  WebSocket) additionally require a session established by the password. At
-  rest only a SHA-256 hash is stored, in `config.json` with `0600` permissions. Verification is constant-time against a
-  SHA-256 digest; the session is a random 192-bit id in an `HttpOnly;
-  SameSite=Strict` cookie valid 12 hours; failed logins lock the source
-  address out after 10 attempts per 15 minutes; sessions die with the server.
-  The page is plain http — rely on the network layer (LAN, tailnet, or an
-  https tunnel) for transport privacy, which every preset provides.
-- **Server-side watch-only.** `--watch-only` (or `interactive: false`) is
-  enforced in the worker; the browser-side toggle is a convenience, never an
-  authority. Handoffs force interactive on for their duration only.
-- **Origin check + headers.** WebSocket upgrades with a mismatched `Origin`
-  are dropped; the page is served with `Cache-Control: no-store`,
-  `Referrer-Policy: no-referrer`, and `X-Frame-Options: DENY`.
-- **Sealed from the model.** Nothing live-view-related exists in the code
-  sandbox. The model can *request* a handoff; it cannot start servers, read
-  the token, or synthesize input.
+## Viewer behavior
 
-## Options
+The active page is streamed from CDP screencast frames. The largest visible
+viewer controls the bucketed stream size; hidden viewer tabs stop receiving
+frames and repaint from the latest frame on return. Tab thumbnails are sent as
+deltas.
 
-| Option / flag | Env | Default | Meaning |
-| --- | --- | --- | --- |
-| `--expose` / `liveView.expose` | `BETTERWRIGHT_LIVE_VIEW_EXPOSE` | `lan` | hosting preset: `lan`, `local`, or `tailscale` |
-| `view --set-password` / config `passwordHash` / `liveView.password` | `BETTERWRIGHT_LIVE_VIEW_PASSWORD` | off | require a password (min 4 chars) before the viewer loads |
-| `--host` / `liveView.host` | `BETTERWRIGHT_LIVE_VIEW_HOST` | `0.0.0.0` | bind host (LAN-reachable by default; overrides `--expose`) |
-| `--public-host` / `liveView.publicHost` | `BETTERWRIGHT_LIVE_VIEW_PUBLIC_HOST` | LAN IPv4 | host printed in the URL when bind is wildcard |
-| `--port` / `liveView.port` | `BETTERWRIGHT_LIVE_VIEW_PORT` | `0` (ephemeral) | bind port |
-| `--watch-only` / `interactive: false` | — | interactive | forbid viewer input outside handoffs |
-| `quality` | — | `60` | screencast JPEG quality (10–90) |
-| `maxWidth` | — | `1440` | max frame dimension in px (the stream also shrinks to fit the largest connected viewer window) |
-| `session` | — | `default` | which session's current tab streams first |
-| — | `BETTERWRIGHT_LIVE_VIEW=1` | off | (MCP) allow a non-loopback bind host |
+The viewer starts in watch mode. **Take control** enables browser input. Human
+navigation still goes through BetterWright's network policy, download limits,
+and credential-capture rules.
 
-## Timeouts & lifecycle
+The session dock supports:
 
-- `waitForHandoff({timeout})` defaults to 1800 s. The worker resolves
-  `action: "timeout"` just before the client's own timeout would fire —
-  letting the client timeout expire instead restarts the browser worker (open
-  tabs are lost; the persistent profile survives). Size handoff timeouts for
-  the worst-case human wait.
-- A pending handoff sets the same page hold the `ask` tool uses, so the idle
-  reaper never closes tabs mid-takeover; any viewer input also refreshes the
-  session's activity clock.
-- **The view survives worker restarts.** A snippet timeout or crash restarts
-  the browser worker, which would otherwise take the in-worker view server
-  with it. The host notices, respawns the worker immediately, and revives the
-  view on the *same port and token* — so the URL you already shared keeps
-  working. The viewer page rides it out with a "Reconnecting…" overlay and
-  resumes automatically (it gives up after ~15 minutes of unreachability).
-  Open tabs are still lost to the restart, and chat history/pending handoffs
-  reset with it.
-- Stopping the browser deliberately stops the viewer (viewers see a clean
-  "ended" screen — only an explicit stop announces one). The agent stops a
-  viewer it started once the task ends, but never one you started yourself.
+- **Chat**: guidance is delivered at the next safe agent-turn boundary.
+- **Ask**: choice chips and free text resolve the agent's pending question.
+- **Handoff**: input is enabled and Done/Cancel returns control to the agent.
+
+Agent progress and the final answer are mirrored only after a Live View has
+been explicitly started.
+
+## JavaScript API
+
+```js
+import { BetterWright } from "betterwright";
+
+const browser = new BetterWright({
+  liveView: { transport: "relay" },
+});
+
+const view = await browser.startLiveView({
+  session: "support-case-42",
+  interactive: true,
+});
+console.log(view.url);
+
+const status = await browser.liveViewStatus();
+await browser.liveViewPostChat({
+  session: "support-case-42",
+  role: "agent",
+  text: "Waiting for your confirmation",
+});
+await browser.stopLiveView();
+await browser.close();
+```
+
+`startLiveView()` returns `transport`, the immutable `session`, viewer count,
+and transport-specific fields. Managed results can include `sessionId`, quota,
+and expiry metadata. Do not log the returned URL.
+
+## Lifecycle and recovery
+
+- An explicit stop closes the viewer and terminates the managed session.
+- The host performs best-effort managed-session deletion on normal teardown.
+- A worker crash or snippet timeout reconnects the bound Live View without
+  silently creating a different session or changing its URL.
+- Managed sessions expire no later than the service session TTL, currently 24
+  hours. Direct capabilities end with their listener.
+- A viewer reconnects after a bounded lease ends if quota and service admission
+  still allow it.
+- If the host disconnects, viewer input is closed rather than buffered for a
+  later process.
+
+## Security checklist
+
+- Treat the complete viewer URL and personal API key as credentials.
+- Revoke unused API keys from <https://betterwright.com/account>; at most five
+  active keys are allowed per account.
+- Use `--watch-only` or `interactive: false` when control is unnecessary.
+- Do not put API keys or viewer links in logs, issue trackers, or model prompts.
+- Use Relay, Tailscale, SSH, or an HTTPS tunnel for remote use. Never expose a
+  Direct HTTP listener to the public internet.
+- Re-observe the page after a handoff before automation continues.
 
 ## Limitations
 
-- Native Chrome UI is not part of the screencast: OS file pickers and
-  permission bubbles are invisible to the viewer (JS dialogs are already
-  auto-handled by the worker). If a step needs a file picker, use the
-  download/upload APIs instead.
-- Credentials you type manually during a handoff are treated as *manual*
-  logins by the capture engine: in headless sessions the save prompt cannot
-  render, so they are not captured into the vault. The characters you type are
-  visible as pixels in your own viewer stream (and nowhere else — frames never
-  enter the model transcript).
-- One page streams full-res at a time. When more than one tab is open, the
-  tab strip shows a live low-res thumbnail of every tab (refreshed every few
-  seconds, re-sent only when it changes); click a card to switch the main
-  stream — the old stream keeps painting until the new tab's first frame
-  lands, with the thumbnail as an instant placeholder. All connected viewers
-  see (and, if interactive, share) the same controls.
+- Native browser chrome, OS file pickers, and permission bubbles are not part
+  of the page screencast.
+- One page streams at full resolution at a time. The tab strip provides live
+  thumbnails for other pages.
+- One host and one viewer are paired per managed session, with one active
+  viewer lease across the account.
+- Manual credentials typed during a headless handoff are not automatically
+  saved when no trusted save prompt can be shown.

--- a/examples/javascript/live-view.mjs
+++ b/examples/javascript/live-view.mjs
@@ -1,0 +1,35 @@
+// Start an account-backed, endpoint-encrypted Live View for one session.
+//
+// First create a key at https://betterwright.com/account and run:
+//   betterwright account set-key
+//
+// Then:
+//   node examples/javascript/live-view.mjs
+
+import { BetterWright, BrowserError } from "betterwright";
+
+const session = "live-view-example";
+const bw = new BetterWright({ liveView: { transport: "relay" } });
+
+try {
+  const opened = await bw.run("await page.goto('https://example.com'); return page.title()", {
+    session,
+  });
+  if (!opened.ok) throw new BrowserError(opened.error);
+
+  const view = await bw.startLiveView({ session, interactive: true });
+  if (!view.ok) throw new BrowserError(view.error);
+
+  // This URL contains the private viewer capability. Give it only to the
+  // intended viewer and do not put it in logs or model prompts.
+  console.log(`Open ${view.url}`);
+  console.log("Press Ctrl-C to end the Live View.");
+
+  await new Promise((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+} finally {
+  await bw.stopLiveView().catch(() => {});
+  await bw.close();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/relay/.gitignore
+++ b/relay/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+coverage/
+.wrangler/
+.dev.vars
+*.log
+.DS_Store

--- a/relay/README.md
+++ b/relay/README.md
@@ -37,6 +37,10 @@ deploys itself.
   current 15-minute lease and cannot reconnect.
 - One host and one viewer are accepted per session. WebSockets use Cloudflare's
   hibernation API and store rate/lease metadata in socket attachments.
+- Explicitly ended and absolutely expired sessions are removed from both D1 and
+  Durable Object storage after peers and quota leases close. Initialization
+  failures are purged too; ordinary production traffic does not accumulate
+  permanent per-session records.
 - Peer payloads must be binary and at most 2 MiB. Default token buckets allow 15
   messages per second sustained, 20 burst, and 10 Mbps per sender. Slow peers
   are closed rather than accumulating unbounded queues.
@@ -62,11 +66,11 @@ the session Durable Object. The viewer URL puts the root in `#k=...`; URL
 fragments are not sent in HTTP requests. The page removes the fragment from the
 address bar immediately after reading it.
 
-The root derives separate AES-256-GCM keys for host-to-viewer and
-viewer-to-host traffic with HKDF-SHA-256. The viewer sends an encrypted random
-challenge after every connection. `HostRelayCodec` does not release viewer
-input to BetterWright until it has validated that challenge and returned the
-encrypted response. The relay forwards all encrypted text and JPEG messages as
+The root derives separate, epoch-bound AES-256-GCM keys for host-to-viewer and
+viewer-to-host traffic with HKDF-SHA-256. The host sends an encrypted random
+challenge after every viewer connection. `HostRelayCodec` does not release
+viewer input to BetterWright until the viewer has decrypted and echoed that
+challenge exactly. The relay forwards all encrypted text and JPEG messages as
 opaque binary WebSocket messages.
 
 No WebRTC API is used. The relay never gives a peer the other peer's address.

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,0 +1,298 @@
+# BetterWright Cloudflare relay
+
+A standalone Cloudflare Worker service for BetterWright live view. It pairs one
+BetterWright host with one browser viewer through a per-session Durable Object.
+The relay sees message sizes, timing, account/session identifiers, and normal
+Cloudflare connection metadata, but it does not receive the viewer root key and
+cannot decrypt frames, browser input, chat, or BetterWright protocol controls.
+
+This directory is independent of the parent BetterWright package. Nothing here
+deploys itself.
+
+## What is enforced
+
+- Clerk session JWTs protect account, usage, and API-key endpoints.
+- BetterWright API keys have the format `bw_live_<id>_<secret>`. D1 stores only a
+  role-separated HMAC-SHA-256 digest, never the secret or complete credential.
+  An account can have at most five active keys; a D1 trigger makes that limit
+  race safe. A new key's complete value is returned once.
+- CLI session creation and session management require a BetterWright API key.
+- One `RelaySession` Durable Object exists per session, one `UserQuota` object
+  per Clerk user, and one `BudgetWindow` object per billing window.
+- The default weekly viewer allowance is exactly 7,200 connected seconds. ISO
+  weeks begin Monday at 00:00 UTC. Host-only time and idle sessions do not
+  consume viewer time.
+- A viewer receives at most a 15-minute lease. The viewer automatically
+  reconnects and re-challenges at a lease boundary if quota and budget remain.
+  Usage is the accepted viewer-WebSocket interval, clamped to the lease, and is
+  settled on disconnect. Frames sent, host connection time, and session age are
+  not billing signals.
+- Only one active viewer lease can exist for an account, even across sessions.
+- Every admitted lease reserves a conservative $0.0025 estimate in the current
+  `BudgetWindow`. A serialized reservation cannot take the default relay total
+  above $900 for that billing window.
+- A persistent admin kill switch and an environment kill switch deny new relay
+  admission. Enabling the persistent switch also signals active session objects;
+  any connection not reached by that best-effort fan-out is still bounded by its
+  current 15-minute lease and cannot reconnect.
+- One host and one viewer are accepted per session. WebSockets use Cloudflare's
+  hibernation API and store rate/lease metadata in socket attachments.
+- Peer payloads must be binary and at most 2 MiB. Default token buckets allow 15
+  messages per second sustained, 20 burst, and 10 Mbps per sender. Slow peers
+  are closed rather than accumulating unbounded queues.
+- CORS reflects only the exact configured app origin. Viewer WebSockets require
+  the exact relay origin. No wildcard or suffix origin matching is used.
+- The relay code does not log frames, input, chat, ciphertext, API keys,
+  capabilities, roots, or WebSocket subprotocol headers. Wrangler observability
+  is disabled in the template.
+
+All numeric policy defaults are environment-overridable. Raising a security
+limit weakens the reviewed defaults and should be treated as a policy change.
+
+## End-to-end channel
+
+The CLI calls `prepareRelaySession()` locally to create a random session ID, a
+32-byte base64url root, and the viewer proof derived from both. It sends only
+the session ID and proof to `POST /v1/sessions`; the root never enters an HTTP
+request or response. Session creation returns a one-time host WebSocket
+capability.
+
+Only HMAC digests of the host capability and viewer proof are stored in D1 and
+the session Durable Object. The viewer URL puts the root in `#k=...`; URL
+fragments are not sent in HTTP requests. The page removes the fragment from the
+address bar immediately after reading it.
+
+The root derives separate AES-256-GCM keys for host-to-viewer and
+viewer-to-host traffic with HKDF-SHA-256. The viewer sends an encrypted random
+challenge after every connection. `HostRelayCodec` does not release viewer
+input to BetterWright until it has validated that challenge and returned the
+encrypted response. The relay forwards all encrypted text and JPEG messages as
+opaque binary WebSocket messages.
+
+No WebRTC API is used. The relay never gives a peer the other peer's address.
+Cloudflare necessarily observes each endpoint IP and traffic metadata as the
+network provider; this design prevents peer-to-peer IP disclosure, not provider
+visibility.
+
+See [docs/PROTOCOL.md](docs/PROTOCOL.md) for the byte format and host adapter
+contract.
+
+## Routes
+
+| Route | Method | Authentication |
+| --- | --- | --- |
+| `/healthz` | GET | none |
+| `/v1/me` | GET | Clerk session JWT |
+| `/v1/me/usage` | GET | Clerk session JWT |
+| `/v1/cli/me` | GET | BetterWright API key |
+| `/v1/keys` | GET, POST | Clerk session JWT |
+| `/v1/keys/:id` | DELETE | Clerk session JWT |
+| `/v1/sessions` | POST | BetterWright API key |
+| `/v1/sessions/:id` | GET, DELETE | BetterWright API key for the owning account |
+| `/v1/sessions/:id/ws` | WebSocket | role capability in subprotocol |
+| `/s/:id` | GET | root remains in the URL fragment |
+| `/v1/webhooks/clerk` | POST | Clerk/Svix signed webhook |
+| `/v1/admin/kill-switch` | GET, PUT | `ADMIN_TOKEN` bearer token |
+
+Clerk JWTs can arrive as `Authorization: Bearer <jwt>` or the Clerk `__session`
+cookie. Mutations using the cookie require the exact `APP_ORIGIN`. Verification
+uses `@clerk/backend` with `authorizedParties`; a networkless Clerk PEM public
+key is preferred.
+
+### Create an API key
+
+From the app frontend, send a Clerk session JWT:
+
+```http
+POST /v1/keys
+Authorization: Bearer <clerk-session-jwt>
+Content-Type: application/json
+Origin: https://app.example.com
+
+{"name":"MacBook CLI"}
+```
+
+The `secret` field in the response is the complete `bw_live_...` key and is
+never available from `GET /v1/keys`.
+
+### Create a relay session
+
+```http
+POST /v1/sessions
+Authorization: Bearer bw_live_<id>_<secret>
+Content-Type: application/json
+
+{"sessionId":"bws_<client-random>","viewerProof":"<client-derived-proof>"}
+```
+
+Use `prepareRelaySession()` from `src/client/host-codec.ts` to produce those
+request fields and retain its `rootKey` locally. The response returns the viewer
+base URL plus `host.websocketUrl` and one-time `host.subprotocols`. The CLI
+appends `#k=<rootKey>` to the viewer base URL without sending that fragment to
+the relay. A later `GET /v1/sessions/:id` returns state only.
+
+## Initial setup
+
+Requirements: Node.js 22+, npm, a Cloudflare account with Workers, Durable
+Objects, and D1, plus a Clerk application.
+
+```bash
+cd relay
+npm install
+cp wrangler.example.toml wrangler.toml
+npx wrangler d1 create betterwright-relay
+```
+
+Put the returned D1 UUID in `wrangler.toml`. Set the two exact origins and Clerk
+allowed parties. Add the production custom-domain route; do not leave
+`relay.example.com` placeholders.
+
+Create independent high-entropy secrets. Do not reuse values:
+
+```bash
+openssl rand -base64 48 | npx wrangler secret put API_KEY_HMAC_SECRET
+openssl rand -base64 48 | npx wrangler secret put CAPABILITY_HMAC_SECRET
+openssl rand -base64 48 | npx wrangler secret put INTERNAL_DO_SECRET
+openssl rand -base64 48 | npx wrangler secret put ADMIN_TOKEN
+```
+
+For networkless Clerk verification, copy the instance's PEM JWT public key from
+Clerk Dashboard, then run:
+
+```bash
+npx wrangler secret put CLERK_JWT_KEY
+```
+
+`CLERK_SECRET_KEY` is supported as a JWKS-fetching fallback but should not be
+set when `CLERK_JWT_KEY` is available. Set `CLERK_AUTHORIZED_PARTIES` to a
+comma-separated exact-origin allowlist and optionally set `CLERK_AUDIENCE`.
+
+Create a Clerk production webhook endpoint at
+`<PUBLIC_ORIGIN>/v1/webhooks/clerk`, subscribe it only to
+`user.deleted`, and upload its signing secret:
+
+```bash
+npx wrangler secret put CLERK_WEBHOOK_SIGNING_SECRET
+```
+
+Webhook signatures are verified over the raw request body. A valid
+`user.deleted` event ends the user's sessions, revokes their API keys, removes
+account metadata, and asks the quota object to clear its ledger. Missing or
+invalid signing configuration fails closed, including relay readiness.
+
+Apply D1 migrations before deploying code:
+
+```bash
+npx wrangler d1 migrations apply betterwright-relay --remote
+npm run check
+```
+
+Deployment is intentionally a separate operator action:
+
+```bash
+npx wrangler deploy -c wrangler.toml
+```
+
+No deployment is performed by tests or package scripts.
+
+## Local development
+
+Copy the template, use a local D1 database, and put development secrets in
+`.dev.vars` (gitignored). `http://localhost:<port>` is accepted only for local
+origin configuration.
+
+```bash
+npx wrangler d1 migrations apply betterwright-relay --local
+npm run dev
+npm test
+npm run typecheck
+```
+
+## Kill switch
+
+The environment switch is fail-safe configuration:
+
+```toml
+RELAY_KILL_SWITCH = "true"
+```
+
+Changing it requires a Worker configuration deployment. The persistent switch
+is immediate for new admission and does not require a deployment:
+
+```bash
+curl -X PUT https://relay.example.com/v1/admin/kill-switch \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"enabled":true,"reason":"operator stop"}'
+```
+
+Disable only after the incident is understood:
+
+```bash
+curl -X PUT https://relay.example.com/v1/admin/kill-switch \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"enabled":false,"reason":"operator reopen"}'
+```
+
+If `RELAY_KILL_SWITCH=true`, the API cannot override it.
+
+## Budget caveat
+
+The $900 value is a **hard admission ceiling inside this relay**, based on the
+configured conservative reservation per lease. It is not a Cloudflare account spending cap
+and cannot guarantee that an invoice stays below $900. Actual cost
+can differ from the estimate; other Workers and Cloudflare products are outside
+this service; already-incurred or delayed usage may not be represented here.
+Cloudflare budget alerts are informational and do not stop workloads. Keep the
+relay kill switch, Cloudflare alerts, account-level monitoring, and a tested
+incident procedure. Lower `BUDGET_CEILING_USD` if the account needs headroom for
+anything else.
+
+An explicit `BILLING_WINDOW_ID` pins all reservations to that identifier and
+must be rotated by the operator at each real billing-period boundary. Without
+it, windows are monthly UTC and anchored by
+`BILLING_PERIOD_START_DAY_UTC` (1 through 28, default 1). Leases are clamped at
+the boundary so each period receives its own reservation.
+
+## Rotation and recovery assumptions
+
+- Rotating `API_KEY_HMAC_SECRET` invalidates every existing BetterWright API
+  key. Rotate with a deliberate reissue plan.
+- Rotating `CAPABILITY_HMAC_SECRET` invalidates outstanding session
+  capabilities. End sessions before rotating it.
+- Rotating `INTERNAL_DO_SECRET` while sessions are live can make lease release
+  calls fail until old leases expire. Drain sessions first.
+- Anyone with the complete viewer fragment can view and, when BetterWright
+  permits, control that session. Share it as a password and revoke the session
+  if it leaks.
+- AES-GCM protects relay payloads, not a compromised host, browser, extension,
+  or endpoint OS. The Cloudflare account and Worker code remain trusted for
+  availability, quota enforcement, routing, metadata handling, and serving the
+  viewer JavaScript unchanged. An account compromise could replace that script
+  and exfiltrate a fragment root.
+- The host must use the codec and binary-only adapter in
+  `src/client/host-codec.ts`, treat only relay lifecycle strings as plaintext,
+  and never forward viewer input before the codec reports `viewerVerified`.
+- Cloudflare's hibernating WebSocket close event is the usage settlement signal.
+  A lease expiry is the conservative fail-safe if release delivery is
+  interrupted.
+
+## Explicit WebSocket close codes
+
+| Code | Meaning |
+| ---: | --- |
+| 4401 | session closed |
+| 4403 | capability, origin, or encrypted-channel authentication failed |
+| 4404 | required peer unavailable |
+| 4407 | weekly viewer quota exhausted |
+| 4408 | message-rate or bandwidth limit exceeded |
+| 4409 | duplicate peer or another account viewer lease is active |
+| 4410 | receiver backpressure limit exceeded |
+| 4411 | relay budget admission ceiling reached |
+| 4412 | kill switch enabled |
+| 4413 | 15-minute lease ended; viewer may reconnect to renew |
+| 4414 | message exceeds configured maximum |
+| 4415 | peer sent plaintext instead of an encrypted binary envelope |
+| 4416 | session expired |
+| 4500 | internal admission or socket state unavailable |

--- a/relay/docs/PROTOCOL.md
+++ b/relay/docs/PROTOCOL.md
@@ -60,10 +60,14 @@ socket has been accepted. The preceding reservation phase is not charged.
 
 ## Key derivation
 
-Decode the root to 32 bytes. Compute:
+Decode the root to 32 bytes. Each sender generates a fresh random 16-byte
+`senderEpoch` when its WebSocket connection is created. Compute:
 
 ```text
-salt = SHA-256(UTF8("BetterWright relay HKDF salt v1" || NUL || sessionId))
+salt = SHA-256(
+  UTF8("BetterWright relay HKDF salt v1" || NUL || sessionId || NUL) ||
+  senderEpoch
+)
 ```
 
 Use HKDF-SHA-256 with that salt and one of these exact info strings to derive a
@@ -74,21 +78,33 @@ BetterWright relay host-to-viewer AES-GCM v1
 BetterWright relay viewer-to-host AES-GCM v1
 ```
 
-Keys are directional. Decrypting with the opposite key or direction AAD must
-fail.
+Keys are directional and epoch-specific. Decrypting with the opposite key,
+direction, session, or epoch must fail.
 
 ## Binary envelope
 
-Every peer message is a binary WebSocket message:
+Every peer message is a binary WebSocket message. Integer sequences are
+unsigned, big-endian, begin at zero, and increase by exactly one per sender:
 
 ```text
 Offset  Length  Meaning
 0       1       version = 0x01
-1       12      random AES-GCM nonce
-13      rest    AES-GCM ciphertext and 16-byte tag
+1       1       direction: 0x01 host-to-viewer, 0x02 viewer-to-host
+2       16      senderEpoch
+18      8       sequence
+26      rest    AES-GCM ciphertext and 16-byte tag
 ```
 
-The authenticated additional data is:
+The 12-byte AES-GCM nonce is derived, not transmitted separately:
+
+```text
+byte 0      0x01 (version)
+byte 1      direction byte
+bytes 2-3   0x00 0x00
+bytes 4-11  sequence, unsigned big-endian
+```
+
+The authenticated additional data is the complete 26-byte header followed by:
 
 ```text
 UTF8("BetterWright relay envelope v1" || NUL || sessionId || NUL || direction)
@@ -100,47 +116,50 @@ The decrypted AES-GCM plaintext begins with one protected kind byte followed by
 the existing protocol bytes:
 
 ```text
-0x01  BetterWright JSON text message, UTF-8
-0x02  BetterWright binary payload, currently a JPEG screencast frame
-0x03  relay root-key challenge JSON, UTF-8
+0x00  BetterWright JSON text message, UTF-8
+0x01  BetterWright binary payload, currently a JPEG screencast frame
+0x02  relay root-key challenge JSON, UTF-8
 ```
 
 The kind is encrypted. The relay does not inspect it and therefore cannot tell
 a frame from input, chat, or protocol control. It forwards the complete envelope
-unchanged. Nonces are fresh random 96-bit values for each message. A connection
-must be closed if nonce generation fails.
+unchanged. A receiver latches the first authenticated sender epoch, rejects a
+changed epoch until reconnect, and rejects every non-increasing sequence as a
+replay. Sequence exhaustion is terminal; reconnecting creates a fresh epoch and
+new keys.
 
-The complete envelope, including version, nonce, ciphertext, and tag, must not
-exceed 2 MiB under the reviewed default.
+The complete envelope, including the 26-byte header, protected kind,
+ciphertext, and tag, must not exceed 2 MiB under the reviewed default.
 
 ## Root-key challenge
 
-A fresh viewer connection generates a random 16-byte unpadded-base64url nonce
-and sends encrypted kind `0x03` in the viewer-to-host direction:
+After the relay announces `viewer_connected`, the host generates 32 random
+bytes as a 43-character unpadded-base64url challenge and sends encrypted kind
+`0x02` in the host-to-viewer direction:
 
 ```json
 {
-  "t": "relay_challenge",
-  "nonce": "<22-character-base64url>",
-  "protocol": "betterwright-live-view-v1"
+  "t": "bw_e2e_challenge",
+  "challenge": "<43-character-base64url>"
 }
 ```
 
-The host decrypts and validates it, then sends encrypted kind `0x03` in the
-host-to-viewer direction:
+The viewer decrypts it and echoes the exact value in encrypted kind `0x02` in
+the viewer-to-host direction:
 
 ```json
 {
-  "t": "relay_challenge_response",
-  "nonce": "<same value>"
+  "t": "bw_e2e_ready",
+  "challenge": "<same value>"
 }
 ```
 
 The viewer disables mouse, keyboard, paste, chat, tab switching, and handoff
-actions until this exact response decrypts. The host's `HostRelayCodec` also
-refuses to release any viewer kind `0x01` or `0x02` message to BetterWright until
-it has validated a challenge. Create a new codec for every WebSocket connection;
-do not carry challenge state across reconnects.
+actions until it has successfully decrypted the host challenge and sent the
+echo. The host refuses to release any viewer text or binary message to
+BetterWright until that echo decrypts and matches in constant time. Create fresh
+senders, receivers, epochs, and challenge state for every viewer connection; do
+not carry them across reconnects.
 
 ## Existing BetterWright protocol
 
@@ -153,8 +172,8 @@ live viewer:
 - viewer JSON text: `refresh`, `view`, `vis`, `tab`, `input`, `chat`, `answer`,
   `done`, and `cancel`.
 
-The host adapter encrypts each existing text message as kind `0x01` and each
-existing binary frame as kind `0x02`. It decrypts viewer kind `0x01` and passes
+The host adapter encrypts each existing text message as kind `0x00` and each
+existing binary frame as kind `0x01`. It decrypts viewer kind `0x00` and passes
 the resulting UTF-8 string to the existing JSON handler. No JSON is parsed by
 the Cloudflare relay.
 
@@ -196,3 +215,9 @@ Viewer time starts when the viewer socket is accepted after admission and ends
 at its close event, clamped to the lease expiry. A 15-minute lease never crosses
 an ISO-week or billing-window boundary. The viewer reconnects for a new lease;
 the root challenge runs again.
+
+Explicit termination first closes peers and settles any viewer lease, then
+removes the session's Durable Object storage and D1 row. At absolute expiry the
+Durable Object performs the same peer/lease close, deletes its D1 row, and calls
+`deleteAll()`; a transient D1 failure keeps only the minimal session config and
+re-arms cleanup instead of orphaning permanent state.

--- a/relay/docs/PROTOCOL.md
+++ b/relay/docs/PROTOCOL.md
@@ -71,7 +71,7 @@ salt = SHA-256(
 ```
 
 Use HKDF-SHA-256 with that salt and one of these exact info strings to derive a
-non-exportable 256-bit AES-GCM key:
+256-bit AES-GCM key:
 
 ```text
 BetterWright relay host-to-viewer AES-GCM v1

--- a/relay/docs/PROTOCOL.md
+++ b/relay/docs/PROTOCOL.md
@@ -1,0 +1,198 @@
+# Relay wire protocol v1
+
+This document is the interoperability contract between the BetterWright host
+adapter and `/s/:id`. Multi-byte application values are UTF-8; relay envelopes
+are raw WebSocket binary messages.
+
+## Session material
+
+Before session creation, the CLI locally generates:
+
+- `sessionId`: `bws_` plus 18 random bytes encoded as unpadded base64url;
+- `rootKey`: 32 random bytes encoded as unpadded base64url.
+
+The viewer proof is:
+
+```text
+HMAC-SHA-256(
+  key = base64url_decode(rootKey),
+  data = UTF8("BetterWright relay viewer proof v1" || NUL || sessionId)
+)
+```
+
+and is encoded as unpadded base64url. The CLI sends `sessionId` and
+`viewerProof`, but not `rootKey`, to `POST /v1/sessions`. The relay creates and
+returns a 32-byte random `hostCapability`. The CLI appends its retained root as
+`#k=<rootKey>` to the returned viewer base URL.
+
+The relay persists only these digests:
+
+```text
+HMAC-SHA-256(
+  key = CAPABILITY_HMAC_SECRET,
+  data = UTF8("betterwright-relay-capability-v1" || NUL ||
+              sessionId || NUL || role || NUL || presentedCapability)
+)
+```
+
+`role` is exactly `host` or `viewer`. The root never enters the relay. The host
+capability and viewer proof exist transiently for verification/creation but are
+not persisted; only their HMAC digests are. AES keys and full BetterWright API
+keys are also never persisted.
+
+## WebSocket authentication
+
+Connect to `/v1/sessions/:id/ws` with exactly two ordered subprotocols:
+
+```text
+Host:   betterwright.relay.v1, bw.host.<hostCapability>
+Viewer: betterwright.relay.v1, bw.viewer.<viewerProof>
+```
+
+The server selects only the non-secret `betterwright.relay.v1` protocol. A
+viewer browser must send an `Origin` exactly equal to `PUBLIC_ORIGIN`. A
+non-browser host can omit `Origin`; if present, it must also match exactly.
+
+There can be one host and one viewer. The host must connect first. A viewer
+connection begins quota charging only after capability, origin, host presence,
+kill-switch, user quota, and budget reservation checks pass and the viewer
+socket has been accepted. The preceding reservation phase is not charged.
+
+## Key derivation
+
+Decode the root to 32 bytes. Compute:
+
+```text
+salt = SHA-256(UTF8("BetterWright relay HKDF salt v1" || NUL || sessionId))
+```
+
+Use HKDF-SHA-256 with that salt and one of these exact info strings to derive a
+non-exportable 256-bit AES-GCM key:
+
+```text
+BetterWright relay host-to-viewer AES-GCM v1
+BetterWright relay viewer-to-host AES-GCM v1
+```
+
+Keys are directional. Decrypting with the opposite key or direction AAD must
+fail.
+
+## Binary envelope
+
+Every peer message is a binary WebSocket message:
+
+```text
+Offset  Length  Meaning
+0       1       version = 0x01
+1       12      random AES-GCM nonce
+13      rest    AES-GCM ciphertext and 16-byte tag
+```
+
+The authenticated additional data is:
+
+```text
+UTF8("BetterWright relay envelope v1" || NUL || sessionId || NUL || direction)
+```
+
+where direction is exactly `h2v` or `v2h`.
+
+The decrypted AES-GCM plaintext begins with one protected kind byte followed by
+the existing protocol bytes:
+
+```text
+0x01  BetterWright JSON text message, UTF-8
+0x02  BetterWright binary payload, currently a JPEG screencast frame
+0x03  relay root-key challenge JSON, UTF-8
+```
+
+The kind is encrypted. The relay does not inspect it and therefore cannot tell
+a frame from input, chat, or protocol control. It forwards the complete envelope
+unchanged. Nonces are fresh random 96-bit values for each message. A connection
+must be closed if nonce generation fails.
+
+The complete envelope, including version, nonce, ciphertext, and tag, must not
+exceed 2 MiB under the reviewed default.
+
+## Root-key challenge
+
+A fresh viewer connection generates a random 16-byte unpadded-base64url nonce
+and sends encrypted kind `0x03` in the viewer-to-host direction:
+
+```json
+{
+  "t": "relay_challenge",
+  "nonce": "<22-character-base64url>",
+  "protocol": "betterwright-live-view-v1"
+}
+```
+
+The host decrypts and validates it, then sends encrypted kind `0x03` in the
+host-to-viewer direction:
+
+```json
+{
+  "t": "relay_challenge_response",
+  "nonce": "<same value>"
+}
+```
+
+The viewer disables mouse, keyboard, paste, chat, tab switching, and handoff
+actions until this exact response decrypts. The host's `HostRelayCodec` also
+refuses to release any viewer kind `0x01` or `0x02` message to BetterWright until
+it has validated a challenge. Create a new codec for every WebSocket connection;
+do not carry challenge state across reconnects.
+
+## Existing BetterWright protocol
+
+After the challenge, the encrypted inner messages are unchanged from the local
+live viewer:
+
+- host JSON text: `hello`, `state`, `meta`, `tabs`, `thumb`, `chat`, `toast`,
+  and `bye`;
+- host binary: JPEG screencast bytes;
+- viewer JSON text: `refresh`, `view`, `vis`, `tab`, `input`, `chat`, `answer`,
+  `done`, and `cancel`.
+
+The host adapter encrypts each existing text message as kind `0x01` and each
+existing binary frame as kind `0x02`. It decrypts viewer kind `0x01` and passes
+the resulting UTF-8 string to the existing JSON handler. No JSON is parsed by
+the Cloudflare relay.
+
+The host should throttle the screencast before encryption so normal control
+messages fit within the relay's sustained token bucket. The relay's byte and
+message buckets are a final abuse safeguard, not a video pacing algorithm.
+
+## Relay-to-host plaintext lifecycle notices
+
+The only application text messages emitted by the relay go to the host. They
+are never forwarded from a peer and contain no frame, input, chat, URL, root,
+capability, or ciphertext data:
+
+```json
+{"t":"relay","event":"host_ready","sessionExpiresAtMs":0}
+{"t":"relay","event":"viewer_connected","leaseExpiresAtMs":0}
+{"t":"relay","event":"viewer_disconnected","code":1000}
+{"t":"relay","event":"lease_expiring","leaseExpiresAtMs":0}
+{"t":"relay","event":"lease_expired","leaseExpiresAtMs":0}
+{"t":"relay","event":"quota_exhausted"}
+{"t":"relay","event":"budget_exhausted"}
+{"t":"relay","event":"session_expired"}
+{"t":"relay","event":"session_closed"}
+{"t":"relay","event":"kill_switch"}
+```
+
+A host receiving a WebSocket text message must treat it only as relay lifecycle
+control. It must never feed that text to the existing BetterWright viewer
+protocol. A viewer receiving any plaintext message closes the connection.
+
+## Hibernation and accounting
+
+`RelaySession` accepts sockets with `DurableObjectState.acceptWebSocket()` and
+tags them `host` or `viewer`. Attachments persist role, connection time, token
+buckets, lease ID, lease expiry, warning state, and whether release was sent.
+No relayed payload is placed in an attachment or Durable Object storage.
+
+Viewer time starts when the viewer socket is accepted after admission and ends
+at its close event, clamped to the lease expiry. A 15-minute lease never crosses
+an ISO-week or billing-window boundary. The viewer reconnects for a new lease;
+the root challenge runs again.

--- a/relay/migrations/0001_initial.sql
+++ b/relay/migrations/0001_initial.sql
@@ -1,0 +1,57 @@
+PRAGMA foreign_keys = ON;
+
+-- API-key secrets are never stored. key_hash is an HMAC-SHA-256 digest of
+-- the complete bw_live_<id>_<secret> credential under API_KEY_HMAC_SECRET.
+CREATE TABLE api_keys (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  created_at_ms INTEGER NOT NULL,
+  last_used_at_ms INTEGER,
+  revoked_at_ms INTEGER
+) STRICT;
+
+CREATE INDEX api_keys_by_user
+  ON api_keys (user_id, revoked_at_ms, created_at_ms DESC);
+
+-- The trigger makes the five-active-key limit race safe inside D1.
+CREATE TRIGGER api_keys_max_five
+BEFORE INSERT ON api_keys
+WHEN (
+  SELECT COUNT(*) FROM api_keys
+  WHERE user_id = NEW.user_id AND revoked_at_ms IS NULL
+) >= 5
+BEGIN
+  SELECT RAISE(ABORT, 'active_api_key_limit');
+END;
+
+-- Capability plaintext and the viewer root key are never persisted. The two
+-- capability columns hold role-separated HMAC-SHA-256 digests only.
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  api_key_id TEXT NOT NULL,
+  host_cap_hash TEXT NOT NULL,
+  viewer_cap_hash TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  expires_at_ms INTEGER NOT NULL,
+  ended_at_ms INTEGER,
+  ended_reason TEXT,
+  FOREIGN KEY (api_key_id) REFERENCES api_keys(id)
+) STRICT;
+
+CREATE INDEX sessions_by_user
+  ON sessions (user_id, created_at_ms DESC);
+CREATE INDEX sessions_active
+  ON sessions (ended_at_ms, expires_at_ms);
+
+CREATE TABLE relay_control (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  kill_switch_enabled INTEGER NOT NULL DEFAULT 0 CHECK (kill_switch_enabled IN (0, 1)),
+  reason TEXT NOT NULL DEFAULT '',
+  updated_at_ms INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO relay_control (singleton, kill_switch_enabled, reason, updated_at_ms)
+VALUES (1, 0, '', 0);

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -1,0 +1,3246 @@
+{
+  "name": "@betterwright/relay-worker",
+  "version": "1.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@betterwright/relay-worker",
+      "version": "1.2.0",
+      "dependencies": {
+        "@clerk/backend": "^3.13.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260724.1",
+        "@types/node": "^24.0.0",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10",
+        "wrangler": "^4.114.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.13.0.tgz",
+      "integrity": "sha512-kYOgeR48iXYypudpYITE0L2yxi4TeFXU+ISAOULlVgOcurw8qnm1/JEuK6Mr2IFUbRS9hcHk1HVO0Ceo0XmL8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.25.7",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.25.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.7.tgz",
+      "integrity": "sha512-FfBbDeFkxwDuz/2YcVs4DhyZ0VxnqNtdbO0Tn/lkLAiDvFFspWw+PDYqo7LQiBymEQaOQkb094dX21WWnZbmlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
+      "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
+      "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
+      "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
+      "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
+      "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260724.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260724.1.tgz",
+      "integrity": "sha512-gl0brZ60JhkZU3INgr1jsxaFEiWf3AB9RsCjLTMwT5RKspWRUpsFd0wxwbys7gb8Ywkfq9tORhw0y9G+7bDUYw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260722.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
+      "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260722.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
+      "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260722.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
+        "@cloudflare/workerd-linux-64": "1.20260722.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260722.1",
+        "@cloudflare/workerd-windows-64": "1.20260722.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.114.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
+      "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260722.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260722.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260722.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/relay/package.json
+++ b/relay/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@betterwright/relay-worker",
+  "version": "1.2.0",
+  "private": true,
+  "description": "Cloudflare Worker relay for end-to-end encrypted BetterWright live-view sessions",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run typecheck && npm test",
+    "dev": "wrangler dev -c wrangler.toml",
+    "cf-typegen": "wrangler types -c wrangler.toml"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@clerk/backend": "^3.13.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260724.1",
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10",
+    "wrangler": "^4.114.0"
+  }
+}

--- a/relay/public/viewer-crypto.js
+++ b/relay/public/viewer-crypto.js
@@ -1,0 +1,262 @@
+const encoder = new TextEncoder();
+const ROOT_BYTES = 32;
+const VERSION = 1;
+const HOST_TO_VIEWER = 1;
+const VIEWER_TO_HOST = 2;
+const EPOCH_BYTES = 16;
+const SEQUENCE_BYTES = 8;
+const NONCE_BYTES = 12;
+const HEADER_BYTES = 26;
+const TAG_BYTES = 16;
+const MAX_SEQUENCE = (1n << 64n) - 1n;
+const DEFAULT_MAX_ENVELOPE_BYTES = 2 * 1024 * 1024;
+const HKDF_SALT_DOMAIN = "BetterWright relay HKDF salt v1";
+const ENVELOPE_DOMAIN = "BetterWright relay envelope v1";
+
+export const ENVELOPE_DIRECTION = Object.freeze({ HOST_TO_VIEWER, VIEWER_TO_HOST });
+export const ENVELOPE_KIND = Object.freeze({ TEXT: 0, BINARY: 1, CHALLENGE: 2 });
+
+const DIRECTION_PARAMETERS = Object.freeze({
+  h2v: Object.freeze({
+    byte: HOST_TO_VIEWER,
+    keyInfo: "BetterWright relay host-to-viewer AES-GCM v1",
+  }),
+  v2h: Object.freeze({
+    byte: VIEWER_TO_HOST,
+    keyInfo: "BetterWright relay viewer-to-host AES-GCM v1",
+  }),
+});
+
+export function bytesToBase64Url(bytes) {
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000));
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function base64UrlToBytes(value, expectedLength) {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error("invalid base64url value");
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4);
+  let binary;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new Error("invalid base64url value");
+  }
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  if (expectedLength !== undefined && bytes.length !== expectedLength) throw new Error("unexpected decoded length");
+  if (bytesToBase64Url(bytes) !== value) throw new Error("non-canonical base64url value");
+  return bytes;
+}
+
+async function importHmacKey(bytes) {
+  return crypto.subtle.importKey("raw", bytes, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+}
+
+export async function deriveViewerProof(rootKey, sessionId) {
+  const root = base64UrlToBytes(rootKey, ROOT_BYTES);
+  const key = await importHmacKey(root);
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`BetterWright relay viewer proof v1\0${sessionId}`),
+  );
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+function concatenate(...parts) {
+  const joined = new Uint8Array(parts.reduce((length, part) => length + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.length;
+  }
+  return joined;
+}
+
+function equalBytes(left, right) {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) difference |= left[index] ^ right[index];
+  return difference === 0;
+}
+
+function isEnvelopeKind(value) {
+  return value === ENVELOPE_KIND.TEXT || value === ENVELOPE_KIND.BINARY || value === ENVELOPE_KIND.CHALLENGE;
+}
+
+function parametersFor(direction) {
+  const parameters = DIRECTION_PARAMETERS[direction];
+  if (!parameters) throw new Error("invalid envelope direction");
+  return parameters;
+}
+
+function sequenceView(bytes) {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function nonceFor(direction, sequence) {
+  const nonce = new Uint8Array(NONCE_BYTES);
+  nonce[0] = VERSION;
+  nonce[1] = parametersFor(direction).byte;
+  sequenceView(nonce).setBigUint64(4, sequence, false);
+  return nonce;
+}
+
+function additionalData(header, sessionId, direction) {
+  return concatenate(
+    header,
+    encoder.encode(`${ENVELOPE_DOMAIN}\0${sessionId}\0${direction}`),
+  );
+}
+
+async function deriveEnvelopeKey(root, epoch, sessionId, direction) {
+  const saltInput = concatenate(
+    encoder.encode(`${HKDF_SALT_DOMAIN}\0${sessionId}\0`),
+    epoch,
+  );
+  const salt = new Uint8Array(await crypto.subtle.digest("SHA-256", saltInput));
+  const material = await crypto.subtle.importKey("raw", root, "HKDF", false, ["deriveKey"]);
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt,
+      info: encoder.encode(parametersFor(direction).keyInfo),
+    },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+function envelopeHeader(direction, epoch, sequence) {
+  const header = new Uint8Array(HEADER_BYTES);
+  header[0] = VERSION;
+  header[1] = parametersFor(direction).byte;
+  header.set(epoch, 2);
+  sequenceView(header).setBigUint64(HEADER_BYTES - SEQUENCE_BYTES, sequence, false);
+  return header;
+}
+
+export function createEnvelopeSender(rootKey, sessionId, direction, epochOverride) {
+  const root = base64UrlToBytes(rootKey, ROOT_BYTES);
+  parametersFor(direction);
+  const senderEpoch = epochOverride
+    ? new Uint8Array(epochOverride)
+    : crypto.getRandomValues(new Uint8Array(EPOCH_BYTES));
+  if (senderEpoch.length !== EPOCH_BYTES) throw new Error("invalid sender epoch length");
+  const key = deriveEnvelopeKey(root, senderEpoch, sessionId, direction);
+  let nextSequence = 0n;
+  let pending = Promise.resolve();
+
+  return Object.freeze({
+    direction,
+    get epoch() {
+      return new Uint8Array(senderEpoch);
+    },
+    seal(kind, plaintext, maxEnvelopeBytes = DEFAULT_MAX_ENVELOPE_BYTES) {
+      const body = new Uint8Array(plaintext);
+      const operation = pending.then(async () => {
+        if (!isEnvelopeKind(kind)) throw new Error("unsupported envelope kind");
+        if (body.length + HEADER_BYTES + TAG_BYTES + 1 > maxEnvelopeBytes) {
+          throw new Error("envelope exceeds maximum size");
+        }
+        if (nextSequence > MAX_SEQUENCE) throw new Error("envelope sequence exhausted");
+        const sequence = nextSequence;
+        const header = envelopeHeader(direction, senderEpoch, sequence);
+        const protectedPlaintext = new Uint8Array(body.length + 1);
+        protectedPlaintext[0] = kind;
+        protectedPlaintext.set(body, 1);
+        const ciphertext = new Uint8Array(
+          await crypto.subtle.encrypt(
+            {
+              name: "AES-GCM",
+              iv: nonceFor(direction, sequence),
+              additionalData: additionalData(header, sessionId, direction),
+              tagLength: 128,
+            },
+            await key,
+            protectedPlaintext,
+          ),
+        );
+        nextSequence = sequence + 1n;
+        return concatenate(header, ciphertext);
+      });
+      pending = operation.then(() => undefined, () => undefined);
+      return operation;
+    },
+  });
+}
+
+export function createEnvelopeReceiver(rootKey, sessionId, direction) {
+  const root = base64UrlToBytes(rootKey, ROOT_BYTES);
+  parametersFor(direction);
+  let senderEpoch = null;
+  let key = null;
+  let acceptedSequence = null;
+  let pending = Promise.resolve();
+
+  return Object.freeze({
+    direction,
+    get epoch() {
+      return senderEpoch ? new Uint8Array(senderEpoch) : null;
+    },
+    get lastSequence() {
+      return acceptedSequence;
+    },
+    open(envelope, maxEnvelopeBytes = DEFAULT_MAX_ENVELOPE_BYTES) {
+      const bytes = new Uint8Array(envelope);
+      const operation = pending.then(async () => {
+        if (bytes.length > maxEnvelopeBytes) throw new Error("envelope exceeds maximum size");
+        if (bytes.length < HEADER_BYTES + TAG_BYTES + 1) throw new Error("truncated envelope");
+        const header = bytes.subarray(0, HEADER_BYTES);
+        if (header[0] !== VERSION || header[1] !== parametersFor(direction).byte) {
+          throw new Error("envelope direction or version mismatch");
+        }
+        const candidateEpoch = new Uint8Array(header.subarray(2, 2 + EPOCH_BYTES));
+        const sequence = sequenceView(header).getBigUint64(HEADER_BYTES - SEQUENCE_BYTES, false);
+        if (senderEpoch && !equalBytes(candidateEpoch, senderEpoch)) {
+          throw new Error("sender epoch changed without reconnect");
+        }
+        if (acceptedSequence !== null && sequence <= acceptedSequence) {
+          throw new Error("non-monotonic envelope replay rejected");
+        }
+        const candidateKey = key ?? await deriveEnvelopeKey(root, candidateEpoch, sessionId, direction);
+        const protectedPlaintext = new Uint8Array(
+          await crypto.subtle.decrypt(
+            {
+              name: "AES-GCM",
+              iv: nonceFor(direction, sequence),
+              additionalData: additionalData(header, sessionId, direction),
+              tagLength: 128,
+            },
+            candidateKey,
+            bytes.subarray(HEADER_BYTES),
+          ),
+        );
+        const kind = protectedPlaintext[0];
+        if (!isEnvelopeKind(kind)) throw new Error("unsupported envelope kind");
+        if (!senderEpoch) {
+          senderEpoch = candidateEpoch;
+          key = candidateKey;
+        }
+        acceptedSequence = sequence;
+        return {
+          kind,
+          plaintext: protectedPlaintext.subarray(1),
+          epoch: new Uint8Array(candidateEpoch),
+          sequence,
+        };
+      });
+      pending = operation.then(() => undefined, () => undefined);
+      return operation;
+    },
+  });
+}
+
+export function randomBase64Url(byteLength) {
+  return bytesToBase64Url(crypto.getRandomValues(new Uint8Array(byteLength)));
+}

--- a/relay/public/viewer.css
+++ b/relay/public/viewer.css
@@ -1,0 +1,361 @@
+:root {
+  color-scheme: dark;
+  --ink: #0a0b0d;
+  --window: #101114;
+  --chrome: #15171b;
+  --raised: #1b1d22;
+  --line: rgba(255, 244, 223, 0.09);
+  --line-strong: rgba(255, 244, 223, 0.17);
+  --paper: #f6f2ea;
+  --muted: #a39d93;
+  --faint: #706b63;
+  --orange: #ff7a1a;
+  --orange-hot: #ff963f;
+  --orange-dark: #d95d08;
+  --amber: #e9b158;
+  --red: #ef6a6a;
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+html, body { width: 100%; height: 100%; }
+body {
+  margin: 0;
+  padding: 14px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% -20%, rgba(255, 122, 26, 0.08), transparent 34rem),
+    var(--ink);
+  color: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+button, input { font: inherit; }
+button { -webkit-tap-highlight-color: transparent; }
+
+.viewer-shell {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-rows: 43px auto 47px minmax(180px, 1fr) auto minmax(92px, auto);
+  overflow: hidden;
+  background: var(--window);
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.5);
+}
+
+.titlebar, .browser-bar {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+.titlebar { padding: 0 14px; border-bottom: 1px solid var(--line); }
+.brand { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.brand-mark {
+  width: 13px;
+  height: 13px;
+  flex: none;
+  border: 2px solid var(--orange);
+  border-left-color: var(--paper);
+  transform: rotate(45deg);
+}
+.brand strong { font-size: 13px; letter-spacing: -0.02em; }
+.brand strong span { color: var(--orange); }
+.brand small {
+  margin-left: 4px;
+  color: var(--faint);
+  font: 600 9px/1.2 ui-monospace, "SFMono-Regular", Consolas, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.status {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+.status > span {
+  width: 18px;
+  height: 1px;
+  background: currentColor;
+  box-shadow: 5px 0 0 currentColor;
+}
+.status b { font-weight: 550; }
+.status.secure { color: var(--orange-hot); }
+.status.busy { color: var(--amber); }
+.status.off { color: var(--red); }
+.status.connecting > span { animation: signal 1.15s steps(3, end) infinite; }
+@keyframes signal { 50% { opacity: 0.25; transform: translateX(3px); } }
+
+.tabs {
+  display: flex;
+  min-height: 0;
+  gap: 2px;
+  padding: 4px 10px 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  border-bottom: 1px solid var(--line);
+  background: #0e0f12;
+}
+.tabs:empty { display: none; }
+.tabs::-webkit-scrollbar { display: none; }
+.tab {
+  max-width: 220px;
+  height: 30px;
+  padding: 0 12px;
+  overflow: hidden;
+  flex: 0 1 220px;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  border-radius: 8px 8px 0 0;
+  background: transparent;
+  color: var(--muted);
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  font-size: 11.5px;
+}
+.tab:hover:not(:disabled) { background: rgba(255, 255, 255, 0.035); color: var(--paper); }
+.tab.active {
+  border-color: var(--line);
+  background: var(--chrome);
+  color: var(--paper);
+}
+.tab:disabled { cursor: default; }
+
+.browser-bar {
+  gap: 10px;
+  padding: 0 11px;
+  background: var(--chrome);
+  border-bottom: 1px solid var(--line);
+}
+.address {
+  height: 30px;
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 11px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+.lock-glyph {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border: 1px solid var(--orange);
+  transform: rotate(45deg);
+}
+#page-url {
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 11px/1.2 ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+.dimensions {
+  color: var(--faint);
+  white-space: nowrap;
+  font: 10.5px/1 ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+button {
+  height: 31px;
+  padding: 0 12px;
+  border: 1px solid var(--orange-dark);
+  border-radius: 8px;
+  background: var(--orange);
+  color: #1d0d03;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.22);
+}
+button:hover:not(:disabled) { background: var(--orange-hot); }
+button:active:not(:disabled) { transform: translateY(1px); box-shadow: none; }
+button:disabled { cursor: default; opacity: 0.4; }
+button.quiet, #control.active {
+  border-color: var(--line-strong);
+  background: transparent;
+  color: var(--paper);
+  box-shadow: none;
+}
+button:focus-visible, input:focus-visible, canvas:focus-visible {
+  outline: 2px solid var(--orange-hot);
+  outline-offset: 2px;
+}
+
+.viewport {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #060708;
+}
+canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  outline: 0;
+}
+canvas.controlling { box-shadow: inset 0 0 0 2px var(--orange); }
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  align-content: center;
+  justify-items: center;
+  justify-content: center;
+  grid-template-columns: minmax(0, 390px);
+  padding: 30px;
+  background: rgba(7, 8, 10, 0.92);
+  text-align: center;
+}
+.overlay.active { display: grid; }
+.overlay strong { margin-top: 22px; font-size: 14px; }
+.overlay p { margin: 7px 0 0; color: var(--muted); font-size: 12px; line-height: 1.5; }
+.overlay.terminal .aperture { animation: none; border-color: var(--line-strong); }
+.aperture {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--orange);
+  transform: rotate(45deg);
+  animation: aperture 1.4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+}
+.aperture::before {
+  content: "";
+  position: absolute;
+  inset: 7px;
+  border: 1px solid var(--paper);
+}
+@keyframes aperture {
+  50% { transform: rotate(135deg) scale(0.72); border-color: var(--paper); }
+}
+
+.handoff {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 12px;
+  border-top: 1px solid rgba(255, 122, 26, 0.25);
+  background: rgba(255, 122, 26, 0.07);
+}
+.handoff[hidden] { display: none; }
+.handoff > div { min-width: 0; flex: 1; }
+.handoff strong { font-size: 12px; }
+.handoff p { margin: 2px 0 0; overflow: hidden; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+
+.session-dock {
+  min-height: 92px;
+  max-height: 220px;
+  display: grid;
+  grid-template-rows: minmax(44px, 1fr) 42px;
+  padding: 8px 11px 10px;
+  border-top: 1px solid var(--line);
+  background: var(--window);
+}
+.messages {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1px 2px 7px;
+  scrollbar-color: var(--line-strong) transparent;
+}
+.messages:empty::before {
+  content: "Messages stay end-to-end encrypted";
+  margin: auto 0;
+  color: var(--faint);
+  font-size: 11px;
+}
+.message { max-width: min(78%, 720px); }
+.message.you { align-self: flex-end; }
+.message small { display: block; margin: 0 5px 2px; color: var(--faint); font-size: 9px; text-transform: uppercase; }
+.message p {
+  margin: 0;
+  padding: 6px 9px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--paper);
+  font-size: 11.5px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.message.you p { border-color: rgba(255, 122, 26, 0.26); background: rgba(255, 122, 26, 0.09); }
+#composer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  padding: 5px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--raised);
+}
+#composer:focus-within { border-color: rgba(255, 122, 26, 0.4); }
+input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  padding: 0 7px;
+  background: transparent;
+  color: var(--paper);
+  font-size: 12px;
+}
+input::placeholder { color: var(--faint); }
+#composer button { height: 30px; }
+
+.toasts {
+  position: fixed;
+  z-index: 10;
+  top: 64px;
+  right: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  pointer-events: none;
+}
+.toast {
+  max-width: 330px;
+  padding: 9px 12px;
+  border: 1px solid var(--line-strong);
+  border-left: 2px solid var(--orange);
+  border-radius: 8px;
+  background: var(--raised);
+  color: var(--paper);
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.42);
+  font-size: 11.5px;
+  animation: toast-in 0.16s ease-out;
+}
+@keyframes toast-in { from { opacity: 0; transform: translateY(-5px); } }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
+
+@media (max-width: 680px) {
+  body { padding: 0; }
+  .viewer-shell { border: 0; border-radius: 0; }
+  .brand small, .dimensions { display: none; }
+  .browser-bar { gap: 7px; }
+  .address { padding-inline: 8px; }
+  #control { padding-inline: 9px; }
+  .session-dock { max-height: 180px; }
+  .handoff { align-items: stretch; flex-wrap: wrap; }
+  .handoff > div { flex-basis: 100%; }
+  .toasts { top: 50px; right: 12px; left: 12px; }
+  .toast { max-width: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; }
+}

--- a/relay/public/viewer.js
+++ b/relay/public/viewer.js
@@ -1,0 +1,522 @@
+import {
+  ENVELOPE_KIND,
+  base64UrlToBytes,
+  createEnvelopeReceiver,
+  createEnvelopeSender,
+  deriveViewerProof,
+} from "/viewer-crypto.js";
+
+const sessionId = document.querySelector('meta[name="bw-session-id"]')?.content || "";
+const hash = new URLSearchParams(location.hash.slice(1));
+const rootKey = hash.get("k") || "";
+history.replaceState(null, "", location.pathname + location.search);
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const status = document.getElementById("status");
+const statusText = status.querySelector("b");
+const overlay = document.getElementById("overlay");
+const overlayTitle = document.getElementById("overlay-title");
+const overlayDetail = document.getElementById("overlay-detail");
+const canvas = document.getElementById("screen");
+const context = canvas.getContext("2d", { alpha: false, desynchronized: true });
+const viewport = document.getElementById("viewport");
+const pageUrl = document.getElementById("page-url");
+const dimensions = document.getElementById("dimensions");
+const tabs = document.getElementById("tabs");
+const control = document.getElementById("control");
+const handoff = document.getElementById("handoff");
+const handoffDetail = document.getElementById("handoff-detail");
+const messages = document.getElementById("messages");
+const composer = document.getElementById("composer");
+const messageInput = document.getElementById("message");
+const sendButton = document.getElementById("send");
+const toasts = document.getElementById("toasts");
+
+let socket = null;
+let viewerProof = "";
+let challengeTimer = null;
+let trustedHost = false;
+let intentionallyEnded = false;
+let reconnectAttempts = 0;
+let sendChain = Promise.resolve();
+let receiveChain = Promise.resolve();
+let interactiveAllowed = false;
+let controlling = false;
+let handoffActive = false;
+let askActive = false;
+let meta = { deviceWidth: 1280, deviceHeight: 800, url: "" };
+let pendingFrame = null;
+let decodingFrame = false;
+let lastPointer = null;
+let pointerTimer = null;
+let lastDown = { time: 0, x: 0, y: 0, count: 0 };
+const seenMessages = new Set();
+
+function setStatus(kind, text) {
+  status.className = `status ${kind}`;
+  statusText.textContent = text;
+}
+
+function showOverlay(title, detail, terminal = false) {
+  overlay.className = terminal ? "overlay active terminal" : "overlay active";
+  overlayTitle.textContent = title;
+  overlayDetail.textContent = detail;
+}
+
+function hideOverlay() {
+  overlay.className = "overlay";
+}
+
+function toast(text) {
+  if (!text) return;
+  const item = document.createElement("div");
+  item.className = "toast";
+  item.textContent = String(text).slice(0, 300);
+  toasts.appendChild(item);
+  setTimeout(() => item.remove(), 4_000);
+}
+
+function fatal(title, detail) {
+  intentionallyEnded = true;
+  trustedHost = false;
+  refreshControls();
+  setStatus("off", "Disconnected");
+  showOverlay(title, detail, true);
+  try {
+    socket?.close();
+  } catch {
+    // Socket is already gone.
+  }
+}
+
+function refreshControls() {
+  const canControl = trustedHost && (interactiveAllowed || handoffActive);
+  if (!canControl) controlling = false;
+  if (handoffActive && canControl) controlling = true;
+  control.disabled = !canControl;
+  control.textContent = controlling ? "Release control" : "Take control";
+  control.className = controlling ? "active" : "";
+  canvas.className = controlling ? "controlling" : "";
+  handoff.hidden = !handoffActive;
+  messageInput.placeholder = askActive ? "Answer the agent" : handoffActive ? "Optional note before resuming" : "Message the agent";
+  sendButton.textContent = askActive ? "Answer" : "Send";
+}
+
+function websocketUrl() {
+  const url = new URL(`/v1/sessions/${sessionId}/ws`, location.origin);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+function enqueueEnvelope(kind, plaintext, connection = socket, sender = connection?.bwSender) {
+  const operation = sendChain.then(async () => {
+    if (!connection || socket !== connection || connection.readyState !== WebSocket.OPEN || !sender) return;
+    const envelope = await sender.seal(kind, plaintext);
+    if (socket === connection && connection.readyState === WebSocket.OPEN) connection.send(envelope);
+  });
+  sendChain = operation.catch(() => {
+    try {
+      connection?.close(4403, "encryption failed");
+    } catch {
+      // Connection teardown is already in progress.
+    }
+  });
+  return operation;
+}
+
+function sendProtocol(message) {
+  if (!trustedHost) return;
+  void enqueueEnvelope(ENVELOPE_KIND.TEXT, encoder.encode(JSON.stringify(message)));
+}
+
+async function acceptHostChallenge(plaintext, connection) {
+  let value;
+  try {
+    value = JSON.parse(decoder.decode(plaintext));
+  } catch {
+    return false;
+  }
+  if (
+    value?.t !== "bw_e2e_challenge" ||
+    typeof value.challenge !== "string" ||
+    !/^[A-Za-z0-9_-]{43}$/.test(value.challenge)
+  ) {
+    return false;
+  }
+  await enqueueEnvelope(
+    ENVELOPE_KIND.CHALLENGE,
+    encoder.encode(JSON.stringify({ t: "bw_e2e_ready", challenge: value.challenge })),
+    connection,
+    connection.bwSender,
+  );
+  if (socket !== connection || connection.readyState !== WebSocket.OPEN) return false;
+  clearTimeout(challengeTimer);
+  trustedHost = true;
+  reconnectAttempts = 0;
+  setStatus("secure", "End-to-end encrypted");
+  hideOverlay();
+  refreshControls();
+  sendProtocol({ t: "refresh" });
+  sendViewport();
+  sendProtocol({ t: "vis", hidden: document.hidden });
+  return true;
+}
+
+function renderMeta() {
+  pageUrl.textContent = meta.url || "Waiting for the browser";
+  dimensions.textContent = `${meta.deviceWidth}×${meta.deviceHeight}`;
+}
+
+function renderTabs(items) {
+  const fragment = document.createDocumentFragment();
+  for (const item of Array.isArray(items) ? items : []) {
+    if (!item || typeof item.id !== "string") continue;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = item.streaming ? "tab active" : "tab";
+    button.disabled = Boolean(item.streaming) || !trustedHost;
+    button.textContent = String(item.title || item.url || "about:blank").slice(0, 160);
+    button.addEventListener("click", () => {
+      sendProtocol({ t: "tab", id: item.id });
+      canvas.focus();
+    });
+    fragment.appendChild(button);
+  }
+  tabs.replaceChildren(fragment);
+}
+
+function appendMessage(entry) {
+  if (!entry || typeof entry.text !== "string" || !entry.text) return;
+  if (entry.id !== undefined) {
+    const key = String(entry.id);
+    if (seenMessages.has(key)) return;
+    seenMessages.add(key);
+    if (seenMessages.size > 500) seenMessages.delete(seenMessages.values().next().value);
+  }
+  const role = entry.role === "you" ? "you" : entry.role === "system" ? "system" : "agent";
+  const row = document.createElement("div");
+  row.className = `message ${role}`;
+  const label = document.createElement("small");
+  label.textContent = role;
+  const bubble = document.createElement("p");
+  bubble.textContent = entry.text.slice(0, 4_000);
+  row.append(label, bubble);
+  messages.appendChild(row);
+  while (messages.children.length > 100) messages.firstElementChild?.remove();
+  messages.scrollTop = messages.scrollHeight;
+}
+
+function applyState(value) {
+  interactiveAllowed = value?.interactive === true;
+  handoffActive = value?.handoff?.active === true;
+  askActive = value?.ask?.active === true;
+  handoffDetail.textContent = handoffActive ? String(value.handoff.prompt || "Complete the browser step, then resume the agent.") : "";
+  if (value?.agent === "driving" && trustedHost) setStatus("busy", "Agent driving");
+  else if (trustedHost) setStatus("secure", "End-to-end encrypted");
+  refreshControls();
+}
+
+function handleProtocolText(plaintext) {
+  let value;
+  try {
+    value = JSON.parse(decoder.decode(plaintext));
+  } catch {
+    return;
+  }
+  if (value?.t === "hello" || value?.t === "state") {
+    applyState(value);
+  } else if (value?.t === "meta") {
+    if (Number.isFinite(value.deviceWidth) && value.deviceWidth > 0) meta.deviceWidth = value.deviceWidth;
+    if (Number.isFinite(value.deviceHeight) && value.deviceHeight > 0) meta.deviceHeight = value.deviceHeight;
+    if (typeof value.url === "string") meta.url = value.url;
+    renderMeta();
+  } else if (value?.t === "tabs") {
+    renderTabs(value.tabs);
+  } else if (value?.t === "chat") {
+    if (Array.isArray(value.messages)) value.messages.forEach(appendMessage);
+    else appendMessage(value.message);
+  } else if (value?.t === "toast") {
+    toast(value.text);
+  } else if (value?.t === "bye") {
+    fatal("Live view ended", String(value.reason || "The host stopped this session."));
+  }
+}
+
+async function paintFrame(bytes) {
+  const blob = new Blob([bytes], { type: "image/jpeg" });
+  try {
+    const bitmap = await createImageBitmap(blob);
+    if (canvas.width !== bitmap.width || canvas.height !== bitmap.height) {
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+    }
+    context.drawImage(bitmap, 0, 0);
+    bitmap.close();
+  } catch {
+    // A malformed or superseded image is discarded without exposing its bytes.
+  }
+}
+
+async function pumpFrames() {
+  if (decodingFrame || !pendingFrame || document.hidden) return;
+  const frame = pendingFrame;
+  pendingFrame = null;
+  decodingFrame = true;
+  await paintFrame(frame);
+  decodingFrame = false;
+  if (pendingFrame) void pumpFrames();
+}
+
+async function receiveBinary(data, connection, receiver) {
+  const opened = await receiver.open(new Uint8Array(data));
+  if (!trustedHost) {
+    if (opened.kind !== ENVELOPE_KIND.CHALLENGE) {
+      throw new Error("application payload arrived before host verification");
+    }
+    if (!(await acceptHostChallenge(opened.plaintext, connection))) {
+      throw new Error("host challenge failed");
+    }
+    return;
+  }
+  if (opened.kind === ENVELOPE_KIND.TEXT) {
+    handleProtocolText(opened.plaintext);
+  } else if (opened.kind === ENVELOPE_KIND.BINARY) {
+    pendingFrame = opened.plaintext;
+    void pumpFrames();
+  } else {
+    throw new Error("unexpected challenge after host verification");
+  }
+}
+
+function connect() {
+  if (intentionallyEnded) return;
+  setStatus("connecting", reconnectAttempts ? "Reconnecting" : "Securing connection");
+  showOverlay(
+    reconnectAttempts ? "Reconnecting to the host" : "Opening a private channel",
+    "The key stays in this tab and is never sent to the relay.",
+  );
+  const connection = new WebSocket(websocketUrl(), ["betterwright.relay.v1", `bw.viewer.${viewerProof}`]);
+  const receiver = createEnvelopeReceiver(rootKey, sessionId, "h2v");
+  connection.bwSender = createEnvelopeSender(rootKey, sessionId, "v2h");
+  socket = connection;
+  trustedHost = false;
+  sendChain = Promise.resolve();
+  receiveChain = Promise.resolve();
+  connection.binaryType = "arraybuffer";
+  connection.addEventListener("open", () => {
+    refreshControls();
+    clearTimeout(challengeTimer);
+    challengeTimer = setTimeout(() => {
+      try {
+        connection.close(4403, "host challenge timed out");
+      } catch {
+        // Socket is already gone.
+      }
+    }, 10_000);
+  });
+  connection.addEventListener("message", (event) => {
+    if (typeof event.data === "string") {
+      connection.close(4415, "unexpected plaintext from relay");
+      return;
+    }
+    receiveChain = receiveChain.then(() => receiveBinary(event.data, connection, receiver)).catch(() => {
+      try {
+        connection.close(4403, "encrypted channel verification failed");
+      } catch {
+        // Connection is already closing.
+      }
+    });
+  });
+  connection.addEventListener("close", (event) => {
+    if (socket !== connection) return;
+    clearTimeout(challengeTimer);
+    trustedHost = false;
+    refreshControls();
+    if (intentionallyEnded) return;
+    const terminalCodes = new Set([4401, 4403, 4407, 4408, 4411, 4412, 4414, 4415, 4416]);
+    if (terminalCodes.has(event.code)) {
+      fatal("Live view unavailable", event.reason || "The relay rejected this connection.");
+      return;
+    }
+    reconnectAttempts += 1;
+    if (reconnectAttempts > 90) {
+      fatal("Host unreachable", "The live view could not reconnect after 15 minutes.");
+      return;
+    }
+    const base = event.code === 4413 ? 150 : Math.min(10_000, 500 * 1.55 ** Math.min(reconnectAttempts, 8));
+    const delay = base + Math.random() * 250;
+    setTimeout(connect, delay);
+  });
+  connection.addEventListener("error", () => {
+    try {
+      connection.close();
+    } catch {
+      // Close event handles retry.
+    }
+  });
+}
+
+function scaleCoordinates(event) {
+  const rect = canvas.getBoundingClientRect();
+  const bitmapAspect = canvas.width > 0 && canvas.height > 0 ? canvas.width / canvas.height : rect.width / rect.height;
+  const width = Math.min(rect.width, rect.height * bitmapAspect);
+  const height = width / bitmapAspect;
+  const left = rect.left + (rect.width - width) / 2;
+  const top = rect.top + (rect.height - height) / 2;
+  return {
+    x: Math.round(Math.min(Math.max(((event.clientX - left) / width) * meta.deviceWidth, 0), meta.deviceWidth) * 100) / 100,
+    y: Math.round(Math.min(Math.max(((event.clientY - top) / height) * meta.deviceHeight, 0), meta.deviceHeight) * 100) / 100,
+  };
+}
+
+function modifiers(event) {
+  return (event.altKey ? 1 : 0) | (event.ctrlKey ? 2 : 0) | (event.metaKey ? 4 : 0) | (event.shiftKey ? 8 : 0);
+}
+
+const buttonNames = ["left", "middle", "right", "back", "forward"];
+function sendMouse(type, event, extra = {}) {
+  if (!trustedHost || !controlling) return;
+  const point = scaleCoordinates(event);
+  sendProtocol({
+    t: "input",
+    kind: "mouse",
+    type,
+    x: point.x,
+    y: point.y,
+    button: buttonNames[event.button] || "none",
+    buttons: event.buttons || 0,
+    modifiers: modifiers(event),
+    clickCount: extra.clickCount || 0,
+    ...(extra.deltaX === undefined ? {} : { deltaX: extra.deltaX, deltaY: extra.deltaY }),
+  });
+}
+
+control.addEventListener("click", () => {
+  controlling = !controlling;
+  if (controlling) canvas.focus();
+  refreshControls();
+});
+
+canvas.addEventListener("pointerdown", (event) => {
+  if (!controlling) return;
+  event.preventDefault();
+  canvas.focus();
+  const point = scaleCoordinates(event);
+  const now = Date.now();
+  lastDown.count = now - lastDown.time < 400 && Math.abs(point.x - lastDown.x) < 6 && Math.abs(point.y - lastDown.y) < 6
+    ? lastDown.count + 1
+    : 1;
+  lastDown = { time: now, x: point.x, y: point.y, count: lastDown.count };
+  sendMouse("mousePressed", event, { clickCount: lastDown.count });
+});
+canvas.addEventListener("pointerup", (event) => {
+  if (!controlling) return;
+  event.preventDefault();
+  sendMouse("mouseReleased", event, { clickCount: lastDown.count || 1 });
+});
+canvas.addEventListener("pointermove", (event) => {
+  if (!controlling) return;
+  lastPointer = event;
+  if (pointerTimer) return;
+  pointerTimer = setTimeout(() => {
+    pointerTimer = null;
+    const pending = lastPointer;
+    lastPointer = null;
+    if (pending) sendMouse("mouseMoved", pending);
+  }, 70);
+});
+canvas.addEventListener("wheel", (event) => {
+  if (!controlling) return;
+  event.preventDefault();
+  sendMouse("mouseWheel", event, { deltaX: event.deltaX, deltaY: event.deltaY });
+}, { passive: false });
+canvas.addEventListener("contextmenu", (event) => {
+  if (controlling) event.preventDefault();
+});
+
+function uiFocused() {
+  const active = document.activeElement;
+  return active && active !== canvas && active !== document.body;
+}
+
+window.addEventListener("keydown", (event) => {
+  if (!controlling || uiFocused()) return;
+  event.preventDefault();
+  sendProtocol({
+    t: "input",
+    kind: "key",
+    type: "keyDown",
+    key: event.key,
+    code: event.code,
+    keyCode: event.keyCode || 0,
+    modifiers: modifiers(event),
+    ...(event.key === "Enter" ? { text: "\r" } : event.key.length === 1 && !event.ctrlKey && !event.metaKey ? { text: event.key } : {}),
+  });
+});
+window.addEventListener("keyup", (event) => {
+  if (!controlling || uiFocused()) return;
+  event.preventDefault();
+  sendProtocol({
+    t: "input",
+    kind: "key",
+    type: "keyUp",
+    key: event.key,
+    code: event.code,
+    keyCode: event.keyCode || 0,
+    modifiers: modifiers(event),
+  });
+});
+window.addEventListener("paste", (event) => {
+  if (!controlling || uiFocused()) return;
+  const text = event.clipboardData?.getData("text") || "";
+  if (text) sendProtocol({ t: "input", kind: "insertText", text: text.slice(0, 8_192) });
+  event.preventDefault();
+});
+
+composer.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const text = messageInput.value.trim();
+  if (!text || !trustedHost) return;
+  sendProtocol({ t: askActive ? "answer" : "chat", text });
+  messageInput.value = "";
+});
+document.getElementById("done").addEventListener("click", () => {
+  sendProtocol({ t: "done", note: messageInput.value.trim() });
+  messageInput.value = "";
+});
+document.getElementById("cancel").addEventListener("click", () => {
+  sendProtocol({ t: "cancel", note: messageInput.value.trim() });
+  messageInput.value = "";
+});
+
+function sendViewport() {
+  if (!trustedHost) return;
+  const rect = viewport.getBoundingClientRect();
+  const pixels = Math.ceil(Math.max(rect.width, rect.height) * (devicePixelRatio || 1));
+  if (pixels > 0) sendProtocol({ t: "view", px: pixels });
+}
+let resizeTimer = null;
+window.addEventListener("resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(sendViewport, 300);
+});
+document.addEventListener("visibilitychange", () => {
+  sendProtocol({ t: "vis", hidden: document.hidden });
+  if (!document.hidden) void pumpFrames();
+});
+
+async function start() {
+  try {
+    base64UrlToBytes(rootKey, 32);
+    if (!/^bws_[A-Za-z0-9_-]{24}$/.test(sessionId)) throw new Error("invalid session");
+    viewerProof = await deriveViewerProof(rootKey, sessionId);
+    renderMeta();
+    refreshControls();
+    connect();
+  } catch {
+    fatal("Invalid private link", "This URL is missing a valid 32-byte #k root key. Ask for a fresh viewer link.");
+  }
+}
+
+void start();

--- a/relay/src/auth.ts
+++ b/relay/src/auth.ts
@@ -1,0 +1,82 @@
+import { verifyToken } from "@clerk/backend";
+import type { RelayConfig } from "./config";
+import { requireSecret } from "./config";
+import { secureTokenEqual } from "./crypto";
+import type { Env } from "./env";
+import { bearerCredential, cookieValue, HttpError } from "./http";
+
+export interface ClerkPrincipal {
+  userId: string;
+  sessionId?: string;
+}
+
+export async function authenticateClerkRequest(
+  request: Request,
+  env: Env,
+  config: RelayConfig,
+): Promise<ClerkPrincipal> {
+  const bearer = bearerCredential(request);
+  const cookie = bearer ? null : cookieValue(request, "__session");
+  const token = bearer ?? cookie;
+  if (!token || token.length > 8_192) {
+    throw new HttpError(401, "authentication_required", "A valid Clerk session token is required");
+  }
+  if (cookie && !["GET", "HEAD", "OPTIONS"].includes(request.method) && request.headers.get("Origin") !== config.appOrigin) {
+    throw new HttpError(403, "origin_required", "Cookie-authenticated mutations require the exact app origin");
+  }
+
+  const jwtKey = env.CLERK_JWT_KEY?.replace(/\\n/g, "\n").trim();
+  const secretKey = env.CLERK_SECRET_KEY?.trim();
+  if (!jwtKey && !secretKey) {
+    throw new HttpError(500, "auth_not_configured", "Clerk token verification is not configured");
+  }
+
+  try {
+    const verified = await verifyToken(token, {
+      ...(jwtKey ? { jwtKey } : { secretKey }),
+      authorizedParties: config.clerkAuthorizedParties,
+      ...(config.clerkAudience ? { audience: config.clerkAudience } : {}),
+      clockSkewInMs: 5_000,
+    });
+    return clerkPrincipalFromVerification(verified);
+  } catch {
+    throw new HttpError(401, "invalid_session", "The Clerk session token is invalid or expired");
+  }
+}
+
+export async function authenticateAdminRequest(request: Request, env: Env): Promise<void> {
+  const candidate = bearerCredential(request);
+  const expected = requireSecret(env, "ADMIN_TOKEN");
+  if (!candidate || !(await secureTokenEqual(candidate, expected))) {
+    throw new HttpError(401, "admin_authentication_required", "A valid admin token is required");
+  }
+}
+
+export async function authenticateInternalRequest(request: Request, env: Env): Promise<void> {
+  const candidate = request.headers.get("X-Relay-Internal") ?? "";
+  const expected = requireSecret(env, "INTERNAL_DO_SECRET");
+  if (candidate.length > 256 || !(await secureTokenEqual(candidate, expected))) {
+    throw new HttpError(403, "forbidden", "Internal request denied");
+  }
+}
+
+export function internalHeaders(env: Env): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+    "X-Relay-Internal": requireSecret(env, "INTERNAL_DO_SECRET"),
+  };
+}
+
+export function clerkPrincipalFromVerification(result: unknown): ClerkPrincipal {
+  if (!result || typeof result !== "object") throw new Error("invalid Clerk verification result");
+  const verified = result as { data?: { sub?: unknown; sid?: unknown }; errors?: unknown };
+  if (verified.errors || !verified.data) throw new Error("Clerk token verification failed");
+  const payload = verified.data;
+  if (typeof payload.sub !== "string" || !/^user_[A-Za-z0-9]+$/.test(payload.sub)) {
+    throw new Error("missing Clerk subject");
+  }
+  return {
+    userId: payload.sub,
+    sessionId: typeof payload.sid === "string" ? payload.sid : undefined,
+  };
+}

--- a/relay/src/auth.ts
+++ b/relay/src/auth.ts
@@ -69,9 +69,20 @@ export function internalHeaders(env: Env): HeadersInit {
 
 export function clerkPrincipalFromVerification(result: unknown): ClerkPrincipal {
   if (!result || typeof result !== "object") throw new Error("invalid Clerk verification result");
-  const verified = result as { data?: { sub?: unknown; sid?: unknown }; errors?: unknown };
-  if (verified.errors || !verified.data) throw new Error("Clerk token verification failed");
-  const payload = verified.data;
+  // @clerk/backend's public verifyToken() returns the verified JwtPayload
+  // directly. Accept the older low-level {data, errors} shape too so a patch
+  // release cannot turn every valid production session into a 401.
+  const verified = result as {
+    sub?: unknown;
+    sid?: unknown;
+    data?: { sub?: unknown; sid?: unknown };
+    errors?: unknown;
+  };
+  const legacyShape = Object.hasOwn(verified, "data");
+  if (legacyShape && (verified.errors || !verified.data)) {
+    throw new Error("Clerk token verification failed");
+  }
+  const payload = legacyShape ? verified.data! : verified;
   if (typeof payload.sub !== "string" || !/^user_[A-Za-z0-9]+$/.test(payload.sub)) {
     throw new Error("missing Clerk subject");
   }

--- a/relay/src/client/host-codec.ts
+++ b/relay/src/client/host-codec.ts
@@ -1,0 +1,120 @@
+import { ENVELOPE_KIND, HOST_PROTOCOL_PREFIX, RELAY_PROTOCOL } from "../constants";
+import {
+  constantTimeEqual,
+  createEnvelopeReceiver,
+  createEnvelopeSender,
+  deriveViewerProof,
+  generateRootKey,
+  generateSessionId,
+  randomBase64Url,
+  type EnvelopeReceiver,
+  type EnvelopeSender,
+} from "../crypto";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
+export interface PreparedRelaySession {
+  sessionId: string;
+  rootKey: string;
+  viewerProof: string;
+}
+
+/** Prepare session material locally so the root never enters a relay HTTP request. */
+export async function prepareRelaySession(): Promise<PreparedRelaySession> {
+  const sessionId = generateSessionId();
+  const rootKey = generateRootKey();
+  const viewerProof = await deriveViewerProof(rootKey, sessionId);
+  return { sessionId, rootKey, viewerProof };
+}
+
+export type DecodedViewerMessage =
+  | { type: "ready" }
+  | { type: "text"; data: string }
+  | { type: "binary"; data: Uint8Array };
+
+/**
+ * Host-side codec seam for BetterWright's existing live-view server. Create a
+ * fresh instance for every relay WebSocket connection. On viewer_connected,
+ * send encodeChallenge() before accepting or emitting application payloads.
+ */
+export class HostRelayCodec {
+  private challengeComplete = false;
+  private pendingChallenge: string | null = null;
+
+  private constructor(
+    readonly sessionId: string,
+    readonly subprotocols: readonly [string, string],
+    private readonly hostSender: EnvelopeSender,
+    private readonly viewerReceiver: EnvelopeReceiver,
+  ) {}
+
+  static async create(sessionId: string, rootKey: string, hostCapability: string): Promise<HostRelayCodec> {
+    return new HostRelayCodec(
+      sessionId,
+      [RELAY_PROTOCOL, `${HOST_PROTOCOL_PREFIX}${hostCapability}`],
+      createEnvelopeSender(rootKey, sessionId, "h2v"),
+      createEnvelopeReceiver(rootKey, sessionId, "v2h"),
+    );
+  }
+
+  get viewerVerified(): boolean {
+    return this.challengeComplete;
+  }
+
+  async encodeChallenge(): Promise<Uint8Array> {
+    if (this.pendingChallenge || this.challengeComplete) {
+      throw new Error("host challenge already started");
+    }
+    const challenge = randomBase64Url(32);
+    this.pendingChallenge = challenge;
+    return this.hostSender.seal(
+      ENVELOPE_KIND.CHALLENGE,
+      encoder.encode(JSON.stringify({ t: "bw_e2e_challenge", challenge })),
+    );
+  }
+
+  async encodeText(text: string): Promise<Uint8Array> {
+    if (!this.challengeComplete) throw new Error("viewer is not verified");
+    return this.hostSender.seal(ENVELOPE_KIND.TEXT, encoder.encode(text));
+  }
+
+  async encodeBinary(data: Uint8Array): Promise<Uint8Array> {
+    if (!this.challengeComplete) throw new Error("viewer is not verified");
+    return this.hostSender.seal(ENVELOPE_KIND.BINARY, data);
+  }
+
+  async receiveViewer(envelope: Uint8Array): Promise<DecodedViewerMessage> {
+    const opened = await this.viewerReceiver.open(envelope);
+    if (!this.challengeComplete) {
+      if (!this.pendingChallenge) throw new Error("host challenge has not started");
+      if (opened.kind !== ENVELOPE_KIND.CHALLENGE) {
+        throw new Error("viewer input arrived before matching challenge echo");
+      }
+      let ready: unknown;
+      try {
+        ready = JSON.parse(decoder.decode(opened.plaintext));
+      } catch {
+        throw new Error("invalid viewer ready echo");
+      }
+      const value = ready as { t?: unknown; challenge?: unknown };
+      if (
+        value.t !== "bw_e2e_ready" ||
+        typeof value.challenge !== "string" ||
+        !constantTimeEqual(value.challenge, this.pendingChallenge)
+      ) {
+        throw new Error("invalid viewer ready echo");
+      }
+      this.pendingChallenge = null;
+      this.challengeComplete = true;
+      return { type: "ready" };
+    }
+    if (opened.kind === ENVELOPE_KIND.TEXT) {
+      return { type: "text", data: decoder.decode(opened.plaintext) };
+    }
+    if (opened.kind === ENVELOPE_KIND.BINARY) {
+      return { type: "binary", data: opened.plaintext };
+    }
+    throw new Error("unexpected viewer challenge envelope");
+  }
+}

--- a/relay/src/config.ts
+++ b/relay/src/config.ts
@@ -1,0 +1,212 @@
+import { DEFAULTS } from "./constants";
+import type { Env } from "./env";
+
+export interface RelayConfig {
+  publicOrigin: string;
+  appOrigin: string;
+  clerkAuthorizedParties: string[];
+  clerkAudience?: string;
+  weeklyViewerMs: number;
+  leaseMs: number;
+  leaseReservationMicroUsd: number;
+  budgetCeilingMicroUsd: number;
+  billingPeriodStartDayUtc: number;
+  billingWindowId?: string;
+  sessionTtlMs: number;
+  maxMessageBytes: number;
+  sustainedMessagesPerSecond: number;
+  burstMessages: number;
+  maxBytesPerSecond: number;
+  maxBufferedBytes: number;
+  envKillSwitch: boolean;
+}
+
+export class ConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigurationError";
+  }
+}
+
+function positiveInteger(
+  value: string | undefined,
+  fallback: number,
+  name: string,
+  min: number,
+  max: number,
+): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  if (!/^\d+$/.test(value.trim())) throw new ConfigurationError(`${name} must be an integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new ConfigurationError(`${name} is outside the supported range`);
+  }
+  return parsed;
+}
+
+export function usdToMicroUsd(value: string, name: string): number {
+  const trimmed = value.trim();
+  const match = /^(\d{1,9})(?:\.(\d{1,6}))?$/.exec(trimmed);
+  if (!match) throw new ConfigurationError(`${name} must be a non-negative USD decimal`);
+  const whole = BigInt(match[1]);
+  const fraction = BigInt((match[2] ?? "").padEnd(6, "0"));
+  const result = whole * 1_000_000n + fraction;
+  if (result > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new ConfigurationError(`${name} is too large`);
+  }
+  return Number(result);
+}
+
+function exactOrigin(value: string | undefined, name: string): string {
+  if (!value) throw new ConfigurationError(`${name} is required`);
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new ConfigurationError(`${name} must be an absolute origin`);
+  }
+  const localHttp = parsed.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
+  if (parsed.protocol !== "https:" && !localHttp) {
+    throw new ConfigurationError(`${name} must use HTTPS outside local development`);
+  }
+  if (
+    value.includes("*") ||
+    parsed.hostname.includes("*") ||
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== "/" ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new ConfigurationError(`${name} must contain only scheme, host, and optional port`);
+  }
+  if (value.replace(/\/$/, "") !== parsed.origin) {
+    throw new ConfigurationError(`${name} must be a canonical exact origin`);
+  }
+  return parsed.origin;
+}
+
+function parseAuthorizedParties(value: string | undefined): string[] {
+  if (!value) throw new ConfigurationError("CLERK_AUTHORIZED_PARTIES is required");
+  const parties = value
+    .split(",")
+    .map((entry) => exactOrigin(entry.trim(), "CLERK_AUTHORIZED_PARTIES entry"));
+  if (parties.length === 0 || parties.some((entry) => !entry)) {
+    throw new ConfigurationError("CLERK_AUTHORIZED_PARTIES must not be empty");
+  }
+  return [...new Set(parties)];
+}
+
+function booleanValue(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+export function getConfig(env: Env): RelayConfig {
+  // Fail closed before reporting readiness or admitting any request. A Worker
+  // deployment without its cryptographic/authentication secrets must never
+  // appear healthy.
+  requireSecret(env, "API_KEY_HMAC_SECRET");
+  requireSecret(env, "CAPABILITY_HMAC_SECRET");
+  requireSecret(env, "INTERNAL_DO_SECRET");
+  requireSecret(env, "ADMIN_TOKEN");
+  requireSecret(env, "CLERK_WEBHOOK_SIGNING_SECRET");
+  if (!env.CLERK_JWT_KEY?.trim() && !env.CLERK_SECRET_KEY?.trim()) {
+    throw new ConfigurationError("Clerk token verification is not configured");
+  }
+
+  const weeklyViewerSeconds = positiveInteger(
+    env.WEEKLY_VIEWER_SECONDS,
+    DEFAULTS.WEEKLY_VIEWER_SECONDS,
+    "WEEKLY_VIEWER_SECONDS",
+    60,
+    7 * 24 * 60 * 60,
+  );
+  const leaseSeconds = positiveInteger(
+    env.LEASE_SECONDS,
+    DEFAULTS.LEASE_SECONDS,
+    "LEASE_SECONDS",
+    60,
+    60 * 60,
+  );
+  const sessionTtlSeconds = positiveInteger(
+    env.SESSION_TTL_SECONDS,
+    DEFAULTS.SESSION_TTL_SECONDS,
+    "SESSION_TTL_SECONDS",
+    leaseSeconds,
+    7 * 24 * 60 * 60,
+  );
+  const maxBitsPerSecond = positiveInteger(
+    env.MAX_BITS_PER_SECOND,
+    DEFAULTS.MAX_BITS_PER_SECOND,
+    "MAX_BITS_PER_SECOND",
+    8_000,
+    1_000_000_000,
+  );
+  const billingWindowId = env.BILLING_WINDOW_ID?.trim();
+  if (billingWindowId && !/^[A-Za-z0-9._:-]{1,80}$/.test(billingWindowId)) {
+    throw new ConfigurationError("BILLING_WINDOW_ID contains unsupported characters");
+  }
+
+  return {
+    publicOrigin: exactOrigin(env.PUBLIC_ORIGIN, "PUBLIC_ORIGIN"),
+    appOrigin: exactOrigin(env.APP_ORIGIN, "APP_ORIGIN"),
+    clerkAuthorizedParties: parseAuthorizedParties(env.CLERK_AUTHORIZED_PARTIES),
+    clerkAudience: env.CLERK_AUDIENCE?.trim() || undefined,
+    weeklyViewerMs: weeklyViewerSeconds * 1_000,
+    leaseMs: leaseSeconds * 1_000,
+    leaseReservationMicroUsd: env.LEASE_RESERVATION_USD
+      ? usdToMicroUsd(env.LEASE_RESERVATION_USD, "LEASE_RESERVATION_USD")
+      : DEFAULTS.LEASE_RESERVATION_MICRO_USD,
+    budgetCeilingMicroUsd: env.BUDGET_CEILING_USD
+      ? usdToMicroUsd(env.BUDGET_CEILING_USD, "BUDGET_CEILING_USD")
+      : DEFAULTS.BUDGET_CEILING_MICRO_USD,
+    billingPeriodStartDayUtc: positiveInteger(
+      env.BILLING_PERIOD_START_DAY_UTC,
+      DEFAULTS.BILLING_PERIOD_START_DAY_UTC,
+      "BILLING_PERIOD_START_DAY_UTC",
+      1,
+      28,
+    ),
+    billingWindowId: billingWindowId || undefined,
+    sessionTtlMs: sessionTtlSeconds * 1_000,
+    maxMessageBytes: positiveInteger(
+      env.MAX_MESSAGE_BYTES,
+      DEFAULTS.MAX_MESSAGE_BYTES,
+      "MAX_MESSAGE_BYTES",
+      1_024,
+      32 * 1024 * 1024,
+    ),
+    sustainedMessagesPerSecond: positiveInteger(
+      env.SUSTAINED_MESSAGES_PER_SECOND,
+      DEFAULTS.SUSTAINED_MESSAGES_PER_SECOND,
+      "SUSTAINED_MESSAGES_PER_SECOND",
+      1,
+      1_000,
+    ),
+    burstMessages: positiveInteger(
+      env.BURST_MESSAGES,
+      DEFAULTS.BURST_MESSAGES,
+      "BURST_MESSAGES",
+      1,
+      10_000,
+    ),
+    maxBytesPerSecond: Math.floor(maxBitsPerSecond / 8),
+    maxBufferedBytes: positiveInteger(
+      env.MAX_BUFFERED_BYTES,
+      DEFAULTS.MAX_BUFFERED_BYTES,
+      "MAX_BUFFERED_BYTES",
+      64 * 1024,
+      64 * 1024 * 1024,
+    ),
+    envKillSwitch: booleanValue(env.RELAY_KILL_SWITCH),
+  };
+}
+
+export function requireSecret(env: Env, name: keyof Env, minimumLength = 32): string {
+  const value = env[name];
+  if (typeof value !== "string" || value.length < minimumLength) {
+    throw new ConfigurationError(`${String(name)} must be a secret of at least ${minimumLength} characters`);
+  }
+  return value;
+}

--- a/relay/src/constants.ts
+++ b/relay/src/constants.ts
@@ -1,0 +1,68 @@
+export const API_KEY_PREFIX = "bw_live";
+export const API_KEY_ID_BYTES = 12;
+export const API_KEY_SECRET_BYTES = 32;
+export const ROOT_KEY_BYTES = 32;
+export const CAPABILITY_BYTES = 32;
+export const SESSION_ID_BYTES = 18;
+export const MAX_ACTIVE_API_KEYS = 5;
+
+export const RELAY_PROTOCOL = "betterwright.relay.v1";
+export const HOST_PROTOCOL_PREFIX = "bw.host.";
+export const VIEWER_PROTOCOL_PREFIX = "bw.viewer.";
+
+export const ENVELOPE_VERSION = 1;
+export const ENVELOPE_DIRECTION = {
+  HOST_TO_VIEWER: 1,
+  VIEWER_TO_HOST: 2,
+} as const;
+export const ENVELOPE_EPOCH_BYTES = 16;
+export const ENVELOPE_SEQUENCE_BYTES = 8;
+export const ENVELOPE_NONCE_BYTES = 12;
+export const ENVELOPE_HEADER_BYTES = 26;
+export const ENVELOPE_TAG_BYTES = 16;
+export const ENVELOPE_KIND = {
+  TEXT: 0,
+  BINARY: 1,
+  CHALLENGE: 2,
+} as const;
+
+export const CLOSE_CODE = {
+  SESSION_CLOSED: 4401,
+  AUTH_FAILED: 4403,
+  PEER_UNAVAILABLE: 4404,
+  QUOTA_EXHAUSTED: 4407,
+  RATE_LIMITED: 4408,
+  DUPLICATE_PEER: 4409,
+  BACKPRESSURE: 4410,
+  BUDGET_EXHAUSTED: 4411,
+  KILL_SWITCH: 4412,
+  LEASE_EXPIRED: 4413,
+  MESSAGE_TOO_LARGE: 4414,
+  BINARY_ONLY: 4415,
+  SESSION_EXPIRED: 4416,
+  INTERNAL_ERROR: 4500,
+} as const;
+
+export const DEFAULTS = {
+  WEEKLY_VIEWER_SECONDS: 2 * 60 * 60,
+  LEASE_SECONDS: 15 * 60,
+  LEASE_RESERVATION_MICRO_USD: 2_500,
+  BUDGET_CEILING_MICRO_USD: 900_000_000,
+  BILLING_PERIOD_START_DAY_UTC: 1,
+  SESSION_TTL_SECONDS: 24 * 60 * 60,
+  MAX_MESSAGE_BYTES: 2 * 1024 * 1024,
+  SUSTAINED_MESSAGES_PER_SECOND: 15,
+  BURST_MESSAGES: 20,
+  MAX_BITS_PER_SECOND: 10_000_000,
+  MAX_BUFFERED_BYTES: 4 * 1024 * 1024,
+} as const;
+
+export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "Cache-Control": "no-store",
+  "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+};

--- a/relay/src/crypto.ts
+++ b/relay/src/crypto.ts
@@ -1,0 +1,400 @@
+import {
+  API_KEY_ID_BYTES,
+  API_KEY_PREFIX,
+  API_KEY_SECRET_BYTES,
+  CAPABILITY_BYTES,
+  ENVELOPE_DIRECTION,
+  ENVELOPE_EPOCH_BYTES,
+  ENVELOPE_HEADER_BYTES,
+  ENVELOPE_KIND,
+  ENVELOPE_NONCE_BYTES,
+  ENVELOPE_SEQUENCE_BYTES,
+  ENVELOPE_TAG_BYTES,
+  ENVELOPE_VERSION,
+  ROOT_KEY_BYTES,
+  SESSION_ID_BYTES,
+} from "./constants";
+
+const encoder = new TextEncoder();
+
+export type RelayDirection = "h2v" | "v2h";
+export type EnvelopeKind = (typeof ENVELOPE_KIND)[keyof typeof ENVELOPE_KIND];
+
+export interface OpenedEnvelope {
+  kind: EnvelopeKind;
+  plaintext: Uint8Array;
+  epoch: Uint8Array;
+  sequence: bigint;
+}
+
+export interface EnvelopeSender {
+  readonly direction: RelayDirection;
+  readonly epoch: Uint8Array;
+  seal(kind: EnvelopeKind, plaintext: Uint8Array, maxEnvelopeBytes?: number): Promise<Uint8Array>;
+}
+
+export interface EnvelopeReceiver {
+  readonly direction: RelayDirection;
+  readonly epoch: Uint8Array | null;
+  readonly lastSequence: bigint | null;
+  open(envelope: Uint8Array, maxEnvelopeBytes?: number): Promise<OpenedEnvelope>;
+}
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000));
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function base64UrlToBytes(value: string, expectedLength?: number): Uint8Array {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error("invalid base64url value");
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new Error("invalid base64url value");
+  }
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  if (expectedLength !== undefined && bytes.length !== expectedLength) {
+    throw new Error("unexpected decoded length");
+  }
+  if (bytesToBase64Url(bytes) !== value) throw new Error("non-canonical base64url value");
+  return bytes;
+}
+
+export function randomBase64Url(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return bytesToBase64Url(bytes);
+}
+
+export interface GeneratedApiKey {
+  id: string;
+  secret: string;
+  value: string;
+}
+
+export function generateApiKey(): GeneratedApiKey {
+  const id = randomBase64Url(API_KEY_ID_BYTES);
+  const secret = randomBase64Url(API_KEY_SECRET_BYTES);
+  return { id, secret, value: `${API_KEY_PREFIX}_${id}_${secret}` };
+}
+
+export function parseApiKey(value: string): { id: string; secret: string } | null {
+  const match = /^bw_live_([A-Za-z0-9_-]{16})_([A-Za-z0-9_-]{43})$/.exec(value);
+  if (!match) return null;
+  try {
+    base64UrlToBytes(match[1], API_KEY_ID_BYTES);
+    base64UrlToBytes(match[2], API_KEY_SECRET_BYTES);
+  } catch {
+    return null;
+  }
+  return { id: match[1], secret: match[2] };
+}
+
+export function generateSessionId(): string {
+  return `bws_${randomBase64Url(SESSION_ID_BYTES)}`;
+}
+
+export function isSessionId(value: string): boolean {
+  if (!/^bws_[A-Za-z0-9_-]{24}$/.test(value)) return false;
+  try {
+    base64UrlToBytes(value.slice(4), SESSION_ID_BYTES);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function generateCapability(): string {
+  return randomBase64Url(CAPABILITY_BYTES);
+}
+
+export function generateRootKey(): string {
+  return randomBase64Url(ROOT_KEY_BYTES);
+}
+
+async function importHmacKey(secret: string | Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    typeof secret === "string" ? encoder.encode(secret) : secret,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+export async function hmacBase64Url(secret: string | Uint8Array, value: string): Promise<string> {
+  const key = await importHmacKey(secret);
+  const digest = await crypto.subtle.sign("HMAC", key, encoder.encode(value));
+  return bytesToBase64Url(new Uint8Array(digest));
+}
+
+export async function hashApiKey(hmacSecret: string, apiKey: string): Promise<string> {
+  return hmacBase64Url(hmacSecret, `betterwright-api-key-v1\0${apiKey}`);
+}
+
+export async function hashCapability(
+  hmacSecret: string,
+  sessionId: string,
+  role: "host" | "viewer",
+  capability: string,
+): Promise<string> {
+  return hmacBase64Url(
+    hmacSecret,
+    `betterwright-relay-capability-v1\0${sessionId}\0${role}\0${capability}`,
+  );
+}
+
+export function constantTimeEqual(left: string, right: string): boolean {
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  const length = Math.max(leftBytes.length, rightBytes.length, 1);
+  let difference = leftBytes.length ^ rightBytes.length;
+  for (let index = 0; index < length; index += 1) {
+    difference |= (leftBytes[index % leftBytes.length] ?? 0) ^ (rightBytes[index % rightBytes.length] ?? 0);
+  }
+  return difference === 0;
+}
+
+export async function secureTokenEqual(candidate: string, expected: string): Promise<boolean> {
+  const [candidateDigest, expectedDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(candidate)),
+    crypto.subtle.digest("SHA-256", encoder.encode(expected)),
+  ]);
+  return constantTimeEqual(
+    bytesToBase64Url(new Uint8Array(candidateDigest)),
+    bytesToBase64Url(new Uint8Array(expectedDigest)),
+  );
+}
+
+export async function deriveViewerProof(rootKey: string, sessionId: string): Promise<string> {
+  const root = base64UrlToBytes(rootKey, ROOT_KEY_BYTES);
+  return hmacBase64Url(root, `BetterWright relay viewer proof v1\0${sessionId}`);
+}
+
+const MAX_SEQUENCE = (1n << 64n) - 1n;
+const DEFAULT_MAX_ENVELOPE_BYTES = 2 * 1024 * 1024;
+const HKDF_SALT_DOMAIN = "BetterWright relay HKDF salt v1";
+const ENVELOPE_DOMAIN = "BetterWright relay envelope v1";
+
+const DIRECTION_PARAMETERS: Record<
+  RelayDirection,
+  { byte: number; keyInfo: string }
+> = {
+  h2v: {
+    byte: ENVELOPE_DIRECTION.HOST_TO_VIEWER,
+    keyInfo: "BetterWright relay host-to-viewer AES-GCM v1",
+  },
+  v2h: {
+    byte: ENVELOPE_DIRECTION.VIEWER_TO_HOST,
+    keyInfo: "BetterWright relay viewer-to-host AES-GCM v1",
+  },
+};
+
+function concatenate(...parts: Uint8Array[]): Uint8Array {
+  const joined = new Uint8Array(parts.reduce((length, part) => length + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.length;
+  }
+  return joined;
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) difference |= left[index] ^ right[index];
+  return difference === 0;
+}
+
+function isEnvelopeKind(value: number): value is EnvelopeKind {
+  return value === ENVELOPE_KIND.TEXT || value === ENVELOPE_KIND.BINARY || value === ENVELOPE_KIND.CHALLENGE;
+}
+
+function sequenceView(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function nonceFor(direction: RelayDirection, sequence: bigint): Uint8Array {
+  const nonce = new Uint8Array(ENVELOPE_NONCE_BYTES);
+  nonce[0] = ENVELOPE_VERSION;
+  nonce[1] = DIRECTION_PARAMETERS[direction].byte;
+  sequenceView(nonce).setBigUint64(4, sequence, false);
+  return nonce;
+}
+
+function additionalData(header: Uint8Array, sessionId: string, direction: RelayDirection): Uint8Array {
+  return concatenate(
+    header,
+    encoder.encode(`${ENVELOPE_DOMAIN}\0${sessionId}\0${direction}`),
+  );
+}
+
+async function deriveEnvelopeKey(
+  root: Uint8Array,
+  epoch: Uint8Array,
+  sessionId: string,
+  direction: RelayDirection,
+): Promise<CryptoKey> {
+  const saltInput = concatenate(
+    encoder.encode(`${HKDF_SALT_DOMAIN}\0${sessionId}\0`),
+    epoch,
+  );
+  const salt = new Uint8Array(await crypto.subtle.digest("SHA-256", saltInput));
+  const keyMaterial = await crypto.subtle.importKey("raw", root, "HKDF", false, ["deriveKey"]);
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt,
+      info: encoder.encode(DIRECTION_PARAMETERS[direction].keyInfo),
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+function envelopeHeader(direction: RelayDirection, epoch: Uint8Array, sequence: bigint): Uint8Array {
+  const header = new Uint8Array(ENVELOPE_HEADER_BYTES);
+  header[0] = ENVELOPE_VERSION;
+  header[1] = DIRECTION_PARAMETERS[direction].byte;
+  header.set(epoch, 2);
+  sequenceView(header).setBigUint64(18, sequence, false);
+  return header;
+}
+
+export function createEnvelopeSender(
+  rootKey: string,
+  sessionId: string,
+  direction: RelayDirection,
+  epochOverride?: Uint8Array,
+): EnvelopeSender {
+  const root = base64UrlToBytes(rootKey, ROOT_KEY_BYTES);
+  const senderEpoch = epochOverride
+    ? new Uint8Array(epochOverride)
+    : crypto.getRandomValues(new Uint8Array(ENVELOPE_EPOCH_BYTES));
+  if (senderEpoch.length !== ENVELOPE_EPOCH_BYTES) throw new Error("invalid sender epoch length");
+  const key = deriveEnvelopeKey(root, senderEpoch, sessionId, direction);
+  let nextSequence = 0n;
+  let pending: Promise<void> = Promise.resolve();
+
+  return {
+    direction,
+    get epoch(): Uint8Array {
+      return new Uint8Array(senderEpoch);
+    },
+    seal(kind, plaintext, maxEnvelopeBytes = DEFAULT_MAX_ENVELOPE_BYTES): Promise<Uint8Array> {
+      const body = new Uint8Array(plaintext);
+      const operation = pending.then(async () => {
+        if (!isEnvelopeKind(kind)) throw new Error("unsupported envelope kind");
+        if (body.length + ENVELOPE_HEADER_BYTES + ENVELOPE_TAG_BYTES + 1 > maxEnvelopeBytes) {
+          throw new Error("envelope exceeds maximum size");
+        }
+        if (nextSequence > MAX_SEQUENCE) throw new Error("envelope sequence exhausted");
+        const sequence = nextSequence;
+        const header = envelopeHeader(direction, senderEpoch, sequence);
+        const protectedPlaintext = new Uint8Array(body.length + 1);
+        protectedPlaintext[0] = kind;
+        protectedPlaintext.set(body, 1);
+        const ciphertext = new Uint8Array(
+          await crypto.subtle.encrypt(
+            {
+              name: "AES-GCM",
+              iv: nonceFor(direction, sequence),
+              additionalData: additionalData(header, sessionId, direction),
+              tagLength: 128,
+            },
+            await key,
+            protectedPlaintext,
+          ),
+        );
+        const envelope = concatenate(header, ciphertext);
+        nextSequence = sequence + 1n;
+        return envelope;
+      });
+      pending = operation.then(() => undefined, () => undefined);
+      return operation;
+    },
+  };
+}
+
+export function createEnvelopeReceiver(
+  rootKey: string,
+  sessionId: string,
+  direction: RelayDirection,
+): EnvelopeReceiver {
+  const root = base64UrlToBytes(rootKey, ROOT_KEY_BYTES);
+  let senderEpoch: Uint8Array | null = null;
+  let key: CryptoKey | null = null;
+  let acceptedSequence: bigint | null = null;
+  let pending: Promise<void> = Promise.resolve();
+
+  return {
+    direction,
+    get epoch(): Uint8Array | null {
+      return senderEpoch ? new Uint8Array(senderEpoch) : null;
+    },
+    get lastSequence(): bigint | null {
+      return acceptedSequence;
+    },
+    open(envelope, maxEnvelopeBytes = DEFAULT_MAX_ENVELOPE_BYTES): Promise<OpenedEnvelope> {
+      const bytes = new Uint8Array(envelope);
+      const operation = pending.then(async () => {
+        if (bytes.length > maxEnvelopeBytes) throw new Error("envelope exceeds maximum size");
+        if (bytes.length < ENVELOPE_HEADER_BYTES + ENVELOPE_TAG_BYTES + 1) {
+          throw new Error("truncated envelope");
+        }
+        const header = bytes.subarray(0, ENVELOPE_HEADER_BYTES);
+        if (
+          header[0] !== ENVELOPE_VERSION ||
+          header[1] !== DIRECTION_PARAMETERS[direction].byte
+        ) {
+          throw new Error("envelope direction or version mismatch");
+        }
+        const candidateEpoch = new Uint8Array(header.subarray(2, 2 + ENVELOPE_EPOCH_BYTES));
+        const sequence = sequenceView(header).getBigUint64(18, false);
+        if (senderEpoch && !equalBytes(candidateEpoch, senderEpoch)) {
+          throw new Error("sender epoch changed without reconnect");
+        }
+        if (acceptedSequence !== null && sequence <= acceptedSequence) {
+          throw new Error("non-monotonic envelope replay rejected");
+        }
+        const candidateKey = key ?? await deriveEnvelopeKey(root, candidateEpoch, sessionId, direction);
+        const protectedPlaintext = new Uint8Array(
+          await crypto.subtle.decrypt(
+            {
+              name: "AES-GCM",
+              iv: nonceFor(direction, sequence),
+              additionalData: additionalData(header, sessionId, direction),
+              tagLength: 128,
+            },
+            candidateKey,
+            bytes.subarray(ENVELOPE_HEADER_BYTES),
+          ),
+        );
+        const kind = protectedPlaintext[0];
+        if (!isEnvelopeKind(kind)) throw new Error("unsupported envelope kind");
+        if (!senderEpoch) {
+          senderEpoch = candidateEpoch;
+          key = candidateKey;
+        }
+        acceptedSequence = sequence;
+        return {
+          kind,
+          plaintext: protectedPlaintext.subarray(1),
+          epoch: new Uint8Array(candidateEpoch),
+          sequence,
+        };
+      });
+      pending = operation.then(() => undefined, () => undefined);
+      return operation;
+    },
+  };
+}

--- a/relay/src/durable/budget-window.ts
+++ b/relay/src/durable/budget-window.ts
@@ -1,0 +1,96 @@
+import { authenticateInternalRequest } from "../auth";
+import type { Env } from "../env";
+import { HttpError, jsonResponse, normalizeThrownError, readJsonObject } from "../http";
+import { SerialGate } from "../serial";
+
+interface WindowMeta {
+  key: string;
+  startsAtMs: number;
+  endsAtMs: number;
+}
+
+function integerField(body: Record<string, unknown>, name: string, minimum = 0): number {
+  const value = body[name];
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    throw new HttpError(400, "invalid_internal_request", `${name} must be an integer`);
+  }
+  return value as number;
+}
+
+export class BudgetWindow implements DurableObject {
+  private readonly gate = new SerialGate();
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    try {
+      await authenticateInternalRequest(request, this.env);
+      const path = new URL(request.url).pathname;
+      if (path === "/reserve" && request.method === "POST") {
+        return await this.gate.run(() => this.reserve(request));
+      }
+      if (path === "/status" && request.method === "GET") {
+        return await this.gate.run(() => this.status());
+      }
+      throw new HttpError(404, "not_found", "Internal endpoint not found");
+    } catch (error) {
+      return normalizeThrownError(error);
+    }
+  }
+
+  private async reserve(request: Request): Promise<Response> {
+    const body = await readJsonObject(request, 4_096);
+    const reservationId = typeof body.reservationId === "string" ? body.reservationId : "";
+    const key = typeof body.windowKey === "string" ? body.windowKey : "";
+    if (!/^[A-Za-z0-9._:-]{1,200}$/.test(reservationId) || !/^[A-Za-z0-9._:-]{1,80}$/.test(key)) {
+      throw new HttpError(400, "invalid_internal_request", "Invalid reservation or window identifier");
+    }
+    const amountMicroUsd = integerField(body, "amountMicroUsd", 1);
+    const ceilingMicroUsd = integerField(body, "ceilingMicroUsd", 1);
+    const startsAtMs = integerField(body, "startsAtMs", 0);
+    const endsAtMs = integerField(body, "endsAtMs", startsAtMs + 1);
+    const reservationStorageKey = `reservation:${reservationId}`;
+
+    const existing = await this.state.storage.get<number>(reservationStorageKey);
+    const currentTotal = (await this.state.storage.get<number>("totalMicroUsd")) ?? 0;
+    if (existing !== undefined) {
+      return jsonResponse({ ok: true, idempotent: true, reservedMicroUsd: currentTotal });
+    }
+
+    const meta = await this.state.storage.get<WindowMeta>("window");
+    if (meta && (meta.key !== key || meta.startsAtMs !== startsAtMs || meta.endsAtMs !== endsAtMs)) {
+      throw new HttpError(409, "window_mismatch", "Budget window identity does not match this object");
+    }
+    if (currentTotal + amountMicroUsd > ceilingMicroUsd) {
+      return jsonResponse(
+        {
+          ok: false,
+          code: "budget_exhausted",
+          reservedMicroUsd: currentTotal,
+          ceilingMicroUsd,
+        },
+        409,
+      );
+    }
+
+    const nextTotal = currentTotal + amountMicroUsd;
+    const writes: Record<string, unknown> = {
+      [reservationStorageKey]: amountMicroUsd,
+      totalMicroUsd: nextTotal,
+    };
+    if (!meta) writes.window = { key, startsAtMs, endsAtMs } satisfies WindowMeta;
+    await this.state.storage.put(writes);
+    return jsonResponse({ ok: true, idempotent: false, reservedMicroUsd: nextTotal });
+  }
+
+  private async status(): Promise<Response> {
+    const [window, totalMicroUsd] = await Promise.all([
+      this.state.storage.get<WindowMeta>("window"),
+      this.state.storage.get<number>("totalMicroUsd"),
+    ]);
+    return jsonResponse({ ok: true, window: window ?? null, reservedMicroUsd: totalMicroUsd ?? 0 });
+  }
+}

--- a/relay/src/durable/relay-session.ts
+++ b/relay/src/durable/relay-session.ts
@@ -1,0 +1,504 @@
+import { authenticateInternalRequest, internalHeaders } from "../auth";
+import { CLOSE_CODE } from "../constants";
+import { getConfig, requireSecret, type RelayConfig } from "../config";
+import { base64UrlToBytes, constantTimeEqual, hashCapability, isSessionId } from "../crypto";
+import type { Env } from "../env";
+import { HttpError, jsonResponse, normalizeThrownError, readJsonObject } from "../http";
+import {
+  acceptedWebSocketResponse,
+  hostControlNotice,
+  isWebSocketUpgrade,
+  parseWebSocketProtocols,
+  rejectedWebSocketResponse,
+  type PeerRole,
+} from "../protocol";
+import { consumeRate, initialRateState, type RatePolicy, type RateState } from "../rate-limit";
+import { getKillSwitch } from "../repositories/control";
+import { SerialGate } from "../serial";
+import type { ActiveLease } from "./user-quota";
+
+interface StoredSessionConfig {
+  sessionId: string;
+  userId: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+  hostCapHash: string;
+  viewerCapHash: string;
+  terminatedAtMs?: number;
+}
+
+interface SocketAttachment {
+  role: PeerRole;
+  connectedAtMs: number;
+  rate: RateState;
+  lease?: ActiveLease;
+  leaseReleased?: boolean;
+  leaseWarningSent?: boolean;
+}
+
+interface QuotaAcquireResult {
+  ok?: boolean;
+  code?: string;
+  lease?: ActiveLease;
+}
+
+function validUserId(value: unknown): value is string {
+  return typeof value === "string" && /^user_[A-Za-z0-9]+$/.test(value);
+}
+
+function validHash(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    base64UrlToBytes(value, 32);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class RelaySession implements DurableObject {
+  private readonly gate = new SerialGate();
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    try {
+      await authenticateInternalRequest(request, this.env);
+      const path = new URL(request.url).pathname;
+      if (path === "/init" && request.method === "POST") {
+        return await this.gate.run(() => this.initialize(request));
+      }
+      if (path === "/ws" && request.method === "GET") {
+        return await this.gate.run(() => this.upgrade(request));
+      }
+      if (path === "/status" && request.method === "GET") {
+        return this.status();
+      }
+      if (path === "/terminate" && request.method === "POST") {
+        return await this.gate.run(() => this.terminate(request));
+      }
+      if (path === "/evict" && request.method === "POST") {
+        return await this.gate.run(() => this.evict());
+      }
+      throw new HttpError(404, "not_found", "Internal endpoint not found");
+    } catch (error) {
+      return normalizeThrownError(error);
+    }
+  }
+
+  private async initialize(request: Request): Promise<Response> {
+    const body = await readJsonObject(request, 8_192);
+    const candidate: StoredSessionConfig = {
+      sessionId: typeof body.sessionId === "string" ? body.sessionId : "",
+      userId: typeof body.userId === "string" ? body.userId : "",
+      createdAtMs: Number(body.createdAtMs),
+      expiresAtMs: Number(body.expiresAtMs),
+      hostCapHash: typeof body.hostCapHash === "string" ? body.hostCapHash : "",
+      viewerCapHash: typeof body.viewerCapHash === "string" ? body.viewerCapHash : "",
+    };
+    if (
+      !isSessionId(candidate.sessionId) ||
+      !validUserId(candidate.userId) ||
+      !Number.isSafeInteger(candidate.createdAtMs) ||
+      !Number.isSafeInteger(candidate.expiresAtMs) ||
+      candidate.expiresAtMs <= candidate.createdAtMs ||
+      !validHash(candidate.hostCapHash) ||
+      !validHash(candidate.viewerCapHash)
+    ) {
+      throw new HttpError(400, "invalid_internal_request", "Invalid relay session initialization");
+    }
+    const existing = await this.state.storage.get<StoredSessionConfig>("config");
+    if (existing) {
+      const same =
+        existing.sessionId === candidate.sessionId &&
+        existing.userId === candidate.userId &&
+        existing.createdAtMs === candidate.createdAtMs &&
+        existing.expiresAtMs === candidate.expiresAtMs &&
+        constantTimeEqual(existing.hostCapHash, candidate.hostCapHash) &&
+        constantTimeEqual(existing.viewerCapHash, candidate.viewerCapHash);
+      if (!same) throw new HttpError(409, "already_initialized", "Relay session is already initialized");
+      return jsonResponse({ ok: true, idempotent: true });
+    }
+    await this.state.storage.put("config", candidate);
+    await this.state.storage.setAlarm(candidate.expiresAtMs);
+    return jsonResponse({ ok: true, idempotent: false });
+  }
+
+  private async upgrade(request: Request): Promise<Response> {
+    if (!isWebSocketUpgrade(request)) {
+      throw new HttpError(426, "upgrade_required", "A WebSocket upgrade is required");
+    }
+    const session = await this.state.storage.get<StoredSessionConfig>("config");
+    if (!session || session.terminatedAtMs) {
+      return rejectedWebSocketResponse(CLOSE_CODE.SESSION_CLOSED, "session closed");
+    }
+    const nowMs = Date.now();
+    if (session.expiresAtMs <= nowMs) {
+      return rejectedWebSocketResponse(CLOSE_CODE.SESSION_EXPIRED, "session expired");
+    }
+    const presented = parseWebSocketProtocols(request.headers.get("Sec-WebSocket-Protocol"));
+    if (!presented) return rejectedWebSocketResponse(CLOSE_CODE.AUTH_FAILED, "authentication failed");
+
+    const config = getConfig(this.env);
+    const origin = request.headers.get("Origin");
+    if (
+      (presented.role === "viewer" && origin !== config.publicOrigin) ||
+      (presented.role === "host" && origin !== null && origin !== config.publicOrigin)
+    ) {
+      return rejectedWebSocketResponse(CLOSE_CODE.AUTH_FAILED, "origin denied");
+    }
+
+    let killed = true;
+    try {
+      killed = (await getKillSwitch(this.env, config)).effectiveEnabled;
+    } catch {
+      killed = true;
+    }
+    if (killed) return rejectedWebSocketResponse(CLOSE_CODE.KILL_SWITCH, "relay disabled");
+
+    const actualHash = await hashCapability(
+      requireSecret(this.env, "CAPABILITY_HMAC_SECRET"),
+      session.sessionId,
+      presented.role,
+      presented.capability,
+    );
+    const expectedHash = presented.role === "host" ? session.hostCapHash : session.viewerCapHash;
+    if (!constantTimeEqual(actualHash, expectedHash)) {
+      return rejectedWebSocketResponse(CLOSE_CODE.AUTH_FAILED, "authentication failed");
+    }
+    if (this.state.getWebSockets(presented.role).length > 0) {
+      return rejectedWebSocketResponse(CLOSE_CODE.DUPLICATE_PEER, `${presented.role} already connected`);
+    }
+    if (presented.role === "viewer" && this.state.getWebSockets("host").length !== 1) {
+      return rejectedWebSocketResponse(CLOSE_CODE.PEER_UNAVAILABLE, "host unavailable");
+    }
+
+    let lease: ActiveLease | undefined;
+    if (presented.role === "viewer") {
+      const admission = await this.acquireViewerLease(session);
+      if (!admission.ok || !admission.lease) {
+        if (admission.code === "quota_exhausted" || admission.code === "lease_unavailable") {
+          this.notifyHost("quota_exhausted");
+          return rejectedWebSocketResponse(CLOSE_CODE.QUOTA_EXHAUSTED, "viewer quota exhausted");
+        }
+        if (admission.code === "budget_exhausted") {
+          this.notifyHost("budget_exhausted");
+          return rejectedWebSocketResponse(CLOSE_CODE.BUDGET_EXHAUSTED, "relay budget exhausted");
+        }
+        if (admission.code === "active_viewer_lease") {
+          return rejectedWebSocketResponse(CLOSE_CODE.DUPLICATE_PEER, "account viewer already active");
+        }
+        return rejectedWebSocketResponse(CLOSE_CODE.INTERNAL_ERROR, "admission unavailable");
+      }
+      lease = admission.lease;
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    const policy = this.ratePolicy(config);
+    const attachment: SocketAttachment = {
+      role: presented.role,
+      connectedAtMs: nowMs,
+      rate: initialRateState(policy, nowMs),
+      ...(lease ? { lease, leaseReleased: false, leaseWarningSent: false } : {}),
+    };
+    this.state.acceptWebSocket(server, [presented.role]);
+    server.serializeAttachment(attachment);
+
+    if (presented.role === "host") {
+      this.sendHost(server, "host_ready", { sessionExpiresAtMs: session.expiresAtMs });
+    } else if (lease) {
+      const activation = await this.activateViewerLease(lease);
+      if (!activation.ok || !activation.lease) {
+        await this.releaseViewerLease(attachment, Date.now());
+        server.serializeAttachment(attachment);
+        server.close(CLOSE_CODE.INTERNAL_ERROR, "viewer lease activation failed");
+        return acceptedWebSocketResponse(client);
+      }
+      lease = activation.lease;
+      attachment.lease = lease;
+      server.serializeAttachment(attachment);
+      this.notifyHost("viewer_connected", { leaseExpiresAtMs: lease.expiresAtMs });
+    }
+    await this.scheduleAlarm(session);
+    return acceptedWebSocketResponse(client);
+  }
+
+  private ratePolicy(config: RelayConfig): RatePolicy {
+    return {
+      sustainedMessagesPerSecond: config.sustainedMessagesPerSecond,
+      burstMessages: config.burstMessages,
+      maxBytesPerSecond: config.maxBytesPerSecond,
+      byteBurstCapacity: Math.max(config.maxMessageBytes, config.maxBytesPerSecond),
+    };
+  }
+
+  private async acquireViewerLease(session: StoredSessionConfig): Promise<QuotaAcquireResult> {
+    const stub = this.env.USER_QUOTA.get(this.env.USER_QUOTA.idFromName(`user:${session.userId}`));
+    try {
+      const response = await stub.fetch(
+        new Request("https://internal/acquire", {
+          method: "POST",
+          headers: internalHeaders(this.env),
+          body: JSON.stringify({
+            userId: session.userId,
+            sessionId: session.sessionId,
+            sessionExpiresAtMs: session.expiresAtMs,
+          }),
+        }),
+      );
+      return (await response.json()) as QuotaAcquireResult;
+    } catch {
+      return { ok: false, code: "admission_unavailable" };
+    }
+  }
+
+  private async activateViewerLease(lease: ActiveLease): Promise<QuotaAcquireResult> {
+    const stub = this.env.USER_QUOTA.get(this.env.USER_QUOTA.idFromName(`user:${lease.userId}`));
+    try {
+      const response = await stub.fetch(
+        new Request("https://internal/activate", {
+          method: "POST",
+          headers: internalHeaders(this.env),
+          body: JSON.stringify({ leaseId: lease.leaseId, sessionId: lease.sessionId }),
+        }),
+      );
+      return (await response.json()) as QuotaAcquireResult;
+    } catch {
+      return { ok: false, code: "activation_unavailable" };
+    }
+  }
+
+  private async releaseViewerLease(attachment: SocketAttachment, endedAtMs: number): Promise<void> {
+    if (!attachment.lease || attachment.leaseReleased) return;
+    attachment.leaseReleased = true;
+    const lease = attachment.lease;
+    const stub = this.env.USER_QUOTA.get(this.env.USER_QUOTA.idFromName(`user:${lease.userId}`));
+    try {
+      await stub.fetch(
+        new Request("https://internal/release", {
+          method: "POST",
+          headers: internalHeaders(this.env),
+          body: JSON.stringify({
+            leaseId: lease.leaseId,
+            sessionId: lease.sessionId,
+            endedAtMs: Math.min(endedAtMs, lease.expiresAtMs),
+          }),
+        }),
+      );
+    } catch {
+      // No payload is logged. UserQuota's lease expiry is the fail-safe settlement path.
+    }
+  }
+
+  private attachment(webSocket: WebSocket): SocketAttachment | null {
+    try {
+      const value = webSocket.deserializeAttachment() as SocketAttachment | null;
+      return value?.role === "host" || value?.role === "viewer" ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private sendHost(
+    webSocket: WebSocket,
+    event: Parameters<typeof hostControlNotice>[0],
+    fields: Record<string, string | number | boolean | null> = {},
+  ): void {
+    try {
+      webSocket.send(hostControlNotice(event, fields));
+    } catch {
+      // Lifecycle notices are best effort and never contain relayed payloads.
+    }
+  }
+
+  private notifyHost(
+    event: Parameters<typeof hostControlNotice>[0],
+    fields: Record<string, string | number | boolean | null> = {},
+  ): void {
+    for (const host of this.state.getWebSockets("host")) this.sendHost(host, event, fields);
+  }
+
+  async webSocketMessage(webSocket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const attachment = this.attachment(webSocket);
+    if (!attachment) {
+      webSocket.close(CLOSE_CODE.INTERNAL_ERROR, "socket state unavailable");
+      return;
+    }
+    if (typeof message === "string") {
+      webSocket.close(CLOSE_CODE.BINARY_ONLY, "encrypted binary messages only");
+      return;
+    }
+    const config = getConfig(this.env);
+    if (message.byteLength > config.maxMessageBytes) {
+      webSocket.close(CLOSE_CODE.MESSAGE_TOO_LARGE, "message too large");
+      return;
+    }
+    const decision = consumeRate(attachment.rate, message.byteLength, Date.now(), this.ratePolicy(config));
+    attachment.rate = decision.state;
+    webSocket.serializeAttachment(attachment);
+    if (!decision.allowed) {
+      webSocket.close(CLOSE_CODE.RATE_LIMITED, "relay rate limit exceeded");
+      return;
+    }
+
+    const targetRole: PeerRole = attachment.role === "host" ? "viewer" : "host";
+    const target = this.state.getWebSockets(targetRole)[0];
+    if (!target) {
+      if (attachment.role === "viewer") webSocket.close(CLOSE_CODE.PEER_UNAVAILABLE, "host unavailable");
+      return;
+    }
+    const bufferedAmount = Number(
+      (target as WebSocket & { bufferedAmount?: number }).bufferedAmount ?? 0,
+    );
+    if (bufferedAmount > config.maxBufferedBytes) {
+      target.close(CLOSE_CODE.BACKPRESSURE, "peer is too slow");
+      return;
+    }
+    try {
+      target.send(message);
+    } catch {
+      target.close(CLOSE_CODE.PEER_UNAVAILABLE, "peer unavailable");
+    }
+  }
+
+  async webSocketClose(
+    webSocket: WebSocket,
+    code: number,
+    _reason: string,
+    _wasClean: boolean,
+  ): Promise<void> {
+    await this.gate.run(async () => {
+      const attachment = this.attachment(webSocket);
+      if (!attachment) return;
+      const nowMs = Date.now();
+      if (attachment.role === "viewer") {
+        await this.releaseViewerLease(attachment, nowMs);
+        this.notifyHost("viewer_disconnected", { code });
+      } else {
+        for (const viewer of this.state.getWebSockets("viewer")) {
+          const viewerAttachment = this.attachment(viewer);
+          if (viewerAttachment) await this.releaseViewerLease(viewerAttachment, nowMs);
+          viewer.close(CLOSE_CODE.PEER_UNAVAILABLE, "host disconnected");
+        }
+      }
+      const session = await this.state.storage.get<StoredSessionConfig>("config");
+      if (session && !session.terminatedAtMs) await this.scheduleAlarm(session);
+    });
+  }
+
+  async webSocketError(webSocket: WebSocket, _error: unknown): Promise<void> {
+    const attachment = this.attachment(webSocket);
+    if (attachment?.role === "viewer") await this.releaseViewerLease(attachment, Date.now());
+    try {
+      webSocket.close(CLOSE_CODE.INTERNAL_ERROR, "socket error");
+    } catch {
+      // The socket may already be gone.
+    }
+  }
+
+  private async status(): Promise<Response> {
+    const session = await this.state.storage.get<StoredSessionConfig>("config");
+    const viewer = this.state.getWebSockets("viewer")[0];
+    const viewerAttachment = viewer ? this.attachment(viewer) : null;
+    return jsonResponse({
+      ok: true,
+      initialized: Boolean(session),
+      terminated: Boolean(session?.terminatedAtMs),
+      hostConnected: this.state.getWebSockets("host").length === 1,
+      viewerConnected: Boolean(viewer),
+      leaseExpiresAtMs: viewerAttachment?.lease?.expiresAtMs ?? null,
+    });
+  }
+
+  private async terminate(request: Request): Promise<Response> {
+    const body = await readJsonObject(request, 2_048);
+    const reason = typeof body.reason === "string" ? body.reason.slice(0, 80) : "session closed";
+    const session = await this.state.storage.get<StoredSessionConfig>("config");
+    if (!session) return jsonResponse({ ok: true, idempotent: true });
+    const idempotent = Boolean(session.terminatedAtMs);
+    if (!session.terminatedAtMs) {
+      session.terminatedAtMs = Date.now();
+      await this.state.storage.put("config", session);
+    }
+    await this.closeAll(CLOSE_CODE.SESSION_CLOSED, reason, "session_closed");
+    await this.state.storage.deleteAlarm();
+    return jsonResponse({ ok: true, idempotent });
+  }
+
+  private async evict(): Promise<Response> {
+    await this.closeAll(CLOSE_CODE.KILL_SWITCH, "relay disabled", "kill_switch");
+    const session = await this.state.storage.get<StoredSessionConfig>("config");
+    if (session && !session.terminatedAtMs) await this.scheduleAlarm(session);
+    return jsonResponse({ ok: true });
+  }
+
+  private async closeAll(
+    closeCode: number,
+    closeReason: string,
+    hostEvent: Parameters<typeof hostControlNotice>[0],
+  ): Promise<void> {
+    const nowMs = Date.now();
+    this.notifyHost(hostEvent);
+    for (const viewer of this.state.getWebSockets("viewer")) {
+      const attachment = this.attachment(viewer);
+      if (attachment) {
+        await this.releaseViewerLease(attachment, nowMs);
+        try {
+          viewer.serializeAttachment(attachment);
+        } catch {
+          // Closing socket may already be detached.
+        }
+      }
+      viewer.close(closeCode, closeReason);
+    }
+    for (const host of this.state.getWebSockets("host")) host.close(closeCode, closeReason);
+  }
+
+  private async scheduleAlarm(session: StoredSessionConfig): Promise<void> {
+    let next = session.expiresAtMs;
+    const viewer = this.state.getWebSockets("viewer")[0];
+    const attachment = viewer ? this.attachment(viewer) : null;
+    if (attachment?.lease) {
+      const warningAt = attachment.lease.expiresAtMs - 60_000;
+      next = Math.min(next, attachment.leaseWarningSent ? attachment.lease.expiresAtMs : Math.max(Date.now() + 1, warningAt));
+    }
+    await this.state.storage.setAlarm(next);
+  }
+
+  async alarm(): Promise<void> {
+    await this.gate.run(async () => {
+      const session = await this.state.storage.get<StoredSessionConfig>("config");
+      if (!session || session.terminatedAtMs) return;
+      const nowMs = Date.now();
+      if (nowMs >= session.expiresAtMs) {
+        await this.closeAll(CLOSE_CODE.SESSION_EXPIRED, "session expired", "session_expired");
+        return;
+      }
+      const viewer = this.state.getWebSockets("viewer")[0];
+      const attachment = viewer ? this.attachment(viewer) : null;
+      if (viewer && attachment?.lease) {
+        if (nowMs >= attachment.lease.expiresAtMs) {
+          this.notifyHost("lease_expired", { leaseExpiresAtMs: attachment.lease.expiresAtMs });
+          await this.releaseViewerLease(attachment, attachment.lease.expiresAtMs);
+          viewer.serializeAttachment(attachment);
+          viewer.close(CLOSE_CODE.LEASE_EXPIRED, "viewer lease expired; reconnect to renew");
+          // The close callback will reschedule once the socket is detached.
+          // Until then, avoid re-arming an alarm at the already-expired lease.
+          await this.state.storage.setAlarm(session.expiresAtMs);
+          return;
+        }
+        if (!attachment.leaseWarningSent && nowMs >= attachment.lease.expiresAtMs - 60_000) {
+          attachment.leaseWarningSent = true;
+          viewer.serializeAttachment(attachment);
+          this.notifyHost("lease_expiring", { leaseExpiresAtMs: attachment.lease.expiresAtMs });
+        }
+      }
+      await this.scheduleAlarm(session);
+    });
+  }
+}

--- a/relay/src/durable/relay-session.ts
+++ b/relay/src/durable/relay-session.ts
@@ -419,6 +419,9 @@ export class RelaySession implements DurableObject {
     session: StoredSessionConfig,
     retryAtMs = Date.now() + 60_000,
   ): Promise<void> {
+    // Arm the retry before either deletion. If the process dies or deleteAll
+    // fails after D1 is gone, the tombstone still has a near-term cleanup owner.
+    await this.state.storage.setAlarm(retryAtMs);
     try {
       await this.env.DB
         .prepare("DELETE FROM sessions WHERE id = ?1 AND user_id = ?2")
@@ -427,11 +430,12 @@ export class RelaySession implements DurableObject {
     } catch (error) {
       // Keep only the minimal config/tombstone and retry. Never delete the
       // object's last cleanup owner while its D1 row may still exist.
-      await this.state.storage.setAlarm(retryAtMs);
       throw error;
     }
-    await this.state.storage.deleteAlarm();
+    // Delete key/value state before the alarm. A crash between these awaits
+    // leaves at most a one-shot empty-object alarm, never permanent config.
     await this.state.storage.deleteAll();
+    await this.state.storage.deleteAlarm();
   }
 
   private async terminate(request: Request): Promise<Response> {

--- a/relay/src/durable/relay-session.ts
+++ b/relay/src/durable/relay-session.ts
@@ -415,6 +415,25 @@ export class RelaySession implements DurableObject {
     });
   }
 
+  private async purgeSessionState(
+    session: StoredSessionConfig,
+    retryAtMs = Date.now() + 60_000,
+  ): Promise<void> {
+    try {
+      await this.env.DB
+        .prepare("DELETE FROM sessions WHERE id = ?1 AND user_id = ?2")
+        .bind(session.sessionId, session.userId)
+        .run();
+    } catch (error) {
+      // Keep only the minimal config/tombstone and retry. Never delete the
+      // object's last cleanup owner while its D1 row may still exist.
+      await this.state.storage.setAlarm(retryAtMs);
+      throw error;
+    }
+    await this.state.storage.deleteAlarm();
+    await this.state.storage.deleteAll();
+  }
+
   private async terminate(request: Request): Promise<Response> {
     const body = await readJsonObject(request, 2_048);
     const reason = typeof body.reason === "string" ? body.reason.slice(0, 80) : "session closed";
@@ -426,8 +445,7 @@ export class RelaySession implements DurableObject {
       await this.state.storage.put("config", session);
     }
     await this.closeAll(CLOSE_CODE.SESSION_CLOSED, reason, "session_closed");
-    await this.state.storage.deleteAlarm();
-    await this.state.storage.deleteAll();
+    await this.purgeSessionState(session);
     return jsonResponse({ ok: true, idempotent });
   }
 
@@ -474,23 +492,15 @@ export class RelaySession implements DurableObject {
   async alarm(): Promise<void> {
     await this.gate.run(async () => {
       const session = await this.state.storage.get<StoredSessionConfig>("config");
-      if (!session || session.terminatedAtMs) return;
+      if (!session) return;
       const nowMs = Date.now();
+      if (session.terminatedAtMs) {
+        await this.purgeSessionState(session, nowMs + 60_000);
+        return;
+      }
       if (nowMs >= session.expiresAtMs) {
         await this.closeAll(CLOSE_CODE.SESSION_EXPIRED, "session expired", "session_expired");
-        try {
-          await this.env.DB
-            .prepare("DELETE FROM sessions WHERE id = ?1 AND user_id = ?2")
-            .bind(session.sessionId, session.userId)
-            .run();
-        } catch (error) {
-          // Keep the minimal config and retry cleanup rather than orphaning a
-          // permanent D1 row after a transient database failure.
-          await this.state.storage.setAlarm(nowMs + 60_000);
-          throw error;
-        }
-        await this.state.storage.deleteAlarm();
-        await this.state.storage.deleteAll();
+        await this.purgeSessionState(session, nowMs + 60_000);
         return;
       }
       const viewer = this.state.getWebSockets("viewer")[0];

--- a/relay/src/durable/relay-session.ts
+++ b/relay/src/durable/relay-session.ts
@@ -427,6 +427,7 @@ export class RelaySession implements DurableObject {
     }
     await this.closeAll(CLOSE_CODE.SESSION_CLOSED, reason, "session_closed");
     await this.state.storage.deleteAlarm();
+    await this.state.storage.deleteAll();
     return jsonResponse({ ok: true, idempotent });
   }
 
@@ -477,6 +478,19 @@ export class RelaySession implements DurableObject {
       const nowMs = Date.now();
       if (nowMs >= session.expiresAtMs) {
         await this.closeAll(CLOSE_CODE.SESSION_EXPIRED, "session expired", "session_expired");
+        try {
+          await this.env.DB
+            .prepare("DELETE FROM sessions WHERE id = ?1 AND user_id = ?2")
+            .bind(session.sessionId, session.userId)
+            .run();
+        } catch (error) {
+          // Keep the minimal config and retry cleanup rather than orphaning a
+          // permanent D1 row after a transient database failure.
+          await this.state.storage.setAlarm(nowMs + 60_000);
+          throw error;
+        }
+        await this.state.storage.deleteAlarm();
+        await this.state.storage.deleteAll();
         return;
       }
       const viewer = this.state.getWebSockets("viewer")[0];

--- a/relay/src/durable/user-quota.ts
+++ b/relay/src/durable/user-quota.ts
@@ -1,0 +1,340 @@
+import { authenticateInternalRequest, internalHeaders } from "../auth";
+import { getConfig, type RelayConfig } from "../config";
+import { isSessionId } from "../crypto";
+import type { Env } from "../env";
+import { HttpError, jsonResponse, normalizeThrownError, readJsonObject } from "../http";
+import { SerialGate } from "../serial";
+import { billingWindow, isoWeekWindow } from "../time";
+
+export interface ActiveLease {
+  leaseId: string;
+  sessionId: string;
+  userId: string;
+  startedAtMs: number;
+  expiresAtMs: number;
+  status: "reserving" | "reserved" | "active";
+  activationDeadlineMs: number;
+  maxDurationMs: number;
+  notAfterMs: number;
+  budgetWindowKey: string;
+  budgetWindowStartsAtMs: number;
+  budgetWindowEndsAtMs: number;
+}
+
+interface QuotaLedger {
+  weekKey: string;
+  weekStartsAtMs: number;
+  weekEndsAtMs: number;
+  usedMs: number;
+  active?: ActiveLease;
+}
+
+export function computeLeaseDurationMs(
+  nowMs: number,
+  usedMs: number,
+  weeklyLimitMs: number,
+  leaseLimitMs: number,
+  weekEndsAtMs: number,
+  billingWindowEndsAtMs: number,
+  sessionExpiresAtMs: number,
+): number {
+  return Math.max(
+    0,
+    Math.floor(
+      Math.min(
+        leaseLimitMs,
+        weeklyLimitMs - usedMs,
+        weekEndsAtMs - nowMs,
+        billingWindowEndsAtMs - nowMs,
+        sessionExpiresAtMs - nowMs,
+      ),
+    ),
+  );
+}
+
+export function chargedLeaseMs(lease: ActiveLease, endedAtMs: number): number {
+  return Math.max(0, Math.min(endedAtMs, lease.expiresAtMs) - lease.startedAtMs);
+}
+
+function validUserId(value: unknown): value is string {
+  return typeof value === "string" && /^user_[A-Za-z0-9]+$/.test(value);
+}
+
+export class UserQuota implements DurableObject {
+  private readonly gate = new SerialGate();
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    try {
+      await authenticateInternalRequest(request, this.env);
+      const path = new URL(request.url).pathname;
+      if (path === "/acquire" && request.method === "POST") {
+        return await this.gate.run(() => this.acquire(request));
+      }
+      if (path === "/activate" && request.method === "POST") {
+        return await this.gate.run(() => this.activate(request));
+      }
+      if (path === "/release" && request.method === "POST") {
+        return await this.gate.run(() => this.release(request));
+      }
+      if (path === "/status" && request.method === "GET") {
+        return await this.gate.run(() => this.status());
+      }
+      if (path === "/delete" && request.method === "POST") {
+        return await this.gate.run(async () => {
+          await this.state.storage.deleteAll();
+          return jsonResponse({ ok: true });
+        });
+      }
+      throw new HttpError(404, "not_found", "Internal endpoint not found");
+    } catch (error) {
+      return normalizeThrownError(error);
+    }
+  }
+
+  private freshLedger(nowMs: number): QuotaLedger {
+    const week = isoWeekWindow(nowMs);
+    return {
+      weekKey: week.key,
+      weekStartsAtMs: week.startsAtMs,
+      weekEndsAtMs: week.endsAtMs,
+      usedMs: 0,
+    };
+  }
+
+  private async loadNormalized(nowMs: number): Promise<QuotaLedger> {
+    let ledger = (await this.state.storage.get<QuotaLedger>("ledger")) ?? this.freshLedger(nowMs);
+    let changed = false;
+    if (
+      ledger.active &&
+      ledger.active.status !== "active" &&
+      ledger.active.activationDeadlineMs <= nowMs
+    ) {
+      delete ledger.active;
+      changed = true;
+    } else if (ledger.active?.status === "active" && ledger.active.expiresAtMs <= nowMs) {
+      ledger.usedMs += chargedLeaseMs(ledger.active, ledger.active.expiresAtMs);
+      delete ledger.active;
+      changed = true;
+    }
+    const week = isoWeekWindow(nowMs);
+    if (ledger.weekKey !== week.key) {
+      if (ledger.active) throw new Error("active quota lease crossed an ISO week boundary");
+      ledger = this.freshLedger(nowMs);
+      changed = true;
+    }
+    if (changed) await this.state.storage.put("ledger", ledger);
+    return ledger;
+  }
+
+  private async reserveBudget(lease: ActiveLease, config: RelayConfig): Promise<"ok" | "exhausted" | "uncertain"> {
+    const namespaceId = this.env.BUDGET_WINDOW.idFromName(`billing:${lease.budgetWindowKey}`);
+    const stub = this.env.BUDGET_WINDOW.get(namespaceId);
+    try {
+      const response = await stub.fetch(
+        new Request("https://internal/reserve", {
+          method: "POST",
+          headers: internalHeaders(this.env),
+          body: JSON.stringify({
+            reservationId: `${lease.userId}:${lease.leaseId}`,
+            windowKey: lease.budgetWindowKey,
+            startsAtMs: lease.budgetWindowStartsAtMs,
+            endsAtMs: lease.budgetWindowEndsAtMs,
+            amountMicroUsd: config.leaseReservationMicroUsd,
+            ceilingMicroUsd: config.budgetCeilingMicroUsd,
+          }),
+        }),
+      );
+      const result = (await response.json()) as { ok?: boolean; code?: string };
+      if (response.ok && result.ok === true) return "ok";
+      if (response.status === 409 && result.code === "budget_exhausted") return "exhausted";
+      return "uncertain";
+    } catch {
+      return "uncertain";
+    }
+  }
+
+  private async acquire(request: Request): Promise<Response> {
+    const config = getConfig(this.env);
+    const body = await readJsonObject(request, 4_096);
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+    const sessionExpiresAtMs = body.sessionExpiresAtMs;
+    const userId = body.userId;
+    if (!isSessionId(sessionId) || !validUserId(userId) || !Number.isSafeInteger(sessionExpiresAtMs)) {
+      throw new HttpError(400, "invalid_internal_request", "Invalid quota lease request");
+    }
+    const nowMs = Date.now();
+    let ledger = await this.loadNormalized(nowMs);
+
+    if (ledger.active) {
+      if (ledger.active.status === "reserving" && ledger.active.sessionId === sessionId && ledger.active.userId === userId) {
+        const reservation = await this.reserveBudget(ledger.active, config);
+        if (reservation === "ok") {
+          ledger.active.status = "reserved";
+          await this.state.storage.put("ledger", ledger);
+          return jsonResponse({ ok: true, lease: ledger.active, resumed: true });
+        }
+        if (reservation === "exhausted") {
+          delete ledger.active;
+          await this.state.storage.put("ledger", ledger);
+          return jsonResponse({ ok: false, code: "budget_exhausted" }, 409);
+        }
+        return jsonResponse({ ok: false, code: "budget_unavailable" }, 503);
+      }
+      if (ledger.active.status === "reserved" && ledger.active.sessionId === sessionId && ledger.active.userId === userId) {
+        return jsonResponse({ ok: true, lease: ledger.active, resumed: true });
+      }
+      return jsonResponse(
+        {
+          ok: false,
+          code: "active_viewer_lease",
+          activeSessionId: ledger.active.sessionId,
+          expiresAtMs: ledger.active.expiresAtMs,
+        },
+        409,
+      );
+    }
+
+    const billing = billingWindow(nowMs, config.billingPeriodStartDayUtc, config.billingWindowId);
+    const durationMs = computeLeaseDurationMs(
+      nowMs,
+      ledger.usedMs,
+      config.weeklyViewerMs,
+      config.leaseMs,
+      ledger.weekEndsAtMs,
+      billing.endsAtMs,
+      sessionExpiresAtMs as number,
+    );
+    const maxDurationMs = Math.max(
+      0,
+      Math.min(config.leaseMs, config.weeklyViewerMs - ledger.usedMs),
+    );
+    const notAfterMs = Math.min(
+      ledger.weekEndsAtMs,
+      billing.endsAtMs,
+      sessionExpiresAtMs as number,
+    );
+    if (durationMs < 1_000) {
+      return jsonResponse(
+        {
+          ok: false,
+          code: ledger.usedMs >= config.weeklyViewerMs ? "quota_exhausted" : "lease_unavailable",
+          usedMs: ledger.usedMs,
+          limitMs: config.weeklyViewerMs,
+        },
+        409,
+      );
+    }
+
+    const lease: ActiveLease = {
+      leaseId: crypto.randomUUID(),
+      sessionId,
+      userId,
+      startedAtMs: nowMs,
+      expiresAtMs: nowMs + durationMs,
+      status: "reserving",
+      activationDeadlineMs: Math.min(nowMs + 30_000, notAfterMs),
+      maxDurationMs,
+      notAfterMs,
+      budgetWindowKey: billing.key,
+      budgetWindowStartsAtMs: billing.startsAtMs,
+      budgetWindowEndsAtMs: billing.endsAtMs,
+    };
+    ledger.active = lease;
+    await this.state.storage.put("ledger", ledger);
+
+    const reservation = await this.reserveBudget(lease, config);
+    if (reservation === "ok") {
+      lease.status = "reserved";
+      ledger.active = lease;
+      await this.state.storage.put("ledger", ledger);
+      return jsonResponse({ ok: true, lease });
+    }
+    if (reservation === "exhausted") {
+      delete ledger.active;
+      await this.state.storage.put("ledger", ledger);
+      return jsonResponse({ ok: false, code: "budget_exhausted" }, 409);
+    }
+    return jsonResponse({ ok: false, code: "budget_unavailable" }, 503);
+  }
+
+  private async activate(request: Request): Promise<Response> {
+    const body = await readJsonObject(request, 4_096);
+    const leaseId = typeof body.leaseId === "string" ? body.leaseId : "";
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+    if (!leaseId || !isSessionId(sessionId)) {
+      throw new HttpError(400, "invalid_internal_request", "Invalid quota activation request");
+    }
+    const nowMs = Date.now();
+    const ledger = await this.loadNormalized(nowMs);
+    const lease = ledger.active;
+    if (!lease || lease.leaseId !== leaseId || lease.sessionId !== sessionId) {
+      return jsonResponse({ ok: false, code: "lease_unavailable" }, 409);
+    }
+    if (lease.status === "active") {
+      return jsonResponse({ ok: true, lease, idempotent: true });
+    }
+    if (lease.status !== "reserved") {
+      return jsonResponse({ ok: false, code: "lease_not_reserved" }, 409);
+    }
+    const durationMs = Math.max(0, Math.min(lease.maxDurationMs, lease.notAfterMs - nowMs));
+    if (durationMs < 1_000) {
+      delete ledger.active;
+      await this.state.storage.put("ledger", ledger);
+      return jsonResponse({ ok: false, code: "lease_unavailable" }, 409);
+    }
+    lease.startedAtMs = nowMs;
+    lease.expiresAtMs = nowMs + durationMs;
+    lease.status = "active";
+    ledger.active = lease;
+    await this.state.storage.put("ledger", ledger);
+    return jsonResponse({ ok: true, lease, idempotent: false });
+  }
+
+  private async release(request: Request): Promise<Response> {
+    const body = await readJsonObject(request, 4_096);
+    const leaseId = typeof body.leaseId === "string" ? body.leaseId : "";
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+    const endedAtMs = body.endedAtMs;
+    if (!leaseId || !isSessionId(sessionId) || !Number.isSafeInteger(endedAtMs)) {
+      throw new HttpError(400, "invalid_internal_request", "Invalid quota release request");
+    }
+    const nowMs = Date.now();
+    const ledger = await this.loadNormalized(nowMs);
+    if (!ledger.active || ledger.active.leaseId !== leaseId || ledger.active.sessionId !== sessionId) {
+      return jsonResponse({ ok: true, idempotent: true, usedMs: ledger.usedMs });
+    }
+    const lease = ledger.active;
+    if (lease.status === "active") {
+      const boundedEnd = Math.min(endedAtMs as number, nowMs + 5_000);
+      ledger.usedMs += chargedLeaseMs(lease, boundedEnd);
+    }
+    delete ledger.active;
+    await this.state.storage.put("ledger", ledger);
+    return jsonResponse({ ok: true, idempotent: false, usedMs: ledger.usedMs });
+  }
+
+  private async status(): Promise<Response> {
+    const config = getConfig(this.env);
+    const nowMs = Date.now();
+    const ledger = await this.loadNormalized(nowMs);
+    const liveMs = ledger.active?.status === "active" ? chargedLeaseMs(ledger.active, nowMs) : 0;
+    const usedMs = Math.min(config.weeklyViewerMs, ledger.usedMs + liveMs);
+    return jsonResponse({
+      ok: true,
+      week: {
+        key: ledger.weekKey,
+        startsAtMs: ledger.weekStartsAtMs,
+        endsAtMs: ledger.weekEndsAtMs,
+        usedMs,
+        remainingMs: Math.max(0, config.weeklyViewerMs - usedMs),
+        limitMs: config.weeklyViewerMs,
+      },
+      activeLease: ledger.active?.status === "active" ? ledger.active : null,
+    });
+  }
+}

--- a/relay/src/env.ts
+++ b/relay/src/env.ts
@@ -1,0 +1,39 @@
+export interface Env {
+  DB: D1Database;
+  RELAY_SESSION: DurableObjectNamespace;
+  USER_QUOTA: DurableObjectNamespace;
+  BUDGET_WINDOW: DurableObjectNamespace;
+  ASSETS: Fetcher;
+
+  PUBLIC_ORIGIN: string;
+  APP_ORIGIN: string;
+  CLERK_AUTHORIZED_PARTIES: string;
+  CLERK_AUDIENCE?: string;
+  CLERK_JWT_KEY?: string;
+  CLERK_SECRET_KEY?: string;
+  CLERK_WEBHOOK_SIGNING_SECRET?: string;
+
+  API_KEY_HMAC_SECRET: string;
+  CAPABILITY_HMAC_SECRET: string;
+  INTERNAL_DO_SECRET: string;
+  ADMIN_TOKEN: string;
+
+  WEEKLY_VIEWER_SECONDS?: string;
+  LEASE_SECONDS?: string;
+  LEASE_RESERVATION_USD?: string;
+  BUDGET_CEILING_USD?: string;
+  BILLING_PERIOD_START_DAY_UTC?: string;
+  BILLING_WINDOW_ID?: string;
+  SESSION_TTL_SECONDS?: string;
+  MAX_MESSAGE_BYTES?: string;
+  SUSTAINED_MESSAGES_PER_SECOND?: string;
+  BURST_MESSAGES?: string;
+  MAX_BITS_PER_SECOND?: string;
+  MAX_BUFFERED_BYTES?: string;
+  RELAY_KILL_SWITCH?: string;
+}
+
+export interface ExecutionContextLike {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException?(): void;
+}

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -1,0 +1,119 @@
+import { SECURITY_HEADERS } from "./constants";
+
+export interface ApiErrorBody {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export function jsonResponse(value: unknown, status = 200, headers?: HeadersInit): Response {
+  const combined = new Headers(SECURITY_HEADERS);
+  combined.set("Content-Type", "application/json; charset=utf-8");
+  if (headers) new Headers(headers).forEach((entry, key) => combined.set(key, entry));
+  return Response.json(value, { status, headers: combined });
+}
+
+export function errorResponse(status: number, code: string, message: string): Response {
+  return jsonResponse({ error: { code, message } satisfies ApiErrorBody["error"] }, status);
+}
+
+export function emptyResponse(status = 204, headers?: HeadersInit): Response {
+  const combined = new Headers(SECURITY_HEADERS);
+  if (headers) new Headers(headers).forEach((entry, key) => combined.set(key, entry));
+  return new Response(null, { status, headers: combined });
+}
+
+export async function readJsonObject(request: Request, maximumBytes = 16_384): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get("Content-Type")?.split(";", 1)[0].trim().toLowerCase();
+  if (contentType !== "application/json") throw new HttpError(415, "unsupported_media_type", "Use application/json");
+  const declaredLength = Number(request.headers.get("Content-Length") ?? "0");
+  if (Number.isFinite(declaredLength) && declaredLength > maximumBytes) {
+    throw new HttpError(413, "body_too_large", "Request body is too large");
+  }
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > maximumBytes) {
+    throw new HttpError(413, "body_too_large", "Request body is too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new HttpError(400, "invalid_json", "Request body is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new HttpError(400, "invalid_body", "Request body must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+export function normalizeThrownError(error: unknown): Response {
+  if (error instanceof HttpError) return errorResponse(error.status, error.code, error.message);
+  return errorResponse(500, "internal_error", "The relay could not complete the request");
+}
+
+export function enforceExactApiOrigin(request: Request, appOrigin: string): void {
+  const origin = request.headers.get("Origin");
+  if (origin !== null && origin !== appOrigin) {
+    throw new HttpError(403, "origin_denied", "Request origin is not allowed");
+  }
+}
+
+export function applyCors(response: Response, request: Request, appOrigin: string): Response {
+  if (request.headers.get("Origin") !== appOrigin) return response;
+  const headers = new Headers(response.headers);
+  headers.set("Access-Control-Allow-Origin", appOrigin);
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.append("Vary", "Origin");
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export function preflightResponse(request: Request, appOrigin: string): Response {
+  enforceExactApiOrigin(request, appOrigin);
+  if (request.headers.get("Origin") !== appOrigin) {
+    throw new HttpError(403, "origin_required", "An exact browser origin is required");
+  }
+  const requestedMethod = request.headers.get("Access-Control-Request-Method")?.toUpperCase();
+  if (!requestedMethod || !["GET", "POST", "DELETE", "PUT"].includes(requestedMethod)) {
+    throw new HttpError(405, "method_not_allowed", "Requested method is not allowed");
+  }
+  const headers = new Headers(SECURITY_HEADERS);
+  headers.set("Access-Control-Allow-Origin", appOrigin);
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS");
+  headers.set("Access-Control-Allow-Headers", "Authorization, Content-Type");
+  headers.set("Access-Control-Max-Age", "600");
+  headers.set("Vary", "Origin, Access-Control-Request-Method, Access-Control-Request-Headers");
+  return new Response(null, { status: 204, headers });
+}
+
+export function bearerCredential(request: Request): string | null {
+  const header = request.headers.get("Authorization");
+  if (!header || header.length > 8_192) return null;
+  const match = /^Bearer ([^\s]+)$/i.exec(header);
+  return match?.[1] ?? null;
+}
+
+export function cookieValue(request: Request, name: string): string | null {
+  const cookie = request.headers.get("Cookie");
+  if (!cookie || cookie.length > 16_384) return null;
+  for (const entry of cookie.split(";")) {
+    const separator = entry.indexOf("=");
+    if (separator < 0) continue;
+    if (entry.slice(0, separator).trim() === name) {
+      return entry.slice(separator + 1).trim() || null;
+    }
+  }
+  return null;
+}

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -1,0 +1,604 @@
+import { verifyWebhook } from "@clerk/backend/webhooks";
+import { authenticateAdminRequest, authenticateClerkRequest, internalHeaders } from "./auth";
+import {
+  CLOSE_CODE,
+  HOST_PROTOCOL_PREFIX,
+  RELAY_PROTOCOL,
+} from "./constants";
+import { ConfigurationError, getConfig, requireSecret, type RelayConfig } from "./config";
+import {
+  base64UrlToBytes,
+  generateCapability,
+  hashCapability,
+  isSessionId,
+} from "./crypto";
+import { BudgetWindow } from "./durable/budget-window";
+import { RelaySession } from "./durable/relay-session";
+import { UserQuota } from "./durable/user-quota";
+import type { Env, ExecutionContextLike } from "./env";
+import {
+  applyCors,
+  emptyResponse,
+  enforceExactApiOrigin,
+  errorResponse,
+  HttpError,
+  jsonResponse,
+  normalizeThrownError,
+  preflightResponse,
+  readJsonObject,
+} from "./http";
+import { rejectedWebSocketResponse } from "./protocol";
+import {
+  authenticateApiKeyRequest,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+} from "./repositories/api-keys";
+import { getKillSwitch, setPersistentKillSwitch } from "./repositories/control";
+import {
+  countActiveSessions,
+  endSession,
+  findSessionForAdmission,
+  findSessionForOwner,
+  insertSession,
+  listActiveSessionIds,
+  listSessionIdsForUser,
+  publicSession,
+  type SessionRow,
+} from "./repositories/sessions";
+import { billingWindow, toIso } from "./time";
+import { viewerPageResponse } from "./viewer-page";
+
+export { BudgetWindow, RelaySession, UserQuota };
+
+interface HandlerDependencies {
+  authenticateClerk: typeof authenticateClerkRequest;
+  authenticateApiKey: typeof authenticateApiKeyRequest;
+  now: () => number;
+}
+
+const defaultDependencies: HandlerDependencies = {
+  authenticateClerk: authenticateClerkRequest,
+  authenticateApiKey: authenticateApiKeyRequest,
+  now: Date.now,
+};
+
+function methodNotAllowed(allowed: string[]): Response {
+  const response = errorResponse(405, "method_not_allowed", "Method not allowed");
+  const headers = new Headers(response.headers);
+  headers.set("Allow", allowed.join(", "));
+  return new Response(response.body, { status: response.status, headers });
+}
+
+function doStub(env: Env, namespace: DurableObjectNamespace, name: string): DurableObjectStub {
+  return namespace.get(namespace.idFromName(name));
+}
+
+async function internalFetch(
+  stub: DurableObjectStub,
+  env: Env,
+  path: string,
+  method: "GET" | "POST",
+  body?: unknown,
+): Promise<Response> {
+  return stub.fetch(
+    new Request(`https://internal${path}`, {
+      method,
+      headers: internalHeaders(env),
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    }),
+  );
+}
+
+async function assertAdmissionOpen(env: Env, config: RelayConfig): Promise<void> {
+  let state;
+  try {
+    state = await getKillSwitch(env, config);
+  } catch {
+    throw new HttpError(503, "admission_unavailable", "Relay admission is temporarily unavailable");
+  }
+  if (state.effectiveEnabled) {
+    throw new HttpError(503, "relay_disabled", "New relay connections are disabled");
+  }
+}
+
+async function createSession(
+  request: Request,
+  env: Env,
+  context: ExecutionContextLike,
+  config: RelayConfig,
+  dependencies: HandlerDependencies,
+): Promise<Response> {
+  const principal = await dependencies.authenticateApiKey(request, env, context);
+  await assertAdmissionOpen(env, config);
+  const body = await readJsonObject(request, 8_192);
+  let ttlMs = config.sessionTtlMs;
+  if (body.expiresInSeconds !== undefined) {
+    if (!Number.isSafeInteger(body.expiresInSeconds)) {
+      throw new HttpError(400, "invalid_expiry", "expiresInSeconds must be an integer");
+    }
+    ttlMs = (body.expiresInSeconds as number) * 1_000;
+    if (ttlMs < config.leaseMs || ttlMs > config.sessionTtlMs) {
+      throw new HttpError(400, "invalid_expiry", "Session expiry is outside the allowed range");
+    }
+  }
+
+  const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+  const viewerCapability = typeof body.viewerProof === "string" ? body.viewerProof : "";
+  if (!isSessionId(sessionId)) {
+    throw new HttpError(400, "invalid_session_id", "sessionId must be a client-generated BetterWright session ID");
+  }
+  try {
+    base64UrlToBytes(viewerCapability, 32);
+  } catch {
+    throw new HttpError(400, "invalid_viewer_proof", "viewerProof must be a canonical 32-byte base64url proof");
+  }
+
+  const nowMs = dependencies.now();
+  const hostCapability = generateCapability();
+  const capabilitySecret = requireSecret(env, "CAPABILITY_HMAC_SECRET");
+  const [hostCapHash, viewerCapHash] = await Promise.all([
+    hashCapability(capabilitySecret, sessionId, "host", hostCapability),
+    hashCapability(capabilitySecret, sessionId, "viewer", viewerCapability),
+  ]);
+  const row: SessionRow = {
+    id: sessionId,
+    user_id: principal.userId,
+    api_key_id: principal.apiKeyId,
+    host_cap_hash: hostCapHash,
+    viewer_cap_hash: viewerCapHash,
+    created_at_ms: nowMs,
+    expires_at_ms: nowMs + ttlMs,
+    ended_at_ms: null,
+    ended_reason: null,
+  };
+  try {
+    await insertSession(env, row);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (/unique|primary key/i.test(message)) {
+      throw new HttpError(409, "session_id_conflict", "Generate fresh client session material and retry");
+    }
+    throw error;
+  }
+
+  const stub = doStub(env, env.RELAY_SESSION, `session:${sessionId}`);
+  const initialized = await internalFetch(stub, env, "/init", "POST", {
+    sessionId,
+    userId: principal.userId,
+    createdAtMs: row.created_at_ms,
+    expiresAtMs: row.expires_at_ms,
+    hostCapHash,
+    viewerCapHash,
+  });
+  if (!initialized.ok) {
+    await endSession(env.DB, sessionId, principal.userId, "initialization failed", nowMs);
+    throw new HttpError(503, "session_unavailable", "The relay session could not be initialized");
+  }
+
+  const websocketUrl = new URL(`/v1/sessions/${sessionId}/ws`, config.publicOrigin);
+  websocketUrl.protocol = websocketUrl.protocol === "https:" ? "wss:" : "ws:";
+  const viewerUrl = new URL(`/s/${sessionId}`, config.publicOrigin);
+  return jsonResponse(
+    {
+      session: {
+        id: sessionId,
+        createdAt: new Date(row.created_at_ms).toISOString(),
+        expiresAt: new Date(row.expires_at_ms).toISOString(),
+      },
+      host: {
+        websocketUrl: websocketUrl.toString(),
+        subprotocols: [RELAY_PROTOCOL, `${HOST_PROTOCOL_PREFIX}${hostCapability}`],
+      },
+      viewer: {
+        url: viewerUrl.toString(),
+        fragmentParameter: "k",
+      },
+      oneTimeSecrets: { hostCapability: true },
+    },
+    201,
+  );
+}
+
+async function sessionStatus(
+  request: Request,
+  env: Env,
+  context: ExecutionContextLike,
+  sessionId: string,
+  dependencies: HandlerDependencies,
+): Promise<Response> {
+  const principal = await dependencies.authenticateApiKey(request, env, context);
+  const row = await findSessionForOwner(env.DB, sessionId, principal.userId);
+  if (!row) throw new HttpError(404, "session_not_found", "Session not found");
+  const result = publicSession(row, dependencies.now());
+  let relay = { hostConnected: false, viewerConnected: false, leaseExpiresAt: null as string | null };
+  if (result.status !== "ended" && result.status !== "expired") {
+    try {
+      const response = await internalFetch(
+        doStub(env, env.RELAY_SESSION, `session:${sessionId}`),
+        env,
+        "/status",
+        "GET",
+      );
+      if (response.ok) {
+        const state = (await response.json()) as {
+          hostConnected?: boolean;
+          viewerConnected?: boolean;
+          leaseExpiresAtMs?: number | null;
+        };
+        relay = {
+          hostConnected: state.hostConnected === true,
+          viewerConnected: state.viewerConnected === true,
+          leaseExpiresAt: toIso(state.leaseExpiresAtMs),
+        };
+        result.status = relay.viewerConnected ? "active" : "waiting";
+      }
+    } catch {
+      // D1 remains authoritative for ownership and lifecycle if the DO is briefly unavailable.
+    }
+  }
+  return jsonResponse({ session: result, relay });
+}
+
+async function deleteSession(
+  request: Request,
+  env: Env,
+  context: ExecutionContextLike,
+  sessionId: string,
+  dependencies: HandlerDependencies,
+): Promise<Response> {
+  const principal = await dependencies.authenticateApiKey(request, env, context);
+  const row = await findSessionForOwner(env.DB, sessionId, principal.userId);
+  if (!row) throw new HttpError(404, "session_not_found", "Session not found");
+  await endSession(env.DB, sessionId, principal.userId, "deleted", dependencies.now());
+  const response = await internalFetch(
+    doStub(env, env.RELAY_SESSION, `session:${sessionId}`),
+    env,
+    "/terminate",
+    "POST",
+    { reason: "session deleted" },
+  );
+  if (!response.ok) throw new HttpError(503, "session_close_pending", "Session was marked ended but peers may still be closing");
+  return emptyResponse();
+}
+
+async function websocketRoute(request: Request, env: Env, config: RelayConfig, sessionId: string): Promise<Response> {
+  if (request.method !== "GET") return methodNotAllowed(["GET"]);
+  if (new URL(request.url).origin !== config.publicOrigin) {
+    return rejectedWebSocketResponse(CLOSE_CODE.AUTH_FAILED, "origin denied");
+  }
+  let session;
+  try {
+    session = await findSessionForAdmission(env.DB, sessionId);
+  } catch {
+    return rejectedWebSocketResponse(CLOSE_CODE.INTERNAL_ERROR, "admission unavailable");
+  }
+  if (!session || session.ended_at_ms !== null) {
+    return rejectedWebSocketResponse(CLOSE_CODE.SESSION_CLOSED, "session closed");
+  }
+  if (session.expires_at_ms <= Date.now()) {
+    return rejectedWebSocketResponse(CLOSE_CODE.SESSION_EXPIRED, "session expired");
+  }
+  try {
+    await assertAdmissionOpen(env, config);
+  } catch {
+    return rejectedWebSocketResponse(CLOSE_CODE.KILL_SWITCH, "relay disabled");
+  }
+  const headers = new Headers(request.headers);
+  headers.set("X-Relay-Internal", requireSecret(env, "INTERNAL_DO_SECRET"));
+  const forwarded = new Request("https://internal/ws", { method: "GET", headers });
+  return doStub(env, env.RELAY_SESSION, `session:${sessionId}`).fetch(forwarded);
+}
+
+async function accountServiceState(
+  env: Env,
+  config: RelayConfig,
+  nowMs: number,
+): Promise<Record<string, unknown>> {
+  const killSwitch = await getKillSwitch(env, config);
+  const window = billingWindow(
+    nowMs,
+    config.billingPeriodStartDayUtc,
+    config.billingWindowId,
+  );
+  let reservedMicroUsd: number | null = null;
+  try {
+    const response = await internalFetch(
+      doStub(env, env.BUDGET_WINDOW, `billing:${window.key}`),
+      env,
+      "/status",
+      "GET",
+    );
+    if (response.ok) {
+      const body = (await response.json()) as { reservedMicroUsd?: number };
+      if (Number.isSafeInteger(body.reservedMicroUsd)) {
+        reservedMicroUsd = Number(body.reservedMicroUsd);
+      }
+    }
+  } catch {
+    reservedMicroUsd = null;
+  }
+  const budgetUnavailable = reservedMicroUsd === null;
+  const globalCapReached =
+    reservedMicroUsd !== null &&
+    reservedMicroUsd + config.leaseReservationMicroUsd > config.budgetCeilingMicroUsd;
+  const acceptingSessions =
+    !killSwitch.effectiveEnabled && !budgetUnavailable && !globalCapReached;
+  return {
+    status: killSwitch.effectiveEnabled
+      ? "disabled"
+      : budgetUnavailable
+        ? "unavailable"
+        : globalCapReached
+          ? "budget_exhausted"
+          : "active",
+    acceptingSessions,
+    disabled: killSwitch.effectiveEnabled || budgetUnavailable,
+    globalCapReached,
+    reason: killSwitch.reason || (budgetUnavailable ? "Budget admission state is unavailable" : ""),
+    budget: {
+      windowKey: window.key,
+      reservedEstimateUsd:
+        reservedMicroUsd === null ? null : reservedMicroUsd / 1_000_000,
+      admissionCeilingUsd: config.budgetCeilingMicroUsd / 1_000_000,
+    },
+  };
+}
+
+async function usageRoute(env: Env, userId: string): Promise<Response> {
+  const response = await internalFetch(
+    doStub(env, env.USER_QUOTA, `user:${userId}`),
+    env,
+    "/status",
+    "GET",
+  );
+  if (!response.ok) throw new HttpError(503, "usage_unavailable", "Usage is temporarily unavailable");
+  const value = (await response.json()) as {
+    week: {
+      key: string;
+      startsAtMs: number;
+      endsAtMs: number;
+      usedMs: number;
+      remainingMs: number;
+      limitMs: number;
+    };
+    activeLease?: { sessionId: string; startedAtMs: number; expiresAtMs: number } | null;
+  };
+  return jsonResponse({
+    week: {
+      key: value.week.key,
+      startsAt: toIso(value.week.startsAtMs),
+      endsAt: toIso(value.week.endsAtMs),
+      usedSeconds: Math.floor(value.week.usedMs / 1_000),
+      remainingSeconds: Math.floor(value.week.remainingMs / 1_000),
+      limitSeconds: Math.floor(value.week.limitMs / 1_000),
+    },
+    activeViewerLease: value.activeLease
+      ? {
+          sessionId: value.activeLease.sessionId,
+          startedAt: toIso(value.activeLease.startedAtMs),
+          expiresAt: toIso(value.activeLease.expiresAtMs),
+        }
+      : null,
+  });
+}
+
+async function adminKillSwitch(request: Request, env: Env, config: RelayConfig): Promise<Response> {
+  await authenticateAdminRequest(request, env);
+  if (request.method === "GET") return jsonResponse(await getKillSwitch(env, config));
+  if (request.method !== "PUT") return methodNotAllowed(["GET", "PUT"]);
+  const body = await readJsonObject(request, 4_096);
+  await setPersistentKillSwitch(env, body.enabled, body.reason);
+  let signaledSessions = 0;
+  let truncated = false;
+  if (body.enabled === true) {
+    const ids = await listActiveSessionIds(env.DB, Date.now(), 10_001);
+    truncated = ids.length > 10_000;
+    const selected = ids.slice(0, 10_000);
+    for (let offset = 0; offset < selected.length; offset += 50) {
+      const batch = selected.slice(offset, offset + 50);
+      const results = await Promise.allSettled(
+        batch.map((id) =>
+          internalFetch(doStub(env, env.RELAY_SESSION, `session:${id}`), env, "/evict", "POST"),
+        ),
+      );
+      signaledSessions += results.filter(
+        (result) => result.status === "fulfilled" && result.value.ok,
+      ).length;
+    }
+  }
+  return jsonResponse({ ...(await getKillSwitch(env, config)), signaledSessions, truncated });
+}
+
+async function clerkWebhook(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "POST") return methodNotAllowed(["POST"]);
+  let event;
+  try {
+    event = await verifyWebhook(request, {
+      signingSecret: requireSecret(env, "CLERK_WEBHOOK_SIGNING_SECRET"),
+    });
+  } catch {
+    throw new HttpError(400, "invalid_webhook", "Clerk webhook verification failed");
+  }
+  if (event.type !== "user.deleted") return emptyResponse();
+  const userId = event.data?.id;
+  if (typeof userId !== "string" || !/^user_[A-Za-z0-9]+$/.test(userId)) {
+    throw new HttpError(400, "invalid_webhook", "Clerk deletion event has no valid user ID");
+  }
+
+  const sessionIds = await listSessionIdsForUser(env.DB, userId);
+  const terminations = await Promise.all(
+    sessionIds.map((sessionId) =>
+      internalFetch(
+        doStub(env, env.RELAY_SESSION, `session:${sessionId}`),
+        env,
+        "/terminate",
+        "POST",
+        { reason: "account deleted" },
+      ),
+    ),
+  );
+  if (terminations.some((response) => !response.ok)) {
+    throw new HttpError(503, "deletion_pending", "Relay sessions are still closing");
+  }
+  const quota = await internalFetch(
+    doStub(env, env.USER_QUOTA, `user:${userId}`),
+    env,
+    "/delete",
+    "POST",
+  );
+  if (!quota.ok) throw new HttpError(503, "deletion_pending", "Quota deletion is still pending");
+
+  await env.DB.batch([
+    env.DB.prepare("DELETE FROM sessions WHERE user_id = ?1").bind(userId),
+    env.DB.prepare("DELETE FROM api_keys WHERE user_id = ?1").bind(userId),
+  ]);
+  return emptyResponse();
+}
+
+async function routeApi(
+  request: Request,
+  env: Env,
+  context: ExecutionContextLike,
+  config: RelayConfig,
+  dependencies: HandlerDependencies,
+): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname === "/v1/webhooks/clerk") return clerkWebhook(request, env);
+  enforceExactApiOrigin(request, config.appOrigin);
+  if (request.method === "OPTIONS") return preflightResponse(request, config.appOrigin);
+
+  if (url.pathname === "/v1/admin/kill-switch") return adminKillSwitch(request, env, config);
+
+  // The CLI verifies a BetterWright API key without requiring a Clerk browser
+  // session. Keep this separate from /v1/me so the two credential types cannot
+  // be confused by clients or middleware.
+  if (url.pathname === "/v1/cli/me") {
+    if (request.method !== "GET") return methodNotAllowed(["GET"]);
+    const principal = await dependencies.authenticateApiKey(request, env, context);
+    const usageResponse = await usageRoute(env, principal.userId);
+    if (!usageResponse.ok) throw new HttpError(503, "usage_unavailable", "Usage is temporarily unavailable");
+    const usage = (await usageResponse.json()) as {
+      week?: Record<string, unknown>;
+      activeViewerLease?: Record<string, unknown> | null;
+    };
+    return jsonResponse({
+      ok: true,
+      id: principal.userId,
+      apiKeyId: principal.apiKeyId,
+      quota: usage.week ?? null,
+      activeViewerLease: usage.activeViewerLease ?? null,
+    });
+  }
+
+  if (url.pathname === "/v1/me") {
+    if (request.method !== "GET") return methodNotAllowed(["GET"]);
+    const principal = await dependencies.authenticateClerk(request, env, config);
+    const nowMs = dependencies.now();
+    const [keys, activeSessions, service] = await Promise.all([
+      listApiKeys(env.DB, principal.userId),
+      countActiveSessions(env.DB, principal.userId, nowMs),
+      accountServiceState(env, config, nowMs),
+    ]);
+    return jsonResponse({
+      id: principal.userId,
+      activeApiKeys: keys.length,
+      activeSessions,
+      service,
+    });
+  }
+  if (url.pathname === "/v1/me/usage") {
+    if (request.method !== "GET") return methodNotAllowed(["GET"]);
+    const principal = await dependencies.authenticateClerk(request, env, config);
+    return usageRoute(env, principal.userId);
+  }
+  if (url.pathname === "/v1/keys") {
+    const principal = await dependencies.authenticateClerk(request, env, config);
+    if (request.method === "GET") return jsonResponse({ keys: await listApiKeys(env.DB, principal.userId) });
+    if (request.method === "POST") {
+      const body = await readJsonObject(request, 8_192);
+      const created = await createApiKey(env, principal.userId, body.name ?? "CLI key", dependencies.now());
+      return jsonResponse({ key: created.key, secret: created.secret, oneTimeSecret: true }, 201);
+    }
+    return methodNotAllowed(["GET", "POST"]);
+  }
+  const keyMatch = /^\/v1\/keys\/([^/]+)$/.exec(url.pathname);
+  if (keyMatch) {
+    if (request.method !== "DELETE") return methodNotAllowed(["DELETE"]);
+    const principal = await dependencies.authenticateClerk(request, env, config);
+    const revoked = await revokeApiKey(env.DB, principal.userId, keyMatch[1], dependencies.now());
+    if (!revoked) throw new HttpError(404, "key_not_found", "API key not found");
+    return emptyResponse();
+  }
+
+  if (url.pathname === "/v1/sessions") {
+    if (request.method !== "POST") return methodNotAllowed(["POST"]);
+    return createSession(request, env, context, config, dependencies);
+  }
+  const sessionMatch = /^\/v1\/sessions\/([^/]+)$/.exec(url.pathname);
+  if (sessionMatch) {
+    const sessionId = sessionMatch[1];
+    if (!isSessionId(sessionId)) throw new HttpError(404, "session_not_found", "Session not found");
+    if (request.method === "GET") return sessionStatus(request, env, context, sessionId, dependencies);
+    if (request.method === "DELETE") return deleteSession(request, env, context, sessionId, dependencies);
+    return methodNotAllowed(["GET", "DELETE"]);
+  }
+  throw new HttpError(404, "not_found", "Endpoint not found");
+}
+
+export function createWorkerHandler(overrides: Partial<HandlerDependencies> = {}): ExportedHandler<Env> {
+  const dependencies = { ...defaultDependencies, ...overrides };
+  return {
+    async fetch(request: Request, env: Env, context: ExecutionContext): Promise<Response> {
+      const url = new URL(request.url);
+      let config: RelayConfig;
+      try {
+        config = getConfig(env);
+      } catch (error) {
+        const response = error instanceof ConfigurationError
+          ? errorResponse(503, "relay_not_configured", "Relay configuration is incomplete")
+          : normalizeThrownError(error);
+        return response;
+      }
+
+      if (url.pathname === "/healthz") {
+        if (request.method !== "GET") return methodNotAllowed(["GET"]);
+        try {
+          const killSwitch = await getKillSwitch(env, config);
+          return jsonResponse({ ok: true, admissionEnabled: !killSwitch.effectiveEnabled });
+        } catch {
+          return errorResponse(503, "database_unavailable", "Relay database is unavailable");
+        }
+      }
+
+      const webSocketMatch = /^\/v1\/sessions\/([^/]+)\/ws$/.exec(url.pathname);
+      if (webSocketMatch) {
+        const sessionId = webSocketMatch[1];
+        if (!isSessionId(sessionId)) return rejectedWebSocketResponse(CLOSE_CODE.SESSION_CLOSED, "session closed");
+        return websocketRoute(request, env, config, sessionId);
+      }
+
+      const viewerMatch = /^\/s\/([^/]+)$/.exec(url.pathname);
+      if (viewerMatch) {
+        if (request.method !== "GET") return methodNotAllowed(["GET"]);
+        if (url.origin !== config.publicOrigin) return errorResponse(404, "not_found", "Not found");
+        const sessionId = viewerMatch[1];
+        if (!isSessionId(sessionId)) return errorResponse(404, "not_found", "Not found");
+        return viewerPageResponse(sessionId, config.publicOrigin);
+      }
+
+      if (url.pathname.startsWith("/v1/")) {
+        try {
+          const response = await routeApi(request, env, context, config, dependencies);
+          return applyCors(response, request, config.appOrigin);
+        } catch (error) {
+          return applyCors(normalizeThrownError(error), request, config.appOrigin);
+        }
+      }
+
+      return env.ASSETS.fetch(request);
+    },
+  };
+}
+
+export default createWorkerHandler();

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -153,32 +153,40 @@ async function createSession(
     ended_at_ms: null,
     ended_reason: null,
   };
+  // Initialize the Durable Object first. Its absolute-expiry alarm bounds any
+  // crash between the two persistence steps; inserting D1 first could leave a
+  // row forever with no object or alarm to own cleanup.
+  const stub = doStub(env, env.RELAY_SESSION, `session:${sessionId}`);
+  let initialized: Response;
+  try {
+    initialized = await internalFetch(stub, env, "/init", "POST", {
+      sessionId,
+      userId: principal.userId,
+      createdAtMs: row.created_at_ms,
+      expiresAtMs: row.expires_at_ms,
+      hostCapHash,
+      viewerCapHash,
+    });
+  } catch {
+    throw new HttpError(503, "session_unavailable", "The relay session could not be initialized");
+  }
+  if (!initialized.ok) {
+    throw new HttpError(503, "session_unavailable", "The relay session could not be initialized");
+  }
+
   try {
     await insertSession(env, row);
   } catch (error) {
+    // The initialized object now owns a cleanup alarm. Ask it to purge early;
+    // if this call or its D1 deletion fails, its tombstone alarm retries.
+    await internalFetch(stub, env, "/terminate", "POST", {
+      reason: "session metadata insertion failed",
+    }).catch(() => null);
     const message = error instanceof Error ? error.message : "";
     if (/unique|primary key/i.test(message)) {
       throw new HttpError(409, "session_id_conflict", "Generate fresh client session material and retry");
     }
     throw error;
-  }
-
-  const stub = doStub(env, env.RELAY_SESSION, `session:${sessionId}`);
-  const initialized = await internalFetch(stub, env, "/init", "POST", {
-    sessionId,
-    userId: principal.userId,
-    createdAtMs: row.created_at_ms,
-    expiresAtMs: row.expires_at_ms,
-    hostCapHash,
-    viewerCapHash,
-  });
-  if (!initialized.ok) {
-    await endSession(env.DB, sessionId, principal.userId, "initialization failed", nowMs);
-    await internalFetch(stub, env, "/terminate", "POST", {
-      reason: "initialization failed",
-    }).catch(() => null);
-    await removeSession(env.DB, sessionId, principal.userId);
-    throw new HttpError(503, "session_unavailable", "The relay session could not be initialized");
   }
 
   const websocketUrl = new URL(`/v1/sessions/${sessionId}/ws`, config.publicOrigin);
@@ -264,10 +272,9 @@ async function deleteSession(
     { reason: "session deleted" },
   );
   if (!response.ok) throw new HttpError(503, "session_close_pending", "Session was marked ended but peers may still be closing");
-  const removed = await removeSession(env.DB, sessionId, principal.userId);
-  if (!removed) {
-    throw new HttpError(503, "session_cleanup_pending", "Session peers closed but metadata cleanup is still pending");
-  }
+  // RelaySession normally removes its own row before acknowledging. This
+  // idempotent fallback handles legacy/orphan rows whose object had no config.
+  await removeSession(env.DB, sessionId, principal.userId);
   return emptyResponse();
 }
 

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -44,6 +44,7 @@ import {
   listActiveSessionIds,
   listSessionIdsForUser,
   publicSession,
+  removeSession,
   type SessionRow,
 } from "./repositories/sessions";
 import { billingWindow, toIso } from "./time";
@@ -173,6 +174,10 @@ async function createSession(
   });
   if (!initialized.ok) {
     await endSession(env.DB, sessionId, principal.userId, "initialization failed", nowMs);
+    await internalFetch(stub, env, "/terminate", "POST", {
+      reason: "initialization failed",
+    }).catch(() => null);
+    await removeSession(env.DB, sessionId, principal.userId);
     throw new HttpError(503, "session_unavailable", "The relay session could not be initialized");
   }
 
@@ -259,6 +264,10 @@ async function deleteSession(
     { reason: "session deleted" },
   );
   if (!response.ok) throw new HttpError(503, "session_close_pending", "Session was marked ended but peers may still be closing");
+  const removed = await removeSession(env.DB, sessionId, principal.userId);
+  if (!removed) {
+    throw new HttpError(503, "session_cleanup_pending", "Session peers closed but metadata cleanup is still pending");
+  }
   return emptyResponse();
 }
 

--- a/relay/src/protocol.ts
+++ b/relay/src/protocol.ts
@@ -1,0 +1,79 @@
+import {
+  CAPABILITY_BYTES,
+  HOST_PROTOCOL_PREFIX,
+  RELAY_PROTOCOL,
+  VIEWER_PROTOCOL_PREFIX,
+} from "./constants";
+import { base64UrlToBytes } from "./crypto";
+
+export type PeerRole = "host" | "viewer";
+
+export interface PresentedCapability {
+  role: PeerRole;
+  capability: string;
+}
+
+export type HostLifecycleEvent =
+  | "host_ready"
+  | "viewer_connected"
+  | "viewer_disconnected"
+  | "lease_expiring"
+  | "lease_expired"
+  | "quota_exhausted"
+  | "budget_exhausted"
+  | "session_expired"
+  | "session_closed"
+  | "kill_switch";
+
+export function parseWebSocketProtocols(header: string | null): PresentedCapability | null {
+  if (!header || header.length > 512) return null;
+  const protocols = header.split(",").map((entry) => entry.trim());
+  if (protocols.length !== 2 || protocols[0] !== RELAY_PROTOCOL) return null;
+  const credential = protocols[1];
+  let role: PeerRole;
+  let capability: string;
+  if (credential.startsWith(HOST_PROTOCOL_PREFIX)) {
+    role = "host";
+    capability = credential.slice(HOST_PROTOCOL_PREFIX.length);
+  } else if (credential.startsWith(VIEWER_PROTOCOL_PREFIX)) {
+    role = "viewer";
+    capability = credential.slice(VIEWER_PROTOCOL_PREFIX.length);
+  } else {
+    return null;
+  }
+  try {
+    base64UrlToBytes(capability, CAPABILITY_BYTES);
+  } catch {
+    return null;
+  }
+  return { role, capability };
+}
+
+export function hostControlNotice(
+  event: HostLifecycleEvent,
+  fields: Record<string, string | number | boolean | null> = {},
+): string {
+  return JSON.stringify({ t: "relay", event, ...fields });
+}
+
+export function isWebSocketUpgrade(request: Request): boolean {
+  return request.headers.get("Upgrade")?.toLowerCase() === "websocket";
+}
+
+export function acceptedWebSocketResponse(client: WebSocket): Response {
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+    headers: { "Sec-WebSocket-Protocol": RELAY_PROTOCOL },
+  });
+}
+
+/** Return a real WebSocket close code to browser callers instead of a vague HTTP failure. */
+export function rejectedWebSocketResponse(code: number, reason: string): Response {
+  const pair = new WebSocketPair();
+  const client = pair[0];
+  const server = pair[1];
+  server.accept();
+  server.close(code, reason.slice(0, 120));
+  return acceptedWebSocketResponse(client);
+}

--- a/relay/src/rate-limit.ts
+++ b/relay/src/rate-limit.ts
@@ -1,0 +1,56 @@
+export interface RateState {
+  messageTokens: number;
+  byteTokens: number;
+  updatedAtMs: number;
+}
+
+export interface RatePolicy {
+  sustainedMessagesPerSecond: number;
+  burstMessages: number;
+  maxBytesPerSecond: number;
+  byteBurstCapacity: number;
+}
+
+export interface RateDecision {
+  allowed: boolean;
+  state: RateState;
+  reason?: "message_rate" | "bandwidth";
+}
+
+export function initialRateState(policy: RatePolicy, nowMs: number): RateState {
+  return {
+    messageTokens: policy.burstMessages,
+    byteTokens: policy.byteBurstCapacity,
+    updatedAtMs: nowMs,
+  };
+}
+
+/** Token buckets provide 15 messages/s sustained, 20 burst, and 10 Mbps by default. */
+export function consumeRate(
+  previous: RateState,
+  byteLength: number,
+  nowMs: number,
+  policy: RatePolicy,
+): RateDecision {
+  const elapsedSeconds = Math.max(0, nowMs - previous.updatedAtMs) / 1_000;
+  const messageTokens = Math.min(
+    policy.burstMessages,
+    previous.messageTokens + elapsedSeconds * policy.sustainedMessagesPerSecond,
+  );
+  const byteTokens = Math.min(
+    policy.byteBurstCapacity,
+    previous.byteTokens + elapsedSeconds * policy.maxBytesPerSecond,
+  );
+  const replenished: RateState = { messageTokens, byteTokens, updatedAtMs: nowMs };
+
+  if (messageTokens < 1) return { allowed: false, state: replenished, reason: "message_rate" };
+  if (byteTokens < byteLength) return { allowed: false, state: replenished, reason: "bandwidth" };
+  return {
+    allowed: true,
+    state: {
+      messageTokens: messageTokens - 1,
+      byteTokens: byteTokens - byteLength,
+      updatedAtMs: nowMs,
+    },
+  };
+}

--- a/relay/src/repositories/api-keys.ts
+++ b/relay/src/repositories/api-keys.ts
@@ -1,0 +1,142 @@
+import { requireSecret } from "../config";
+import { constantTimeEqual, generateApiKey, hashApiKey, parseApiKey } from "../crypto";
+import type { Env, ExecutionContextLike } from "../env";
+import { bearerCredential, HttpError } from "../http";
+import { toIso } from "../time";
+
+interface ApiKeyRow {
+  id: string;
+  user_id: string;
+  name: string;
+  key_hash: string;
+  created_at_ms: number;
+  last_used_at_ms: number | null;
+  revoked_at_ms: number | null;
+}
+
+export interface ApiKeyPrincipal {
+  userId: string;
+  apiKeyId: string;
+}
+
+export interface PublicApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+function publicKey(row: Pick<ApiKeyRow, "id" | "name" | "created_at_ms" | "last_used_at_ms">): PublicApiKey {
+  return {
+    id: row.id,
+    name: row.name,
+    prefix: `bw_live_${row.id}_…`,
+    createdAt: new Date(row.created_at_ms).toISOString(),
+    lastUsedAt: toIso(row.last_used_at_ms),
+  };
+}
+
+export function validateApiKeyName(value: unknown): string {
+  if (typeof value !== "string") throw new HttpError(400, "invalid_name", "Key name must be a string");
+  const name = value.trim();
+  if (name.length < 1 || name.length > 80 || /[\u0000-\u001f\u007f]/.test(name)) {
+    throw new HttpError(400, "invalid_name", "Key name must contain 1 to 80 printable characters");
+  }
+  return name;
+}
+
+export async function listApiKeys(db: D1Database, userId: string): Promise<PublicApiKey[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, name, created_at_ms, last_used_at_ms
+       FROM api_keys
+       WHERE user_id = ?1 AND revoked_at_ms IS NULL
+       ORDER BY created_at_ms DESC`,
+    )
+    .bind(userId)
+    .all<Pick<ApiKeyRow, "id" | "name" | "created_at_ms" | "last_used_at_ms">>();
+  return (result.results ?? []).map(publicKey);
+}
+
+export async function createApiKey(
+  env: Env,
+  userId: string,
+  nameValue: unknown,
+  nowMs = Date.now(),
+): Promise<{ key: PublicApiKey; secret: string }> {
+  const name = validateApiKeyName(nameValue);
+  const generated = generateApiKey();
+  const keyHash = await hashApiKey(requireSecret(env, "API_KEY_HMAC_SECRET"), generated.value);
+  try {
+    await env.DB
+      .prepare(
+        `INSERT INTO api_keys (id, user_id, name, key_hash, created_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5)`,
+      )
+      .bind(generated.id, userId, name, keyHash, nowMs)
+      .run();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("active_api_key_limit")) {
+      throw new HttpError(409, "key_limit_reached", "An account can have at most five active API keys");
+    }
+    throw error;
+  }
+  return {
+    key: publicKey({ id: generated.id, name, created_at_ms: nowMs, last_used_at_ms: null }),
+    secret: generated.value,
+  };
+}
+
+export async function revokeApiKey(
+  db: D1Database,
+  userId: string,
+  keyId: string,
+  nowMs = Date.now(),
+): Promise<boolean> {
+  if (!/^[A-Za-z0-9_-]{16}$/.test(keyId)) return false;
+  const result = await db
+    .prepare(
+      `UPDATE api_keys
+       SET revoked_at_ms = ?1
+       WHERE id = ?2 AND user_id = ?3 AND revoked_at_ms IS NULL`,
+    )
+    .bind(nowMs, keyId, userId)
+    .run();
+  return Number(result.meta.changes ?? 0) === 1;
+}
+
+export async function authenticateApiKeyRequest(
+  request: Request,
+  env: Env,
+  context?: ExecutionContextLike,
+): Promise<ApiKeyPrincipal> {
+  const candidate = bearerCredential(request);
+  const parsed = candidate ? parseApiKey(candidate) : null;
+  if (!candidate || !parsed) {
+    throw new HttpError(401, "invalid_api_key", "A valid BetterWright API key is required");
+  }
+  const row = await env.DB
+    .prepare(
+      `SELECT id, user_id, key_hash, revoked_at_ms
+       FROM api_keys WHERE id = ?1`,
+    )
+    .bind(parsed.id)
+    .first<Pick<ApiKeyRow, "id" | "user_id" | "key_hash" | "revoked_at_ms">>();
+  if (!row || row.revoked_at_ms !== null) {
+    throw new HttpError(401, "invalid_api_key", "A valid BetterWright API key is required");
+  }
+  const candidateHash = await hashApiKey(requireSecret(env, "API_KEY_HMAC_SECRET"), candidate);
+  if (!constantTimeEqual(candidateHash, row.key_hash)) {
+    throw new HttpError(401, "invalid_api_key", "A valid BetterWright API key is required");
+  }
+  const update = env.DB
+    .prepare("UPDATE api_keys SET last_used_at_ms = ?1 WHERE id = ?2 AND revoked_at_ms IS NULL")
+    .bind(Date.now(), row.id)
+    .run()
+    .catch(() => undefined);
+  if (context) context.waitUntil(update);
+  else await update;
+  return { userId: row.user_id, apiKeyId: row.id };
+}

--- a/relay/src/repositories/control.ts
+++ b/relay/src/repositories/control.ts
@@ -1,0 +1,59 @@
+import type { RelayConfig } from "../config";
+import type { Env } from "../env";
+import { HttpError } from "../http";
+import { toIso } from "../time";
+
+interface ControlRow {
+  kill_switch_enabled: number;
+  reason: string;
+  updated_at_ms: number;
+}
+
+export interface KillSwitchState {
+  persistentEnabled: boolean;
+  environmentEnabled: boolean;
+  effectiveEnabled: boolean;
+  reason: string;
+  updatedAt: string | null;
+}
+
+export async function getKillSwitch(env: Env, config: RelayConfig): Promise<KillSwitchState> {
+  const row = await env.DB
+    .prepare(
+      `SELECT kill_switch_enabled, reason, updated_at_ms
+       FROM relay_control WHERE singleton = 1`,
+    )
+    .first<ControlRow>();
+  if (!row) throw new Error("relay control row is missing");
+  const persistentEnabled = row.kill_switch_enabled === 1;
+  return {
+    persistentEnabled,
+    environmentEnabled: config.envKillSwitch,
+    effectiveEnabled: persistentEnabled || config.envKillSwitch,
+    reason: row.reason,
+    updatedAt: row.updated_at_ms > 0 ? toIso(row.updated_at_ms) : null,
+  };
+}
+
+export async function setPersistentKillSwitch(
+  env: Env,
+  enabledValue: unknown,
+  reasonValue: unknown,
+  nowMs = Date.now(),
+): Promise<void> {
+  if (typeof enabledValue !== "boolean") {
+    throw new HttpError(400, "invalid_enabled", "enabled must be a boolean");
+  }
+  const reason = reasonValue === undefined ? "" : String(reasonValue).trim();
+  if (reason.length > 200 || /[\u0000-\u001f\u007f]/.test(reason)) {
+    throw new HttpError(400, "invalid_reason", "reason must contain at most 200 printable characters");
+  }
+  await env.DB
+    .prepare(
+      `UPDATE relay_control
+       SET kill_switch_enabled = ?1, reason = ?2, updated_at_ms = ?3
+       WHERE singleton = 1`,
+    )
+    .bind(enabledValue ? 1 : 0, reason, nowMs)
+    .run();
+}

--- a/relay/src/repositories/sessions.ts
+++ b/relay/src/repositories/sessions.ts
@@ -1,0 +1,145 @@
+import { isSessionId } from "../crypto";
+import type { Env } from "../env";
+import { toIso } from "../time";
+
+export interface SessionRow {
+  id: string;
+  user_id: string;
+  api_key_id: string;
+  host_cap_hash: string;
+  viewer_cap_hash: string;
+  created_at_ms: number;
+  expires_at_ms: number;
+  ended_at_ms: number | null;
+  ended_reason: string | null;
+}
+
+export interface PublicSession {
+  id: string;
+  createdAt: string;
+  expiresAt: string;
+  endedAt: string | null;
+  status: "waiting" | "active" | "ended" | "expired";
+}
+
+export function publicSession(row: SessionRow, nowMs = Date.now()): PublicSession {
+  const ended = row.ended_at_ms !== null;
+  const expired = !ended && row.expires_at_ms <= nowMs;
+  return {
+    id: row.id,
+    createdAt: new Date(row.created_at_ms).toISOString(),
+    expiresAt: new Date(row.expires_at_ms).toISOString(),
+    endedAt: toIso(row.ended_at_ms),
+    status: ended ? "ended" : expired ? "expired" : "waiting",
+  };
+}
+
+export async function insertSession(env: Env, row: SessionRow): Promise<void> {
+  await env.DB
+    .prepare(
+      `INSERT INTO sessions (
+         id, user_id, api_key_id, host_cap_hash, viewer_cap_hash,
+         created_at_ms, expires_at_ms, ended_at_ms, ended_reason
+       ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, NULL)`,
+    )
+    .bind(
+      row.id,
+      row.user_id,
+      row.api_key_id,
+      row.host_cap_hash,
+      row.viewer_cap_hash,
+      row.created_at_ms,
+      row.expires_at_ms,
+    )
+    .run();
+}
+
+export async function findSessionForOwner(
+  db: D1Database,
+  sessionId: string,
+  userId: string,
+): Promise<SessionRow | null> {
+  if (!isSessionId(sessionId)) return null;
+  return db
+    .prepare(
+      `SELECT id, user_id, api_key_id, host_cap_hash, viewer_cap_hash,
+              created_at_ms, expires_at_ms, ended_at_ms, ended_reason
+       FROM sessions WHERE id = ?1 AND user_id = ?2`,
+    )
+    .bind(sessionId, userId)
+    .first<SessionRow>();
+}
+
+export async function findSessionForAdmission(
+  db: D1Database,
+  sessionId: string,
+): Promise<Pick<SessionRow, "id" | "user_id" | "expires_at_ms" | "ended_at_ms"> | null> {
+  if (!isSessionId(sessionId)) return null;
+  return db
+    .prepare(
+      `SELECT id, user_id, expires_at_ms, ended_at_ms
+       FROM sessions WHERE id = ?1`,
+    )
+    .bind(sessionId)
+    .first<Pick<SessionRow, "id" | "user_id" | "expires_at_ms" | "ended_at_ms">>();
+}
+
+export async function endSession(
+  db: D1Database,
+  sessionId: string,
+  userId: string,
+  reason: string,
+  nowMs = Date.now(),
+): Promise<boolean> {
+  if (!isSessionId(sessionId)) return false;
+  const result = await db
+    .prepare(
+      `UPDATE sessions
+       SET ended_at_ms = COALESCE(ended_at_ms, ?1),
+           ended_reason = COALESCE(ended_reason, ?2)
+       WHERE id = ?3 AND user_id = ?4`,
+    )
+    .bind(nowMs, reason.slice(0, 80), sessionId, userId)
+    .run();
+  return Number(result.meta.changes ?? 0) === 1;
+}
+
+export async function countActiveSessions(db: D1Database, userId: string, nowMs = Date.now()): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM sessions
+       WHERE user_id = ?1 AND ended_at_ms IS NULL AND expires_at_ms > ?2`,
+    )
+    .bind(userId, nowMs)
+    .first<{ count: number }>();
+  return Number(row?.count ?? 0);
+}
+
+export async function listActiveSessionIds(
+  db: D1Database,
+  nowMs = Date.now(),
+  limit = 10_000,
+): Promise<string[]> {
+  const result = await db
+    .prepare(
+      `SELECT id FROM sessions
+       WHERE ended_at_ms IS NULL AND expires_at_ms > ?1
+       ORDER BY created_at_ms ASC LIMIT ?2`,
+    )
+    .bind(nowMs, limit)
+    .all<{ id: string }>();
+  return (result.results ?? []).map((row) => row.id);
+}
+
+
+export async function listSessionIdsForUser(
+  db: D1Database,
+  userId: string,
+): Promise<string[]> {
+  const result = await db
+    .prepare("SELECT id FROM sessions WHERE user_id = ?1")
+    .bind(userId)
+    .all<{ id: string }>();
+  return (result.results ?? []).map((row) => row.id);
+}

--- a/relay/src/repositories/sessions.ts
+++ b/relay/src/repositories/sessions.ts
@@ -104,6 +104,19 @@ export async function endSession(
   return Number(result.meta.changes ?? 0) === 1;
 }
 
+export async function removeSession(
+  db: D1Database,
+  sessionId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!isSessionId(sessionId)) return false;
+  const result = await db
+    .prepare("DELETE FROM sessions WHERE id = ?1 AND user_id = ?2")
+    .bind(sessionId, userId)
+    .run();
+  return Number(result.meta.changes ?? 0) === 1;
+}
+
 export async function countActiveSessions(db: D1Database, userId: string, nowMs = Date.now()): Promise<number> {
   const row = await db
     .prepare(

--- a/relay/src/serial.ts
+++ b/relay/src/serial.ts
@@ -1,0 +1,12 @@
+export class SerialGate {
+  private tail: Promise<void> = Promise.resolve();
+
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(operation, operation);
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}

--- a/relay/src/time.ts
+++ b/relay/src/time.ts
@@ -1,0 +1,57 @@
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const WEEK_MS = 7 * DAY_MS;
+
+export interface TimeWindow {
+  key: string;
+  startsAtMs: number;
+  endsAtMs: number;
+}
+
+function dateKey(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** ISO week in UTC: Monday 00:00:00 through the next Monday. */
+export function isoWeekWindow(nowMs: number): TimeWindow {
+  const now = new Date(nowMs);
+  const midnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const daysSinceMonday = (now.getUTCDay() + 6) % 7;
+  const startsAtMs = midnight - daysSinceMonday * DAY_MS;
+  return {
+    key: dateKey(startsAtMs),
+    startsAtMs,
+    endsAtMs: startsAtMs + WEEK_MS,
+  };
+}
+
+/**
+ * Monthly UTC billing window anchored to a day in [1, 28]. An explicit key is
+ * useful when the Cloudflare account has a non-calendar contractual period.
+ */
+export function billingWindow(
+  nowMs: number,
+  startDayUtc: number,
+  explicitKey?: string,
+): TimeWindow {
+  const now = new Date(nowMs);
+  let year = now.getUTCFullYear();
+  let month = now.getUTCMonth();
+  if (now.getUTCDate() < startDayUtc) {
+    month -= 1;
+    if (month < 0) {
+      year -= 1;
+      month = 11;
+    }
+  }
+  const startsAtMs = Date.UTC(year, month, startDayUtc);
+  const endsAtMs = Date.UTC(year, month + 1, startDayUtc);
+  return {
+    key: explicitKey || dateKey(startsAtMs),
+    startsAtMs,
+    endsAtMs,
+  };
+}
+
+export function toIso(ms: number | null | undefined): string | null {
+  return typeof ms === "number" && Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}

--- a/relay/src/viewer-page.ts
+++ b/relay/src/viewer-page.ts
@@ -1,0 +1,87 @@
+import { SECURITY_HEADERS } from "./constants";
+
+function escapeAttribute(value: string): string {
+  return value.replace(/[&"'<>]/g, (character) => ({
+    "&": "&amp;",
+    '"': "&quot;",
+    "'": "&#39;",
+    "<": "&lt;",
+    ">": "&gt;",
+  })[character] as string);
+}
+
+export function viewerPageResponse(sessionId: string, publicOrigin: string): Response {
+  const wsOrigin = publicOrigin.replace(/^http/, "ws");
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <meta name="theme-color" content="#0a0b0d">
+  <meta name="bw-session-id" content="${escapeAttribute(sessionId)}">
+  <title>BetterWright live view</title>
+  <link rel="stylesheet" href="/viewer.css">
+  <script type="module" src="/viewer.js"></script>
+</head>
+<body>
+  <main class="viewer-shell">
+    <header class="titlebar">
+      <div class="brand" aria-label="BetterWright live view">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <strong>Better<span>Wright</span></strong>
+        <small>private relay</small>
+      </div>
+      <div id="status" class="status" role="status" aria-live="polite">
+        <span aria-hidden="true"></span><b>Securing connection</b>
+      </div>
+    </header>
+
+    <nav id="tabs" class="tabs" aria-label="Browser tabs"></nav>
+
+    <section class="browser-bar" aria-label="Current page">
+      <div class="address">
+        <span class="lock-glyph" aria-hidden="true"></span>
+        <span id="page-url">Waiting for the browser</span>
+      </div>
+      <span id="dimensions" class="dimensions"></span>
+      <button id="control" type="button" disabled>Take control</button>
+    </section>
+
+    <section id="viewport" class="viewport">
+      <canvas id="screen" width="1280" height="800" tabindex="0" aria-label="Remote browser screen"></canvas>
+      <div id="overlay" class="overlay active">
+        <span class="aperture" aria-hidden="true"></span>
+        <strong id="overlay-title">Opening a private channel</strong>
+        <p id="overlay-detail">The key stays in this tab and is never sent to the relay.</p>
+      </div>
+    </section>
+
+    <section id="handoff" class="handoff" hidden>
+      <div><strong>The agent needs you</strong><p id="handoff-detail"></p></div>
+      <button id="cancel" class="quiet" type="button">Cancel step</button>
+      <button id="done" type="button">Done, resume agent</button>
+    </section>
+
+    <section class="session-dock" aria-label="Session messages">
+      <div id="messages" class="messages" aria-live="polite"></div>
+      <form id="composer" autocomplete="off">
+        <label class="sr-only" for="message">Message the agent</label>
+        <input id="message" maxlength="2000" placeholder="Message the agent">
+        <button id="send" type="submit">Send</button>
+      </form>
+    </section>
+  </main>
+  <div id="toasts" class="toasts" aria-live="polite"></div>
+</body>
+</html>`;
+
+  const headers = new Headers(SECURITY_HEADERS);
+  headers.set("Content-Type", "text/html; charset=utf-8");
+  headers.set(
+    "Content-Security-Policy",
+    `default-src 'none'; script-src 'self'; style-src 'self'; connect-src 'self' ${wsOrigin}; img-src data: blob:; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'`,
+  );
+  headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  return new Response(html, { status: 200, headers });
+}

--- a/relay/test/auth.test.ts
+++ b/relay/test/auth.test.ts
@@ -9,7 +9,17 @@ import { getConfig } from "../src/config";
 import { makeBaseEnv } from "./helpers";
 
 describe("Clerk verification result handling", () => {
-  it("reads the current @clerk/backend {data, errors} return shape", () => {
+  it("reads the direct JwtPayload returned by the locked @clerk/backend verifyToken", () => {
+    expect(
+      clerkPrincipalFromVerification({
+        sub: "user_2RfWKJREkjKbHZy0Wqa5qrHeAnb",
+        sid: "sess_123",
+        errors: "a custom JWT claim must not be mistaken for SDK errors",
+      }),
+    ).toEqual({ userId: "user_2RfWKJREkjKbHZy0Wqa5qrHeAnb", sessionId: "sess_123" });
+  });
+
+  it("retains compatibility with the low-level {data, errors} result shape", () => {
     expect(
       clerkPrincipalFromVerification({
         data: { sub: "user_2RfWKJREkjKbHZy0Wqa5qrHeAnb", sid: "sess_123" },
@@ -22,6 +32,7 @@ describe("Clerk verification result handling", () => {
     {},
     { errors: [new Error("bad")] },
     { data: {} },
+    { sub: "not-a-clerk-user" },
     { data: { sub: "not-a-clerk-user" } },
   ])("fails closed for malformed verification result %#", (result) => {
     expect(() => clerkPrincipalFromVerification(result)).toThrow();

--- a/relay/test/auth.test.ts
+++ b/relay/test/auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  authenticateAdminRequest,
+  authenticateClerkRequest,
+  authenticateInternalRequest,
+  clerkPrincipalFromVerification,
+} from "../src/auth";
+import { getConfig } from "../src/config";
+import { makeBaseEnv } from "./helpers";
+
+describe("Clerk verification result handling", () => {
+  it("reads the current @clerk/backend {data, errors} return shape", () => {
+    expect(
+      clerkPrincipalFromVerification({
+        data: { sub: "user_2RfWKJREkjKbHZy0Wqa5qrHeAnb", sid: "sess_123" },
+      }),
+    ).toEqual({ userId: "user_2RfWKJREkjKbHZy0Wqa5qrHeAnb", sessionId: "sess_123" });
+  });
+
+  it.each([
+    null,
+    {},
+    { errors: [new Error("bad")] },
+    { data: {} },
+    { data: { sub: "not-a-clerk-user" } },
+  ])("fails closed for malformed verification result %#", (result) => {
+    expect(() => clerkPrincipalFromVerification(result)).toThrow();
+  });
+
+  it("requires a token and converts SDK verification errors to a generic 401", async () => {
+    const env = makeBaseEnv();
+    const config = getConfig(env);
+    await expect(
+      authenticateClerkRequest(new Request("https://relay.example.com/v1/me"), env, config),
+    ).rejects.toMatchObject({ status: 401, code: "authentication_required" });
+    await expect(
+      authenticateClerkRequest(
+        new Request("https://relay.example.com/v1/me", {
+          headers: { Authorization: "Bearer not.a.jwt" },
+        }),
+        env,
+        config,
+      ),
+    ).rejects.toMatchObject({ status: 401, code: "invalid_session" });
+  });
+
+  it("requires the exact app origin for cookie-authenticated mutations", async () => {
+    const env = makeBaseEnv();
+    const config = getConfig(env);
+    await expect(
+      authenticateClerkRequest(
+        new Request("https://relay.example.com/v1/keys", {
+          method: "POST",
+          headers: { Cookie: "__session=not.a.jwt", Origin: "https://attacker.example" },
+        }),
+        env,
+        config,
+      ),
+    ).rejects.toMatchObject({ status: 403, code: "origin_required" });
+  });
+});
+
+describe("operator and internal bearer checks", () => {
+  it("accepts only the exact admin bearer token", async () => {
+    const env = makeBaseEnv();
+    await expect(
+      authenticateAdminRequest(
+        new Request("https://relay.example.com/v1/admin/kill-switch", {
+          headers: { Authorization: `Bearer ${env.ADMIN_TOKEN}` },
+        }),
+        env,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      authenticateAdminRequest(
+        new Request("https://relay.example.com/v1/admin/kill-switch", {
+          headers: { Authorization: "Bearer wrong" },
+        }),
+        env,
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("accepts only the exact service-to-Durable-Object token", async () => {
+    const env = makeBaseEnv();
+    await expect(
+      authenticateInternalRequest(
+        new Request("https://internal/status", {
+          headers: { "X-Relay-Internal": env.INTERNAL_DO_SECRET },
+        }),
+        env,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      authenticateInternalRequest(
+        new Request("https://internal/status", { headers: { "X-Relay-Internal": "wrong" } }),
+        env,
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/relay/test/crypto.test.ts
+++ b/relay/test/crypto.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { HostRelayCodec, prepareRelaySession } from "../src/client/host-codec";
+import { ENVELOPE_KIND } from "../src/constants";
+import {
+  base64UrlToBytes,
+  bytesToBase64Url,
+  constantTimeEqual,
+  createEnvelopeReceiver,
+  createEnvelopeSender,
+  deriveViewerProof,
+  generateApiKey,
+  generateCapability,
+  generateRootKey,
+  generateSessionId,
+  hashApiKey,
+  hashCapability,
+  parseApiKey,
+  secureTokenEqual,
+} from "../src/crypto";
+import * as browserCrypto from "../public/viewer-crypto.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const deterministicRoot = bytesToBase64Url(Uint8Array.from({ length: 32 }, (_, index) => index));
+const deterministicSession = `bws_${bytesToBase64Url(Uint8Array.from({ length: 18 }, (_, index) => index + 30))}`;
+const hostEpoch = Uint8Array.from({ length: 16 }, (_, index) => index + 1);
+const viewerEpoch = Uint8Array.from({ length: 16 }, (_, index) => index + 41);
+
+describe("credential formats and HMAC storage", () => {
+  it("generates and parses the exact BetterWright API-key format", () => {
+    const generated = generateApiKey();
+    expect(generated.value).toBe(`bw_live_${generated.id}_${generated.secret}`);
+    expect(generated.id).toHaveLength(16);
+    expect(generated.secret).toHaveLength(43);
+    expect(parseApiKey(generated.value)).toEqual({ id: generated.id, secret: generated.secret });
+  });
+
+  it.each([
+    "",
+    "bw_live_short_secret",
+    `bw_test_${"a".repeat(16)}_${"b".repeat(43)}`,
+    `bw_live_${"!".repeat(16)}_${"b".repeat(43)}`,
+    `bw_live_${"a".repeat(16)}_${"b".repeat(42)}`,
+  ])("rejects malformed API key %j", (value) => {
+    expect(parseApiKey(value)).toBeNull();
+  });
+
+  it("generates canonical session material locally", async () => {
+    expect(base64UrlToBytes(generateRootKey(), 32)).toHaveLength(32);
+    expect(base64UrlToBytes(generateCapability(), 32)).toHaveLength(32);
+    expect(generateSessionId()).toMatch(/^bws_[A-Za-z0-9_-]{24}$/);
+    const prepared = await prepareRelaySession();
+    expect(prepared.sessionId).toMatch(/^bws_[A-Za-z0-9_-]{24}$/);
+    expect(base64UrlToBytes(prepared.rootKey, 32)).toHaveLength(32);
+    expect(prepared.viewerProof).toBe(await deriveViewerProof(prepared.rootKey, prepared.sessionId));
+    expect(prepared.viewerProof).not.toBe(prepared.rootKey);
+  });
+
+  it("rejects non-canonical or wrongly sized base64url", () => {
+    expect(() => base64UrlToBytes("abc=", 2)).toThrow();
+    expect(() => base64UrlToBytes("a", 1)).toThrow();
+    expect(() => base64UrlToBytes(bytesToBase64Url(new Uint8Array(31)), 32)).toThrow();
+  });
+
+  it("domain-separates API and role capability hashes", async () => {
+    const secret = "x".repeat(48);
+    const value = `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`;
+    const api = await hashApiKey(secret, value);
+    const host = await hashCapability(secret, deterministicSession, "host", value);
+    const viewer = await hashCapability(secret, deterministicSession, "viewer", value);
+    expect(new Set([api, host, viewer]).size).toBe(3);
+    expect(api).toHaveLength(43);
+  });
+
+  it("uses constant-time digest comparisons", async () => {
+    expect(constantTimeEqual("same", "same")).toBe(true);
+    expect(constantTimeEqual("same", "different")).toBe(false);
+    expect(await secureTokenEqual("operator-secret", "operator-secret")).toBe(true);
+    expect(await secureTokenEqual("operator-secret", "wrong")).toBe(false);
+  });
+});
+
+describe("epoch-bound directional encryption", () => {
+  it("matches the browser module's viewer proof", async () => {
+    expect(await deriveViewerProof(deterministicRoot, deterministicSession)).toBe(
+      await browserCrypto.deriveViewerProof(deterministicRoot, deterministicSession),
+    );
+  });
+
+  it("round-trips encrypted kinds with authenticated epoch and monotonic sequence", async () => {
+    const sender = createEnvelopeSender(deterministicRoot, deterministicSession, "h2v", hostEpoch);
+    const receiver = createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v");
+    const first = await sender.seal(ENVELOPE_KIND.TEXT, encoder.encode('{"t":"hello"}'));
+    const second = await sender.seal(ENVELOPE_KIND.BINARY, Uint8Array.of(0xff, 0xd8, 0xff, 0xd9));
+    expect(first[0]).toBe(1);
+    expect(first[1]).toBe(1);
+    expect([...first.subarray(2, 18)]).toEqual([...hostEpoch]);
+    expect(new DataView(first.buffer, first.byteOffset, first.byteLength).getBigUint64(18, false)).toBe(0n);
+    expect(new DataView(second.buffer, second.byteOffset, second.byteLength).getBigUint64(18, false)).toBe(1n);
+    const openedText = await receiver.open(first);
+    expect(openedText.kind).toBe(ENVELOPE_KIND.TEXT);
+    expect(decoder.decode(openedText.plaintext)).toBe('{"t":"hello"}');
+    expect((await receiver.open(second)).kind).toBe(ENVELOPE_KIND.BINARY);
+  });
+
+  it("fails closed for tampering, wrong context, replay, reordering, and epoch changes", async () => {
+    const sender = createEnvelopeSender(deterministicRoot, deterministicSession, "h2v", hostEpoch);
+    const first = await sender.seal(ENVELOPE_KIND.TEXT, encoder.encode("first"));
+    const second = await sender.seal(ENVELOPE_KIND.TEXT, encoder.encode("second"));
+    const tampered = new Uint8Array(first);
+    tampered[tampered.length - 1] ^= 1;
+    await expect(createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v").open(tampered)).rejects.toThrow();
+    await expect(createEnvelopeReceiver(deterministicRoot, deterministicSession, "v2h").open(first)).rejects.toThrow();
+    await expect(createEnvelopeReceiver(generateRootKey(), deterministicSession, "h2v").open(first)).rejects.toThrow();
+    await expect(createEnvelopeReceiver(deterministicRoot, deterministicSession + "x", "h2v").open(first)).rejects.toThrow();
+    await expect(createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v").open(first, 10)).rejects.toThrow(/maximum/);
+
+    const replayReceiver = createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v");
+    await replayReceiver.open(first);
+    await expect(replayReceiver.open(first)).rejects.toThrow(/replay/i);
+
+    const reorderReceiver = createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v");
+    await reorderReceiver.open(second);
+    await expect(reorderReceiver.open(first)).rejects.toThrow(/replay/i);
+
+    const otherEpoch = createEnvelopeSender(deterministicRoot, deterministicSession, "h2v", viewerEpoch);
+    const changed = await otherEpoch.seal(ENVELOPE_KIND.TEXT, encoder.encode("changed"));
+    await expect(replayReceiver.open(changed)).rejects.toThrow(/epoch changed/i);
+  });
+
+  it("interoperates byte-for-byte with the shipped browser crypto", async () => {
+    const browserSender = browserCrypto.createEnvelopeSender(deterministicRoot, deterministicSession, "v2h", viewerEpoch);
+    const workerReceiver = createEnvelopeReceiver(deterministicRoot, deterministicSession, "v2h");
+    const browserEnvelope = await browserSender.seal(browserCrypto.ENVELOPE_KIND.TEXT, encoder.encode("viewer input"));
+    expect(decoder.decode((await workerReceiver.open(browserEnvelope)).plaintext)).toBe("viewer input");
+
+    const workerSender = createEnvelopeSender(deterministicRoot, deterministicSession, "h2v", hostEpoch);
+    const browserReceiver = browserCrypto.createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v");
+    const workerEnvelope = await workerSender.seal(ENVELOPE_KIND.BINARY, Uint8Array.of(9, 8, 7));
+    const opened = await browserReceiver.open(workerEnvelope);
+    expect(opened.kind).toBe(browserCrypto.ENVELOPE_KIND.BINARY);
+    expect([...opened.plaintext]).toEqual([9, 8, 7]);
+  });
+});
+
+describe("host-initiated root-key challenge", () => {
+  it("blocks application data until the exact challenge echo", async () => {
+    const host = await HostRelayCodec.create(deterministicSession, deterministicRoot, generateCapability());
+    await expect(host.encodeText("too early")).rejects.toThrow(/not verified/);
+    const viewerSender = createEnvelopeSender(deterministicRoot, deterministicSession, "v2h", viewerEpoch);
+    const early = await viewerSender.seal(ENVELOPE_KIND.TEXT, encoder.encode('{"t":"input"}'));
+    await expect(host.receiveViewer(early)).rejects.toThrow(/not started/);
+  });
+
+  it("completes the challenge then releases unchanged viewer JSON", async () => {
+    const host = await HostRelayCodec.create(deterministicSession, deterministicRoot, generateCapability());
+    const viewerReceiver = createEnvelopeReceiver(deterministicRoot, deterministicSession, "h2v");
+    const viewerSender = createEnvelopeSender(deterministicRoot, deterministicSession, "v2h", viewerEpoch);
+    const challengeEnvelope = await host.encodeChallenge();
+    const challenge = await viewerReceiver.open(challengeEnvelope);
+    expect(challenge.kind).toBe(ENVELOPE_KIND.CHALLENGE);
+    const challengeValue = JSON.parse(decoder.decode(challenge.plaintext));
+    expect(challengeValue).toMatchObject({ t: "bw_e2e_challenge" });
+    expect(challengeValue.challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    const readyEnvelope = await viewerSender.seal(
+      ENVELOPE_KIND.CHALLENGE,
+      encoder.encode(JSON.stringify({ t: "bw_e2e_ready", challenge: challengeValue.challenge })),
+    );
+    expect(await host.receiveViewer(readyEnvelope)).toEqual({ type: "ready" });
+    expect(host.viewerVerified).toBe(true);
+    const inputJson = '{"t":"input","kind":"mouse","x":12}';
+    const input = await viewerSender.seal(ENVELOPE_KIND.TEXT, encoder.encode(inputJson));
+    expect(await host.receiveViewer(input)).toEqual({ type: "text", data: inputJson });
+  });
+
+  it("rejects a wrong challenge echo", async () => {
+    const host = await HostRelayCodec.create(deterministicSession, deterministicRoot, generateCapability());
+    await host.encodeChallenge();
+    const viewerSender = createEnvelopeSender(deterministicRoot, deterministicSession, "v2h", viewerEpoch);
+    const bad = await viewerSender.seal(
+      ENVELOPE_KIND.CHALLENGE,
+      encoder.encode(JSON.stringify({ t: "bw_e2e_ready", challenge: "x".repeat(43) })),
+    );
+    await expect(host.receiveViewer(bad)).rejects.toThrow(/invalid viewer ready/);
+  });
+});

--- a/relay/test/helpers.ts
+++ b/relay/test/helpers.ts
@@ -83,6 +83,7 @@ interface SessionRow {
 export class FakeD1 {
   readonly apiKeys: ApiKeyRow[] = [];
   readonly sessions: SessionRow[] = [];
+  sessionDeleteFailures = 0;
   control = { kill_switch_enabled: 0, reason: "", updated_at_ms: 0 };
 
   prepare(sql: string): D1PreparedStatement {
@@ -154,6 +155,9 @@ class FakeStatement {
         number,
         number,
       ];
+      if (this.db.sessions.some((row) => row.id === id)) {
+        throw new Error("SQLITE_CONSTRAINT: UNIQUE constraint failed: sessions.id");
+      }
       this.db.sessions.push({
         id,
         user_id: userId,
@@ -175,6 +179,10 @@ class FakeStatement {
         changes = 1;
       }
     } else if (sql.startsWith("delete from sessions where id = ?1 and user_id = ?2")) {
+      if (this.db.sessionDeleteFailures > 0) {
+        this.db.sessionDeleteFailures -= 1;
+        throw new Error("transient D1 session delete failure");
+      }
       const [id, userId] = this.parameters as [string, string];
       const index = this.db.sessions.findIndex(
         (entry) => entry.id === id && entry.user_id === userId,

--- a/relay/test/helpers.ts
+++ b/relay/test/helpers.ts
@@ -1,0 +1,287 @@
+import type { Env } from "../src/env";
+
+export class MemoryStorage {
+  readonly values = new Map<string, unknown>();
+  alarm: number | null = null;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.values.get(key) as T | undefined;
+  }
+
+  async put<T>(keyOrEntries: string | Record<string, unknown>, value?: T): Promise<void> {
+    if (typeof keyOrEntries === "string") this.values.set(keyOrEntries, value);
+    else for (const [key, entry] of Object.entries(keyOrEntries)) this.values.set(key, entry);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+
+  async setAlarm(time: number | Date): Promise<void> {
+    this.alarm = time instanceof Date ? time.getTime() : time;
+  }
+
+  async getAlarm(): Promise<number | null> {
+    return this.alarm;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = null;
+  }
+}
+
+export class MemoryDurableState {
+  readonly storageImpl = new MemoryStorage();
+  readonly sockets = new Map<string, WebSocket[]>();
+  readonly storage = this.storageImpl as unknown as DurableObjectStorage;
+
+  getWebSockets(tag?: string): WebSocket[] {
+    if (tag) return this.sockets.get(tag) ?? [];
+    return [...this.sockets.values()].flat();
+  }
+
+  acceptWebSocket(webSocket: WebSocket, tags?: string[]): void {
+    for (const tag of tags ?? []) {
+      const sockets = this.sockets.get(tag) ?? [];
+      sockets.push(webSocket);
+      this.sockets.set(tag, sockets);
+    }
+  }
+
+  asState(): DurableObjectState {
+    return this as unknown as DurableObjectState;
+  }
+}
+
+interface ApiKeyRow {
+  id: string;
+  user_id: string;
+  name: string;
+  key_hash: string;
+  created_at_ms: number;
+  last_used_at_ms: number | null;
+  revoked_at_ms: number | null;
+}
+
+interface SessionRow {
+  id: string;
+  user_id: string;
+  api_key_id: string;
+  host_cap_hash: string;
+  viewer_cap_hash: string;
+  created_at_ms: number;
+  expires_at_ms: number;
+  ended_at_ms: number | null;
+  ended_reason: string | null;
+}
+
+export class FakeD1 {
+  readonly apiKeys: ApiKeyRow[] = [];
+  readonly sessions: SessionRow[] = [];
+  control = { kill_switch_enabled: 0, reason: "", updated_at_ms: 0 };
+
+  prepare(sql: string): D1PreparedStatement {
+    return new FakeStatement(this, sql) as unknown as D1PreparedStatement;
+  }
+
+  asDatabase(): D1Database {
+    return this as unknown as D1Database;
+  }
+}
+
+class FakeStatement {
+  private parameters: unknown[] = [];
+  private readonly normalized: string;
+
+  constructor(
+    private readonly db: FakeD1,
+    sql: string,
+  ) {
+    this.normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+  }
+
+  bind(...parameters: unknown[]): this {
+    this.parameters = parameters;
+    return this;
+  }
+
+  async run(): Promise<D1Result> {
+    const sql = this.normalized;
+    let changes = 0;
+    if (sql.startsWith("insert into api_keys")) {
+      const [id, userId, name, keyHash, createdAt] = this.parameters as [string, string, string, string, number];
+      if (this.db.apiKeys.filter((row) => row.user_id === userId && row.revoked_at_ms === null).length >= 5) {
+        throw new Error("SQLITE_CONSTRAINT: active_api_key_limit");
+      }
+      this.db.apiKeys.push({
+        id,
+        user_id: userId,
+        name,
+        key_hash: keyHash,
+        created_at_ms: createdAt,
+        last_used_at_ms: null,
+        revoked_at_ms: null,
+      });
+      changes = 1;
+    } else if (sql.startsWith("update api_keys set revoked_at_ms")) {
+      const [now, id, userId] = this.parameters as [number, string, string];
+      const row = this.db.apiKeys.find(
+        (entry) => entry.id === id && entry.user_id === userId && entry.revoked_at_ms === null,
+      );
+      if (row) {
+        row.revoked_at_ms = now;
+        changes = 1;
+      }
+    } else if (sql.startsWith("update api_keys set last_used_at_ms")) {
+      const [now, id] = this.parameters as [number, string];
+      const row = this.db.apiKeys.find((entry) => entry.id === id && entry.revoked_at_ms === null);
+      if (row) {
+        row.last_used_at_ms = now;
+        changes = 1;
+      }
+    } else if (sql.startsWith("insert into sessions")) {
+      const [id, userId, apiKeyId, hostHash, viewerHash, createdAt, expiresAt] = this.parameters as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+      ];
+      this.db.sessions.push({
+        id,
+        user_id: userId,
+        api_key_id: apiKeyId,
+        host_cap_hash: hostHash,
+        viewer_cap_hash: viewerHash,
+        created_at_ms: createdAt,
+        expires_at_ms: expiresAt,
+        ended_at_ms: null,
+        ended_reason: null,
+      });
+      changes = 1;
+    } else if (sql.startsWith("update sessions set ended_at_ms")) {
+      const [now, reason, id, userId] = this.parameters as [number, string, string, string];
+      const row = this.db.sessions.find((entry) => entry.id === id && entry.user_id === userId);
+      if (row) {
+        row.ended_at_ms ??= now;
+        row.ended_reason ??= reason;
+        changes = 1;
+      }
+    } else if (sql.startsWith("update relay_control")) {
+      const [enabled, reason, now] = this.parameters as [number, string, number];
+      this.db.control = { kill_switch_enabled: enabled, reason, updated_at_ms: now };
+      changes = 1;
+    } else {
+      throw new Error(`Unsupported fake D1 run: ${this.normalized}`);
+    }
+    return { success: true, meta: { changes } } as unknown as D1Result;
+  }
+
+  async first<T>(): Promise<T | null> {
+    const sql = this.normalized;
+    if (sql.includes("from relay_control")) return { ...this.db.control } as T;
+    if (sql.includes("from api_keys where id = ?1")) {
+      const row = this.db.apiKeys.find((entry) => entry.id === this.parameters[0]);
+      return (row ? { ...row } : null) as T | null;
+    }
+    if (sql.includes("from sessions where id = ?1 and user_id = ?2")) {
+      const row = this.db.sessions.find(
+        (entry) => entry.id === this.parameters[0] && entry.user_id === this.parameters[1],
+      );
+      return (row ? { ...row } : null) as T | null;
+    }
+    if (sql.includes("from sessions where id = ?1")) {
+      const row = this.db.sessions.find((entry) => entry.id === this.parameters[0]);
+      return (row ? { ...row } : null) as T | null;
+    }
+    if (sql.includes("select count(*) as count from sessions")) {
+      const [userId, now] = this.parameters as [string, number];
+      return {
+        count: this.db.sessions.filter(
+          (entry) => entry.user_id === userId && entry.ended_at_ms === null && entry.expires_at_ms > now,
+        ).length,
+      } as T;
+    }
+    throw new Error(`Unsupported fake D1 first: ${this.normalized}`);
+  }
+
+  async all<T>(): Promise<D1Result<T>> {
+    const sql = this.normalized;
+    let results: unknown[];
+    if (sql.includes("from api_keys") && sql.includes("where user_id = ?1")) {
+      results = this.db.apiKeys
+        .filter((row) => row.user_id === this.parameters[0] && row.revoked_at_ms === null)
+        .sort((left, right) => right.created_at_ms - left.created_at_ms)
+        .map((row) => ({ ...row }));
+    } else if (sql.includes("select id from sessions")) {
+      const [now, limit] = this.parameters as [number, number];
+      results = this.db.sessions
+        .filter((row) => row.ended_at_ms === null && row.expires_at_ms > now)
+        .sort((left, right) => left.created_at_ms - right.created_at_ms)
+        .slice(0, limit)
+        .map((row) => ({ id: row.id }));
+    } else {
+      throw new Error(`Unsupported fake D1 all: ${this.normalized}`);
+    }
+    return { success: true, results } as unknown as D1Result<T>;
+  }
+}
+
+export function makeBaseEnv(overrides: Partial<Env> = {}): Env {
+  const d1 = new FakeD1();
+  const unavailableNamespace = {
+    idFromName: (name: string) => name,
+    get: () => ({ fetch: async () => new Response("not configured", { status: 503 }) }),
+  } as unknown as DurableObjectNamespace;
+  return {
+    DB: d1.asDatabase(),
+    RELAY_SESSION: unavailableNamespace,
+    USER_QUOTA: unavailableNamespace,
+    BUDGET_WINDOW: unavailableNamespace,
+    ASSETS: { fetch: async () => new Response("asset", { status: 404 }) } as unknown as Fetcher,
+    PUBLIC_ORIGIN: "https://relay.example.com",
+    APP_ORIGIN: "https://app.example.com",
+    CLERK_AUTHORIZED_PARTIES: "https://app.example.com",
+    CLERK_JWT_KEY: "test-public-key",
+    CLERK_WEBHOOK_SIGNING_SECRET: "whsec_test-secret-with-at-least-32-chars",
+    API_KEY_HMAC_SECRET: "api-hmac-secret-with-at-least-32-chars",
+    CAPABILITY_HMAC_SECRET: "cap-hmac-secret-with-at-least-32-chars",
+    INTERNAL_DO_SECRET: "internal-secret-with-at-least-32-chars",
+    ADMIN_TOKEN: "admin-token-with-at-least-32-characters",
+    ...overrides,
+  };
+}
+
+export class DirectNamespace {
+  readonly instances = new Map<string, { fetch(request: Request): Promise<Response> }>();
+
+  constructor(private readonly factory: (name: string) => { fetch(request: Request): Promise<Response> }) {}
+
+  idFromName(name: string): DurableObjectId {
+    return name as unknown as DurableObjectId;
+  }
+
+  get(id: DurableObjectId): DurableObjectStub {
+    const name = String(id);
+    let instance = this.instances.get(name);
+    if (!instance) {
+      instance = this.factory(name);
+      this.instances.set(name, instance);
+    }
+    return instance as unknown as DurableObjectStub;
+  }
+
+  asNamespace(): DurableObjectNamespace {
+    return this as unknown as DurableObjectNamespace;
+  }
+}
+
+export function jsonRequest(path: string, body: unknown, headers: HeadersInit = {}): Request {
+  return new Request(`https://internal${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...Object.fromEntries(new Headers(headers)) },
+    body: JSON.stringify(body),
+  });
+}

--- a/relay/test/helpers.ts
+++ b/relay/test/helpers.ts
@@ -3,6 +3,7 @@ import type { Env } from "../src/env";
 export class MemoryStorage {
   readonly values = new Map<string, unknown>();
   alarm: number | null = null;
+  deleteAllFailures = 0;
 
   async get<T>(key: string): Promise<T | undefined> {
     return this.values.get(key) as T | undefined;
@@ -18,8 +19,11 @@ export class MemoryStorage {
   }
 
   async deleteAll(): Promise<void> {
+    if (this.deleteAllFailures > 0) {
+      this.deleteAllFailures -= 1;
+      throw new Error("transient Durable Object deleteAll failure");
+    }
     this.values.clear();
-    this.alarm = null;
   }
 
   async setAlarm(time: number | Date): Promise<void> {

--- a/relay/test/helpers.ts
+++ b/relay/test/helpers.ts
@@ -17,6 +17,11 @@ export class MemoryStorage {
     return this.values.delete(key);
   }
 
+  async deleteAll(): Promise<void> {
+    this.values.clear();
+    this.alarm = null;
+  }
+
   async setAlarm(time: number | Date): Promise<void> {
     this.alarm = time instanceof Date ? time.getTime() : time;
   }
@@ -167,6 +172,15 @@ class FakeStatement {
       if (row) {
         row.ended_at_ms ??= now;
         row.ended_reason ??= reason;
+        changes = 1;
+      }
+    } else if (sql.startsWith("delete from sessions where id = ?1 and user_id = ?2")) {
+      const [id, userId] = this.parameters as [string, string];
+      const index = this.db.sessions.findIndex(
+        (entry) => entry.id === id && entry.user_id === userId,
+      );
+      if (index !== -1) {
+        this.db.sessions.splice(index, 1);
         changes = 1;
       }
     } else if (sql.startsWith("update relay_control")) {

--- a/relay/test/package-schema.test.ts
+++ b/relay/test/package-schema.test.ts
@@ -1,0 +1,76 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (path: string) => readFile(`${root}/${path}`, "utf8");
+
+describe("standalone package and deployment template", () => {
+  it("declares the Worker, Clerk, Workers types, Wrangler, TypeScript, and Vitest", async () => {
+    const packageJson = JSON.parse(await read("package.json"));
+    expect(packageJson.private).toBe(true);
+    expect(packageJson.type).toBe("module");
+    expect(packageJson.dependencies["@clerk/backend"]).toBeTruthy();
+    expect(packageJson.devDependencies["@cloudflare/workers-types"]).toBeTruthy();
+    expect(packageJson.devDependencies.vitest).toBeTruthy();
+    expect(packageJson.devDependencies.wrangler).toBeTruthy();
+    expect(packageJson.scripts.test).toContain("vitest run");
+    expect(Object.values(packageJson.scripts).join(" ")).not.toMatch(/wrangler deploy/);
+  });
+
+  it("binds exactly the three required Durable Object classes and D1 migration directory", async () => {
+    const wrangler = await read("wrangler.example.toml");
+    expect(wrangler.match(/\[\[durable_objects\.bindings\]\]/g)).toHaveLength(3);
+    expect(wrangler).toContain('class_name = "RelaySession"');
+    expect(wrangler).toContain('class_name = "UserQuota"');
+    expect(wrangler).toContain('class_name = "BudgetWindow"');
+    expect(wrangler).toContain('new_sqlite_classes = ["RelaySession", "UserQuota", "BudgetWindow"]');
+    expect(wrangler).toContain('migrations_dir = "migrations"');
+    expect(wrangler).toContain('run_worker_first = true');
+    expect(wrangler).toContain("WEEKLY_VIEWER_SECONDS = \"7200\"");
+    expect(wrangler).toContain("LEASE_SECONDS = \"900\"");
+    expect(wrangler).toContain("BUDGET_CEILING_USD = \"900\"");
+    expect(wrangler).toContain("enabled = false");
+  });
+});
+
+describe("D1 schema security invariants", () => {
+  it("stores only HMAC hash columns for API and WebSocket capabilities", async () => {
+    const migration = await read("migrations/0001_initial.sql");
+    expect(migration).toContain("key_hash TEXT NOT NULL UNIQUE");
+    expect(migration).toContain("host_cap_hash TEXT NOT NULL");
+    expect(migration).toContain("viewer_cap_hash TEXT NOT NULL");
+    expect(migration).not.toMatch(/api_key_secret|host_capability\s+text|viewer_capability\s+text|root_key\s+text/i);
+  });
+
+  it("enforces five active API keys atomically in SQLite", async () => {
+    const migration = await read("migrations/0001_initial.sql");
+    expect(migration).toContain("CREATE TRIGGER api_keys_max_five");
+    expect(migration).toMatch(/COUNT\(\*\)[\s\S]*revoked_at_ms IS NULL[\s\S]*>= 5/);
+    expect(migration).toContain("RAISE(ABORT, 'active_api_key_limit')");
+  });
+
+  it("contains no payload, frame, chat, or input log table", async () => {
+    const migration = (await read("migrations/0001_initial.sql")).toLowerCase();
+    expect(migration).not.toMatch(/create table (?:frames|messages|chat|input|payload)/);
+  });
+});
+
+describe("documentation safety caveats", () => {
+  it("states that Cloudflare alerts and the relay reservation are not an account spending cap", async () => {
+    const readme = await read("README.md");
+    expect(readme).toContain("Cloudflare budget alerts are informational");
+    expect(readme).toContain("not a Cloudflare account spending cap");
+    expect(readme).toContain("No deployment is performed");
+  });
+
+  it("documents the fragment key, peer-IP limitation, close codes, and challenge gate", async () => {
+    const [readme, protocol] = await Promise.all([read("README.md"), read("docs/PROTOCOL.md")]);
+    expect(readme).toContain("`#k=...`");
+    expect(readme).toContain("Cloudflare necessarily observes each endpoint IP");
+    expect(readme).toContain("4413");
+    expect(protocol).toContain("does not inspect it");
+    expect(protocol).toContain("refuses to release any viewer");
+  });
+});

--- a/relay/test/protocol-http-viewer.test.ts
+++ b/relay/test/protocol-http-viewer.test.ts
@@ -1,0 +1,167 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { CLOSE_CODE, HOST_PROTOCOL_PREFIX, RELAY_PROTOCOL, VIEWER_PROTOCOL_PREFIX } from "../src/constants";
+import { generateCapability } from "../src/crypto";
+import {
+  applyCors,
+  bearerCredential,
+  cookieValue,
+  enforceExactApiOrigin,
+  HttpError,
+  preflightResponse,
+  readJsonObject,
+} from "../src/http";
+import { hostControlNotice, parseWebSocketProtocols } from "../src/protocol";
+import { viewerPageResponse } from "../src/viewer-page";
+
+const relayRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("WebSocket subprotocol capabilities", () => {
+  it("accepts exactly the version protocol followed by one canonical host capability", () => {
+    const capability = generateCapability();
+    expect(parseWebSocketProtocols(`${RELAY_PROTOCOL}, ${HOST_PROTOCOL_PREFIX}${capability}`)).toEqual({
+      role: "host",
+      capability,
+    });
+  });
+
+  it("accepts a viewer proof with the same 32-byte canonical shape", () => {
+    const proof = generateCapability();
+    expect(parseWebSocketProtocols(`${RELAY_PROTOCOL},${VIEWER_PROTOCOL_PREFIX}${proof}`)).toEqual({
+      role: "viewer",
+      capability: proof,
+    });
+  });
+
+  it.each([
+    null,
+    "",
+    RELAY_PROTOCOL,
+    `${RELAY_PROTOCOL}, bw.host.short`,
+    `${RELAY_PROTOCOL}, bw.unknown.${"a".repeat(43)}`,
+    `other.v1, bw.host.${"a".repeat(43)}`,
+    `${RELAY_PROTOCOL}, bw.host.${"a".repeat(43)}, extra`,
+    `bw.host.${"a".repeat(43)}, ${RELAY_PROTOCOL}`,
+  ])("rejects ambiguous or malformed protocols %j", (header) => {
+    expect(parseWebSocketProtocols(header)).toBeNull();
+  });
+
+  it("serializes only bounded relay lifecycle metadata for the host", () => {
+    expect(hostControlNotice("viewer_connected", { leaseExpiresAtMs: 123 })).toBe(
+      '{"t":"relay","event":"viewer_connected","leaseExpiresAtMs":123}',
+    );
+  });
+
+  it("defines unique private close codes for every enforcement path", () => {
+    const codes = Object.values(CLOSE_CODE);
+    expect(new Set(codes).size).toBe(codes.length);
+    expect(codes.every((code) => code >= 4000 && code <= 4999)).toBe(true);
+  });
+});
+
+describe("exact-origin CORS and HTTP parsing", () => {
+  const appOrigin = "https://app.example.com";
+
+  it("adds credentials CORS only for the exact configured origin", async () => {
+    const exact = new Request("https://relay.example.com/v1/me", { headers: { Origin: appOrigin } });
+    const allowed = applyCors(new Response("ok"), exact, appOrigin);
+    expect(allowed.headers.get("Access-Control-Allow-Origin")).toBe(appOrigin);
+    expect(allowed.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(await allowed.text()).toBe("ok");
+
+    const suffixAttack = new Request("https://relay.example.com/v1/me", {
+      headers: { Origin: "https://app.example.com.attacker.test" },
+    });
+    const denied = applyCors(new Response("ok"), suffixAttack, appOrigin);
+    expect(denied.headers.has("Access-Control-Allow-Origin")).toBe(false);
+    expect(() => enforceExactApiOrigin(suffixAttack, appOrigin)).toThrow(HttpError);
+  });
+
+  it("returns a narrow preflight and rejects missing or unapproved browser origins", () => {
+    const request = new Request("https://relay.example.com/v1/keys", {
+      method: "OPTIONS",
+      headers: {
+        Origin: appOrigin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    });
+    const response = preflightResponse(request, appOrigin);
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(appOrigin);
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, Content-Type");
+    expect(() =>
+      preflightResponse(new Request(request.url, { method: "OPTIONS" }), appOrigin),
+    ).toThrow(/exact browser origin/);
+  });
+
+  it("extracts a single strict bearer credential and exact cookie name", () => {
+    expect(bearerCredential(new Request("https://x", { headers: { Authorization: "Bearer token_1" } }))).toBe(
+      "token_1",
+    );
+    expect(bearerCredential(new Request("https://x", { headers: { Authorization: "Bearer a b" } }))).toBeNull();
+    expect(cookieValue(new Request("https://x", { headers: { Cookie: "other=1; __session=jwt.value; x=2" } }), "__session")).toBe(
+      "jwt.value",
+    );
+  });
+
+  it("accepts only bounded JSON objects", async () => {
+    await expect(
+      readJsonObject(
+        new Request("https://x", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: '{"ok":true}',
+        }),
+      ),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      readJsonObject(new Request("https://x", { method: "POST", body: "{}" })),
+    ).rejects.toMatchObject({ status: 415 });
+    await expect(
+      readJsonObject(
+        new Request("https://x", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "[]",
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("viewer shell security", () => {
+  it("serves a no-store shell with strict CSP and no root material in HTML", async () => {
+    const sessionId = "bws_ABCDEFGHIJKLMNOPQRSTUVWXYZ".slice(0, 28);
+    const response = viewerPageResponse(sessionId, "https://relay.example.com");
+    const html = await response.text();
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Security-Policy")).toContain("default-src 'none'");
+    expect(response.headers.get("Content-Security-Policy")).toContain("connect-src 'self' wss://relay.example.com");
+    expect(response.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
+    expect(html).toContain(`content="${sessionId}"`);
+    expect(html).toContain('src="/viewer.js"');
+    expect(html).not.toContain("#k=");
+    expect(html).not.toMatch(/<script(?![^>]*src=)/);
+  });
+
+  it("ships a client with no WebRTC, storage persistence, eval, or payload logging", async () => {
+    const [viewer, viewerCrypto, relaySession] = await Promise.all([
+      readFile(`${relayRoot}/public/viewer.js`, "utf8"),
+      readFile(`${relayRoot}/public/viewer-crypto.js`, "utf8"),
+      readFile(`${relayRoot}/src/durable/relay-session.ts`, "utf8"),
+    ]);
+    const browserSource = `${viewer}\n${viewerCrypto}`;
+    expect(browserSource).not.toMatch(/RTCPeerConnection|webkitRTCPeerConnection|mozRTCPeerConnection/);
+    expect(browserSource).not.toMatch(/localStorage|sessionStorage|indexedDB/);
+    expect(browserSource).not.toMatch(/\beval\s*\(|new Function/);
+    expect(browserSource).not.toMatch(/console\.(?:log|debug|info|warn|error)/);
+    expect(relaySession).not.toMatch(/console\.(?:log|debug|info|warn|error)/);
+    expect(viewer).toContain("history.replaceState");
+    expect(viewer).toContain("bw_e2e_ready");
+    expect(viewer).toContain("createEnvelopeReceiver");
+    expect(viewer).toContain("createEnvelopeSender");
+  });
+});

--- a/relay/test/quota-budget.test.ts
+++ b/relay/test/quota-budget.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { internalHeaders } from "../src/auth";
+import { BudgetWindow } from "../src/durable/budget-window";
+import {
+  chargedLeaseMs,
+  computeLeaseDurationMs,
+  UserQuota,
+  type ActiveLease,
+} from "../src/durable/user-quota";
+import type { Env } from "../src/env";
+import { DirectNamespace, makeBaseEnv, MemoryDurableState } from "./helpers";
+
+const sessionA = `bws_${"A".repeat(24)}`;
+const sessionB = `bws_${"B".repeat(24)}`;
+const userId = "user_TestAccount1";
+const monday = Date.parse("2026-07-20T00:00:00.000Z");
+
+interface QuotaHarness {
+  env: Env;
+  quota: UserQuota;
+  quotaState: MemoryDurableState;
+  budgets: DirectNamespace;
+}
+
+function harness(overrides: Partial<Env> = {}): QuotaHarness {
+  let env = makeBaseEnv(overrides);
+  const budgets = new DirectNamespace(() => {
+    const state = new MemoryDurableState();
+    return new BudgetWindow(state.asState(), env);
+  });
+  env = { ...env, BUDGET_WINDOW: budgets.asNamespace() };
+  const quotaState = new MemoryDurableState();
+  const quota = new UserQuota(quotaState.asState(), env);
+  return { env, quota, quotaState, budgets };
+}
+
+function quotaRequest(env: Env, path: string, body?: unknown): Request {
+  return new Request(`https://internal${path}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers: internalHeaders(env),
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+async function reserveLease(h: QuotaHarness, sessionId = sessionA, expiresAtMs = monday + 24 * 60 * 60 * 1_000) {
+  const response = await h.quota.fetch(
+    quotaRequest(h.env, "/acquire", { userId, sessionId, sessionExpiresAtMs: expiresAtMs }),
+  );
+  return { response, body: (await response.json()) as any };
+}
+
+async function acquire(h: QuotaHarness, sessionId = sessionA, expiresAtMs = monday + 24 * 60 * 60 * 1_000) {
+  const reserved = await reserveLease(h, sessionId, expiresAtMs);
+  if (!reserved.body.ok) return reserved;
+  const response = await h.quota.fetch(
+    quotaRequest(h.env, "/activate", {
+      leaseId: reserved.body.lease.leaseId,
+      sessionId: reserved.body.lease.sessionId,
+    }),
+  );
+  return { response, body: (await response.json()) as any };
+}
+
+async function release(h: QuotaHarness, lease: ActiveLease, endedAtMs: number) {
+  const response = await h.quota.fetch(
+    quotaRequest(h.env, "/release", {
+      leaseId: lease.leaseId,
+      sessionId: lease.sessionId,
+      endedAtMs,
+    }),
+  );
+  return { response, body: (await response.json()) as any };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(monday);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("pure lease accounting", () => {
+  it("grants no more than 15 minutes or weekly remaining time", () => {
+    expect(computeLeaseDurationMs(0, 0, 7_200_000, 900_000, 9_000_000, 9_000_000, 9_000_000)).toBe(
+      900_000,
+    );
+    expect(
+      computeLeaseDurationMs(0, 7_150_000, 7_200_000, 900_000, 9_000_000, 9_000_000, 9_000_000),
+    ).toBe(50_000);
+  });
+
+  it("clamps a lease at ISO-week, billing-window, and session boundaries", () => {
+    expect(computeLeaseDurationMs(1_000, 0, 7_200_000, 900_000, 61_000, 91_000, 121_000)).toBe(60_000);
+    expect(computeLeaseDurationMs(1_000, 0, 7_200_000, 900_000, 900_000, 31_000, 121_000)).toBe(30_000);
+    expect(computeLeaseDurationMs(1_000, 0, 7_200_000, 900_000, 900_000, 900_000, 21_000)).toBe(20_000);
+  });
+
+  it("charges only connected elapsed time and never beyond expiry", () => {
+    const lease: ActiveLease = {
+      leaseId: "lease",
+      sessionId: sessionA,
+      userId,
+      startedAtMs: 1_000,
+      expiresAtMs: 901_000,
+      status: "active",
+      activationDeadlineMs: 30_000,
+      maxDurationMs: 900_000,
+      notAfterMs: 901_000,
+      budgetWindowKey: "window",
+      budgetWindowStartsAtMs: 0,
+      budgetWindowEndsAtMs: 1_000_000,
+    };
+    expect(chargedLeaseMs(lease, 1_000)).toBe(0);
+    expect(chargedLeaseMs(lease, 121_000)).toBe(120_000);
+    expect(chargedLeaseMs(lease, 9_000_000)).toBe(900_000);
+    expect(chargedLeaseMs(lease, 0)).toBe(0);
+  });
+});
+
+describe("UserQuota Durable Object", () => {
+  it("issues one 15-minute active lease and reserves $0.0025", async () => {
+    const h = harness();
+    const result = await acquire(h);
+    expect(result.response.status).toBe(200);
+    expect(result.body.ok).toBe(true);
+    expect(result.body.lease.expiresAtMs - result.body.lease.startedAtMs).toBe(900_000);
+    expect(result.body.lease.status).toBe("active");
+
+    const budget = h.budgets.instances.values().next().value as BudgetWindow;
+    const status = await budget.fetch(quotaRequest(h.env, "/status"));
+    expect((await status.json()) as any).toMatchObject({ reservedMicroUsd: 2_500 });
+  });
+
+  it("does not charge the admission reservation before the viewer socket is activated", async () => {
+    const h = harness();
+    const reserved = await reserveLease(h);
+    expect(reserved.body.lease.status).toBe("reserved");
+    vi.setSystemTime(monday + 10_000);
+    const beforeActivation = await h.quota.fetch(quotaRequest(h.env, "/status"));
+    expect(((await beforeActivation.json()) as any).week.usedMs).toBe(0);
+
+    const activated = await h.quota.fetch(
+      quotaRequest(h.env, "/activate", {
+        leaseId: reserved.body.lease.leaseId,
+        sessionId: sessionA,
+      }),
+    );
+    const active = (await activated.json()) as any;
+    expect(active.lease.startedAtMs).toBe(monday + 10_000);
+    expect(active.lease.expiresAtMs - active.lease.startedAtMs).toBe(900_000);
+    vi.setSystemTime(monday + 15_000);
+    const afterActivation = await h.quota.fetch(quotaRequest(h.env, "/status"));
+    expect(((await afterActivation.json()) as any).week.usedMs).toBe(5_000);
+  });
+
+  it("rejects a second session while the account has an active viewer lease", async () => {
+    const h = harness();
+    const first = await acquire(h);
+    const second = await acquire(h, sessionB);
+    expect(first.body.ok).toBe(true);
+    expect(second.response.status).toBe(409);
+    expect(second.body).toMatchObject({ ok: false, code: "active_viewer_lease", activeSessionId: sessionA });
+  });
+
+  it("settles an early disconnect at exact connected time, not the reserved 15 minutes", async () => {
+    const h = harness();
+    const first = await acquire(h);
+    const lease = first.body.lease as ActiveLease;
+    vi.setSystemTime(monday + 123_456);
+    const ended = await release(h, lease, monday + 123_456);
+    expect(ended.body.usedMs).toBe(123_456);
+    const status = await h.quota.fetch(quotaRequest(h.env, "/status"));
+    const usage = (await status.json()) as any;
+    expect(usage.week.usedMs).toBe(123_456);
+    expect(usage.activeLease).toBeNull();
+  });
+
+  it("is idempotent when a release is retried", async () => {
+    const h = harness();
+    const first = await acquire(h);
+    const lease = first.body.lease as ActiveLease;
+    vi.setSystemTime(monday + 60_000);
+    expect((await release(h, lease, monday + 60_000)).body.idempotent).toBe(false);
+    const retry = await release(h, lease, monday + 60_000);
+    expect(retry.body).toMatchObject({ ok: true, idempotent: true, usedMs: 60_000 });
+  });
+
+  it("enforces exactly two connected hours in an ISO week", async () => {
+    const h = harness();
+    for (let index = 0; index < 8; index += 1) {
+      vi.setSystemTime(monday + index * 900_000);
+      const result = await acquire(h);
+      expect(result.body.ok).toBe(true);
+      const lease = result.body.lease as ActiveLease;
+      vi.setSystemTime(lease.expiresAtMs);
+      await release(h, lease, lease.expiresAtMs);
+    }
+    vi.setSystemTime(monday + 7_200_000);
+    const ninth = await acquire(h);
+    expect(ninth.response.status).toBe(409);
+    expect(ninth.body).toMatchObject({ ok: false, code: "quota_exhausted", usedMs: 7_200_000 });
+  });
+
+  it("starts a fresh allowance on the next Monday UTC", async () => {
+    const h = harness({ WEEKLY_VIEWER_SECONDS: "60", LEASE_SECONDS: "60" });
+    const first = await acquire(h, sessionA, monday + 8 * 24 * 60 * 60 * 1_000);
+    const lease = first.body.lease as ActiveLease;
+    vi.setSystemTime(lease.expiresAtMs);
+    await release(h, lease, lease.expiresAtMs);
+    expect((await acquire(h)).body.code).toBe("quota_exhausted");
+    const nextMonday = monday + 7 * 24 * 60 * 60 * 1_000;
+    vi.setSystemTime(nextMonday);
+    const renewed = await acquire(h, sessionA, nextMonday + 24 * 60 * 60 * 1_000);
+    expect(renewed.body.ok).toBe(true);
+    expect(renewed.body.lease.startedAtMs).toBe(nextMonday);
+  });
+
+  it("clamps a Sunday-night lease at Monday 00:00 UTC", async () => {
+    const sunday = Date.parse("2026-07-26T23:55:00.000Z");
+    vi.setSystemTime(sunday);
+    const h = harness();
+    const result = await acquire(h, sessionA, sunday + 24 * 60 * 60 * 1_000);
+    expect(result.body.lease.expiresAtMs - result.body.lease.startedAtMs).toBe(5 * 60_000);
+  });
+
+  it("fails closed when the budget reservation service is unavailable", async () => {
+    const env = makeBaseEnv();
+    const state = new MemoryDurableState();
+    const quota = new UserQuota(state.asState(), env);
+    const response = await quota.fetch(
+      quotaRequest(env, "/acquire", {
+        userId,
+        sessionId: sessionA,
+        sessionExpiresAtMs: monday + 86_400_000,
+      }),
+    );
+    expect(response.status).toBe(503);
+    expect((await response.json()) as any).toMatchObject({ ok: false, code: "budget_unavailable" });
+  });
+});
+
+describe("BudgetWindow Durable Object", () => {
+  function budgetHarness() {
+    const env = makeBaseEnv();
+    const state = new MemoryDurableState();
+    return { env, state, budget: new BudgetWindow(state.asState(), env) };
+  }
+
+  function reserveRequest(env: Env, reservationId: string, ceilingMicroUsd = 5_000) {
+    return quotaRequest(env, "/reserve", {
+      reservationId,
+      windowKey: "2026-07-01",
+      startsAtMs: Date.parse("2026-07-01T00:00:00Z"),
+      endsAtMs: Date.parse("2026-08-01T00:00:00Z"),
+      amountMicroUsd: 2_500,
+      ceilingMicroUsd,
+    });
+  }
+
+  it("serializes concurrent reservations against a hard ceiling", async () => {
+    const h = budgetHarness();
+    const responses = await Promise.all([
+      h.budget.fetch(reserveRequest(h.env, "user_1:lease_1")),
+      h.budget.fetch(reserveRequest(h.env, "user_2:lease_2")),
+      h.budget.fetch(reserveRequest(h.env, "user_3:lease_3")),
+    ]);
+    expect(responses.filter((response) => response.status === 200)).toHaveLength(2);
+    expect(responses.filter((response) => response.status === 409)).toHaveLength(1);
+    expect(h.state.storageImpl.values.get("totalMicroUsd")).toBe(5_000);
+  });
+
+  it("makes reservation IDs idempotent without double counting", async () => {
+    const h = budgetHarness();
+    expect((await h.budget.fetch(reserveRequest(h.env, "user_1:lease_1"))).status).toBe(200);
+    const retry = await h.budget.fetch(reserveRequest(h.env, "user_1:lease_1"));
+    expect((await retry.json()) as any).toMatchObject({ ok: true, idempotent: true, reservedMicroUsd: 2_500 });
+  });
+
+  it("rejects a mismatched window identity in the same Durable Object", async () => {
+    const h = budgetHarness();
+    await h.budget.fetch(reserveRequest(h.env, "user_1:lease_1"));
+    const bad = quotaRequest(h.env, "/reserve", {
+      reservationId: "user_2:lease_2",
+      windowKey: "wrong-window",
+      startsAtMs: 1,
+      endsAtMs: 2,
+      amountMicroUsd: 2_500,
+      ceilingMicroUsd: 5_000,
+    });
+    expect((await h.budget.fetch(bad)).status).toBe(409);
+  });
+
+  it("requires the internal token", async () => {
+    const h = budgetHarness();
+    const request = reserveRequest(h.env, "user_1:lease_1");
+    request.headers.set("X-Relay-Internal", "wrong");
+    expect((await h.budget.fetch(request)).status).toBe(403);
+  });
+});

--- a/relay/test/rate-limit.test.ts
+++ b/relay/test/rate-limit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { consumeRate, initialRateState, type RatePolicy } from "../src/rate-limit";
+
+const policy: RatePolicy = {
+  sustainedMessagesPerSecond: 15,
+  burstMessages: 20,
+  maxBytesPerSecond: 1_250_000,
+  byteBurstCapacity: 2 * 1024 * 1024,
+};
+
+describe("relay token buckets", () => {
+  it("allows a 20-message burst and then enforces 15 messages per second", () => {
+    let state = initialRateState(policy, 1_000);
+    for (let index = 0; index < 20; index += 1) {
+      const decision = consumeRate(state, 1, 1_000, policy);
+      expect(decision.allowed).toBe(true);
+      state = decision.state;
+    }
+    const blocked = consumeRate(state, 1, 1_000, policy);
+    expect(blocked).toMatchObject({ allowed: false, reason: "message_rate" });
+    state = blocked.state;
+    for (let index = 0; index < 15; index += 1) {
+      const decision = consumeRate(state, 1, 2_000, policy);
+      expect(decision.allowed).toBe(true);
+      state = decision.state;
+    }
+    expect(consumeRate(state, 1, 2_000, policy)).toMatchObject({
+      allowed: false,
+      reason: "message_rate",
+    });
+  });
+
+  it("permits one maximum-sized envelope but refills at only 10 Mbps", () => {
+    let state = initialRateState(policy, 0);
+    const maximum = consumeRate(state, 2 * 1024 * 1024, 0, policy);
+    expect(maximum.allowed).toBe(true);
+    state = maximum.state;
+    expect(consumeRate(state, 1, 0, policy)).toMatchObject({ allowed: false, reason: "bandwidth" });
+
+    const afterOneSecond = consumeRate(state, 1_250_000, 1_000, policy);
+    expect(afterOneSecond.allowed).toBe(true);
+    expect(afterOneSecond.state.byteTokens).toBeCloseTo(0, 6);
+  });
+
+  it("does not create tokens when clocks move backwards and caps long-idle accumulation", () => {
+    const initial = initialRateState(policy, 5_000);
+    const one = consumeRate(initial, 100, 5_000, policy);
+    const backward = consumeRate(one.state, 100, 4_000, policy);
+    expect(backward.state.messageTokens).toBe(18);
+    const longIdle = consumeRate(backward.state, 1, 1_000_000, policy);
+    expect(longIdle.allowed).toBe(true);
+    expect(longIdle.state.messageTokens).toBe(19);
+    expect(longIdle.state.byteTokens).toBe(policy.byteBurstCapacity - 1);
+  });
+
+  it("checks message rate before bandwidth without consuming either on denial", () => {
+    const emptyMessages = { messageTokens: 0, byteTokens: 0, updatedAtMs: 0 };
+    const decision = consumeRate(emptyMessages, 999, 0, policy);
+    expect(decision.reason).toBe("message_rate");
+    expect(decision.state).toEqual(emptyMessages);
+  });
+});

--- a/relay/test/relay-session.test.ts
+++ b/relay/test/relay-session.test.ts
@@ -116,6 +116,43 @@ describe("RelaySession Durable Object persistence", () => {
     expect(state.storageImpl.alarm).toBeNull();
   });
 
+  it("retains a tombstone alarm until transient D1 deletion succeeds", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    const config = sessionConfig();
+    await insertSession(env, {
+      id: config.sessionId,
+      user_id: config.userId,
+      api_key_id: "key_test",
+      host_cap_hash: config.hostCapHash,
+      viewer_cap_hash: config.viewerCapHash,
+      created_at_ms: config.createdAtMs,
+      expires_at_ms: config.expiresAtMs,
+      ended_at_ms: null,
+      ended_reason: null,
+    });
+    await relay.fetch(request(env, "/init", config));
+    db.sessionDeleteFailures = 1;
+
+    const first = await relay.fetch(
+      request(env, "/terminate", { reason: "deleted" }),
+    );
+    expect(first.status).toBe(500);
+    expect(db.sessions).toHaveLength(1);
+    expect(state.storageImpl.alarm).not.toBeNull();
+    expect(state.storageImpl.values.get("config")).toMatchObject({
+      sessionId: config.sessionId,
+      terminatedAtMs: expect.any(Number),
+    });
+
+    await relay.alarm();
+    expect(db.sessions).toHaveLength(0);
+    expect(state.storageImpl.values.size).toBe(0);
+    expect(state.storageImpl.alarm).toBeNull();
+  });
+
   it("denies all internal endpoints when the service token is wrong", async () => {
     const env = makeBaseEnv();
     const relay = new RelaySession(new MemoryDurableState().asState(), env);

--- a/relay/test/relay-session.test.ts
+++ b/relay/test/relay-session.test.ts
@@ -153,6 +153,42 @@ describe("RelaySession Durable Object persistence", () => {
     expect(state.storageImpl.alarm).toBeNull();
   });
 
+  it("keeps a retry alarm when Durable Object deleteAll fails", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    const config = sessionConfig();
+    await insertSession(env, {
+      id: config.sessionId,
+      user_id: config.userId,
+      api_key_id: "key_test",
+      host_cap_hash: config.hostCapHash,
+      viewer_cap_hash: config.viewerCapHash,
+      created_at_ms: config.createdAtMs,
+      expires_at_ms: config.expiresAtMs,
+      ended_at_ms: null,
+      ended_reason: null,
+    });
+    await relay.fetch(request(env, "/init", config));
+    state.storageImpl.deleteAllFailures = 1;
+
+    const first = await relay.fetch(
+      request(env, "/terminate", { reason: "deleted" }),
+    );
+    expect(first.status).toBe(500);
+    expect(db.sessions).toHaveLength(0);
+    expect(state.storageImpl.alarm).not.toBeNull();
+    expect(state.storageImpl.values.get("config")).toMatchObject({
+      sessionId: config.sessionId,
+      terminatedAtMs: expect.any(Number),
+    });
+
+    await relay.alarm();
+    expect(state.storageImpl.values.size).toBe(0);
+    expect(state.storageImpl.alarm).toBeNull();
+  });
+
   it("denies all internal endpoints when the service token is wrong", async () => {
     const env = makeBaseEnv();
     const relay = new RelaySession(new MemoryDurableState().asState(), env);

--- a/relay/test/relay-session.test.ts
+++ b/relay/test/relay-session.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { internalHeaders } from "../src/auth";
+import { bytesToBase64Url, generateSessionId } from "../src/crypto";
+import { RelaySession } from "../src/durable/relay-session";
+import { makeBaseEnv, MemoryDurableState } from "./helpers";
+
+function request(env: ReturnType<typeof makeBaseEnv>, path: string, body?: unknown, token = env.INTERNAL_DO_SECRET) {
+  const headers = new Headers(internalHeaders(env));
+  headers.set("X-Relay-Internal", token);
+  return new Request(`https://internal${path}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function sessionConfig() {
+  return {
+    sessionId: generateSessionId(),
+    userId: "user_RelaySessionTest",
+    createdAtMs: 1_000,
+    expiresAtMs: 1_000_000,
+    hostCapHash: bytesToBase64Url(new Uint8Array(32).fill(1)),
+    viewerCapHash: bytesToBase64Url(new Uint8Array(32).fill(2)),
+  };
+}
+
+describe("RelaySession Durable Object persistence", () => {
+  it("initializes once with HMAC digests and no plaintext capability fields", async () => {
+    const env = makeBaseEnv();
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    const config = sessionConfig();
+    const response = await relay.fetch(request(env, "/init", config));
+    expect(response.status).toBe(200);
+    expect((await response.json()) as any).toEqual({ ok: true, idempotent: false });
+    expect(state.storageImpl.alarm).toBe(config.expiresAtMs);
+    const stored = state.storageImpl.values.get("config") as Record<string, unknown>;
+    expect(stored).toMatchObject(config);
+    expect(Object.keys(stored).sort()).toEqual(
+      ["createdAtMs", "expiresAtMs", "hostCapHash", "sessionId", "userId", "viewerCapHash"].sort(),
+    );
+  });
+
+  it("makes identical initialization idempotent and rejects a conflicting reinitialization", async () => {
+    const env = makeBaseEnv();
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    const config = sessionConfig();
+    await relay.fetch(request(env, "/init", config));
+    expect((await (await relay.fetch(request(env, "/init", config))).json()) as any).toEqual({
+      ok: true,
+      idempotent: true,
+    });
+    const conflict = await relay.fetch(
+      request(env, "/init", { ...config, viewerCapHash: bytesToBase64Url(new Uint8Array(32).fill(9)) }),
+    );
+    expect(conflict.status).toBe(409);
+  });
+
+  it("reports only connection lifecycle state, never hashes", async () => {
+    const env = makeBaseEnv();
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    await relay.fetch(request(env, "/init", sessionConfig()));
+    const response = await relay.fetch(request(env, "/status"));
+    const text = await response.text();
+    expect(JSON.parse(text)).toEqual({
+      ok: true,
+      initialized: true,
+      terminated: false,
+      hostConnected: false,
+      viewerConnected: false,
+      leaseExpiresAtMs: null,
+    });
+    expect(text).not.toMatch(/CapHash|capability|root/i);
+  });
+
+  it("persists termination and makes it idempotent", async () => {
+    const env = makeBaseEnv();
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    await relay.fetch(request(env, "/init", sessionConfig()));
+    const first = await relay.fetch(request(env, "/terminate", { reason: "deleted" }));
+    expect((await first.json()) as any).toEqual({ ok: true, idempotent: false });
+    expect(state.storageImpl.alarm).toBeNull();
+    const second = await relay.fetch(request(env, "/terminate", { reason: "again" }));
+    expect((await second.json()) as any).toEqual({ ok: true, idempotent: true });
+  });
+
+  it("denies all internal endpoints when the service token is wrong", async () => {
+    const env = makeBaseEnv();
+    const relay = new RelaySession(new MemoryDurableState().asState(), env);
+    const response = await relay.fetch(request(env, "/status", undefined, "wrong-token"));
+    expect(response.status).toBe(403);
+    expect((await response.json()) as any).toMatchObject({ error: { code: "forbidden" } });
+  });
+
+  it("validates session IDs, users, timestamps, and hash lengths", async () => {
+    const env = makeBaseEnv();
+    const relay = new RelaySession(new MemoryDurableState().asState(), env);
+    const good = sessionConfig();
+    for (const bad of [
+      { ...good, sessionId: "bad" },
+      { ...good, userId: "not-a-clerk-user" },
+      { ...good, expiresAtMs: good.createdAtMs },
+      { ...good, hostCapHash: "short" },
+    ]) {
+      expect((await relay.fetch(request(env, "/init", bad))).status).toBe(400);
+    }
+  });
+});

--- a/relay/test/relay-session.test.ts
+++ b/relay/test/relay-session.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { internalHeaders } from "../src/auth";
 import { bytesToBase64Url, generateSessionId } from "../src/crypto";
 import { RelaySession } from "../src/durable/relay-session";
-import { makeBaseEnv, MemoryDurableState } from "./helpers";
+import { insertSession } from "../src/repositories/sessions";
+import { FakeD1, makeBaseEnv, MemoryDurableState } from "./helpers";
 
 function request(env: ReturnType<typeof makeBaseEnv>, path: string, body?: unknown, token = env.INTERNAL_DO_SECRET) {
   const headers = new Headers(internalHeaders(env));
@@ -76,7 +77,7 @@ describe("RelaySession Durable Object persistence", () => {
     expect(text).not.toMatch(/CapHash|capability|root/i);
   });
 
-  it("persists termination and makes it idempotent", async () => {
+  it("purges termination state and remains idempotent", async () => {
     const env = makeBaseEnv();
     const state = new MemoryDurableState();
     const relay = new RelaySession(state.asState(), env);
@@ -84,8 +85,35 @@ describe("RelaySession Durable Object persistence", () => {
     const first = await relay.fetch(request(env, "/terminate", { reason: "deleted" }));
     expect((await first.json()) as any).toEqual({ ok: true, idempotent: false });
     expect(state.storageImpl.alarm).toBeNull();
+    expect(state.storageImpl.values.size).toBe(0);
     const second = await relay.fetch(request(env, "/terminate", { reason: "again" }));
     expect((await second.json()) as any).toEqual({ ok: true, idempotent: true });
+  });
+
+  it("purges expired Durable Object and D1 session state", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const state = new MemoryDurableState();
+    const relay = new RelaySession(state.asState(), env);
+    const config = sessionConfig();
+    await insertSession(env, {
+      id: config.sessionId,
+      user_id: config.userId,
+      api_key_id: "key_test",
+      host_cap_hash: config.hostCapHash,
+      viewer_cap_hash: config.viewerCapHash,
+      created_at_ms: config.createdAtMs,
+      expires_at_ms: config.expiresAtMs,
+      ended_at_ms: null,
+      ended_reason: null,
+    });
+    await relay.fetch(request(env, "/init", config));
+
+    await relay.alarm();
+
+    expect(db.sessions).toHaveLength(0);
+    expect(state.storageImpl.values.size).toBe(0);
+    expect(state.storageImpl.alarm).toBeNull();
   });
 
   it("denies all internal endpoints when the service token is wrong", async () => {

--- a/relay/test/repositories.test.ts
+++ b/relay/test/repositories.test.ts
@@ -15,6 +15,7 @@ import {
   insertSession,
   listActiveSessionIds,
   publicSession,
+  removeSession,
 } from "../src/repositories/sessions";
 import { getConfig } from "../src/config";
 import { generateSessionId } from "../src/crypto";
@@ -140,6 +141,8 @@ describe("session repository", () => {
       status: "ended",
       endedAt: new Date(60_000).toISOString(),
     });
+    expect(await removeSession(env.DB, id, userId)).toBe(true);
+    expect(await findSessionForOwner(env.DB, id, userId)).toBeNull();
   });
 
   it("marks a non-ended session expired from its absolute timestamp", () => {

--- a/relay/test/repositories.test.ts
+++ b/relay/test/repositories.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  authenticateApiKeyRequest,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  validateApiKeyName,
+} from "../src/repositories/api-keys";
+import { getKillSwitch, setPersistentKillSwitch } from "../src/repositories/control";
+import {
+  countActiveSessions,
+  endSession,
+  findSessionForAdmission,
+  findSessionForOwner,
+  insertSession,
+  listActiveSessionIds,
+  publicSession,
+} from "../src/repositories/sessions";
+import { getConfig } from "../src/config";
+import { generateSessionId } from "../src/crypto";
+import { FakeD1, makeBaseEnv } from "./helpers";
+
+const userId = "user_RepositoryTest";
+
+describe("API-key repository", () => {
+  it("creates a one-time secret while persisting only its HMAC digest", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const created = await createApiKey(env, userId, "Mac CLI", 1_000);
+    expect(created.secret).toMatch(/^bw_live_[A-Za-z0-9_-]{16}_[A-Za-z0-9_-]{43}$/);
+    expect(created.key).toMatchObject({ name: "Mac CLI", createdAt: new Date(1_000).toISOString() });
+    expect(db.apiKeys).toHaveLength(1);
+    expect(db.apiKeys[0].key_hash).toHaveLength(43);
+    expect(db.apiKeys[0].key_hash).not.toContain(created.secret);
+    expect(JSON.stringify(db.apiKeys[0])).not.toContain(created.secret);
+  });
+
+  it("lists public metadata without hash or secret", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const first = await createApiKey(env, userId, "First", 1_000);
+    await createApiKey(env, userId, "Second", 2_000);
+    const listed = await listApiKeys(env.DB, userId);
+    expect(listed.map((key) => key.name)).toEqual(["Second", "First"]);
+    expect(listed[1].prefix).toBe(`bw_live_${first.key.id}_…`);
+    expect(JSON.stringify(listed)).not.toContain("key_hash");
+    expect(JSON.stringify(listed)).not.toContain(first.secret);
+  });
+
+  it("enforces five active keys and permits replacement after revocation", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const created = [];
+    for (let index = 0; index < 5; index += 1) {
+      created.push(await createApiKey(env, userId, `Key ${index + 1}`, index));
+    }
+    await expect(createApiKey(env, userId, "Sixth", 6)).rejects.toMatchObject({
+      status: 409,
+      code: "key_limit_reached",
+    });
+    expect(await revokeApiKey(env.DB, userId, created[0].key.id, 10)).toBe(true);
+    await expect(createApiKey(env, userId, "Replacement", 11)).resolves.toBeDefined();
+    expect(await listApiKeys(env.DB, userId)).toHaveLength(5);
+  });
+
+  it("authenticates the complete API key in constant-shape HMAC form and updates last use", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const created = await createApiKey(env, userId, "CLI", 1_000);
+    const request = new Request("https://relay.example.com/v1/sessions", {
+      headers: { Authorization: `Bearer ${created.secret}` },
+    });
+    await expect(authenticateApiKeyRequest(request, env)).resolves.toEqual({
+      userId,
+      apiKeyId: created.key.id,
+    });
+    expect(db.apiKeys[0].last_used_at_ms).toBeTypeOf("number");
+  });
+
+  it("returns the same generic failure for malformed, wrong-secret, and revoked keys", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const created = await createApiKey(env, userId, "CLI", 1_000);
+    const values = [
+      "not-a-key",
+      `${created.secret.slice(0, -1)}${created.secret.endsWith("A") ? "B" : "A"}`,
+    ];
+    for (const value of values) {
+      await expect(
+        authenticateApiKeyRequest(
+          new Request("https://relay.example.com/v1/sessions", {
+            headers: { Authorization: `Bearer ${value}` },
+          }),
+          env,
+        ),
+      ).rejects.toMatchObject({ status: 401, code: "invalid_api_key" });
+    }
+    await revokeApiKey(env.DB, userId, created.key.id);
+    await expect(
+      authenticateApiKeyRequest(
+        new Request("https://relay.example.com/v1/sessions", {
+          headers: { Authorization: `Bearer ${created.secret}` },
+        }),
+        env,
+      ),
+    ).rejects.toMatchObject({ status: 401, code: "invalid_api_key" });
+  });
+
+  it.each(["", " ", "x".repeat(81), "bad\nname", 123, null])("rejects unsafe key name %j", (name) => {
+    expect(() => validateApiKeyName(name)).toThrow();
+  });
+});
+
+describe("session repository", () => {
+  it("stores only capability hashes and exposes owner-scoped lifecycle state", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase() });
+    const apiKey = await createApiKey(env, userId, "CLI", 1_000);
+    const id = generateSessionId();
+    await insertSession(env, {
+      id,
+      user_id: userId,
+      api_key_id: apiKey.key.id,
+      host_cap_hash: "h".repeat(43),
+      viewer_cap_hash: "v".repeat(43),
+      created_at_ms: 2_000,
+      expires_at_ms: 100_000,
+      ended_at_ms: null,
+      ended_reason: null,
+    });
+    expect(await findSessionForOwner(env.DB, id, userId)).toMatchObject({ id, host_cap_hash: "h".repeat(43) });
+    expect(await findSessionForOwner(env.DB, id, "user_Other")).toBeNull();
+    expect(await findSessionForAdmission(env.DB, id)).toMatchObject({ id, user_id: userId });
+    expect(await countActiveSessions(env.DB, userId, 50_000)).toBe(1);
+    expect(await listActiveSessionIds(env.DB, 50_000)).toEqual([id]);
+    expect(publicSession((await findSessionForOwner(env.DB, id, userId))!, 50_000).status).toBe("waiting");
+
+    expect(await endSession(env.DB, id, userId, "deleted", 60_000)).toBe(true);
+    expect(publicSession((await findSessionForOwner(env.DB, id, userId))!, 70_000)).toMatchObject({
+      status: "ended",
+      endedAt: new Date(60_000).toISOString(),
+    });
+  });
+
+  it("marks a non-ended session expired from its absolute timestamp", () => {
+    expect(
+      publicSession(
+        {
+          id: generateSessionId(),
+          user_id: userId,
+          api_key_id: "key",
+          host_cap_hash: "h",
+          viewer_cap_hash: "v",
+          created_at_ms: 0,
+          expires_at_ms: 10,
+          ended_at_ms: null,
+          ended_reason: null,
+        },
+        10,
+      ).status,
+    ).toBe("expired");
+  });
+});
+
+describe("persistent kill switch repository", () => {
+  it("combines persistent and environment switches without allowing API override of env", async () => {
+    const db = new FakeD1();
+    const env = makeBaseEnv({ DB: db.asDatabase(), RELAY_KILL_SWITCH: "true" });
+    await setPersistentKillSwitch(env, false, "operator reopen", 123);
+    expect(await getKillSwitch(env, getConfig(env))).toEqual({
+      persistentEnabled: false,
+      environmentEnabled: true,
+      effectiveEnabled: true,
+      reason: "operator reopen",
+      updatedAt: new Date(123).toISOString(),
+    });
+  });
+
+  it("validates manual switch input and reason length", async () => {
+    const env = makeBaseEnv();
+    await expect(setPersistentKillSwitch(env, "true", "bad")).rejects.toMatchObject({ status: 400 });
+    await expect(setPersistentKillSwitch(env, true, "x".repeat(201))).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/relay/test/time-config.test.ts
+++ b/relay/test/time-config.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { ConfigurationError, getConfig, requireSecret, usdToMicroUsd } from "../src/config";
+import { billingWindow, isoWeekWindow } from "../src/time";
+import { makeBaseEnv } from "./helpers";
+
+describe("ISO-week accounting windows", () => {
+  it.each([
+    ["2026-07-20T00:00:00.000Z", "2026-07-20", "2026-07-27T00:00:00.000Z"],
+    ["2026-07-26T23:59:59.999Z", "2026-07-20", "2026-07-27T00:00:00.000Z"],
+    ["2026-07-27T00:00:00.000Z", "2026-07-27", "2026-08-03T00:00:00.000Z"],
+    ["2026-01-01T12:00:00.000Z", "2025-12-29", "2026-01-05T00:00:00.000Z"],
+  ])("uses Monday UTC for %s", (instant, key, ending) => {
+    const window = isoWeekWindow(Date.parse(instant));
+    expect(window.key).toBe(key);
+    expect(new Date(window.startsAtMs).getUTCDay()).toBe(1);
+    expect(new Date(window.endsAtMs).toISOString()).toBe(ending);
+    expect(window.endsAtMs - window.startsAtMs).toBe(7 * 24 * 60 * 60 * 1_000);
+  });
+});
+
+describe("billing windows", () => {
+  it("uses a monthly UTC window anchored to the configured day", () => {
+    const before = billingWindow(Date.parse("2026-07-14T23:59:59Z"), 15);
+    expect(new Date(before.startsAtMs).toISOString()).toBe("2026-06-15T00:00:00.000Z");
+    expect(new Date(before.endsAtMs).toISOString()).toBe("2026-07-15T00:00:00.000Z");
+    const on = billingWindow(Date.parse("2026-07-15T00:00:00Z"), 15);
+    expect(on.key).toBe("2026-07-15");
+    expect(new Date(on.endsAtMs).toISOString()).toBe("2026-08-15T00:00:00.000Z");
+  });
+
+  it("supports an operator-supplied contractual period key without changing boundaries", () => {
+    const window = billingWindow(Date.parse("2026-07-24T00:00:00Z"), 1, "invoice-2026-07");
+    expect(window.key).toBe("invoice-2026-07");
+    expect(new Date(window.startsAtMs).toISOString()).toBe("2026-07-01T00:00:00.000Z");
+  });
+});
+
+describe("environment parsing", () => {
+  it("loads the reviewed two-hour, 15-minute, $0.0025, and $900 defaults", () => {
+    const config = getConfig(makeBaseEnv());
+    expect(config.weeklyViewerMs).toBe(7_200_000);
+    expect(config.leaseMs).toBe(900_000);
+    expect(config.leaseReservationMicroUsd).toBe(2_500);
+    expect(config.budgetCeilingMicroUsd).toBe(900_000_000);
+    expect(config.maxMessageBytes).toBe(2 * 1024 * 1024);
+    expect(config.sustainedMessagesPerSecond).toBe(15);
+    expect(config.burstMessages).toBe(20);
+    expect(config.maxBytesPerSecond).toBe(1_250_000);
+  });
+
+  it("parses USD exactly to integer micro-dollars", () => {
+    expect(usdToMicroUsd("0.0025", "cost")).toBe(2_500);
+    expect(usdToMicroUsd("900", "ceiling")).toBe(900_000_000);
+    expect(usdToMicroUsd("1.000001", "cost")).toBe(1_000_001);
+    expect(() => usdToMicroUsd("0.0000001", "cost")).toThrow(ConfigurationError);
+    expect(() => usdToMicroUsd("-1", "cost")).toThrow(ConfigurationError);
+    expect(() => usdToMicroUsd("NaN", "cost")).toThrow(ConfigurationError);
+  });
+
+  it("accepts intentional numeric overrides and a fixed billing key", () => {
+    const config = getConfig(
+      makeBaseEnv({
+        WEEKLY_VIEWER_SECONDS: "3600",
+        LEASE_SECONDS: "600",
+        LEASE_RESERVATION_USD: "0.004",
+        BUDGET_CEILING_USD: "100",
+        BILLING_WINDOW_ID: "contract:2026-07",
+        RELAY_KILL_SWITCH: "yes",
+      }),
+    );
+    expect(config.weeklyViewerMs).toBe(3_600_000);
+    expect(config.leaseMs).toBe(600_000);
+    expect(config.leaseReservationMicroUsd).toBe(4_000);
+    expect(config.budgetCeilingMicroUsd).toBe(100_000_000);
+    expect(config.billingWindowId).toBe("contract:2026-07");
+    expect(config.envKillSwitch).toBe(true);
+  });
+
+  it.each([
+    ["PUBLIC_ORIGIN", "https://relay.example.com/path"],
+    ["PUBLIC_ORIGIN", "https://*.example.com"],
+    ["PUBLIC_ORIGIN", "http://relay.example.com"],
+    ["APP_ORIGIN", "https://app.example.com?x=1"],
+    ["CLERK_AUTHORIZED_PARTIES", "https://app.example.com/path"],
+  ])("rejects non-exact %s value", (field, value) => {
+    expect(() => getConfig(makeBaseEnv({ [field]: value }))).toThrow(ConfigurationError);
+  });
+
+  it("permits plain HTTP only on loopback for local development", () => {
+    const config = getConfig(
+      makeBaseEnv({
+        PUBLIC_ORIGIN: "http://localhost:8787",
+        APP_ORIGIN: "http://127.0.0.1:3000",
+        CLERK_AUTHORIZED_PARTIES: "http://127.0.0.1:3000",
+      }),
+    );
+    expect(config.publicOrigin).toBe("http://localhost:8787");
+  });
+
+  it("rejects short deployment secrets", () => {
+    expect(() => requireSecret(makeBaseEnv({ ADMIN_TOKEN: "short" }), "ADMIN_TOKEN")).toThrow(
+      ConfigurationError,
+    );
+  });
+});

--- a/relay/test/worker.test.ts
+++ b/relay/test/worker.test.ts
@@ -153,6 +153,72 @@ describe("Worker routes", () => {
     expect(statusText).not.toContain(body.host.subprotocols[1]);
   });
 
+  it("does not insert D1 metadata when Durable Object initialization rejects", async () => {
+    const h = workerHarness();
+    const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));
+    const apiKey = ((await keyResponse.json()) as any).secret as string;
+    h.env.RELAY_SESSION = {
+      idFromName: (name: string) => name,
+      get: () => ({
+        fetch: async () => {
+          throw new Error("simulated Durable Object transport failure");
+        },
+      }),
+    } as unknown as DurableObjectNamespace;
+    const prepared = await prepareRelaySession();
+
+    const response = await h.fetch(
+      apiRequest(
+        "/v1/sessions",
+        "POST",
+        { sessionId: prepared.sessionId, viewerProof: prepared.viewerProof },
+        { Authorization: `Bearer ${apiKey}` },
+      ),
+    );
+
+    expect(response.status).toBe(503);
+    expect(h.db.sessions).toHaveLength(0);
+  });
+
+  it("purges an initialized object when D1 rejects the session insert", async () => {
+    const h = workerHarness();
+    const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));
+    const keyBody = (await keyResponse.json()) as any;
+    const prepared = await prepareRelaySession();
+    h.db.sessions.push({
+      id: prepared.sessionId,
+      user_id: "user_WorkerTest",
+      api_key_id: keyBody.key.id,
+      host_cap_hash: "h".repeat(43),
+      viewer_cap_hash: "v".repeat(43),
+      created_at_ms: h.now - 1,
+      expires_at_ms: h.now + 60_000,
+      ended_at_ms: null,
+      ended_reason: null,
+    });
+
+    const response = await h.fetch(
+      apiRequest(
+        "/v1/sessions",
+        "POST",
+        { sessionId: prepared.sessionId, viewerProof: prepared.viewerProof },
+        { Authorization: `Bearer ${keyBody.secret}` },
+      ),
+    );
+
+    expect(response.status).toBe(409);
+    expect(h.db.sessions).toHaveLength(0);
+    const relay = h.relays.instances.get(
+      `session:${prepared.sessionId}`,
+    ) as RelaySession;
+    const status = await relay.fetch(
+      new Request("https://internal/status", {
+        headers: { "X-Relay-Internal": h.env.INTERNAL_DO_SECRET },
+      }),
+    );
+    expect((await status.json()) as any).toMatchObject({ initialized: false });
+  });
+
   it("ends an owned session and purges D1 plus Durable Object state", async () => {
     const h = workerHarness();
     const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));

--- a/relay/test/worker.test.ts
+++ b/relay/test/worker.test.ts
@@ -153,7 +153,7 @@ describe("Worker routes", () => {
     expect(statusText).not.toContain(body.host.subprotocols[1]);
   });
 
-  it("ends an owned session and makes the Durable Object termination durable", async () => {
+  it("ends an owned session and purges D1 plus Durable Object state", async () => {
     const h = workerHarness();
     const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));
     const apiKey = ((await keyResponse.json()) as any).secret as string;
@@ -173,14 +173,17 @@ describe("Worker routes", () => {
       }),
     );
     expect(deleted.status).toBe(204);
-    expect(h.db.sessions[0].ended_at_ms).toBe(h.now);
+    expect(h.db.sessions).toHaveLength(0);
     const relay = h.relays.instances.get(`session:${sessionId}`) as RelaySession;
     const internalStatus = await relay.fetch(
       new Request("https://internal/status", {
         headers: { "X-Relay-Internal": h.env.INTERNAL_DO_SECRET },
       }),
     );
-    expect((await internalStatus.json()) as any).toMatchObject({ terminated: true });
+    expect((await internalStatus.json()) as any).toMatchObject({
+      initialized: false,
+      terminated: false,
+    });
   });
 
   it("returns a zeroed Monday-UTC usage view for an account with no viewer", async () => {

--- a/relay/test/worker.test.ts
+++ b/relay/test/worker.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { prepareRelaySession } from "../src/client/host-codec";
+import { BudgetWindow, createWorkerHandler, RelaySession, UserQuota } from "../src/index";
+import type { Env } from "../src/env";
+import { DirectNamespace, FakeD1, makeBaseEnv, MemoryDurableState } from "./helpers";
+
+function workerHarness() {
+  const db = new FakeD1();
+  let env = makeBaseEnv({
+    DB: db.asDatabase(),
+    ASSETS: { fetch: async () => new Response("static-asset", { status: 200 }) } as unknown as Fetcher,
+  });
+  const budgets = new DirectNamespace(() => new BudgetWindow(new MemoryDurableState().asState(), env));
+  const quotas = new DirectNamespace(() => new UserQuota(new MemoryDurableState().asState(), env));
+  const relays = new DirectNamespace(() => new RelaySession(new MemoryDurableState().asState(), env));
+  env = {
+    ...env,
+    BUDGET_WINDOW: budgets.asNamespace(),
+    USER_QUOTA: quotas.asNamespace(),
+    RELAY_SESSION: relays.asNamespace(),
+  };
+  const pending: Promise<unknown>[] = [];
+  const context = {
+    waitUntil(promise: Promise<unknown>) {
+      pending.push(promise);
+    },
+  } as unknown as ExecutionContext;
+  const now = 1_000_000;
+  const handler = createWorkerHandler({
+    authenticateClerk: async () => ({ userId: "user_WorkerTest", sessionId: "sess_1" }),
+    now: () => now,
+  });
+  const fetch = (request: Request) =>
+    (handler.fetch as (request: Request, env: Env, context: ExecutionContext) => Promise<Response>)(
+      request,
+      env,
+      context,
+    );
+  return { db, env, relays, quotas, budgets, pending, fetch, now };
+}
+
+function apiRequest(
+  path: string,
+  method = "GET",
+  body?: unknown,
+  headers: HeadersInit = {},
+): Request {
+  const requestHeaders = new Headers(headers);
+  if (body !== undefined) requestHeaders.set("Content-Type", "application/json");
+  return new Request(`https://relay.example.com${path}`, {
+    method,
+    headers: requestHeaders,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+describe("Worker routes", () => {
+  it("reports readiness and persistent admission state through healthz", async () => {
+    const h = workerHarness();
+    const response = await h.fetch(apiRequest("/healthz"));
+    expect(response.status).toBe(200);
+    expect((await response.json()) as any).toEqual({ ok: true, admissionEnabled: true });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("serves the viewer only on the exact public origin and delegates static assets", async () => {
+    const h = workerHarness();
+    const id = `bws_${"A".repeat(24)}`;
+    const viewer = await h.fetch(apiRequest(`/s/${id}`));
+    expect(viewer.status).toBe(200);
+    expect(await viewer.text()).toContain(`content="${id}"`);
+    const wrongOrigin = await h.fetch(new Request(`https://other.example.com/s/${id}`));
+    expect(wrongOrigin.status).toBe(404);
+    expect(await (await h.fetch(apiRequest("/viewer.css"))).text()).toBe("static-asset");
+  });
+
+  it("creates and lists one-time API-key secrets under Clerk auth", async () => {
+    const h = workerHarness();
+    const origin = "https://app.example.com";
+    const created = await h.fetch(
+      apiRequest("/v1/keys", "POST", { name: "Laptop" }, { Origin: origin, Authorization: "Bearer clerk" }),
+    );
+    expect(created.status).toBe(201);
+    expect(created.headers.get("Access-Control-Allow-Origin")).toBe(origin);
+    const body = (await created.json()) as any;
+    expect(body.oneTimeSecret).toBe(true);
+    expect(body.secret).toMatch(/^bw_live_/);
+
+    const listed = await h.fetch(apiRequest("/v1/keys", "GET", undefined, { Origin: origin }));
+    const listBody = (await listed.json()) as any;
+    expect(listBody.keys).toHaveLength(1);
+    expect(listBody.keys[0]).toMatchObject({ id: body.key.id, name: "Laptop" });
+    expect(JSON.stringify(listBody)).not.toContain(body.secret);
+
+    const cliIdentity = await h.fetch(
+      apiRequest("/v1/cli/me", "GET", undefined, {
+        Authorization: `Bearer ${body.secret}`,
+      }),
+    );
+    expect(cliIdentity.status).toBe(200);
+    expect((await cliIdentity.json()) as any).toMatchObject({
+      ok: true,
+      id: "user_WorkerTest",
+      apiKeyId: body.key.id,
+      quota: { limitSeconds: 7_200, remainingSeconds: 7_200 },
+      activeViewerLease: null,
+    });
+  });
+
+  it("creates a session with one-time host/root material, then returns state without secrets", async () => {
+    const h = workerHarness();
+    const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));
+    const apiKey = ((await keyResponse.json()) as any).secret as string;
+
+    const prepared = await prepareRelaySession();
+    const created = await h.fetch(
+      apiRequest(
+        "/v1/sessions",
+        "POST",
+        { sessionId: prepared.sessionId, viewerProof: prepared.viewerProof },
+        { Authorization: `Bearer ${apiKey}` },
+      ),
+    );
+    expect(created.status).toBe(201);
+    const body = (await created.json()) as any;
+    expect(body.host.subprotocols).toHaveLength(2);
+    expect(body.host).not.toHaveProperty("rootKey");
+    expect(body.viewer.url).toBe(`https://relay.example.com/s/${body.session.id}`);
+    expect(`${body.viewer.url}#k=${prepared.rootKey}`).toBe(
+      `https://relay.example.com/s/${body.session.id}#k=${prepared.rootKey}`,
+    );
+    expect(body.host.websocketUrl).toBe(
+      `wss://relay.example.com/v1/sessions/${body.session.id}/ws`,
+    );
+    const stored = h.db.sessions[0];
+    expect(stored.host_cap_hash).toHaveLength(43);
+    expect(stored.viewer_cap_hash).toHaveLength(43);
+    expect(JSON.stringify(stored)).not.toContain(prepared.rootKey);
+    expect(JSON.stringify(stored)).not.toContain(body.host.subprotocols[1]);
+
+    const status = await h.fetch(
+      apiRequest(`/v1/sessions/${body.session.id}`, "GET", undefined, {
+        Authorization: `Bearer ${apiKey}`,
+      }),
+    );
+    expect(status.status).toBe(200);
+    const statusText = await status.text();
+    expect(JSON.parse(statusText)).toMatchObject({
+      session: { id: body.session.id, status: "waiting" },
+      relay: { hostConnected: false, viewerConnected: false },
+    });
+    expect(statusText).not.toContain(prepared.rootKey);
+    expect(statusText).not.toContain(body.host.subprotocols[1]);
+  });
+
+  it("ends an owned session and makes the Durable Object termination durable", async () => {
+    const h = workerHarness();
+    const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));
+    const apiKey = ((await keyResponse.json()) as any).secret as string;
+    const prepared = await prepareRelaySession();
+    const sessionResponse = await h.fetch(
+      apiRequest(
+        "/v1/sessions",
+        "POST",
+        { sessionId: prepared.sessionId, viewerProof: prepared.viewerProof },
+        { Authorization: `Bearer ${apiKey}` },
+      ),
+    );
+    const sessionId = ((await sessionResponse.json()) as any).session.id as string;
+    const deleted = await h.fetch(
+      apiRequest(`/v1/sessions/${sessionId}`, "DELETE", undefined, {
+        Authorization: `Bearer ${apiKey}`,
+      }),
+    );
+    expect(deleted.status).toBe(204);
+    expect(h.db.sessions[0].ended_at_ms).toBe(h.now);
+    const relay = h.relays.instances.get(`session:${sessionId}`) as RelaySession;
+    const internalStatus = await relay.fetch(
+      new Request("https://internal/status", {
+        headers: { "X-Relay-Internal": h.env.INTERNAL_DO_SECRET },
+      }),
+    );
+    expect((await internalStatus.json()) as any).toMatchObject({ terminated: true });
+  });
+
+  it("returns a zeroed Monday-UTC usage view for an account with no viewer", async () => {
+    const h = workerHarness();
+    const response = await h.fetch(apiRequest("/v1/me/usage"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.week.limitSeconds).toBe(7_200);
+    expect(body.week.usedSeconds).toBe(0);
+    expect(body.week.remainingSeconds).toBe(7_200);
+    expect(body.activeViewerLease).toBeNull();
+  });
+
+  it("rejects suffix-origin attacks without reflecting them", async () => {
+    const h = workerHarness();
+    const attack = "https://app.example.com.attacker.test";
+    const response = await h.fetch(apiRequest("/v1/me", "GET", undefined, { Origin: attack }));
+    expect(response.status).toBe(403);
+    expect(response.headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+
+  it("authenticates the admin switch, disables admission, and cannot override an env switch", async () => {
+    const h = workerHarness();
+    expect((await h.fetch(apiRequest("/v1/admin/kill-switch"))).status).toBe(401);
+    const enabled = await h.fetch(
+      apiRequest(
+        "/v1/admin/kill-switch",
+        "PUT",
+        { enabled: true, reason: "test stop" },
+        { Authorization: `Bearer ${h.env.ADMIN_TOKEN}` },
+      ),
+    );
+    expect(enabled.status).toBe(200);
+    expect((await enabled.json()) as any).toMatchObject({ effectiveEnabled: true, reason: "test stop" });
+    expect((await (await h.fetch(apiRequest("/healthz"))).json()) as any).toEqual({
+      ok: true,
+      admissionEnabled: false,
+    });
+
+    const keyResponse = await h.fetch(apiRequest("/v1/keys", "POST", { name: "CLI" }));
+    const apiKey = ((await keyResponse.json()) as any).secret as string;
+    const blocked = await h.fetch(
+      apiRequest("/v1/sessions", "POST", {}, { Authorization: `Bearer ${apiKey}` }),
+    );
+    expect(blocked.status).toBe(503);
+    expect((await blocked.json()) as any).toMatchObject({ error: { code: "relay_disabled" } });
+  });
+
+  it("returns a configuration-safe 503 without disclosing missing secret values", async () => {
+    const h = workerHarness();
+    h.env.PUBLIC_ORIGIN = "";
+    const response = await h.fetch(apiRequest("/healthz"));
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe(
+      '{"error":{"code":"relay_not_configured","message":"Relay configuration is incomplete"}}',
+    );
+  });
+});

--- a/relay/tsconfig.json
+++ b/relay/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types", "vitest/globals", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/relay/vitest.config.ts
+++ b/relay/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      include: ["src/**/*.ts", "public/viewer-crypto.js"],
+      reporter: ["text", "json-summary"],
+    },
+  },
+});

--- a/relay/wrangler.example.toml
+++ b/relay/wrangler.example.toml
@@ -1,0 +1,58 @@
+name = "betterwright-relay"
+main = "src/index.ts"
+compatibility_date = "2026-07-24"
+compatibility_flags = ["nodejs_compat"]
+workers_dev = false
+preview_urls = false
+
+# Add the production custom-domain route after copying this file to
+# wrangler.toml. PUBLIC_ORIGIN must be that exact HTTPS origin.
+# routes = [{ pattern = "relay.example.com", custom_domain = true }]
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+run_worker_first = true
+not_found_handling = "none"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "betterwright-relay"
+database_id = "REPLACE_WITH_D1_DATABASE_UUID"
+migrations_dir = "migrations"
+
+[[durable_objects.bindings]]
+name = "RELAY_SESSION"
+class_name = "RelaySession"
+
+[[durable_objects.bindings]]
+name = "USER_QUOTA"
+class_name = "UserQuota"
+
+[[durable_objects.bindings]]
+name = "BUDGET_WINDOW"
+class_name = "BudgetWindow"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RelaySession", "UserQuota", "BudgetWindow"]
+
+[vars]
+PUBLIC_ORIGIN = "https://relay.example.com"
+APP_ORIGIN = "https://app.example.com"
+CLERK_AUTHORIZED_PARTIES = "https://app.example.com"
+# CLERK_AUDIENCE = "betterwright-relay"
+WEEKLY_VIEWER_SECONDS = "7200"
+LEASE_SECONDS = "900"
+LEASE_RESERVATION_USD = "0.0025"
+BUDGET_CEILING_USD = "900"
+BILLING_PERIOD_START_DAY_UTC = "1"
+SESSION_TTL_SECONDS = "86400"
+MAX_MESSAGE_BYTES = "2097152"
+SUSTAINED_MESSAGES_PER_SECOND = "15"
+BURST_MESSAGES = "20"
+MAX_BITS_PER_SECOND = "10000000"
+RELAY_KILL_SWITCH = "false"
+
+[observability]
+enabled = false

--- a/relay/wrangler.toml
+++ b/relay/wrangler.toml
@@ -1,0 +1,56 @@
+name = "betterwright-relay"
+main = "src/index.ts"
+account_id = "a744b97600c8be02911d75060177b24a"
+compatibility_date = "2026-07-24"
+compatibility_flags = ["nodejs_compat"]
+workers_dev = false
+preview_urls = false
+routes = [{ pattern = "live.betterwright.com", custom_domain = true }]
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+run_worker_first = true
+not_found_handling = "none"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "betterwright-relay"
+database_id = "fb9481c8-9c03-4cb0-8ed0-f137e553b254"
+migrations_dir = "migrations"
+
+[[durable_objects.bindings]]
+name = "RELAY_SESSION"
+class_name = "RelaySession"
+
+[[durable_objects.bindings]]
+name = "USER_QUOTA"
+class_name = "UserQuota"
+
+[[durable_objects.bindings]]
+name = "BUDGET_WINDOW"
+class_name = "BudgetWindow"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RelaySession", "UserQuota", "BudgetWindow"]
+
+[vars]
+PUBLIC_ORIGIN = "https://live.betterwright.com"
+APP_ORIGIN = "https://betterwright.com"
+CLERK_AUTHORIZED_PARTIES = "https://betterwright.com"
+WEEKLY_VIEWER_SECONDS = "7200"
+LEASE_SECONDS = "900"
+LEASE_RESERVATION_USD = "0.0025"
+BUDGET_CEILING_USD = "900"
+BILLING_PERIOD_START_DAY_UTC = "1"
+SESSION_TTL_SECONDS = "86400"
+MAX_MESSAGE_BYTES = "2097152"
+SUSTAINED_MESSAGES_PER_SECOND = "15"
+BURST_MESSAGES = "20"
+MAX_BITS_PER_SECOND = "10000000"
+MAX_BUFFERED_BYTES = "4194304"
+RELAY_KILL_SWITCH = "false"
+
+[observability]
+enabled = false

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -21,6 +21,18 @@ if (lock.version !== pkg.version || lockRoot.version !== pkg.version) {
     `package-lock.json version must be ${pkg.version}; found ${lock.version}/${lockRoot.version}`,
   );
 }
+const relayPkg = JSON.parse(read("relay/package.json"));
+const relayLock = JSON.parse(read("relay/package-lock.json"));
+const relayLockRoot = relayLock.packages?.[""] || {};
+if (
+  relayPkg.version !== pkg.version ||
+  relayLock.version !== pkg.version ||
+  relayLockRoot.version !== pkg.version
+) {
+  failures.push(
+    `relay package versions must be ${pkg.version}; found ${relayPkg.version}/${relayLock.version}/${relayLockRoot.version}`,
+  );
+}
 for (const dependency of ["playwright-core", "cloakbrowser"]) {
   if (lockRoot.dependencies?.[dependency] !== pkg.dependencies[dependency]) {
     failures.push(`package-lock.json ${dependency} pin does not match package.json`);
@@ -61,5 +73,5 @@ if (failures.length) {
   process.exit(1);
 }
 console.log(
-  `versions aligned: betterwright ${pkg.version}, playwright-core ${pkg.dependencies["playwright-core"]}, cloakbrowser ${pkg.dependencies.cloakbrowser}`,
+  `versions aligned: betterwright/relay ${pkg.version}, playwright-core ${pkg.dependencies["playwright-core"]}, cloakbrowser ${pkg.dependencies.cloakbrowser}`,
 );

--- a/src/account-config.mjs
+++ b/src/account-config.mjs
@@ -1,0 +1,165 @@
+// BetterWright account credentials used by the optional managed live-view relay.
+//
+// Account secrets are intentionally separate from config.json so ordinary
+// configuration inspection never prints them. The file is always written
+// with owner-only permissions and the API key is never accepted as a normal
+// command-line flag (which would leak through shell history and process lists).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const ACCOUNT_FILE = "account.json";
+const DEFAULT_RELAY_URL = "https://live.betterwright.com";
+const API_KEY_PATTERN = /^bw_live_([A-Za-z0-9_-]{16})_([A-Za-z0-9_-]{43})$/;
+
+function defaultHome() {
+  const configured = String(process.env.BETTERWRIGHT_HOME || "").trim();
+  return configured || path.join(os.homedir(), ".betterwright");
+}
+
+export function accountConfigPath(home = defaultHome()) {
+  return path.join(home, ACCOUNT_FILE);
+}
+
+export function normalizeRelayUrl(value = DEFAULT_RELAY_URL) {
+  const raw = String(value || DEFAULT_RELAY_URL).trim().replace(/\/+$/, "");
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("BetterWright relay URL must be a valid https URL.");
+  }
+  const local = parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "::1";
+  if (parsed.protocol !== "https:" && !(local && parsed.protocol === "http:")) {
+    throw new Error("BetterWright relay URL must use https (http is allowed only for loopback tests).");
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error("BetterWright relay URL cannot contain credentials, a query, or a fragment.");
+  }
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export function isBetterWrightApiKey(value) {
+  return API_KEY_PATTERN.test(String(value || "").trim());
+}
+
+export function maskBetterWrightApiKey(value) {
+  const key = String(value || "").trim();
+  const match = key.match(API_KEY_PATTERN);
+  if (!match) return "not configured";
+  return `bw_live_${match[1]}_${"•".repeat(8)}${match[2].slice(-4)}`;
+}
+
+export function loadAccountConfig(home = defaultHome()) {
+  let parsed = {};
+  try {
+    parsed = JSON.parse(fs.readFileSync(accountConfigPath(home), "utf8"));
+  } catch {
+    parsed = {};
+  }
+  const fileKey = isBetterWrightApiKey(parsed?.apiKey) ? String(parsed.apiKey).trim() : "";
+  const envKey = String(process.env.BETTERWRIGHT_API_KEY || "").trim();
+  if (envKey && !isBetterWrightApiKey(envKey)) {
+    throw new Error(
+      "BETTERWRIGHT_API_KEY is not a valid BetterWright API key; refusing to fall back to a stored credential.",
+    );
+  }
+  const apiKey = envKey || fileKey;
+  // Invalid custom destinations must fail closed. Silently falling back to the
+  // hosted relay could disclose a self-hosted key to the wrong service.
+  const relayUrl = normalizeRelayUrl(
+    process.env.BETTERWRIGHT_RELAY_URL || parsed?.relayUrl || DEFAULT_RELAY_URL,
+  );
+  return {
+    ...(apiKey ? { apiKey } : {}),
+    relayUrl,
+    source: isBetterWrightApiKey(envKey) ? "environment" : fileKey ? "file" : "none",
+  };
+}
+
+function writeAccount(config, home) {
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  const file = accountConfigPath(home);
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    /* best effort on exotic filesystems */
+  }
+  return file;
+}
+
+export function saveAccountApiKey(apiKey, { home = defaultHome(), relayUrl } = {}) {
+  const key = String(apiKey || "").trim();
+  if (!isBetterWrightApiKey(key)) {
+    throw new Error("That is not a BetterWright API key. Create one at https://betterwright.com/account.");
+  }
+  const current = loadAccountConfig(home);
+  return writeAccount(
+    {
+      apiKey: key,
+      relayUrl: normalizeRelayUrl(relayUrl || current.relayUrl || DEFAULT_RELAY_URL),
+    },
+    home,
+  );
+}
+
+export function clearAccountConfig(home = defaultHome()) {
+  const file = accountConfigPath(home);
+  try {
+    fs.rmSync(file, { force: true });
+  } catch {
+    /* a missing file is already logged out */
+  }
+  return file;
+}
+
+export async function verifyBetterWrightApiKey(
+  apiKey,
+  { relayUrl = DEFAULT_RELAY_URL, timeoutMs = 10_000, fetchImpl = fetch } = {},
+) {
+  const key = String(apiKey || "").trim();
+  if (!isBetterWrightApiKey(key)) {
+    return { ok: false, error: "That is not a BetterWright API key." };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(Number(timeoutMs) || 0, 1_000));
+  timer.unref?.();
+  try {
+    const response = await fetchImpl(`${normalizeRelayUrl(relayUrl)}/v1/cli/me`, {
+      headers: { authorization: `Bearer ${key}`, accept: "application/json" },
+      signal: controller.signal,
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok || body?.ok === false) {
+      const relayMessage =
+        typeof body?.error?.message === "string"
+          ? body.error.message
+          : typeof body?.error === "string"
+            ? body.error
+            : `BetterWright relay returned HTTP ${response.status}.`;
+      return {
+        ok: false,
+        error:
+          response.status === 401
+            ? "The BetterWright API key was rejected. Create a new key and try again."
+            : relayMessage,
+      };
+    }
+    return { ok: true, ...body };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error?.name === "AbortError"
+          ? "Timed out while contacting the BetterWright relay."
+          : `Could not contact the BetterWright relay: ${error?.message || error}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export const BETTERWRIGHT_ACCOUNT_URL = "https://betterwright.com/account";
+export const DEFAULT_BETTERWRIGHT_RELAY_URL = DEFAULT_RELAY_URL;

--- a/src/agent.mjs
+++ b/src/agent.mjs
@@ -461,11 +461,12 @@ export async function runAgentTask(options = {}) {
   async function postLiveChat({ text, kind, role = "agent" } = {}) {
     if (!withHandoff || typeof browser.liveViewPostChat !== "function") return;
     const body = String(text || "").trim();
-    if (!body) return;
+    // Progress mirroring is passive. It must never create a local listener or
+    // managed relay session; only explicit liveView/live_view, ask, or handoff
+    // paths are allowed to start one.
+    if (!body || !liveViewReady) return;
     try {
-      if (!liveViewReady) await ensureAgentLiveView();
-      if (!liveViewReady) return;
-      await browser.liveViewPostChat({ role, text: body, kind });
+      await browser.liveViewPostChat({ session, role, text: body, kind });
     } catch {
       /* chat mirror must never break the agent loop */
     }
@@ -481,7 +482,7 @@ export async function runAgentTask(options = {}) {
     if (!withHandoff || typeof browser.liveViewDrainChat !== "function") return [];
     if (!liveViewReady) return [];
     try {
-      const drained = await browser.liveViewDrainChat();
+      const drained = await browser.liveViewDrainChat({ session });
       const items = Array.isArray(drained?.messages) ? drained.messages : [];
       return normalizeGuidanceLines(items.map((item) => item?.text));
     } catch {

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -13,7 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
-
+import { loadAccountConfig } from "./account-config.mjs";
 import {
   MAX_PENDING_CREDENTIAL_ORIGINS,
   VAULT_MATCH_MODES,
@@ -288,9 +288,10 @@ export class BetterWright {
    *   realistic consumer-Mac fingerprint captured from real Chrome on Apple
    *   Silicon); the managed CloakBrowser path defaults to the host platform.
    * @param {object} [options.liveView] defaults for {@link startLiveView}:
-   *   `{host, port, interactive, quality, maxWidth, publicHost}`. Defaults to
-   *   bind `0.0.0.0` with a LAN `publicHost` so printed URLs open from another
-   *   machine on the network. Pass `{host:"127.0.0.1"}` for loopback-only.
+   *   `{transport, expose, host, port, interactive, quality, maxWidth,
+   *   publicHost}`. The safe default is a direct loopback-only viewer. Select
+   *   `{transport:"relay"}` for BetterWright's managed outbound relay or
+   *   `{expose:"lan"}` explicitly for a direct LAN listener.
    */
   constructor(options = {}) {
     this.home = options.home || defaultHome();
@@ -334,23 +335,51 @@ export class BetterWright {
     this.platform = options.platform || null;
     this.defaultTimeout = Math.max(Number(options.defaultTimeout) || DEFAULT_TIMEOUT_SECONDS, 5);
     // Live-view defaults ride in each live_view_start message rather than in
-    // _workerConfig(), so changing them never restarts the worker. Default is
-    // LAN-reachable (0.0.0.0 + guessed private IP in the URL). Persistent
-    // settings from <home>/config.json (expose preset, password hash, …) sit
-    // between the built-ins and explicit constructor options.
-    const lanDefaults = defaultLiveViewListen();
-    this.liveView = {
-      host: lanDefaults.host,
+    // _workerConfig(), so changing them never restarts the worker. The safe
+    // no-config default is loopback. Persistent mode settings and the separate
+    // owner-only account credential file sit between built-ins and explicit
+    // constructor options.
+    const localDefaults = defaultLiveViewListen();
+    const account = loadAccountConfig(this.home);
+    this._liveViewBuiltinDefaults = {
+      transport: "direct",
+      expose: "local",
+      host: localDefaults.host,
       port: 0,
-      publicHost: lanDefaults.publicHost,
+      publicHost: localDefaults.publicHost,
       interactive: true,
       quality: 60,
       maxWidth: 1440,
-      ...loadLiveViewConfig(this.home),
-      ...(options.liveView && typeof options.liveView === "object"
-        ? options.liveView
-        : {}),
+      clientVersion: JSON.parse(
+        fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+      ).version,
     };
+    this._liveViewExplicit =
+      options.liveView && typeof options.liveView === "object"
+        ? { ...options.liveView }
+        : {};
+    this._liveViewMutable = {};
+    this._liveViewState = {
+      ...this._liveViewBuiltinDefaults,
+      ...loadLiveViewConfig(this.home),
+      ...(account.apiKey ? { apiKey: account.apiKey } : {}),
+      relayUrl: account.relayUrl,
+      ...this._liveViewExplicit,
+    };
+    // Preserve the documented mutable browser.liveView compatibility surface
+    // while still rebuilding file-backed settings on every start. Only caller
+    // mutations are recorded as explicit overrides; internal refreshes update
+    // the raw target below and therefore do not make deleted file values sticky.
+    this.liveView = new Proxy(this._liveViewState, {
+      set: (target, property, value) => {
+        this._liveViewMutable[property] = value;
+        return Reflect.set(target, property, value);
+      },
+      deleteProperty: (target, property) => {
+        delete this._liveViewMutable[property];
+        return Reflect.deleteProperty(target, property);
+      },
+    });
 
     this._process = null;
     this._pending = new Map();
@@ -371,6 +400,15 @@ export class BetterWright {
     // stopLiveView and by a non-restart close.
     this._liveViewRestore = null;
     this._workerGeneration = 0;
+  }
+
+  _handleLiveViewEnded(message, child) {
+    if (this._process !== child || !this._liveViewRestore) return false;
+    const bound = String(this._liveViewRestore.options?.session || "default");
+    const ended = String(message?.session || "default");
+    if (bound !== ended) return false;
+    this._liveViewRestore = null;
+    return true;
   }
 
   _workerConfig() {
@@ -493,6 +531,9 @@ export class BetterWright {
           () => rpcTasks.delete(task),
           () => rpcTasks.delete(task),
         );
+      }
+      else if (message.type === "live_view_ended") {
+        this._handleLiveViewEnded(message, child);
       }
       else if (message.type === "result") {
         const pending = this._pending.get(String(message.id));
@@ -993,35 +1034,103 @@ export class BetterWright {
    * token-gated local web page that streams the live browser and, when
    * interactive, relays the viewer's mouse and keyboard into it.
    *
-   * Resolves with `{ok, url, host, port, token, interactive, viewers}`. The
-   * `url` embeds a per-start capability token; anyone holding it can watch
-   * (and drive, when interactive) the session — treat it like a password.
+   * Resolves with `{ok, url, transport, interactive, viewers}` plus direct
+   * listener fields (`host`, `port`, `token`) or managed relay fields
+   * (`sessionId`, `quota`). The URL embeds a capability; anyone holding it can
+   * watch and, when interactive, drive the bound session, so treat it like a
+   * password.
    *
    * @param {object} [options] overrides for the constructor's `liveView`
-   *   defaults: { expose, password, host, port, interactive, quality,
-   *   maxWidth, publicHost, session } — `expose` is a one-word hosting preset
-   *   ("lan" | "local" | "tailscale") that overrides host/publicHost,
-   *   `password` adds a login gate on top of the URL token, and `session`
-   *   picks which session's current tab streams first.
+   *   defaults: { transport, expose, password, host, port, interactive,
+   *   quality, maxWidth, publicHost, session }. `transport` is `direct` or
+   *   `relay`; `expose` is `lan`, `local`, or `tailscale` for direct mode.
+   *   Direct-view passwords do not apply to managed relay links, which use a
+   *   private URL-fragment capability and endpoint encryption.
    */
   startLiveView(options = {}) {
     return this._enqueue(async () => {
       const config = await this._prepare();
-      const merged = { ...this.liveView, ...options };
+      // Re-read files on every start so setup/account changes apply to an
+      // already-running daemon without requiring a restart.
+      const persisted = loadLiveViewConfig(this.home);
+      const account = loadAccountConfig(this.home);
+      // Precedence is explicit call > explicit constructor > environment/
+      // account and config files > safe built-ins. Rebuilding from those
+      // sources (instead of the previous merged object) also makes deletions
+      // and credential revocation take effect immediately.
+      const callerDefaults = {
+        ...this._liveViewExplicit,
+        ...this._liveViewMutable,
+      };
+      const explicit = { ...callerDefaults, ...options };
+      const activeDefaults = this._liveViewRestore?.options || {};
+      const merged = {
+        ...this._liveViewBuiltinDefaults,
+        ...persisted,
+        ...(account.apiKey ? { apiKey: account.apiKey } : {}),
+        relayUrl: account.relayUrl,
+        ...callerDefaults,
+        ...activeDefaults,
+        ...options,
+      };
+      // A caller choosing a concrete bind/exposure expects a direct listener;
+      // do not let a persisted relay transport silently override it.
+      const hasExplicitHost =
+        Object.hasOwn(explicit, "host") ||
+        Object.hasOwn(explicit, "publicHost");
+      if (
+        !Object.hasOwn(explicit, "transport") &&
+        (hasExplicitHost || Object.hasOwn(explicit, "expose"))
+      ) {
+        merged.transport = "direct";
+      }
+      // A concrete host is itself the exposure choice. A lower-precedence
+      // preset such as persisted expose:"local" must not silently rewrite it
+      // back to loopback inside createLiveViewServer().
+      if (hasExplicitHost && !Object.hasOwn(explicit, "expose")) {
+        delete merged.expose;
+      }
+      for (const key of Reflect.ownKeys(this._liveViewState)) {
+        delete this._liveViewState[key];
+      }
+      Object.assign(this._liveViewState, merged);
       const result = await this._dispatch(
         { type: "live_view_start", config, options: merged },
         30,
       );
+      const relayRestore = result?._restore;
+      if (result && Object.hasOwn(result, "_restore")) delete result._restore;
       if (result?.ok && result.url) {
-        // Pin the bound port and token so a worker restart revives the view
-        // on the same URL (see _prepare); viewers reconnect seamlessly.
+        // Direct views pin port/token. Managed views pin only opaque relay
+        // restore state; neither the account API key nor local loopback token
+        // is exposed in the public result.
         this._liveViewRestore = {
-          options: { ...merged, port: result.port, token: result.token },
+          options:
+            result.transport === "relay"
+              ? {
+                  ...merged,
+                  transport: "relay",
+                  session: result.session || merged.session || "default",
+                  relayRestore,
+                }
+              : {
+                  ...merged,
+                  transport: "direct",
+                  session: result.session || merged.session || "default",
+                  port: result.port,
+                  token: result.token,
+                },
           generation: this._workerGeneration,
         };
       }
       return result;
     });
+  }
+
+  _resolvedLiveViewSession(value) {
+    return String(
+      value || this._liveViewRestore?.options?.session || "default",
+    );
   }
 
   /** Stop the live-view server (no-op when it is not running). */
@@ -1072,7 +1181,7 @@ export class BetterWright {
     return this._dispatch(
       {
         type: "handoff_wait",
-        sessionId: String(options.session || "default"),
+        sessionId: this._resolvedLiveViewSession(options.session),
         prompt: String(options.prompt || ""),
         // Resolve inside the worker a beat before the client's restart timer.
         timeoutMs: timeoutSeconds * 1000,
@@ -1085,7 +1194,7 @@ export class BetterWright {
    * Post a line into the live-view chat (agent steps, system notices). No-op
    * friendly when the viewer is not running.
    *
-   * @param {object} [options] { role?: "agent"|"system"|"you", text, kind? }
+   * @param {object} [options] { session?, role?: "agent"|"system"|"you", text, kind? }
    */
   async liveViewPostChat(options = {}) {
     if (this._closed) throw new BrowserError("This browser has been closed.");
@@ -1095,6 +1204,7 @@ export class BetterWright {
     return this._dispatch(
       {
         type: "live_view_chat_post",
+        sessionId: this._resolvedLiveViewSession(options.session),
         role: String(options.role || "agent"),
         text: String(options.text || ""),
         kind: options.kind != null ? String(options.kind) : undefined,
@@ -1108,12 +1218,18 @@ export class BetterWright {
    * drain. Returns `{ok, messages: [{text, at}]}`. Used by the agent harness
    * between turns so guidance arrives at a safe turn boundary.
    */
-  async liveViewDrainChat() {
+  async liveViewDrainChat(options = {}) {
     if (this._closed) throw new BrowserError("This browser has been closed.");
     if (!this._process || this._process.exitCode !== null) {
       return { ok: true, messages: [] };
     }
-    return this._dispatch({ type: "live_view_chat_drain" }, 10);
+    return this._dispatch(
+      {
+        type: "live_view_chat_drain",
+        sessionId: this._resolvedLiveViewSession(options.session),
+      },
+      10,
+    );
   }
 
   /**
@@ -1137,7 +1253,7 @@ export class BetterWright {
     return this._dispatch(
       {
         type: "ask_wait",
-        sessionId: String(options.session || "default"),
+        sessionId: this._resolvedLiveViewSession(options.session),
         question: String(options.question || ""),
         options: choices,
         timeoutMs: timeoutSeconds * 1000,
@@ -1283,7 +1399,7 @@ export class BetterWright {
     const killer = setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null)
         child.kill("SIGKILL");
-    }, 5_000);
+    }, 20_000);
     try {
       await closed;
     } finally {

--- a/src/live-view-config.mjs
+++ b/src/live-view-config.mjs
@@ -2,11 +2,11 @@
 //
 // This is where "set once, works everywhere" lives: the CLI, the library and
 // the MCP server all merge these values under any explicit options. The
-// password is stored as an unsalted SHA-256 digest ("sha256:<hex>") — it gates
-// a screen-share viewer, not an account store, and the capability token in the
-// URL remains the primary secret; the hash simply keeps the plaintext out of
-// the config file, shell history and process listings. Set it with
-// `betterwright view --set-password`.
+// New passwords are stored with a random salt and scrypt. Legacy
+// "sha256:<hex>" values remain readable for downgrade/upgrade compatibility,
+// but saveLiveViewPassword always writes the stronger format. The capability
+// token in the URL remains the primary direct-view secret. Set the optional
+// extra gate with `betterwright view --set-password`.
 
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -14,7 +14,10 @@ import os from "node:os";
 import path from "node:path";
 
 const CONFIG_FILE = "config.json";
-const PASSWORD_HASH_PATTERN = /^(sha256:)?[0-9a-f]{64}$/i;
+const LEGACY_PASSWORD_HASH_PATTERN = /^(sha256:)?[0-9a-f]{64}$/i;
+const SCRYPT_PASSWORD_HASH_PATTERN =
+  /^scrypt:16384:8:1:([A-Za-z0-9_-]{22}):([A-Za-z0-9_-]{43})$/;
+const SCRYPT_OPTIONS = { N: 16_384, r: 8, p: 1, maxmem: 32 * 1024 * 1024 };
 
 function defaultHome() {
   const configured = (process.env.BETTERWRIGHT_HOME || "").trim();
@@ -25,13 +28,18 @@ export function liveViewConfigPath(home = defaultHome()) {
   return path.join(home, CONFIG_FILE);
 }
 
-/** "sha256:<hex>" digest for storing a live-view password at rest. */
-export function hashLiveViewPassword(password) {
-  return `sha256:${crypto.createHash("sha256").update(String(password)).digest("hex")}`;
+/** Salted scrypt digest for storing a direct live-view password at rest. */
+export function hashLiveViewPassword(password, salt = crypto.randomBytes(16)) {
+  const saltBytes = Buffer.from(salt);
+  if (saltBytes.length !== 16) throw new Error("Live-view password salt must be 16 bytes.");
+  const digest = crypto.scryptSync(String(password), saltBytes, 32, SCRYPT_OPTIONS);
+  return `scrypt:16384:8:1:${saltBytes.toString("base64url")}:${digest.toString("base64url")}`;
 }
 
 export function isLiveViewPasswordHash(value) {
-  return typeof value === "string" && PASSWORD_HASH_PATTERN.test(value.trim());
+  if (typeof value !== "string") return false;
+  const hash = value.trim();
+  return SCRYPT_PASSWORD_HASH_PATTERN.test(hash) || LEGACY_PASSWORD_HASH_PATTERN.test(hash);
 }
 
 function readConfigFile(home) {
@@ -54,8 +62,12 @@ export function loadLiveViewConfig(home = defaultHome()) {
   if (typeof section.expose === "string" && section.expose.trim()) {
     out.expose = section.expose.trim().toLowerCase();
   }
+  if (typeof section.transport === "string" && section.transport.trim()) {
+    const transport = section.transport.trim().toLowerCase();
+    if (["direct", "relay"].includes(transport)) out.transport = transport;
+  }
   if (isLiveViewPasswordHash(section.passwordHash)) {
-    out.passwordHash = section.passwordHash.trim().toLowerCase();
+    out.passwordHash = section.passwordHash.trim();
   }
   if (typeof section.password === "string" && section.password) {
     // Plaintext is accepted for hand-edited configs but hashed storage
@@ -73,6 +85,43 @@ export function loadLiveViewConfig(home = defaultHome()) {
   if (Number.isFinite(Number(section.quality))) out.quality = Number(section.quality);
   if (Number.isFinite(Number(section.maxWidth))) out.maxWidth = Number(section.maxWidth);
   return out;
+}
+
+/**
+ * Persist sanitized live-view mode settings without disturbing unrelated
+ * config keys. `transport: "relay"` always keeps the local origin loopback;
+ * direct modes use the explicit expose preset selected by the user.
+ */
+export function saveLiveViewSettings(settings = {}, home = defaultHome()) {
+  const config = readConfigFile(home);
+  const section =
+    config.liveView && typeof config.liveView === "object" && !Array.isArray(config.liveView)
+      ? config.liveView
+      : {};
+  if (settings.transport != null) {
+    const transport = String(settings.transport).trim().toLowerCase();
+    if (!["direct", "relay"].includes(transport)) {
+      throw new Error('liveView.transport must be "direct" or "relay".');
+    }
+    section.transport = transport;
+  }
+  if (settings.expose != null) {
+    const expose = String(settings.expose).trim().toLowerCase();
+    if (!["local", "lan", "tailscale"].includes(expose)) {
+      throw new Error('liveView.expose must be "local", "lan", or "tailscale".');
+    }
+    section.expose = expose;
+  }
+  config.liveView = section;
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  const file = liveViewConfigPath(home);
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    /* best effort on exotic filesystems */
+  }
+  return file;
 }
 
 /**

--- a/src/live-view.mjs
+++ b/src/live-view.mjs
@@ -8,9 +8,9 @@
 // proxy, download limits, credential capture — exactly like model-driven
 // navigation. Takeover does not bypass policy.
 //
-// Security model (self-host): the listener is off by default; bind defaults to
-// all interfaces with a LAN publicHost so printed URLs open from another
-// machine on the network. Every HTTP request and WebSocket upgrade must present
+// Security model (self-host): the listener is off by default and binds to
+// loopback unless the caller explicitly selects LAN or Tailscale exposure.
+// Every HTTP request and WebSocket upgrade must present
 // the per-start capability token (`?t=...`). Watch-only vs interactive is
 // enforced here, server-side; the viewer's "take control" toggle is a
 // client-side convenience, never an authority. Nothing in this module is
@@ -79,9 +79,9 @@ export function guessLanHost() {
   return preferred[0] || others[0] || "127.0.0.1";
 }
 
-/** Default bind: all interfaces + LAN hostname in the printed URL. */
+/** Safe default bind: this machine only. LAN exposure is always explicit. */
 export function defaultLiveViewListen() {
-  return { host: "0.0.0.0", publicHost: guessLanHost() };
+  return { host: "127.0.0.1", publicHost: "127.0.0.1" };
 }
 // Latest-frame-wins: skip a viewer whose socket backlog exceeds this instead
 // of queueing unbounded JPEG history on a slow tunnel.
@@ -113,7 +113,11 @@ const SESSION_LIMIT = 200;
 const LOGIN_MAX_FAILURES = 10;
 const LOGIN_FAILURE_WINDOW_MS = 15 * 60 * 1_000;
 const LOGIN_BODY_LIMIT = 4_096;
-const MIN_PASSWORD_LENGTH = 4;
+const MIN_PASSWORD_LENGTH = 8;
+const LEGACY_PASSWORD_HASH_PATTERN = /^(sha256:)?[0-9a-f]{64}$/i;
+const SCRYPT_PASSWORD_HASH_PATTERN =
+  /^scrypt:16384:8:1:([A-Za-z0-9_-]{22}):([A-Za-z0-9_-]{43})$/;
+const SCRYPT_OPTIONS = { N: 16_384, r: 8, p: 1, maxmem: 32 * 1024 * 1024 };
 const EXPOSE_MODES = new Set(["", "lan", "local", "tailscale"]);
 
 // Unstyled fallback login form; the worker injects the branded page from
@@ -171,7 +175,10 @@ export function createLiveViewServer({
   let boundHost = "";
   let boundPort = 0;
   let exposeMode = "";
-  let passwordHash = null; // sha256 Buffer when a password is set
+  // { algorithm: "scrypt"|"sha256", digest: Buffer, salt?: Buffer }.
+  // Legacy SHA-256 verifiers remain readable; newly supplied/stored passwords
+  // use salted scrypt.
+  let passwordHash = null;
   const sessions = new Map(); // session id -> expiry epoch ms
   const loginFailures = new Map(); // remote address -> { count, resetAt }
   let options = {
@@ -232,8 +239,19 @@ export function createLiveViewServer({
 
   function passwordOk(candidate) {
     if (!passwordHash || typeof candidate !== "string" || !candidate) return false;
-    const digest = crypto.createHash("sha256").update(candidate).digest();
-    return crypto.timingSafeEqual(digest, passwordHash);
+    let digest;
+    try {
+      digest =
+        passwordHash.algorithm === "scrypt"
+          ? crypto.scryptSync(candidate, passwordHash.salt, 32, SCRYPT_OPTIONS)
+          : crypto.createHash("sha256").update(candidate).digest();
+    } catch {
+      return false;
+    }
+    return (
+      digest.length === passwordHash.digest.length &&
+      crypto.timingSafeEqual(digest, passwordHash.digest)
+    );
   }
 
   function sessionIdOf(request) {
@@ -1132,12 +1150,13 @@ export function createLiveViewServer({
       host = tailnet;
       publicHostOverride = tailnet;
     } else if (expose === "lan") {
-      host = defaults.host;
-      publicHostOverride = startOptions.publicHost || defaults.publicHost;
+      host = "0.0.0.0";
+      publicHostOverride = startOptions.publicHost || guessLanHost();
     }
     exposeMode = expose || (host === "127.0.0.1" ? "local" : "lan");
     // Password gate: either a plaintext password (library callers, env) or a
-    // stored "sha256:<hex>" digest from the config file — never both needed.
+    // stored salted scrypt verifier. Legacy SHA-256 verifiers remain accepted
+    // so upgrading never locks out an existing direct viewer.
     const password = typeof startOptions.password === "string" ? startOptions.password : "";
     const storedHash =
       typeof startOptions.passwordHash === "string" ? startOptions.passwordHash.trim() : "";
@@ -1146,17 +1165,37 @@ export function createLiveViewServer({
         `The live-view password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
       );
     }
-    if (storedHash && !/^(sha256:)?[0-9a-f]{64}$/i.test(storedHash)) {
+    const scryptMatch = storedHash.match(SCRYPT_PASSWORD_HASH_PATTERN);
+    if (
+      storedHash &&
+      !scryptMatch &&
+      !LEGACY_PASSWORD_HASH_PATTERN.test(storedHash)
+    ) {
       throw new Error(
-        'Invalid live-view passwordHash — expected "sha256:<64 hex chars>" ' +
-          "(set it with `betterwright view --set-password`).",
+        "Invalid live-view passwordHash; set it with `betterwright view --set-password`.",
       );
     }
-    passwordHash = password
-      ? crypto.createHash("sha256").update(password).digest()
-      : storedHash
-        ? Buffer.from(storedHash.replace(/^sha256:/i, ""), "hex")
-        : null;
+    if (password) {
+      const salt = crypto.randomBytes(16);
+      passwordHash = {
+        algorithm: "scrypt",
+        salt,
+        digest: crypto.scryptSync(password, salt, 32, SCRYPT_OPTIONS),
+      };
+    } else if (scryptMatch) {
+      passwordHash = {
+        algorithm: "scrypt",
+        salt: Buffer.from(scryptMatch[1], "base64url"),
+        digest: Buffer.from(scryptMatch[2], "base64url"),
+      };
+    } else if (storedHash) {
+      passwordHash = {
+        algorithm: "sha256",
+        digest: Buffer.from(storedHash.replace(/^sha256:/i, ""), "hex"),
+      };
+    } else {
+      passwordHash = null;
+    }
     const port = clamp(Math.round(finiteNumber(startOptions.port, 0)), 0, 65_535);
     options = {
       interactive: startOptions.interactive !== false,
@@ -1189,8 +1228,8 @@ export function createLiveViewServer({
     boundPort = address?.port || port;
     const wildcard = host === "0.0.0.0" || host === "::" || host === "";
     const loopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
-    // Always prefer a LAN address in the printed URL unless the bind is
-    // deliberately loopback-only (or the caller set publicHost).
+    // A wildcard bind is explicit advanced/LAN exposure. Never invent a LAN
+    // URL for the safe loopback default.
     const urlHost = loopback
       ? host === "::1"
         ? "[::1]"

--- a/src/managed-relay.mjs
+++ b/src/managed-relay.mjs
@@ -1,0 +1,729 @@
+// Outbound BetterWright managed-relay bridge.
+//
+// The existing live-view server remains loopback-only and owns all browser/CDP
+// behavior. This bridge connects to that local WebSocket only while a remote
+// viewer is present, wraps its text/binary protocol in endpoint-to-endpoint
+// AES-256-GCM, and forwards opaque envelopes over an outbound WSS connection.
+// The relay never receives the root key and therefore cannot decrypt browser
+// pixels, chat, or input.
+
+import crypto from "node:crypto";
+
+import { normalizeRelayUrl } from "./account-config.mjs";
+
+const PROTOCOL_VERSION = 1;
+const HEADER_BYTES = 26;
+const EPOCH_BYTES = 16;
+const MAX_ENVELOPE_BYTES = 2 * 1024 * 1024;
+const REMOTE_BACKPRESSURE_BYTES = 1_500_000;
+const MAX_RECONNECT_DELAY_MS = 10_000;
+const CREATE_TIMEOUT_MS = 15_000;
+const DELETE_TIMEOUT_MS = 3_500;
+const DELETE_ATTEMPTS = 2;
+const TEXT_PAYLOAD = 0;
+const BINARY_PAYLOAD = 1;
+const CHALLENGE_PAYLOAD = 2;
+const HOST_TO_VIEWER = 1;
+const VIEWER_TO_HOST = 2;
+const RELAY_PROTOCOL = "betterwright.relay.v1";
+const HOST_PROTOCOL_PREFIX = "bw.host.";
+const TERMINAL_CLOSE_CODES = new Set([4401, 4403, 4408, 4411, 4412, 4414, 4415, 4416]);
+
+function asBuffer(value) {
+  if (Buffer.isBuffer(value)) return value;
+  if (value instanceof ArrayBuffer) return Buffer.from(value);
+  if (ArrayBuffer.isView(value)) return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  return Buffer.from(value);
+}
+
+function randomBase64Url(bytes) {
+  return crypto.randomBytes(bytes).toString("base64url");
+}
+
+function constantEqual(a, b) {
+  const left = Buffer.from(String(a || ""));
+  const right = Buffer.from(String(b || ""));
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
+export function deriveManagedViewerProof(root, sessionId) {
+  const key = Buffer.isBuffer(root) ? root : Buffer.from(String(root), "base64url");
+  if (key.length !== 32) throw new Error("Managed relay root key must be 32 bytes.");
+  return crypto
+    .createHmac("sha256", key)
+    .update(`BetterWright relay viewer proof v1\0${String(sessionId)}`)
+    .digest("base64url");
+}
+
+function deriveDirectionKey(root, epoch, sessionId, direction) {
+  const label = direction === HOST_TO_VIEWER ? "host-to-viewer" : "viewer-to-host";
+  const salt = crypto
+    .createHash("sha256")
+    .update(Buffer.from(`BetterWright relay HKDF salt v1\0${sessionId}\0`, "utf8"))
+    .update(epoch)
+    .digest();
+  return Buffer.from(
+    crypto.hkdfSync(
+      "sha256",
+      root,
+      salt,
+      Buffer.from(`BetterWright relay ${label} AES-GCM v1`, "utf8"),
+      32,
+    ),
+  );
+}
+
+function nonceFor(direction, sequence) {
+  const nonce = Buffer.alloc(12);
+  nonce[0] = PROTOCOL_VERSION;
+  nonce[1] = direction;
+  nonce.writeBigUInt64BE(sequence, 4);
+  return nonce;
+}
+
+function aadFor(header, sessionId, direction) {
+  const label = direction === HOST_TO_VIEWER ? "h2v" : "v2h";
+  return Buffer.concat([
+    header,
+    Buffer.from(`BetterWright relay envelope v1\0${String(sessionId)}\0${label}`, "utf8"),
+  ]);
+}
+
+export function createManagedCipher({ root, sessionId, direction, epoch = crypto.randomBytes(EPOCH_BYTES) }) {
+  const keyRoot = Buffer.isBuffer(root) ? root : Buffer.from(String(root), "base64url");
+  if (keyRoot.length !== 32) throw new Error("Managed relay root key must be 32 bytes.");
+  if (![HOST_TO_VIEWER, VIEWER_TO_HOST].includes(direction)) {
+    throw new Error("Invalid managed relay direction.");
+  }
+  const senderEpoch = asBuffer(epoch);
+  if (senderEpoch.length !== EPOCH_BYTES) throw new Error("Managed relay epoch must be 16 bytes.");
+  const key = deriveDirectionKey(keyRoot, senderEpoch, sessionId, direction);
+  let sequence = 0n;
+  return {
+    get epoch() {
+      return Buffer.from(senderEpoch);
+    },
+    seal(type, value) {
+      const body = asBuffer(value);
+      if (body.length + HEADER_BYTES + 17 > MAX_ENVELOPE_BYTES) {
+        throw new Error("Managed relay message exceeds the 2 MiB limit.");
+      }
+      const header = Buffer.alloc(HEADER_BYTES);
+      header[0] = PROTOCOL_VERSION;
+      header[1] = direction;
+      senderEpoch.copy(header, 2);
+      header.writeBigUInt64BE(sequence, 18);
+      const cipher = crypto.createCipheriv("aes-256-gcm", key, nonceFor(direction, sequence));
+      cipher.setAAD(aadFor(header, sessionId, direction));
+      const plaintext = Buffer.concat([Buffer.from([type]), body]);
+      const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+      const tag = cipher.getAuthTag();
+      sequence += 1n;
+      return Buffer.concat([header, ciphertext, tag]);
+    },
+  };
+}
+
+export function createManagedDecipher({ root, sessionId, direction }) {
+  const keyRoot = Buffer.isBuffer(root) ? root : Buffer.from(String(root), "base64url");
+  if (keyRoot.length !== 32) throw new Error("Managed relay root key must be 32 bytes.");
+  let epochHex = "";
+  let key = null;
+  let lastSequence = -1n;
+  return {
+    reset() {
+      epochHex = "";
+      key = null;
+      lastSequence = -1n;
+    },
+    open(value) {
+      const envelope = asBuffer(value);
+      if (envelope.length < HEADER_BYTES + 17 || envelope.length > MAX_ENVELOPE_BYTES) {
+        throw new Error("Invalid managed relay envelope size.");
+      }
+      const header = envelope.subarray(0, HEADER_BYTES);
+      if (header[0] !== PROTOCOL_VERSION || header[1] !== direction) {
+        throw new Error("Managed relay protocol direction/version mismatch.");
+      }
+      const epoch = header.subarray(2, 18);
+      const nextEpochHex = epoch.toString("hex");
+      const sequence = header.readBigUInt64BE(18);
+      if (!epochHex) {
+        epochHex = nextEpochHex;
+        key = deriveDirectionKey(keyRoot, epoch, sessionId, direction);
+      } else if (nextEpochHex !== epochHex) {
+        throw new Error("Managed relay sender epoch changed without reconnect.");
+      }
+      if (sequence <= lastSequence) throw new Error("Managed relay replay rejected.");
+      const ciphertext = envelope.subarray(HEADER_BYTES, -16);
+      const tag = envelope.subarray(-16);
+      const decipher = crypto.createDecipheriv("aes-256-gcm", key, nonceFor(direction, sequence));
+      decipher.setAAD(aadFor(header, sessionId, direction));
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+      if (!plaintext.length || ![TEXT_PAYLOAD, BINARY_PAYLOAD, CHALLENGE_PAYLOAD].includes(plaintext[0])) {
+        throw new Error("Managed relay payload type is invalid.");
+      }
+      lastSequence = sequence;
+      return {
+        type:
+          plaintext[0] === TEXT_PAYLOAD
+            ? "text"
+            : plaintext[0] === BINARY_PAYLOAD
+              ? "binary"
+              : "challenge",
+        data: plaintext.subarray(1),
+      };
+    },
+  };
+}
+
+function localWebSocketUrl(localUrl) {
+  const parsed = new URL(localUrl);
+  parsed.protocol = parsed.protocol === "https:" ? "wss:" : "ws:";
+  parsed.pathname = "/ws";
+  return parsed.toString();
+}
+
+function responseError(status, body) {
+  const code = typeof body?.error?.code === "string" ? body.error.code : body?.code;
+  const message =
+    typeof body?.error?.message === "string"
+      ? body.error.message
+      : typeof body?.error === "string"
+        ? body.error
+        : "";
+  if (status === 401) return "BetterWright API key was rejected. Create a new key at https://betterwright.com/account.";
+  if (status === 402 || code === "budget_exhausted") {
+    return "BetterWright managed relay is temporarily unavailable because its monthly safety budget was reached.";
+  }
+  if (status === 429 || code === "weekly_quota_exhausted" || code === "quota_exhausted") {
+    return message || "Your two-hour weekly managed-relay allowance has been used.";
+  }
+  if (code === "relay_disabled") {
+    return "BetterWright managed Live View is temporarily paused by its safety switch.";
+  }
+  return message || `BetterWright relay returned HTTP ${status}.`;
+}
+
+function expectedSessionUrls(relayUrl, sessionId) {
+  const base = new URL(relayUrl);
+  const viewer = new URL(`/s/${encodeURIComponent(sessionId)}`, base);
+  const websocket = new URL(`/v1/sessions/${encodeURIComponent(sessionId)}/ws`, base);
+  websocket.protocol = websocket.protocol === "https:" ? "wss:" : "ws:";
+  return { viewer, websocket };
+}
+
+function validHostProtocols(protocols) {
+  return (
+    Array.isArray(protocols) &&
+    protocols.length === 2 &&
+    protocols[0] === RELAY_PROTOCOL &&
+    typeof protocols[1] === "string" &&
+    new RegExp(`^${HOST_PROTOCOL_PREFIX.replaceAll(".", "\\.")}[A-Za-z0-9_-]{43}$`).test(protocols[1])
+  );
+}
+
+function validateSessionResponse(body, relayUrl, sessionId, root) {
+  if (body?.session?.id !== sessionId) throw new Error("BetterWright relay returned the wrong session ID.");
+  const expected = expectedSessionUrls(relayUrl, sessionId);
+  let returnedWebSocket;
+  let returnedViewer;
+  try {
+    returnedWebSocket = new URL(String(body?.host?.websocketUrl || ""));
+    returnedViewer = new URL(String(body?.viewer?.url || ""));
+  } catch {
+    throw new Error("BetterWright relay returned invalid session URLs.");
+  }
+  const expectedWsProtocol = expected.websocket.protocol;
+  if (
+    returnedWebSocket.protocol !== expectedWsProtocol ||
+    returnedWebSocket.host !== expected.websocket.host ||
+    returnedWebSocket.pathname !== expected.websocket.pathname ||
+    returnedWebSocket.username ||
+    returnedWebSocket.password ||
+    returnedWebSocket.search ||
+    returnedWebSocket.hash
+  ) {
+    throw new Error("BetterWright relay returned an untrusted WebSocket URL.");
+  }
+  if (
+    returnedViewer.protocol !== expected.viewer.protocol ||
+    returnedViewer.host !== expected.viewer.host ||
+    returnedViewer.pathname !== expected.viewer.pathname ||
+    returnedViewer.username ||
+    returnedViewer.password ||
+    returnedViewer.search ||
+    returnedViewer.hash
+  ) {
+    throw new Error("BetterWright relay returned an untrusted viewer URL.");
+  }
+  const protocols = body?.host?.subprotocols;
+  if (!validHostProtocols(protocols)) {
+    throw new Error("BetterWright relay returned invalid host credentials.");
+  }
+  expected.viewer.hash = `k=${root.toString("base64url")}`;
+  return {
+    websocketUrl: expected.websocket.toString(),
+    subprotocols: [...protocols],
+    viewerUrl: expected.viewer.toString(),
+  };
+}
+
+function validateRestoreState(session, relayUrl, root) {
+  if (!session || !/^bws_[A-Za-z0-9_-]{24}$/.test(String(session.sessionId || ""))) {
+    throw new Error("Managed relay restore state has an invalid session ID.");
+  }
+  const expected = expectedSessionUrls(relayUrl, session.sessionId);
+  let websocket;
+  let viewer;
+  try {
+    websocket = new URL(String(session.websocketUrl || ""));
+    viewer = new URL(String(session.viewerUrl || ""));
+  } catch {
+    throw new Error("Managed relay restore state has invalid URLs.");
+  }
+  const expectedRoot = root.toString("base64url");
+  const fragment = new URLSearchParams(viewer.hash.slice(1));
+  if (
+    websocket.toString() !== expected.websocket.toString() ||
+    viewer.protocol !== expected.viewer.protocol ||
+    viewer.host !== expected.viewer.host ||
+    viewer.pathname !== expected.viewer.pathname ||
+    viewer.search ||
+    viewer.username ||
+    viewer.password ||
+    fragment.get("k") !== expectedRoot ||
+    [...fragment.keys()].some((key) => key !== "k") ||
+    !validHostProtocols(session.subprotocols)
+  ) {
+    throw new Error("Managed relay restore state does not match the configured relay.");
+  }
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.localUrl tokenized loopback live-view URL
+ * @param {string} options.apiKey BetterWright account API key
+ * @param {string} [options.relayUrl]
+ * @param {boolean} [options.interactive]
+ * @param {string} [options.clientVersion]
+ * @param {object} [options.restore] opaque state from a previous worker
+ * @param {(line:string)=>void} [options.log]
+ * @param {(state:{reason:string,status:object})=>void|Promise<void>} [options.onTerminal]
+ * @param {typeof fetch} [options.fetchImpl]
+ * @param {typeof WebSocket} [options.WebSocketImpl]
+ */
+export function createManagedRelayBridge(options) {
+  const localUrl = String(options.localUrl || "");
+  const apiKey = String(options.apiKey || "").trim();
+  const relayUrl = normalizeRelayUrl(options.relayUrl);
+  const WebSocketImpl = options.WebSocketImpl || globalThis.WebSocket;
+  const fetchImpl = options.fetchImpl || fetch;
+  const log = options.log || (() => {});
+  if (!WebSocketImpl) throw new Error("Managed relay requires Node.js 22 or newer (WebSocket unavailable).");
+
+  let session = options.restore && typeof options.restore === "object" ? { ...options.restore } : null;
+  let root = session?.root ? Buffer.from(String(session.root), "base64url") : null;
+  let remote = null;
+  let local = null;
+  let running = false;
+  let stopping = false;
+  let terminal = false;
+  let terminalReason = "";
+  let deletionStarted = false;
+  let viewerConnected = false;
+  let viewerReady = false;
+  let challenge = "";
+  let reconnectAttempts = 0;
+  let reconnectTimer = null;
+  let hostCipher = null;
+  let viewerDecipher = null;
+  let lastQuota = session?.quota || null;
+
+  function publicStatus() {
+    return {
+      ok: true,
+      running,
+      transport: "relay",
+      expose: "relay",
+      url: String(session?.viewerUrl || ""),
+      sessionId: String(session?.sessionId || ""),
+      expiresAt: session?.expiresAt || null,
+      interactive: options.interactive !== false,
+      viewers: viewerConnected ? 1 : 0,
+      quota: lastQuota,
+      ...(terminal ? { terminal: true } : {}),
+      ...(terminalReason ? { error: terminalReason } : {}),
+    };
+  }
+
+  function markTerminal(reason) {
+    if (terminal) return;
+    terminal = true;
+    running = false;
+    terminalReason = String(reason || "Managed relay session ended.");
+    if (!stopping && typeof options.onTerminal === "function") {
+      queueMicrotask(() => {
+        Promise.resolve(
+          options.onTerminal({ reason: terminalReason, status: publicStatus() }),
+        ).catch((error) => {
+          log(`managed-relay: terminal cleanup failed: ${error?.message || error}`);
+        });
+      });
+    }
+  }
+
+  function resetPeerCrypto() {
+    hostCipher = createManagedCipher({ root, sessionId: session.sessionId, direction: HOST_TO_VIEWER });
+    viewerDecipher = createManagedDecipher({ root, sessionId: session.sessionId, direction: VIEWER_TO_HOST });
+    viewerReady = false;
+    challenge = randomBase64Url(32);
+  }
+
+  function sendEncrypted(type, data) {
+    if (!remote || remote.readyState !== WebSocketImpl.OPEN || !hostCipher) return false;
+    if (remote.bufferedAmount > REMOTE_BACKPRESSURE_BYTES) return false;
+    try {
+      const kind =
+        type === "text" ? TEXT_PAYLOAD : type === "binary" ? BINARY_PAYLOAD : CHALLENGE_PAYLOAD;
+      remote.send(hostCipher.seal(kind, data));
+      return true;
+    } catch (error) {
+      log(`managed-relay: encrypt/send failed: ${error?.message || error}`);
+      return false;
+    }
+  }
+
+  function closeLocal() {
+    const socket = local;
+    local = null;
+    if (socket) {
+      try {
+        socket.close(1000, "viewer disconnected");
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+
+  function openLocal() {
+    if (!viewerConnected || !viewerReady || local || stopping) return;
+    const socket = new WebSocketImpl(localWebSocketUrl(localUrl));
+    socket.binaryType = "arraybuffer";
+    local = socket;
+    socket.addEventListener("message", (event) => {
+      if (local !== socket || !viewerConnected || !viewerReady) return;
+      if (typeof event.data === "string") sendEncrypted("text", Buffer.from(event.data, "utf8"));
+      else sendEncrypted("binary", asBuffer(event.data));
+    });
+    socket.addEventListener("close", () => {
+      if (local === socket) local = null;
+    });
+    socket.addEventListener("error", () => {
+      try {
+        socket.close();
+      } catch {
+        /* ignored */
+      }
+    });
+  }
+
+  function failEncryptedPeer(reason) {
+    log(`managed-relay: ${reason}`);
+    try {
+      remote?.close(4403, "encrypted channel verification failed");
+    } catch {
+      /* close event handles cleanup */
+    }
+  }
+
+  function handleViewerEnvelope(data) {
+    if (!viewerDecipher) return;
+    let opened;
+    try {
+      opened = viewerDecipher.open(data);
+    } catch (error) {
+      failEncryptedPeer(`rejected viewer envelope: ${error?.message || error}`);
+      return;
+    }
+    if (!viewerReady) {
+      if (opened.type !== "challenge") {
+        failEncryptedPeer("viewer input arrived before root-key verification");
+        return;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(opened.data.toString("utf8"));
+      } catch {
+        failEncryptedPeer("viewer returned an invalid root-key challenge");
+        return;
+      }
+      if (parsed?.t !== "bw_e2e_ready" || !constantEqual(parsed.challenge, challenge)) {
+        failEncryptedPeer("viewer failed root-key verification");
+        return;
+      }
+      viewerReady = true;
+      challenge = "";
+      openLocal();
+      return;
+    }
+    if (opened.type !== "text") {
+      failEncryptedPeer("viewer sent an unsupported binary payload");
+      return;
+    }
+    if (local?.readyState === WebSocketImpl.OPEN) local.send(opened.data.toString("utf8"));
+  }
+
+  function beginPeer() {
+    closeLocal();
+    viewerConnected = true;
+    resetPeerCrypto();
+    if (
+      !sendEncrypted(
+        "challenge",
+        Buffer.from(JSON.stringify({ t: "bw_e2e_challenge", challenge }), "utf8"),
+      )
+    ) {
+      failEncryptedPeer("could not send the root-key challenge");
+    }
+  }
+
+  function endPeer() {
+    viewerConnected = false;
+    viewerReady = false;
+    challenge = "";
+    closeLocal();
+    viewerDecipher?.reset();
+  }
+
+  function handleControl(text) {
+    let message;
+    try {
+      message = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (message?.t !== "relay" || typeof message.event !== "string") return;
+    if (message.quota && typeof message.quota === "object") lastQuota = message.quota;
+    if (message.event === "viewer_connected") {
+      beginPeer();
+      return;
+    }
+    if (
+      [
+        "viewer_disconnected",
+        "lease_expired",
+        "quota_exhausted",
+        "budget_exhausted",
+      ].includes(message.event)
+    ) {
+      endPeer();
+      return;
+    }
+    if (["session_closed", "session_expired", "kill_switch"].includes(message.event)) {
+      endPeer();
+      markTerminal(`Managed relay ended: ${message.event}.`);
+    }
+  }
+
+  function scheduleReconnect() {
+    if (stopping || terminal || reconnectTimer) return;
+    const expiry = Date.parse(String(session?.expiresAt || ""));
+    if (Number.isFinite(expiry) && expiry <= Date.now()) {
+      markTerminal("Managed relay session expired.");
+      return;
+    }
+    reconnectAttempts += 1;
+    const delay = Math.min(MAX_RECONNECT_DELAY_MS, 500 * 1.7 ** Math.min(reconnectAttempts, 8));
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      void connectRemote().catch((error) => {
+        log(`managed-relay: reconnect failed: ${error?.message || error}`);
+        scheduleReconnect();
+      });
+    }, delay + Math.random() * 250);
+    reconnectTimer.unref?.();
+  }
+
+  function connectRemote() {
+    return new Promise((resolve, reject) => {
+      if (stopping || terminal) return reject(new Error("Managed relay session has ended."));
+      const socket = new WebSocketImpl(session.websocketUrl, session.subprotocols);
+      socket.binaryType = "arraybuffer";
+      remote = socket;
+      let settled = false;
+      const fail = (error) => {
+        if (!settled) {
+          settled = true;
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      };
+      socket.addEventListener("open", () => {
+        if (remote !== socket) return;
+        reconnectAttempts = 0;
+        running = true;
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      });
+      socket.addEventListener("message", (event) => {
+        if (remote !== socket) return;
+        if (typeof event.data === "string") handleControl(event.data);
+        else handleViewerEnvelope(asBuffer(event.data));
+      });
+      socket.addEventListener("error", () => fail(new Error("Could not connect to the BetterWright relay WebSocket.")));
+      socket.addEventListener("close", (event) => {
+        if (remote === socket) remote = null;
+        running = false;
+        endPeer();
+        if (TERMINAL_CLOSE_CODES.has(Number(event?.code))) {
+          markTerminal(
+            event?.reason
+              ? `BetterWright relay ended: ${event.reason}.`
+              : `BetterWright relay ended with code ${event?.code}.`,
+          );
+        }
+        if (!settled) {
+          const detail = event?.reason ? `: ${event.reason}` : "";
+          fail(new Error(`BetterWright relay closed during connection${detail}.`));
+        }
+        if (!stopping && !terminal) scheduleReconnect();
+      });
+    });
+  }
+
+  async function createSession() {
+    root = crypto.randomBytes(32);
+    const sessionId = `bws_${randomBase64Url(18)}`;
+    const viewerProof = deriveManagedViewerProof(root, sessionId);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), CREATE_TIMEOUT_MS);
+    timer.unref?.();
+    try {
+      const response = await fetchImpl(`${relayUrl}/v1/sessions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          sessionId,
+          viewerProof,
+          protocolVersion: PROTOCOL_VERSION,
+          interactive: options.interactive !== false,
+          clientVersion: String(options.clientVersion || "unknown"),
+        }),
+        signal: controller.signal,
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(responseError(response.status, body));
+      // The server now owns this provisional ID. Record it before validating
+      // untrusted response fields so a failed start can still DELETE it.
+      session = { sessionId };
+      const validated = validateSessionResponse(body, relayUrl, sessionId, root);
+      session = {
+        sessionId,
+        websocketUrl: validated.websocketUrl,
+        subprotocols: validated.subprotocols,
+        viewerUrl: validated.viewerUrl,
+        expiresAt: body?.session?.expiresAt || null,
+        quota: body?.quota || null,
+        root: root.toString("base64url"),
+      };
+      lastQuota = session.quota;
+    } catch (error) {
+      if (error?.name === "AbortError") throw new Error("Timed out while creating a BetterWright relay session.");
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function start() {
+    if (running) return { ...publicStatus(), alreadyRunning: true, _restore: { ...session } };
+    if (terminal || stopping) {
+      throw new Error(terminalReason || "Managed relay session has ended.");
+    }
+    if (!session) await createSession();
+    if (root?.length !== 32) throw new Error("Managed relay restore state is invalid.");
+    validateRestoreState(session, relayUrl, root);
+    await connectRemote();
+    return { ...publicStatus(), _restore: { ...session } };
+  }
+
+  async function stop({ preserve = false } = {}) {
+    stopping = true;
+    terminal = true;
+    running = false;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+    endPeer();
+    const socket = remote;
+    remote = null;
+    if (socket) {
+      try {
+        socket.close(1000, preserve ? "worker restarting" : "live view stopped");
+      } catch {
+        /* already closed */
+      }
+    }
+    if (!preserve && !deletionStarted && session?.sessionId && apiKey) {
+      deletionStarted = true;
+      let lastError = null;
+      for (let attempt = 1; attempt <= DELETE_ATTEMPTS; attempt += 1) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), DELETE_TIMEOUT_MS);
+        timer.unref?.();
+        try {
+          const response = await fetchImpl(
+            `${relayUrl}/v1/sessions/${encodeURIComponent(session.sessionId)}`,
+            {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${apiKey}` },
+              signal: controller.signal,
+            },
+          );
+          if (response.ok || response.status === 404) return;
+          lastError = new Error(
+            `BetterWright relay session cleanup returned HTTP ${response.status}.`,
+          );
+          // Authentication and other caller errors are deterministic. Retry
+          // only throttling and server-side failures within the shutdown grace.
+          if (response.status !== 429 && response.status < 500) throw lastError;
+        } catch (error) {
+          lastError =
+            error?.name === "AbortError"
+              ? new Error("Timed out while closing the BetterWright relay session.")
+              : error;
+          if (
+            /HTTP 4\d\d\./.test(String(lastError?.message || "")) &&
+            !/HTTP 429\./.test(String(lastError?.message || ""))
+          ) {
+            throw lastError;
+          }
+        } finally {
+          clearTimeout(timer);
+        }
+        if (attempt < DELETE_ATTEMPTS) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+      }
+      throw lastError || new Error("Could not close the BetterWright relay session.");
+    }
+  }
+
+  return {
+    start,
+    stop,
+    status: publicStatus,
+    get restore() {
+      return session ? { ...session } : null;
+    },
+  };
+}
+
+export const MANAGED_RELAY_PROTOCOL_VERSION = PROTOCOL_VERSION;
+export const MANAGED_RELAY_MAX_ENVELOPE_BYTES = MAX_ENVELOPE_BYTES;

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -31,7 +31,8 @@
 //     BETTERWRIGHT_LIVE_VIEW_HOST=...      live-view bind host (default 127.0.0.1)
 //     BETTERWRIGHT_LIVE_VIEW_PORT=...      live-view port (default ephemeral)
 //     BETTERWRIGHT_LIVE_VIEW=1             allow a non-loopback live-view host
-//     BETTERWRIGHT_LIVE_VIEW_EXPOSE=...    lan | local | tailscale hosting preset
+//     BETTERWRIGHT_LIVE_VIEW_EXPOSE=...    lan | local | tailscale direct preset
+//     BETTERWRIGHT_LIVE_VIEW_TRANSPORT=... direct | relay
 //     BETTERWRIGHT_LIVE_VIEW_PASSWORD=...  require a password to open the live view
 //     (live-view settings persist in <home>/config.json too — see docs/live-view.md;
 //     `betterwright view --set-password` stores a hashed password there)
@@ -100,16 +101,23 @@ export function headlessFromEnv(env = process.env) {
 }
 
 export function liveViewFromEnv(env = process.env, fileConfig = loadLiveViewConfig()) {
-  // Default bind is LAN-reachable (0.0.0.0). Non-loopback still requires the
-  // deployer opt-in BETTERWRIGHT_LIVE_VIEW=1 for MCP exposure. Persistent
-  // settings from <home>/config.json apply beneath the env overrides, so
-  // `betterwright view --set-password` also protects MCP-started views.
+  // Default bind is loopback. A saved or environment-selected relay transport
+  // is itself an explicit MCP authorization; non-loopback direct exposure
+  // still requires BETTERWRIGHT_LIVE_VIEW=1.
   const host =
     String(env.BETTERWRIGHT_LIVE_VIEW_HOST || "").trim() ||
     (typeof fileConfig.host === "string" && fileConfig.host) ||
-    "0.0.0.0";
+    "127.0.0.1";
+  const environmentTransport = String(
+    env.BETTERWRIGHT_LIVE_VIEW_TRANSPORT || "",
+  ).trim().toLowerCase();
+  const transport = environmentTransport || fileConfig.transport || "direct";
+  const relayAuthorized =
+    transport === "relay" &&
+    (environmentTransport === "relay" || fileConfig.transport === "relay");
   return {
-    enabled: boolEnv(env, "BETTERWRIGHT_LIVE_VIEW"),
+    enabled: boolEnv(env, "BETTERWRIGHT_LIVE_VIEW") || relayAuthorized,
+    transport,
     host,
     port:
       Number(env.BETTERWRIGHT_LIVE_VIEW_PORT) || Number(fileConfig.port) || 0,
@@ -451,10 +459,11 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
   // over MCP the host's loop is opaque, so the boundary is each tool call:
   // notes go viewer-ward before a run, typed guidance rides back on results.
   let liveViewActive = false;
-  const drainViewerChat = async () => {
-    if (!liveViewActive) return [];
+  let liveViewSession = "default";
+  const drainViewerChat = async (requestedSession = liveViewSession) => {
+    if (!liveViewActive || String(requestedSession || "default") !== liveViewSession) return [];
     try {
-      const drained = await browser.liveViewDrainChat();
+      const drained = await browser.liveViewDrainChat({ session: liveViewSession });
       return Array.isArray(drained?.messages) ? drained.messages : [];
     } catch {
       return [];
@@ -472,11 +481,13 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
     if (action === "stop") {
       const stopped = await browser.stopLiveView();
       liveViewActive = false;
+      liveViewSession = "default";
       return { content: [{ type: "text", text: JSON.stringify(stopped) }] };
     }
     if (action === "status") {
       const status = await browser.liveViewStatus();
       liveViewActive = Boolean(status?.running);
+      if (status?.session) liveViewSession = String(status.session);
       const userChat = (await drainViewerChat()).map((item) => String(item.text || ""));
       // Never echo the token back on status; start already returned the URL.
       const { token: _token, url: _url, ...safe } = status;
@@ -489,9 +500,9 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
     if (action !== "start") throw new Error(`Unknown browser_handoff action: ${action}`);
     // "local" (loopback) never needs the opt-in; lan/tailscale — like any
     // non-loopback bind host — require the deployer to set the env flag.
-    const reachesBeyondThisMachine = liveView.expose
-      ? liveView.expose !== "local"
-      : !isLoopbackHost(liveView.host);
+    const reachesBeyondThisMachine =
+      liveView.transport === "relay" ||
+      (liveView.expose ? liveView.expose !== "local" : !isLoopbackHost(liveView.host));
     if (reachesBeyondThisMachine && !liveView.enabled) {
       throw new Error(
         "The live view would be reachable beyond this machine; the deployer must " +
@@ -499,25 +510,33 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
           "BETTERWRIGHT_LIVE_VIEW_EXPOSE=local for loopback-only).",
       );
     }
+    const requestedSession = String(args.session || "default");
     const view = await browser.startLiveView({
       host: liveView.host,
       port: liveView.port,
       ...(liveView.publicHost ? { publicHost: liveView.publicHost } : {}),
       ...(liveView.expose ? { expose: liveView.expose } : {}),
+      ...(liveView.transport ? { transport: liveView.transport } : {}),
       ...(liveView.password ? { password: liveView.password } : {}),
       ...(liveView.passwordHash ? { passwordHash: liveView.passwordHash } : {}),
       interactive: args.interactive !== false,
-      session: String(args.session || "default"),
+      session: requestedSession,
     });
     if (!view.ok || !view.url) throw new Error(view.error || "The live view failed to start.");
     liveViewActive = true;
+    liveViewSession = String(view.session || requestedSession);
+    const remoteAccess =
+      view.transport === "relay"
+        ? "The managed link connects outbound through BetterWright; no SSH tunnel or port forwarding is needed. "
+        : view.url.includes("127.0.0.1")
+          ? `If they are remote, tunnel it with \`ssh -L ${view.port}:127.0.0.1:${view.port} <host>\`. `
+          : "";
     const text =
       `Live view started: ${view.url}\n\n` +
-      "Relay that URL to the user verbatim (it embeds a one-time capability " +
-      "token) and tell them exactly what to do in the page" +
+      "Relay that URL to the user verbatim (it embeds a private capability) " +
+      "and tell them exactly what to do in the page" +
       (args.reason ? ` — reason: ${args.reason}` : "") +
-      ". If the URL is on 127.0.0.1 and they are remote, they can tunnel with " +
-      `\`ssh -L ${view.port}:127.0.0.1:${view.port} <host>\`. ` +
+      `. ${remoteAccess}` +
       "Poll browser_handoff {action: \"status\"} to see when they are done, " +
       "then re-observe the page with a snapshot before continuing.";
     return { content: [{ type: "text", text }] };
@@ -534,7 +553,7 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
         }
         if (name === "browser_login" && withLogin) {
           const result = await browser.fillCredential(loginOptionsFromArgs(args));
-          const chat = await drainViewerChat();
+          const chat = await drainViewerChat(String(args.session || "default"));
           const content = await contentForResult(result);
           if (chat.length) content.push(viewerChatBlock(chat));
           return { content };
@@ -558,13 +577,18 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
           if (downloadPolicy === "ask") await approveDownload(server, options.note);
           options.approvedDownloads = true;
         }
-        if (liveViewActive && options.note) {
+        if (liveViewActive && options.session === liveViewSession && options.note) {
           await browser
-            .liveViewPostChat({ role: "agent", text: options.note, kind: "step" })
+            .liveViewPostChat({
+              session: liveViewSession,
+              role: "agent",
+              text: options.note,
+              kind: "step",
+            })
             .catch(() => {});
         }
         const result = await browser.run(String(args.code || ""), options);
-        const chat = await drainViewerChat();
+        const chat = await drainViewerChat(options.session);
         const content = await contentForResult(result);
         if (chat.length) content.push(viewerChatBlock(chat));
         return { content };
@@ -586,6 +610,14 @@ export async function runMcpServer(env = process.env, options = {}) {
     await loadSdk();
 
   const downloadPolicy = downloadPolicyFromEnv(env);
+  const liveView = liveViewFromEnv(env);
+  const apiKey = String(env.BETTERWRIGHT_API_KEY || "").trim();
+  const relayUrl = String(env.BETTERWRIGHT_RELAY_URL || "").trim();
+  const browserLiveView = {
+    ...liveView,
+    ...(apiKey ? { apiKey } : {}),
+    ...(relayUrl ? { relayUrl } : {}),
+  };
   // One persistent browser for the life of the server, so pages and logins
   // survive across tool calls the way an agent expects. The built-in encrypted
   // vault enables `browser_login`; an embedding may override or disable it.
@@ -593,6 +625,7 @@ export async function runMcpServer(env = process.env, options = {}) {
     policy: policyFromEnv(env),
     headless: headlessFromEnv(env),
     downloadPolicy,
+    liveView: browserLiveView,
     // Identity must match egress geography (see docs/getting-started.md):
     // a headless server whose exit IP sits in another country needs these
     // pinned or geo-sensitive sites challenge every run.
@@ -610,7 +643,7 @@ export async function runMcpServer(env = process.env, options = {}) {
     { capabilities: { tools: {} } },
   );
 
-  const handlers = createMcpHandlers({ browser, server, downloadPolicy });
+  const handlers = createMcpHandlers({ browser, server, downloadPolicy, liveView: browserLiveView });
   server.setRequestHandler(ListToolsRequestSchema, handlers.listTools);
   server.setRequestHandler(CallToolRequestSchema, handlers.callTool);
 

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -79,6 +79,7 @@ import {
 } from "./human.mjs";
 import { createLiveViewServer } from "./live-view.mjs";
 import { liveViewHtml, liveViewLoginHtml } from "./live-view-html.mjs";
+import { createManagedRelayBridge } from "./managed-relay.mjs";
 import {
   dismissObstructiveOverlays,
   inspectControls,
@@ -158,6 +159,7 @@ let vaultCapture = null;
 // the CDP sessions frames come from are worker-internal; started only by an
 // explicit live_view_start message from the host, loopback + token by default.
 let liveView = null;
+let managedRelay = null;
 
 const sessions = new Map();
 const pageToSession = new WeakMap();
@@ -1489,11 +1491,26 @@ async function ensureBrowser(config) {
       downloadGuardReady = false;
       disposeVaultCapture();
       releaseProfileLock();
-      // The stream has nothing left to show once the browser is gone; stop the
-      // server so viewers see a clean "ended" screen instead of a dead canvas.
-      const closingLiveView = liveView;
-      liveView = null;
-      if (closingLiveView) void closingLiveView.stop().catch(() => {});
+      // The stream has nothing left to show once the browser is gone. Clear
+      // every capability atomically and DELETE managed relay state rather than
+      // leaving a stale public URL alive until its TTL.
+      const endedSession = liveViewBoundSession;
+      const hadLiveView = Boolean(liveView || managedRelay);
+      void teardownLiveView({ preserve: false, notify: true })
+        .then((cleared) => {
+          if (hadLiveView && cleared) {
+            send({
+              type: "live_view_ended",
+              session: endedSession,
+              reason: "Browser context closed.",
+            });
+          }
+        })
+        .catch((error) => {
+          process.stderr.write(
+            `live-view: browser-close cleanup failed: ${error?.message || error}\n`,
+          );
+        });
     });
     await installContextGuard(launchedContext);
     await installDownloadGuard(launchedContext);
@@ -4651,21 +4668,26 @@ async function execute(message) {
 
 function liveViewPages() {
   const entries = [];
-  for (const [sessionId, session] of sessions) {
-    for (const [id, page] of session.pages) {
-      if (page.isClosed()) continue;
-      entries.push({
-        id,
-        page,
-        sessionId,
-        active: session.currentId === id,
-      });
-    }
+  // A capability for one session must never reveal tabs owned by another
+  // daemon session in the same browser worker.
+  if (!liveViewBoundSession) return entries;
+  const selected = sessions.get(liveViewBoundSession);
+  if (!selected) return entries;
+  for (const [id, page] of selected.pages) {
+    if (page.isClosed()) continue;
+    entries.push({
+      id,
+      page,
+      sessionId: liveViewBoundSession,
+      active: selected.currentId === id,
+    });
   }
   return entries;
 }
 
-let liveViewPreferredSession = "default";
+// A running capability is immutably bound to one daemon session. It can never
+// be retargeted to another session without stopping and minting a fresh view.
+let liveViewBoundSession = null;
 
 /** Tell a running live view to stream the agent's current tab when it changed. */
 function notifyLiveViewPreferred() {
@@ -4676,14 +4698,56 @@ function notifyLiveViewPreferred() {
   }
 }
 
+function liveViewSessionId(value) {
+  return String(value || "default");
+}
+
+async function teardownLiveView({
+  expectedRelay = null,
+  preserve = false,
+  notify = true,
+} = {}) {
+  if (expectedRelay && managedRelay !== expectedRelay) return false;
+  const relay = managedRelay;
+  const view = liveView;
+  managedRelay = null;
+  liveView = null;
+  liveViewBoundSession = null;
+  const failures = [];
+  try {
+    await relay?.stop({ preserve });
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await view?.stop({ notify });
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length) throw failures[0];
+  return Boolean(relay || view);
+}
+
+function assertLiveViewSession(value) {
+  const requested = liveViewSessionId(value);
+  if (liveView && liveViewBoundSession !== requested) {
+    throw new Error(
+      `Live view is bound to session "${liveViewBoundSession}"; stop it before viewing session "${requested}".`,
+    );
+  }
+  return requested;
+}
+
 function ensureLiveView(preferredSessionId) {
-  liveViewPreferredSession = String(preferredSessionId || "default");
-  liveView ??= createLiveViewServer({
+  const requested = assertLiveViewSession(preferredSessionId);
+  if (!liveView) {
+    liveViewBoundSession = requested;
+    liveView = createLiveViewServer({
     html: liveViewHtml,
     loginHtml: liveViewLoginHtml,
     listPages: liveViewPages,
     preferredPage: () => {
-      const session = sessions.get(liveViewPreferredSession);
+      const session = sessions.get(liveViewBoundSession);
       const page = session?.currentId ? session.pages.get(session.currentId) : null;
       return page && !page.isClosed() ? page : null;
     },
@@ -4695,7 +4759,8 @@ function ensureLiveView(preferredSessionId) {
       if (sessionId) sessionFor(sessionId);
     },
     log: (line) => process.stderr.write(`${line}\n`),
-  });
+    });
+  }
   return liveView;
 }
 
@@ -4703,10 +4768,136 @@ async function liveViewStart(message) {
   try {
     await ensureBrowser(message.config);
     const options = message.options && typeof message.options === "object" ? message.options : {};
-    const view = ensureLiveView(options.session);
+    const requestedSession = liveViewSessionId(options.session);
+    const transport = String(options.transport || "direct").trim().toLowerCase();
+    if (!["direct", "relay"].includes(transport)) {
+      throw new Error(`Unknown live-view transport "${transport}"; use "direct" or "relay".`);
+    }
+    // A terminal bridge cannot be revived. Remove it and its hidden loopback
+    // server before session-binding checks so an explicit start mints a fresh
+    // relay session instead of returning a dead URL.
+    if (managedRelay?.status().terminal) {
+      await teardownLiveView({
+        expectedRelay: managedRelay,
+        preserve: false,
+        notify: true,
+      });
+    }
+    assertLiveViewSession(requestedSession);
+
+    if (transport === "relay") {
+      if (managedRelay) {
+        const relayStatus = managedRelay.status();
+        const localStatus = liveView.status();
+        sendResult({
+          type: "result",
+          id: message.id,
+          ...relayStatus,
+          url: relayStatus.url,
+          transport: "relay",
+          expose: "relay",
+          session: liveViewBoundSession,
+          agent: localStatus.agent,
+          handoff: localStatus.handoff,
+          ask: localStatus.ask,
+          pendingChat: localStatus.pendingChat,
+          alreadyRunning: true,
+        });
+        return;
+      }
+      if (liveView?.running) {
+        throw new Error(
+          "A direct live view is already running; stop it before starting the managed relay.",
+        );
+      }
+      const apiKey = String(options.apiKey || "").trim();
+      if (!apiKey) {
+        throw new Error(
+          "BetterWright Relay needs an account API key. Create one at https://betterwright.com/account, then run `betterwright account set-key`.",
+        );
+      }
+      const view = ensureLiveView(requestedSession);
+      // The browser-facing origin remains token-gated but is reachable only on
+      // loopback. The bridge is its sole client and the local URL is never
+      // returned or printed. Managed links use their fragment capability;
+      // direct-view passwords are intentionally not part of the relay protocol.
+      const localInfo = await view.start({
+        ...options,
+        transport: "direct",
+        expose: "local",
+        host: "127.0.0.1",
+        publicHost: "127.0.0.1",
+        password: "",
+        passwordHash: "",
+      });
+      let bridge;
+      bridge = createManagedRelayBridge({
+        localUrl: localInfo.url,
+        apiKey,
+        relayUrl: options.relayUrl,
+        interactive: options.interactive !== false,
+        clientVersion: options.clientVersion,
+        restore: options.relayRestore,
+        log: (line) => process.stderr.write(`${line}\n`),
+        onTerminal: async ({ reason }) => {
+          const endedSession = liveViewBoundSession;
+          const cleared = await teardownLiveView({
+            expectedRelay: bridge,
+            preserve: false,
+            notify: true,
+          });
+          if (cleared) {
+            send({
+              type: "live_view_ended",
+              session: endedSession,
+              reason: redactText(reason),
+            });
+          }
+          process.stderr.write(`managed-relay: ${reason}\n`);
+        },
+      });
+      try {
+        const relayInfo = await bridge.start();
+        if (!relayInfo.running || relayInfo.terminal) {
+          throw new Error(relayInfo.error || "Managed relay session ended during startup.");
+        }
+        managedRelay = bridge;
+        sendResult({
+          type: "result",
+          id: message.id,
+          ...relayInfo,
+          session: liveViewBoundSession,
+          agent: view.status().agent,
+          handoff: view.status().handoff,
+          ask: view.status().ask,
+        });
+      } catch (error) {
+        await bridge.stop().catch(() => {});
+        await view.stop().catch(() => {});
+        if (liveView === view) liveView = null;
+        liveViewBoundSession = null;
+        throw error;
+      }
+      return;
+    }
+
+    if (managedRelay) {
+      throw new Error("A managed live view is already running; stop it before starting a direct view.");
+    }
+    const view = ensureLiveView(requestedSession);
     const info = await view.start(options);
-    sendResult({ type: "result", id: message.id, ...info });
+    sendResult({
+      type: "result",
+      id: message.id,
+      ...info,
+      transport: "direct",
+      session: liveViewBoundSession,
+    });
   } catch (error) {
+    if (liveView && !liveView.running && !managedRelay) {
+      liveView = null;
+      liveViewBoundSession = null;
+    }
     sendResult({
       type: "result",
       id: message.id,
@@ -4718,11 +4909,12 @@ async function liveViewStart(message) {
 
 async function liveViewStop(message) {
   try {
-    const view = liveView;
-    liveView = null;
-    await view?.stop();
+    await teardownLiveView({ preserve: false, notify: true });
     sendResult({ type: "result", id: message.id, ok: true, running: false });
   } catch (error) {
+    process.stderr.write(
+      `live-view: managed cleanup failed: ${error?.message || error}\n`,
+    );
     sendResult({
       type: "result",
       id: message.id,
@@ -4733,13 +4925,46 @@ async function liveViewStop(message) {
 }
 
 function liveViewStatus(message) {
-  const info = liveView ? liveView.status() : { ok: true, running: false };
-  sendResult({ type: "result", id: message.id, ...info });
+  const local = liveView ? liveView.status() : { ok: true, running: false };
+  const relay = managedRelay?.status();
+  if (relay?.terminal) {
+    void teardownLiveView({
+      expectedRelay: managedRelay,
+      preserve: false,
+      notify: true,
+    }).catch((error) => {
+      process.stderr.write(
+        `live-view: terminal cleanup failed: ${error?.message || error}\n`,
+      );
+    });
+    sendResult({ type: "result", id: message.id, ok: true, running: false });
+    return;
+  }
+  const info = relay
+    ? {
+        ...relay,
+        url: relay.url,
+        transport: "relay",
+        expose: "relay",
+        agent: local.agent,
+        handoff: local.handoff,
+        ask: local.ask,
+        pendingChat: local.pendingChat,
+      }
+    : local;
+  sendResult({
+    type: "result",
+    id: message.id,
+    ...info,
+    ...(liveViewBoundSession ? { session: liveViewBoundSession } : {}),
+  });
 }
 
 async function handoffWait(message) {
-  const session = sessionFor(message.sessionId);
+  const requestedSession = liveViewSessionId(message.sessionId);
+  const session = sessionFor(requestedSession);
   try {
+    assertLiveViewSession(requestedSession);
     if (!liveView?.running) {
       throw new Error("Live view is not running; start it before requesting a handoff.");
     }
@@ -4769,8 +4994,10 @@ async function handoffWait(message) {
 }
 
 async function askWait(message) {
-  const session = sessionFor(message.sessionId);
+  const requestedSession = liveViewSessionId(message.sessionId);
+  const session = sessionFor(requestedSession);
   try {
+    assertLiveViewSession(requestedSession);
     if (!liveView?.running) {
       throw new Error("Live view is not running; start it before requesting an ask.");
     }
@@ -4801,6 +5028,7 @@ async function askWait(message) {
 
 function liveViewChatPost(message) {
   try {
+    assertLiveViewSession(message.sessionId);
     if (!liveView?.running) {
       sendResult({
         type: "result",
@@ -4833,6 +5061,7 @@ function liveViewChatPost(message) {
 
 function liveViewChatDrain(message) {
   try {
+    assertLiveViewSession(message.sessionId);
     const messages = liveView?.running ? liveView.drainHumanMessages() : [];
     sendResult({
       type: "result",
@@ -4867,12 +5096,22 @@ async function performShutdown() {
     ? profileLock.profileDir
     : null;
   const closingLiveView = liveView;
+  const closingRelay = managedRelay;
   liveView = null;
+  managedRelay = null;
+  liveViewBoundSession = null;
+  try {
+    // Preserve the Cloudflare relay session across worker replacement. The
+    // parent owns opaque restore state and reconnects the new bridge.
+    await closingRelay?.stop({ preserve: true });
+  } catch {
+    /* parent/process exit */
+  }
   try {
     // Worker teardown (restart or host close) drops viewer sockets without
     // the terminal "bye": viewers reconnect, and if the host revives the
-    // view in a replacement worker (same port + token) they resume
-    // seamlessly. Only an explicit live_view_stop announces the end.
+    // view in a replacement worker they resume seamlessly. Only an explicit
+    // live_view_stop ends the managed relay session.
     await closingLiveView?.stop({ notify: false });
   } catch {
     /* parent/process exit */
@@ -4907,6 +5146,17 @@ async function sessionClose(message) {
   const sessionId = String(message.sessionId || "default");
   const session = sessions.get(sessionId);
   let pagesClosed = 0;
+  let cleanupError = null;
+  if ((liveView || managedRelay) && liveViewBoundSession === sessionId) {
+    try {
+      await teardownLiveView({ preserve: false, notify: true });
+    } catch (error) {
+      cleanupError = error;
+      process.stderr.write(
+        `live-view: session-close cleanup failed: ${error?.message || error}\n`,
+      );
+    }
+  }
   if (session) {
     for (const page of session.pages.values()) {
       if (page.isClosed()) continue;
@@ -4918,11 +5168,16 @@ async function sessionClose(message) {
   sendResult({
     type: "result",
     id: message.id,
-    ok: true,
+    ok: !cleanupError,
     closed: Boolean(session),
     pagesClosed,
+    ...(cleanupError
+      ? { error: redactText(cleanupError?.message || String(cleanupError)) }
+      : {}),
   });
 }
+
+let liveViewStopInFlight = Promise.resolve();
 
 const input = readline.createInterface({
   input: process.stdin,
@@ -4983,7 +5238,11 @@ input.on("line", (line) => {
   // handoffs/asks resolve while executes are in flight, and a pending human
   // wait must never block a queued execute (or vice versa).
   if (message.type === "live_view_start") void liveViewStart(message);
-  if (message.type === "live_view_stop") void liveViewStop(message);
+  if (message.type === "live_view_stop") {
+    liveViewStopInFlight = liveViewStopInFlight
+      .catch(() => {})
+      .then(() => liveViewStop(message));
+  }
   if (message.type === "live_view_status") liveViewStatus(message);
   if (message.type === "live_view_chat_post") liveViewChatPost(message);
   if (message.type === "live_view_chat_drain") liveViewChatDrain(message);
@@ -4996,7 +5255,13 @@ input.on("line", (line) => {
 function exitAfterShutdown(code) {
   const failsafe = setTimeout(() => process.exit(code), 15_000);
   failsafe.unref?.();
-  void shutdown().finally(() => process.exit(code));
+  // EOF can arrive immediately after a terminal live_view_stop. Wait for its
+  // relay DELETE before tearing down the process so a session is not left
+  // active until TTL expiry.
+  void liveViewStopInFlight
+    .catch(() => {})
+    .then(() => shutdown())
+    .finally(() => process.exit(code));
 }
 input.on("close", () => {
   exitAfterShutdown(0);
@@ -5013,6 +5278,14 @@ const idleReaper = setInterval(() => {
   const cutoff = Date.now() - Math.max(timeout, 600_000);
   for (const [sessionId, session] of sessions) {
     if (session.lastActivity >= cutoff || sessionId === activeExecutionSession)
+      continue;
+    // Watching is active use too. Keep the selected session alive while a
+    // local or managed viewer is connected, even if the human is watch-only.
+    if (
+      sessionId === liveViewBoundSession &&
+      liveView?.running &&
+      Number(liveView.status().viewers || 0) > 0
+    )
       continue;
     if (
       session.awaitingAnswerSince &&

--- a/tests/node/account-config.test.mjs
+++ b/tests/node/account-config.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  accountConfigPath,
+  clearAccountConfig,
+  isBetterWrightApiKey,
+  loadAccountConfig,
+  maskBetterWrightApiKey,
+  normalizeRelayUrl,
+  saveAccountApiKey,
+  verifyBetterWrightApiKey,
+} from "../../src/account-config.mjs";
+
+const KEY = `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`;
+
+test("account API keys validate, mask, and persist in an owner-only separate file", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-account-"));
+  try {
+    assert.equal(isBetterWrightApiKey(KEY), true);
+    assert.equal(isBetterWrightApiKey("not-a-key"), false);
+    const file = saveAccountApiKey(KEY, { home, relayUrl: "https://live.betterwright.com/" });
+    assert.equal(file, accountConfigPath(home));
+    assert.equal(loadAccountConfig(home).apiKey, KEY);
+    assert.equal(loadAccountConfig(home).relayUrl, "https://live.betterwright.com");
+    assert.ok(!maskBetterWrightApiKey(KEY).includes("b".repeat(20)));
+    if (process.platform !== "win32") assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+    clearAccountConfig(home);
+    assert.equal(loadAccountConfig(home).apiKey, undefined);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("relay URLs fail closed to HTTPS except explicit loopback tests", () => {
+  assert.equal(normalizeRelayUrl("https://live.betterwright.com/"), "https://live.betterwright.com");
+  assert.equal(normalizeRelayUrl("http://127.0.0.1:8787"), "http://127.0.0.1:8787");
+  assert.throws(() => normalizeRelayUrl("http://example.com"), /https/i);
+  assert.throws(() => normalizeRelayUrl("https://user:pass@example.com"), /credentials/i);
+
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-account-invalid-"));
+  try {
+    fs.writeFileSync(accountConfigPath(home), JSON.stringify({ apiKey: KEY, relayUrl: "http://wrong.example" }));
+    assert.throws(() => loadAccountConfig(home), /https/i);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("API-key verification sends a bearer token and returns quota without exposing it", async () => {
+  let authorization = "";
+  let requestedUrl = "";
+  const result = await verifyBetterWrightApiKey(KEY, {
+    relayUrl: "https://live.betterwright.com",
+    fetchImpl: async (url, options) => {
+      requestedUrl = String(url);
+      authorization = options.headers.authorization;
+      return new Response(
+        JSON.stringify({ ok: true, quota: { remainingSeconds: 7200, resetAt: "2026-07-27T00:00:00.000Z" } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  });
+  assert.equal(requestedUrl, "https://live.betterwright.com/v1/cli/me");
+  assert.equal(authorization, `Bearer ${KEY}`);
+  assert.equal(result.ok, true);
+  assert.equal(result.quota.remainingSeconds, 7200);
+});
+
+
+test("an explicit environment key wins and an invalid one never falls back to disk", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-account-env-"));
+  const previous = process.env.BETTERWRIGHT_API_KEY;
+  const environmentKey = `bw_live_${"c".repeat(16)}_${"d".repeat(43)}`;
+  try {
+    saveAccountApiKey(KEY, { home });
+
+    delete process.env.BETTERWRIGHT_API_KEY;
+    assert.equal(loadAccountConfig(home).apiKey, KEY);
+
+    process.env.BETTERWRIGHT_API_KEY = environmentKey;
+    assert.equal(loadAccountConfig(home).apiKey, environmentKey);
+    assert.equal(loadAccountConfig(home).source, "environment");
+
+    process.env.BETTERWRIGHT_API_KEY = "bw_live_typo";
+    assert.throws(() => loadAccountConfig(home), /refusing to fall back/i);
+  } finally {
+    if (previous === undefined) delete process.env.BETTERWRIGHT_API_KEY;
+    else process.env.BETTERWRIGHT_API_KEY = previous;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/node/agent.test.mjs
+++ b/tests/node/agent.test.mjs
@@ -1419,6 +1419,29 @@ test("handoff is not offered without a URL surface or when liveView is false", a
   assert.equal(disabled.calls.liveView.length, 0);
 });
 
+test("ordinary progress mirroring never starts Live View without explicit activation", async () => {
+  const browser = liveViewBrowser();
+  const model = scriptedModel([
+    {
+      text: "",
+      toolCalls: [
+        { id: "b1", name: "browser", input: { code: "return 1", note: "checking" } },
+      ],
+    },
+    { text: "done", toolCalls: [] },
+  ]);
+  const result = await runAgentTask({
+    task: "check the page",
+    model,
+    browser,
+    onStep: () => {},
+  });
+  assert.equal(result.ok, true);
+  assert.equal(browser.calls.liveView.length, 0);
+  assert.equal(browser.calls.chatPosts.length, 0);
+  assert.equal(browser.calls.stops, 0);
+});
+
 test("liveView: true starts the viewer before step 1 and stops it at task end", async () => {
   const browser = liveViewBrowser();
   const steps = [];

--- a/tests/node/live-view-client.test.mjs
+++ b/tests/node/live-view-client.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { saveAccountApiKey } from "../../src/account-config.mjs";
+import { BetterWright } from "../../src/client.mjs";
+import { saveLiveViewSettings } from "../../src/live-view-config.mjs";
+
+function mockClient(home, options = {}) {
+  const browser = new BetterWright({ home, vault: false, ...options });
+  const messages = [];
+  browser._prepare = async () => ({ mocked: true });
+  browser._dispatch = async (message) => {
+    messages.push(message);
+    if (message.type !== "live_view_start") return { ok: true };
+    const session = String(message.options.session || "default");
+    return {
+      ok: true,
+      running: true,
+      transport: message.options.transport,
+      expose: message.options.expose,
+      host: message.options.host,
+      port: 4321,
+      token: "local-token",
+      url: "http://127.0.0.1:4321/?t=local-token",
+      session,
+    };
+  };
+  return { browser, messages };
+}
+
+test("client construction fails closed on an invalid explicit environment key", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-key-"));
+  const previous = process.env.BETTERWRIGHT_API_KEY;
+  try {
+    saveAccountApiKey(`bw_live_${"a".repeat(16)}_${"b".repeat(43)}`, { home });
+    process.env.BETTERWRIGHT_API_KEY = "invalid-explicit-key";
+    assert.throws(
+      () => new BetterWright({ home, vault: false }),
+      /refusing to fall back/i,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.BETTERWRIGHT_API_KEY;
+    else process.env.BETTERWRIGHT_API_KEY = previous;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("explicit direct bind options beat a persisted relay and remain idempotent", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-client-"));
+  try {
+    saveLiveViewSettings({ transport: "relay", expose: "local" }, home);
+    const { browser, messages } = mockClient(home);
+
+    await browser.startLiveView({ host: "127.0.0.1", session: "private-a" });
+    assert.equal(messages[0].options.transport, "direct");
+    assert.equal(messages[0].options.session, "private-a");
+    assert.equal(messages[0].options.host, "127.0.0.1");
+    assert.equal(messages[0].options.expose, undefined);
+
+    await browser.startLiveView();
+    assert.equal(messages[1].options.transport, "direct");
+    assert.equal(messages[1].options.session, "private-a");
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("constructor host defaults override a lower persisted exposure preset", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-constructor-"));
+  try {
+    saveLiveViewSettings({ transport: "relay", expose: "local" }, home);
+    const { browser, messages } = mockClient(home, {
+      liveView: { host: "0.0.0.0" },
+    });
+    await browser.startLiveView({ session: "constructor" });
+    assert.equal(messages[0].options.transport, "direct");
+    assert.equal(messages[0].options.host, "0.0.0.0");
+    assert.equal(messages[0].options.expose, undefined);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("browser.liveView mutations remain explicit compatibility overrides", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-mutable-"));
+  try {
+    saveLiveViewSettings({ transport: "relay", expose: "local" }, home);
+    const { browser, messages } = mockClient(home);
+    browser.liveView.host = "127.0.0.1";
+    browser.liveView.port = 6789;
+
+    await browser.startLiveView({ session: "mutable" });
+    assert.equal(messages[0].options.transport, "direct");
+    assert.equal(messages[0].options.host, "127.0.0.1");
+    assert.equal(messages[0].options.port, 6789);
+    assert.equal(messages[0].options.expose, undefined);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("removed file settings do not stick in the mutable Live View surface", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-refresh-"));
+  try {
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(
+      path.join(home, "config.json"),
+      JSON.stringify({ liveView: { transport: "direct", port: 7100 } }),
+    );
+    const { browser, messages } = mockClient(home);
+    fs.rmSync(path.join(home, "config.json"));
+
+    await browser.startLiveView();
+    assert.equal(messages[0].options.port, 0);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("terminal worker events clear only the matching client restore state", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-ended-"));
+  try {
+    const { browser } = mockClient(home);
+    const child = {};
+    browser._process = child;
+    browser._liveViewRestore = {
+      options: { transport: "relay", session: "private-a", relayRestore: {} },
+      generation: 1,
+    };
+
+    assert.equal(
+      browser._handleLiveViewEnded({ session: "other-b" }, child),
+      false,
+    );
+    assert.ok(browser._liveViewRestore);
+    assert.equal(
+      browser._handleLiveViewEnded({ session: "private-a" }, child),
+      true,
+    );
+    assert.equal(browser._liveViewRestore, null);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("omitted chat and human-turn sessions use the currently bound Live View session", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-live-chat-"));
+  try {
+    const { browser, messages } = mockClient(home);
+    await browser.startLiveView({ session: "private-a" });
+    browser._process = { exitCode: null };
+
+    await browser.liveViewPostChat({ text: "step" });
+    await browser.liveViewDrainChat();
+    const posted = messages.find((message) => message.type === "live_view_chat_post");
+    const drained = messages.find((message) => message.type === "live_view_chat_drain");
+    assert.equal(posted.sessionId, "private-a");
+    assert.equal(drained.sessionId, "private-a");
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/node/live-view.test.mjs
+++ b/tests/node/live-view.test.mjs
@@ -948,11 +948,42 @@ test("a stored sha256 passwordHash gates exactly like a plaintext password", asy
   );
 });
 
+test("a stored salted scrypt passwordHash unlocks the direct viewer", async () => {
+  const { hashLiveViewPassword } = await import("../../src/live-view-config.mjs");
+  const { server } = makeServer();
+  try {
+    const info = await server.start({
+      host: "127.0.0.1",
+      port: 0,
+      passwordHash: hashLiveViewPassword("hunter22"),
+    });
+    const base = new URL(info.url);
+    const wrong = await fetch(`http://${base.host}/login?t=${info.token}`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "password=incorrect",
+      redirect: "manual",
+    });
+    assert.equal(wrong.status, 303);
+    assert.match(wrong.headers.get("location"), /auth=failed/);
+    const right = await fetch(`http://${base.host}/login?t=${info.token}`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "password=hunter22",
+      redirect: "manual",
+    });
+    assert.equal(right.status, 303);
+    assert.match(String(right.headers.get("set-cookie")), /bw_lv_sess=/);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("live-view config file round-trips a hashed password and sanitizes input", async (t) => {
   const fs = await import("node:fs");
   const os = await import("node:os");
   const path = await import("node:path");
-  const { loadLiveViewConfig, saveLiveViewPassword, hashLiveViewPassword } = await import(
+  const { loadLiveViewConfig, saveLiveViewPassword, isLiveViewPasswordHash } = await import(
     "../../src/live-view-config.mjs"
   );
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-cfg-"));
@@ -970,13 +1001,15 @@ test("live-view config file round-trips a hashed password and sanitizes input", 
   assert.equal(written.other.keep, true);
   assert.equal(written.liveView.expose, "tailscale");
   assert.equal(written.liveView.password, undefined);
-  assert.equal(written.liveView.passwordHash, hashLiveViewPassword("hunter22"));
+  assert.equal(isLiveViewPasswordHash(written.liveView.passwordHash), true);
+  assert.match(written.liveView.passwordHash, /^scrypt:/);
+  assert.equal(JSON.stringify(written).includes("hunter22"), false);
   assert.equal(fs.statSync(file).mode & 0o777, 0o600);
 
   const loaded = loadLiveViewConfig(home);
   assert.deepEqual(loaded, {
     expose: "tailscale",
-    passwordHash: hashLiveViewPassword("hunter22"),
+    passwordHash: written.liveView.passwordHash,
   });
 
   // Clearing removes the hash but keeps the rest.
@@ -995,7 +1028,7 @@ test("password gate rate-limits repeated failures and rejects short passwords", 
   const { server } = makeServer();
   await assert.rejects(
     () => server.start({ host: "127.0.0.1", port: 0, password: "abc" }),
-    /at least 4 characters/,
+    /at least 8 characters/,
   );
   const { server: gated } = makeServer();
   try {

--- a/tests/node/managed-relay.test.mjs
+++ b/tests/node/managed-relay.test.mjs
@@ -1,0 +1,387 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+
+import {
+  createManagedCipher,
+  createManagedDecipher,
+  createManagedRelayBridge,
+  deriveManagedViewerProof,
+} from "../../src/managed-relay.mjs";
+
+const HOST_TO_VIEWER = 1;
+const VIEWER_TO_HOST = 2;
+
+test("managed relay proof is deterministic, session-bound, and does not reveal the root", () => {
+  const root = Buffer.alloc(32, 7);
+  const first = deriveManagedViewerProof(root, "session-a");
+  assert.equal(first, deriveManagedViewerProof(root, "session-a"));
+  assert.notEqual(first, deriveManagedViewerProof(root, "session-b"));
+  assert.ok(!first.includes(root.toString("base64url")));
+});
+
+test("managed relay envelopes round-trip text and binary in each direction", () => {
+  const root = crypto.randomBytes(32);
+  for (const [direction, value] of [
+    [HOST_TO_VIEWER, Buffer.from("hello")],
+    [VIEWER_TO_HOST, crypto.randomBytes(48)],
+  ]) {
+    const sender = createManagedCipher({ root, sessionId: "abc", direction });
+    const receiver = createManagedDecipher({ root, sessionId: "abc", direction });
+    const envelope = sender.seal(direction === HOST_TO_VIEWER ? 0 : 1, value);
+    const opened = receiver.open(envelope);
+    assert.equal(opened.type, direction === HOST_TO_VIEWER ? "text" : "binary");
+    assert.deepEqual(opened.data, value);
+  }
+});
+
+test("managed relay rejects tampering, wrong roots, sessions, directions, and replay", () => {
+  const root = crypto.randomBytes(32);
+  const sender = createManagedCipher({ root, sessionId: "one", direction: HOST_TO_VIEWER });
+  const envelope = sender.seal(0, Buffer.from("secret"));
+
+  const good = createManagedDecipher({ root, sessionId: "one", direction: HOST_TO_VIEWER });
+  assert.equal(good.open(envelope).data.toString(), "secret");
+  assert.throws(() => good.open(envelope), /replay/i);
+
+  const changed = Buffer.from(envelope);
+  changed[changed.length - 17] ^= 1;
+  assert.throws(
+    () => createManagedDecipher({ root, sessionId: "one", direction: HOST_TO_VIEWER }).open(changed),
+    /authenticate|auth|bad decrypt/i,
+  );
+  assert.throws(
+    () => createManagedDecipher({ root: crypto.randomBytes(32), sessionId: "one", direction: HOST_TO_VIEWER }).open(envelope),
+  );
+  assert.throws(
+    () => createManagedDecipher({ root, sessionId: "two", direction: HOST_TO_VIEWER }).open(envelope),
+  );
+  assert.throws(
+    () => createManagedDecipher({ root, sessionId: "one", direction: VIEWER_TO_HOST }).open(envelope),
+    /direction|version/i,
+  );
+});
+
+test("managed relay rejects sender epoch changes without a reconnect reset", () => {
+  const root = crypto.randomBytes(32);
+  const receiver = createManagedDecipher({ root, sessionId: "one", direction: HOST_TO_VIEWER });
+  const first = createManagedCipher({ root, sessionId: "one", direction: HOST_TO_VIEWER });
+  const second = createManagedCipher({ root, sessionId: "one", direction: HOST_TO_VIEWER });
+  receiver.open(first.seal(0, Buffer.from("first")));
+  assert.throws(() => receiver.open(second.seal(0, Buffer.from("second"))), /epoch changed/i);
+  receiver.reset();
+  assert.equal(receiver.open(second.seal(0, Buffer.from("after reset"))).data.toString(), "after reset");
+});
+
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances = [];
+
+  constructor(url, protocols = []) {
+    this.url = String(url);
+    this.protocols = protocols;
+    this.readyState = MockWebSocket.CONNECTING;
+    this.bufferedAmount = 0;
+    this.sent = [];
+    this.listeners = new Map();
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      if (this.readyState !== MockWebSocket.CONNECTING) return;
+      this.readyState = MockWebSocket.OPEN;
+      this.emit("open", {});
+    });
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  emit(type, event) {
+    for (const listener of this.listeners.get(type) || []) listener(event);
+  }
+
+  send(value) {
+    if (this.readyState !== MockWebSocket.OPEN) throw new Error("socket is not open");
+    this.sent.push(value);
+  }
+
+  close(code = 1000, reason = "") {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close", { code, reason });
+  }
+}
+
+function relaySessionResponse(sessionId) {
+  return {
+    session: {
+      id: sessionId,
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    },
+    host: {
+      websocketUrl: `wss://live.betterwright.com/v1/sessions/${sessionId}/ws`,
+      subprotocols: ["betterwright.relay.v1", `bw.host.${"h".repeat(43)}`],
+    },
+    viewer: {
+      url: `https://live.betterwright.com/s/${sessionId}`,
+      fragmentParameter: "k",
+    },
+  };
+}
+
+test("managed bridge validates the session response and relays only after root-key proof", async () => {
+  MockWebSocket.instances = [];
+  const requests = [];
+  const fetchImpl = async (url, options = {}) => {
+    requests.push({ url: String(url), options });
+    if (options.method === "POST") {
+      const body = JSON.parse(options.body);
+      assert.match(body.sessionId, /^bws_[A-Za-z0-9_-]{24}$/);
+      assert.match(body.viewerProof, /^[A-Za-z0-9_-]{43}$/);
+      assert.equal(JSON.stringify(body).includes("root"), false);
+      return Response.json(relaySessionResponse(body.sessionId), { status: 201 });
+    }
+    if (options.method === "DELETE") return new Response(null, { status: 204 });
+    throw new Error(`unexpected request ${options.method || "GET"} ${url}`);
+  };
+
+  const bridge = createManagedRelayBridge({
+    localUrl: "http://127.0.0.1:4321/?t=local-capability",
+    apiKey: `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`,
+    relayUrl: "https://live.betterwright.com",
+    fetchImpl,
+    WebSocketImpl: MockWebSocket,
+  });
+  const started = await bridge.start();
+  assert.equal(started.ok, true);
+  assert.equal(started.transport, "relay");
+  assert.match(started.sessionId, /^bws_/);
+  assert.equal(MockWebSocket.instances.length, 1);
+  const remote = MockWebSocket.instances[0];
+  assert.deepEqual(remote.protocols, ["betterwright.relay.v1", `bw.host.${"h".repeat(43)}`]);
+
+  const viewerUrl = new URL(started.url);
+  const root = Buffer.from(new URLSearchParams(viewerUrl.hash.slice(1)).get("k"), "base64url");
+  assert.equal(root.length, 32);
+  assert.equal(requests[0].options.body.includes(root.toString("base64url")), false);
+
+  remote.emit("message", {
+    data: JSON.stringify({ t: "relay", event: "viewer_connected", leaseExpiresAtMs: Date.now() + 60_000 }),
+  });
+  assert.equal(remote.sent.length, 1);
+  const hostReader = createManagedDecipher({ root, sessionId: started.sessionId, direction: HOST_TO_VIEWER });
+  const challenge = hostReader.open(remote.sent[0]);
+  assert.equal(challenge.type, "challenge");
+  const challengeBody = JSON.parse(challenge.data.toString("utf8"));
+  assert.equal(challengeBody.t, "bw_e2e_challenge");
+
+  // No local browser socket exists until the viewer proves possession of the
+  // fragment root with a fresh connection epoch.
+  assert.equal(MockWebSocket.instances.length, 1);
+  const viewerWriter = createManagedCipher({ root, sessionId: started.sessionId, direction: VIEWER_TO_HOST });
+  remote.emit("message", {
+    data: viewerWriter.seal(
+      2,
+      Buffer.from(JSON.stringify({ t: "bw_e2e_ready", challenge: challengeBody.challenge })),
+    ),
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(MockWebSocket.instances.length, 2);
+  const local = MockWebSocket.instances[1];
+  assert.match(local.url, /^ws:\/\/127\.0\.0\.1:4321\/ws\?t=local-capability$/);
+
+  local.emit("message", { data: JSON.stringify({ t: "hello", interactive: true }) });
+  assert.equal(remote.sent.length, 2);
+  const hello = hostReader.open(remote.sent[1]);
+  assert.equal(hello.type, "text");
+  assert.deepEqual(JSON.parse(hello.data.toString("utf8")), { t: "hello", interactive: true });
+
+  const input = JSON.stringify({ t: "refresh" });
+  remote.emit("message", { data: viewerWriter.seal(0, Buffer.from(input)) });
+  assert.equal(local.sent.at(-1), input);
+
+  await bridge.stop();
+  assert.equal(requests.at(-1).options.method, "DELETE");
+  assert.match(requests.at(-1).url, new RegExp(`/v1/sessions/${started.sessionId}$`));
+});
+
+test("managed bridge rejects relay-controlled URL redirects and can delete the provisional session", async () => {
+  MockWebSocket.instances = [];
+  const requests = [];
+  const bridge = createManagedRelayBridge({
+    localUrl: "http://127.0.0.1:4321/?t=local-capability",
+    apiKey: `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`,
+    relayUrl: "https://live.betterwright.com",
+    WebSocketImpl: MockWebSocket,
+    fetchImpl: async (url, options) => {
+      requests.push({ url: String(url), options });
+      if (options.method === "DELETE") return new Response(null, { status: 204 });
+      const { sessionId } = JSON.parse(options.body);
+      const body = relaySessionResponse(sessionId);
+      body.host.websocketUrl = `wss://attacker.example/v1/sessions/${sessionId}/ws`;
+      return Response.json(body, { status: 201 });
+    },
+  });
+  await assert.rejects(() => bridge.start(), /untrusted WebSocket URL/i);
+  await bridge.stop();
+  assert.equal(MockWebSocket.instances.length, 0);
+  assert.equal(requests.at(-1).options.method, "DELETE");
+  assert.match(requests.at(-1).url, /\/v1\/sessions\/bws_[A-Za-z0-9_-]{24}$/);
+});
+
+test("managed bridge marks terminal relay events and cannot return a stale URL", async () => {
+  MockWebSocket.instances = [];
+  const terminalEvents = [];
+  const fetchImpl = async (_url, options) => {
+    if (options.method === "DELETE") return new Response(null, { status: 204 });
+    const { sessionId } = JSON.parse(options.body);
+    return Response.json(relaySessionResponse(sessionId), { status: 201 });
+  };
+  const bridge = createManagedRelayBridge({
+    localUrl: "http://127.0.0.1:4321/?t=local-capability",
+    apiKey: `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`,
+    relayUrl: "https://live.betterwright.com",
+    WebSocketImpl: MockWebSocket,
+    fetchImpl,
+    onTerminal: (event) => terminalEvents.push(event),
+  });
+  const started = await bridge.start();
+  MockWebSocket.instances[0].emit("message", {
+    data: JSON.stringify({ t: "relay", event: "session_expired" }),
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(bridge.status().running, false);
+  assert.equal(bridge.status().terminal, true);
+  assert.match(bridge.status().error, /session_expired/);
+  assert.equal(terminalEvents.length, 1);
+  assert.equal(terminalEvents[0].status.sessionId, started.sessionId);
+  await assert.rejects(() => bridge.start(), /session_expired|ended/i);
+  await bridge.stop();
+});
+
+test("managed bridge surfaces a failed relay DELETE after a bounded retry", async () => {
+  MockWebSocket.instances = [];
+  let deleteAttempts = 0;
+  const bridge = createManagedRelayBridge({
+    localUrl: "http://127.0.0.1:4321/?t=local-capability",
+    apiKey: `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`,
+    relayUrl: "https://live.betterwright.com",
+    WebSocketImpl: MockWebSocket,
+    fetchImpl: async (_url, options) => {
+      if (options.method === "DELETE") {
+        deleteAttempts += 1;
+        return new Response("unavailable", { status: 503 });
+      }
+      const { sessionId } = JSON.parse(options.body);
+      return Response.json(relaySessionResponse(sessionId), { status: 201 });
+    },
+  });
+  await bridge.start();
+  await assert.rejects(
+    () => bridge.stop(),
+    /cleanup returned HTTP 503/,
+  );
+  assert.equal(deleteAttempts, 2);
+});
+
+test("managed bridge does not retry deterministic cleanup authentication failures", async () => {
+  MockWebSocket.instances = [];
+  let deleteAttempts = 0;
+  const bridge = createManagedRelayBridge({
+    localUrl: "http://127.0.0.1:4321/?t=local-capability",
+    apiKey: `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`,
+    relayUrl: "https://live.betterwright.com",
+    WebSocketImpl: MockWebSocket,
+    fetchImpl: async (_url, options) => {
+      if (options.method === "DELETE") {
+        deleteAttempts += 1;
+        return new Response(null, { status: 401 });
+      }
+      const { sessionId } = JSON.parse(options.body);
+      return Response.json(relaySessionResponse(sessionId), { status: 201 });
+    },
+  });
+  await bridge.start();
+  await assert.rejects(() => bridge.stop(), /cleanup returned HTTP 401/);
+  assert.equal(deleteAttempts, 1);
+});
+
+test("managed bridge accepts an idempotent 404 cleanup and waits for DELETE", async () => {
+  MockWebSocket.instances = [];
+  let releaseDelete;
+  let deleteStarted = false;
+  const bridge = createManagedRelayBridge({
+    localUrl: "http://127.0.0.1:4321/?t=local-capability",
+    apiKey: `bw_live_${"a".repeat(16)}_${"b".repeat(43)}`,
+    relayUrl: "https://live.betterwright.com",
+    WebSocketImpl: MockWebSocket,
+    fetchImpl: async (_url, options) => {
+      if (options.method === "DELETE") {
+        deleteStarted = true;
+        await new Promise((resolve) => {
+          releaseDelete = resolve;
+        });
+        return new Response(null, { status: 404 });
+      }
+      const { sessionId } = JSON.parse(options.body);
+      return Response.json(relaySessionResponse(sessionId), { status: 201 });
+    },
+  });
+  await bridge.start();
+  let stopped = false;
+  const stopping = bridge.stop().then(() => {
+    stopped = true;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(deleteStarted, true);
+  assert.equal(stopped, false);
+  releaseDelete();
+  await stopping;
+  assert.equal(stopped, true);
+});
+
+
+test("core bridge crypto interoperates with the shipped Cloudflare viewer", async () => {
+  const browserCrypto = await import("../../relay/public/viewer-crypto.js");
+  const root = crypto.randomBytes(32);
+  const rootKey = root.toString("base64url");
+  const sessionId = `bws_${crypto.randomBytes(18).toString("base64url")}`;
+  const hostEpoch = Buffer.alloc(16, 11);
+  const viewerEpoch = new Uint8Array(16).fill(22);
+
+  const hostWriter = createManagedCipher({
+    root,
+    sessionId,
+    direction: HOST_TO_VIEWER,
+    epoch: hostEpoch,
+  });
+  const browserReader = browserCrypto.createEnvelopeReceiver(rootKey, sessionId, "h2v");
+  const fromHost = hostWriter.seal(0, Buffer.from("host text"));
+  const openedByBrowser = await browserReader.open(fromHost);
+  assert.equal(openedByBrowser.kind, browserCrypto.ENVELOPE_KIND.TEXT);
+  assert.equal(new TextDecoder().decode(openedByBrowser.plaintext), "host text");
+
+  const browserWriter = browserCrypto.createEnvelopeSender(
+    rootKey,
+    sessionId,
+    "v2h",
+    viewerEpoch,
+  );
+  const hostReader = createManagedDecipher({
+    root,
+    sessionId,
+    direction: VIEWER_TO_HOST,
+  });
+  const fromViewer = await browserWriter.seal(
+    browserCrypto.ENVELOPE_KIND.TEXT,
+    new TextEncoder().encode("viewer text"),
+  );
+  assert.equal(hostReader.open(fromViewer).data.toString("utf8"), "viewer text");
+});

--- a/tests/node/mcp-server.test.mjs
+++ b/tests/node/mcp-server.test.mjs
@@ -214,10 +214,11 @@ test("contentForResult separates screenshots from file paths", async () => {
   assert.equal(content[1].mimeType, "image/png");
 });
 
-test("liveViewFromEnv defaults to LAN bind and disabled remote exposure", () => {
+test("liveViewFromEnv defaults to loopback direct mode and disabled remote exposure", () => {
   assert.deepEqual(liveViewFromEnv({}, {}), {
     enabled: false,
-    host: "0.0.0.0",
+    transport: "direct",
+    host: "127.0.0.1",
     port: 0,
     publicHost: undefined,
     expose: undefined,
@@ -238,11 +239,26 @@ test("liveViewFromEnv defaults to LAN bind and disabled remote exposure", () => 
     ),
     {
       enabled: true,
+      transport: "direct",
       host: "0.0.0.0",
       port: 8484,
       publicHost: "192.168.0.2",
       expose: "tailscale",
       password: "s3cret",
+      passwordHash: undefined,
+    },
+  );
+  // A persisted relay choice is an explicit MCP authorization by itself.
+  assert.deepEqual(
+    liveViewFromEnv({}, { transport: "relay", expose: "local" }),
+    {
+      enabled: true,
+      transport: "relay",
+      host: "127.0.0.1",
+      port: 0,
+      publicHost: undefined,
+      expose: "local",
+      password: undefined,
       passwordHash: undefined,
     },
   );
@@ -254,7 +270,8 @@ test("liveViewFromEnv defaults to LAN bind and disabled remote exposure", () => 
     ),
     {
       enabled: false,
-      host: "0.0.0.0",
+      transport: "direct",
+      host: "127.0.0.1",
       port: 7100,
       publicHost: undefined,
       expose: "lan",
@@ -422,7 +439,7 @@ test("viewer chat rides back on browser results while a live view runs", async (
   assert.match(chatBlock.text, /fresh user instructions/);
   // The step note was mirrored into the viewer chat.
   assert.deepEqual(browser.posted, [
-    { role: "agent", text: "comparing GPUs", kind: "step" },
+    { session: "default", role: "agent", text: "comparing GPUs", kind: "step" },
   ]);
 });
 
@@ -452,4 +469,55 @@ test("browser_handoff status carries drained viewer chat and stop ends mirroring
   });
   assert.ok(!after.content.some((block) => /gone/.test(block.text || "")));
   assert.equal(browser.posted.length, 0);
+});
+
+test("MCP viewer chat never crosses browser, download, or login sessions", async () => {
+  const browser = chatBrowser();
+  browser.vault = {};
+  browser.fillCredential = async (options) => ({
+    ok: true,
+    filled: true,
+    session: options.session,
+  });
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {},
+    downloadPolicy: "allow",
+    liveView: { enabled: false, host: "127.0.0.1", port: 0 },
+  });
+
+  await handlers.callTool({
+    params: {
+      name: "browser_handoff",
+      arguments: { action: "start", session: "private-a" },
+    },
+  });
+  browser.chatQueue.push({ text: "secret instruction for A", at: 9 });
+
+  for (const [name, toolArguments] of [
+    ["browser", { code: "1", session: "other-b" }],
+    ["browser_download", { code: "2", session: "other-b" }],
+    ["browser_login", { session: "other-b" }],
+  ]) {
+    const response = await handlers.callTool({
+      params: { name, arguments: toolArguments },
+    });
+    assert.equal(response.isError, undefined);
+    assert.ok(
+      !response.content.some((block) =>
+        /secret instruction for A/.test(block.text || ""),
+      ),
+      `${name} must not receive another session's chat`,
+    );
+  }
+
+  const owner = await handlers.callTool({
+    params: { name: "browser_login", arguments: { session: "private-a" } },
+  });
+  assert.ok(
+    owner.content.some((block) =>
+      /secret instruction for A/.test(block.text || ""),
+    ),
+    "the bound session should receive its own queued chat",
+  );
 });

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -67,6 +67,7 @@ export class BetterWright {
   waitForHandoff(options?: WaitForHandoffOptions): Promise<HandoffResult>;
   /** Post a line into the live-view chat (agent steps / system notices). */
   liveViewPostChat(options?: {
+    session?: string;
     role?: "agent" | "you" | "system";
     text?: string;
     kind?: string;
@@ -75,7 +76,7 @@ export class BetterWright {
    * Drain freeform human messages typed in the live-view chat since the last
    * drain (agent harness uses this between turns).
    */
-  liveViewDrainChat(): Promise<LiveViewDrainChatResult>;
+  liveViewDrainChat(options?: { session?: string }): Promise<LiveViewDrainChatResult>;
   /** Block until a human answers a question in the live-view chat. */
   waitForAsk(options?: WaitForAskOptions): Promise<AskResult>;
   fillCredential(options?: FillCredentialOptions): Promise<CredentialFillResult>;

--- a/types/mcp-server.d.ts
+++ b/types/mcp-server.d.ts
@@ -5,6 +5,7 @@ import type {
   HeadlessMode,
 } from "./common.js";
 import type { NetworkPolicy } from "./policy.js";
+import type { LiveViewOptions } from "./public.js";
 
 export interface McpContentBlock {
   type: string;
@@ -37,11 +38,19 @@ export function headlessFromEnv(
   env?: Record<string, string | undefined>,
 ): HeadlessMode;
 
-/** Read BETTERWRIGHT_LIVE_VIEW / _HOST / _PORT for the browser_handoff tool. */
-export function liveViewFromEnv(env?: Record<string, string | undefined>): {
+/** Merge BETTERWRIGHT_LIVE_VIEW_* over optional persisted handoff settings. */
+export function liveViewFromEnv(
+  env?: Record<string, string | undefined>,
+  fileConfig?: LiveViewOptions,
+): {
   enabled: boolean;
+  transport: "direct" | "relay" | string;
   host: string;
   port: number;
+  publicHost?: string;
+  expose?: "local" | "lan" | "tailscale" | string;
+  password?: string;
+  passwordHash?: string;
 };
 
 /** Convert a run result to MCP content: a JSON text summary then image blocks. */

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -62,37 +62,38 @@ export interface BetterWrightOptions {
    */
   platform?: "macos" | "windows" | "linux";
   /**
-   * Defaults for `startLiveView()`. Binds `0.0.0.0` with a LAN `publicHost` by
-   * default so printed URLs open from another machine on the network. Pass
-   * `{host:"127.0.0.1"}` for loopback-only.
+   * Defaults for `startLiveView()`. The no-config default is loopback-only;
+   * managed relay and direct LAN/Tailscale exposure are explicit choices.
    */
   liveView?: LiveViewOptions;
 }
 
 /** Options for the live-view server (constructor defaults and per-start overrides). */
 export interface LiveViewOptions {
+  /** Transport: direct self-hosting (default) or the account-backed relay. */
+  transport?: "direct" | "relay";
   /**
-   * One-word hosting preset (overrides host/publicHost):
-   * - "lan": bind all interfaces, print the LAN IP (default behavior)
-   * - "local": loopback only — pair with your own tunnel (ssh, cloudflared, …)
+   * Direct hosting preset (overrides host/publicHost):
+   * - "local": loopback only (safe default)
+   * - "lan": bind all interfaces and print the LAN IP
    * - "tailscale": bind this machine's Tailscale address only
    */
   expose?: "lan" | "local" | "tailscale";
   /**
-   * Require this password (min 4 chars) before the viewer loads, on top of the
-   * URL capability token. Verified constant-time; grants a 12 h HttpOnly
-   * session cookie. Failed attempts are rate-limited per source address.
-   * Prefer persisting a hash in <home>/config.json via
-   * `betterwright view --set-password` instead of passing plaintext here.
+   * Require this password (min 8 chars) before a direct viewer loads, on top
+   * of the URL capability token. Verified constant-time; grants a 12 h
+   * HttpOnly session cookie. Failed attempts are rate-limited per source.
+   * Managed relay links use their fragment capability instead. Prefer
+   * persisting a hash via `betterwright view --set-password`.
    */
   password?: string;
   /**
-   * Stored password digest ("sha256:<64 hex>") — what
-   * `betterwright view --set-password` writes to <home>/config.json.
-   * Ignored when `password` is also set.
+   * Stored password verifier. New values use salted scrypt; legacy
+   * `sha256:<64 hex>` values remain accepted for upgrade compatibility.
+   * Ignored when `password` is also set and applies only to direct mode.
    */
   passwordHash?: string;
-  /** Bind host (default "0.0.0.0"). */
+  /** Bind host for direct mode (default "127.0.0.1"). */
   host?: string;
   /** Bind port (default 0 = ephemeral). */
   port?: number;
@@ -106,6 +107,13 @@ export interface LiveViewOptions {
   publicHost?: string;
   /** Which session's current tab streams first (default "default"). */
   session?: string;
+  /** Managed-relay endpoint override, primarily for self-hosting/tests. */
+  relayUrl?: string;
+  /**
+   * BetterWright personal API key for managed relay. Prefer
+   * `BETTERWRIGHT_API_KEY` or `betterwright account set-key` over source code.
+   */
+  apiKey?: string;
 }
 
 /** Result of `startLiveView()` / `liveViewStatus()`. */
@@ -117,7 +125,9 @@ export interface LiveViewStatus {
   host?: string;
   port?: number;
   token?: string;
-  /** Hosting preset in effect ("lan", "local", or "tailscale"). */
+  /** Transport in effect. */
+  transport?: "direct" | "relay";
+  /** Hosting preset in effect (including "relay" for managed links). */
   expose?: string;
   /** True when a password gate is active. */
   passwordProtected?: boolean;
@@ -128,6 +138,21 @@ export interface LiveViewStatus {
   ask?: { active: boolean; question?: string; options?: string[] };
   /** Count of freeform human chat messages waiting for the agent to drain. */
   pendingChat?: number;
+  /** Daemon session immutably bound to this capability. */
+  session?: string;
+  /** Opaque managed relay session ID. */
+  sessionId?: string;
+  /** Managed-relay allowance state. */
+  quota?: {
+    limitSeconds?: number;
+    usedSeconds?: number;
+    remainingSeconds?: number;
+    startsAt?: string;
+    endsAt?: string;
+    resetAt?: string;
+  } | null;
+  /** Managed relay session expiry. */
+  expiresAt?: string | null;
   /** True when start() found the server already running (URL unchanged). */
   alreadyRunning?: boolean;
   error?: string;


### PR DESCRIPTION
## Summary
- add account-backed, outbound-only managed Live View on Cloudflare with endpoint encryption
- add personal API keys, Clerk auth/webhook integration, weekly viewer-time quotas, reservations, kill switches, and budget safeguards
- make direct Live View loopback-only by default while preserving LAN, Tailscale, tunnel, and Quick Tunnel modes
- bind Live View capabilities to one daemon session and harden teardown, restart, config precedence, chat isolation, and direct passwords
- ship the relay Worker, Durable Objects, D1 schema, viewer assets, docs, examples, types, and v1.2.0 metadata together

## Validation
- core lint, focused lifecycle/security tests, type tests, package smoke, version checks, and production dependency audit pass
- relay TypeScript, 118 tests, Wrangler production dry-run, and production dependency audit pass
- production relay `/healthz` is healthy with admission enabled and HSTS
- complete local browser suites are blocked by the known Chromium SIGABRT/EPERM failure in the Aside macOS runtime; required Linux CI is authoritative

## Deployment dependencies
- relay is already deployed at `https://live.betterwright.com`
- website counterpart: BetterWright/betterwright-site#1
- npm publication remains gated on this PR, website production checks, final E2E, tag, and GitHub release
