### PR TITLE
Allow trusted rollback releases to set latest

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -77,4 +77,4 @@ jobs:
         run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 BETTERWRIGHT_CHROMIUM_ROOT=off node --test tests/node/cloak.test.mjs
       - name: Publish to npm with provenance
         if: steps.existing.outputs.published != 'true'
-        run: npm publish --access public
+        run: npm publish --access public --tag latest


### PR DESCRIPTION
npm refuses to publish a lower semantic version when `latest` already points at a higher withdrawn version unless the tag is explicit. This keeps trusted publishing and provenance while allowing v1.1.4 to replace withdrawn v1.2.0 as `latest`.