### PR TITLE
Release BetterWright 1.3.1 with bounded credential operations

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.3.0
+generated_by: betterwright@1.3.1
 ---
 
 # Browser tool: BetterWright

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/credential-target-scan.mjs
+++ b/src/credential-target-scan.mjs
@@ -41,6 +41,39 @@ export function withProbeDeadline(work, ms, disposeLate) {
   return Promise.race([probe, expiry]).finally(() => clearTimeout(timer));
 }
 
+/** Validate already-resolved explicit credential targets without letting any
+ * renderer round-trip outlive the scan budget. Callbacks are thunks so a spent
+ * budget never starts more Playwright work. */
+export async function probePinnedCredentialOrigin({
+  inspectDocument,
+  originForFrame,
+  probeMs = CREDENTIAL_FRAME_PROBE_MS,
+  budgetMs = CREDENTIAL_SCAN_BUDGET_MS,
+}) {
+  const deadline = Date.now() + Math.max(1, Number(budgetMs) || 1);
+  const probe = async (phase, work) => {
+    const allowance = Math.min(probeMs, deadline - Date.now());
+    if (allowance <= 0) return { timedOut: true, phase };
+    const value = await withProbeDeadline(work(), allowance);
+    return credentialProbeTimedOut(value)
+      ? { timedOut: true, phase }
+      : { timedOut: false, value };
+  };
+
+  const before = await probe("initial document validation", inspectDocument);
+  if (before.timedOut) return before;
+  const origin = await probe("origin validation", originForFrame);
+  if (origin.timedOut) return origin;
+  const after = await probe("final document validation", inspectDocument);
+  if (after.timedOut) return after;
+  return {
+    timedOut: false,
+    documentUrlBefore: before.value,
+    origin: origin.value,
+    documentUrlAfter: after.value,
+  };
+}
+
 function frameLabel(frame) {
   try {
     return String(frame.url() || "") || "about:blank";

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -58,6 +58,7 @@ import {
   collectCredentialFrameDetections,
   credentialProbeTimedOut,
   disposeCredentialFrameDetections,
+  probePinnedCredentialOrigin,
   withProbeDeadline,
 } from "./credential-target-scan.mjs";
 import {
@@ -1266,7 +1267,7 @@ function unwrapHumanTarget(page, value) {
   );
 }
 
-async function humanTargetBox(page, value, timeout = 10_000) {
+async function humanTargetBox(page, value, timeout = 10_000, inputLikeOverride) {
   const target = unwrapHumanTarget(page, value);
   if (typeof target?.boundingBox !== "function") {
     return { target: null, box: target, inputLike: false };
@@ -1274,19 +1275,27 @@ async function humanTargetBox(page, value, timeout = 10_000) {
   await target.scrollIntoViewIfNeeded?.({ timeout });
   const box = await target.boundingBox({ timeout });
   if (!box) throw new Error("human target is not visible.");
-  const inputLike = await target
-    .evaluate(
-      (element) =>
-        ["INPUT", "TEXTAREA", "SELECT"].includes(element.tagName) ||
-        element.isContentEditable,
-    )
-    .catch(() => false);
+  const inputLike =
+    typeof inputLikeOverride === "boolean"
+      ? inputLikeOverride
+      : await target
+          .evaluate(
+            (element) =>
+              ["INPUT", "TEXTAREA", "SELECT"].includes(element.tagName) ||
+              element.isContentEditable,
+          )
+          .catch(() => false);
   return { target, box, inputLike };
 }
 
 async function humanClickTarget(page, session, value, options = {}) {
   const timeout = Math.max(1, Number(options?.timeout) || 10_000);
-  const { box, inputLike } = await humanTargetBox(page, value, timeout);
+  const { box, inputLike } = await humanTargetBox(
+    page,
+    value,
+    timeout,
+    options?.inputLike,
+  );
   const point = pointInside(box, inputLike);
   await movePointer(page.mouse, session.cursor, point, options);
   await pressPointer(page.mouse, inputLike);
@@ -2788,7 +2797,7 @@ async function detectCredentialTargets(page, requestedAction, anchor = null) {
     // so instead of reporting a clean "no password field" the caller would take
     // at face value. Waiting for the page to settle is the fix, not a retry.
     const stalled = unresponsive.length
-      ? `; ${unresponsive.length} frame${unresponsive.length === 1 ? "" : "s"} did not respond in time (still loading or blocked) — let the page settle and retry, or pass explicit selectors`
+      ? `; ${unresponsive.length} frame${unresponsive.length === 1 ? "" : "s"} did not respond in time (still loading or blocked) — let the page settle, stop or reduce live page activity, or retry from a lightweight same-origin page; pass explicit selectors when the form itself is ambiguous`
       : "";
     const reason =
       (ambiguous[0]?.metadata.reason ||
@@ -2842,7 +2851,10 @@ async function fillCredentialField(page, frame, session, target, value) {
     await locator.waitFor({ state: "visible", timeout: 10_000 });
   else await locator.waitForElementState?.("visible", { timeout: 10_000 });
   try {
-    await humanClickTarget(page, session, locator, { timeout: 10_000 });
+    await humanClickTarget(page, session, locator, {
+      timeout: 10_000,
+      inputLike: true,
+    });
   } catch {
     await locator.focus({ timeout: 10_000 }).catch(() => {});
   }
@@ -2892,14 +2904,23 @@ async function pinnedCredentialOrigin(frame, handles) {
     }
   };
 
-  const documentUrlBefore = await inspectDocument();
+  const probe = await probePinnedCredentialOrigin({
+    inspectDocument,
+    originForFrame: () => credentialOriginForFrame(frame),
+  });
+  if (probe.timedOut) {
+    throw new Error(
+      `The explicit credential target frame did not respond in time during ${probe.phase} ` +
+        "(still loading or blocked) — let the page settle, stop or reduce live page activity, " +
+        "or retry from a lightweight same-origin page.",
+    );
+  }
+  const { documentUrlBefore, documentUrlAfter, origin } = probe;
   if (documentUrlBefore == null) {
     throw new Error(
       "The explicit credential targets became detached or their document changed before vault access.",
     );
   }
-  const origin = await credentialOriginForFrame(frame);
-  const documentUrlAfter = await inspectDocument();
   const documentOriginBefore = urlOrigin(documentUrlBefore);
   const documentOriginAfter = urlOrigin(documentUrlAfter);
   if (
@@ -3234,7 +3255,7 @@ async function performCredentialFill(
     // Fire blur so forms that validate the password/confirm match on blur (not
     // just on input) run their check before any submit.
     if (lastLocator) {
-      await lastLocator.evaluate((element) => element.blur?.()).catch(() => {});
+      await lastLocator.press("Tab", { timeout: CREDENTIAL_FRAME_PROBE_MS }).catch(() => {});
     }
 
     let submitted = false;
@@ -3243,6 +3264,7 @@ async function performCredentialFill(
     if (submitTarget) {
       await humanClickTarget(page, session, submitTarget, {
         timeout: 10_000,
+        inputLike: false,
       });
       submitted = true;
     }

--- a/tests/node/credential-fill.test.mjs
+++ b/tests/node/credential-fill.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   collectCredentialFrameDetections,
   disposeCredentialFrameDetections,
+  probePinnedCredentialOrigin,
 } from "../../src/credential-target-scan.mjs";
 import { cloakRuntime } from "../../src/doctor.mjs";
 import { BetterWright, NetworkPolicy } from "../../src/index.mjs";
@@ -134,6 +135,42 @@ test("the scan budget bounds a page full of wedged frames", async () => {
   assert.ok(elapsed < 400, `the scan honoured its budget (took ${elapsed}ms)`);
   assert.equal(detections.length, 0);
   assert.equal(unresponsive.length, frames.length);
+});
+
+test("explicit target origin validation is bounded when its frame stops responding", async () => {
+  let originProbed = false;
+  const started = Date.now();
+  const result = await probePinnedCredentialOrigin({
+    inspectDocument: () => new Promise(() => {}),
+    originForFrame: async () => {
+      originProbed = true;
+      return "https://form.example";
+    },
+    probeMs: 40,
+    budgetMs: 120,
+  });
+  assert.ok(Date.now() - started < 300, "explicit validation honoured its deadline");
+  assert.deepEqual(result, {
+    timedOut: true,
+    phase: "initial document validation",
+  });
+  assert.equal(originProbed, false, "a timed-out document probe stops later validation work");
+});
+
+test("explicit target origin validation preserves both document checks", async () => {
+  const documents = ["https://form.example/signup", "https://form.example/signup"];
+  const result = await probePinnedCredentialOrigin({
+    inspectDocument: async () => documents.shift(),
+    originForFrame: async () => "https://form.example",
+    probeMs: 40,
+    budgetMs: 120,
+  });
+  assert.deepEqual(result, {
+    timedOut: false,
+    documentUrlBefore: "https://form.example/signup",
+    origin: "https://form.example",
+    documentUrlAfter: "https://form.example/signup",
+  });
 });
 
 async function fixtureServer() {
@@ -784,6 +821,14 @@ test("semantic credential detection and pending credential plumbing", opts, asyn
     `<!doctype html><form onsubmit="event.preventDefault(); window.explicitSubmitted=true">
       <label>User <input id="explicit-user"></label><label>Password <input id="explicit-password" type="password"></label><button id="explicit-submit">Go</button>
     </form>`,
+  );
+  server.pages.set(
+    "/never-settling-blur",
+    `<!doctype html><form>
+      <label>User <input id="blur-user"></label><label>Password <input id="blur-password" type="password"></label>
+    </form><script>
+      document.querySelector('#blur-password').blur = () => new Promise(() => {});
+    </script>`,
   );
   server.pages.set(
     "/explicit-race-source",
@@ -1628,6 +1673,31 @@ test("semantic credential detection and pending credential plumbing", opts, asyn
       assert.equal(byRef.ok, true, byRef.error);
       assert.equal(byRef.result.submitted, true);
     });
+
+    await t.test(
+      "a page-defined never-settling blur cannot restart the worker after a credential fill",
+      { timeout: 10_000 },
+      async () => {
+        await visit("/never-settling-blur");
+        const started = Date.now();
+        const result = await bw.fillCredential({
+          usernameSelector: "#blur-user",
+          passwordSelector: "#blur-password",
+        });
+        assert.equal(result.ok, true, result.error);
+        assert.deepEqual(result.result.filled, ["username", "password"]);
+        assert.ok(Date.now() - started < 5_000, "credential blur used bounded browser input");
+        const state = await bw.run(`return page.evaluate(() => ({
+          username: document.querySelector('#blur-user').value,
+          passwordLength: document.querySelector('#blur-password').value.length,
+        }));`);
+        assert.equal(state.ok, true, state.error);
+        assert.deepEqual(state.result, {
+          username: "alice@example.com",
+          passwordLength: loginSecret.length,
+        });
+      },
+    );
 
     await t.test(
       "pins explicit targets and origin before a delayed vault lookup",


### PR DESCRIPTION
## Summary

- bound explicit credential target document/origin probes to the existing credential scan budget
- avoid page-defined `evaluate()` and `blur()` hooks during trusted credential input
- preserve ordinary human-click behavior while optimizing known credential field and submit targets
- improve recovery guidance for busy or blocked renderer frames
- release the fixes as BetterWright 1.3.1

## Compatibility

- no public API or type changes
- existing selector-free and explicit-selector credential behavior remains supported
- all existing browser, worker-restart, redaction, vault, and concurrency tests remain green

## Verification

- `npm run release:check` (483 passed, 5 skipped)
- `npm test` (526 passed, 5 skipped)
- packed 1.3.1 tarball validated with Node 22 on Pro AI's Linux ARM64 host
- reproduced the prior media-heavy renderer failure: it returned within budget, retained the browser session, and exposed recoverable pending metadata
- verified successful trusted signup filling on a lightweight same-origin route in 2.3 seconds; no forms were submitted and both test credentials were discarded
