### PR TITLE
feat: named, lockable browser profiles in one home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Added
+
+- Named, independently-locked browser profiles inside one home. The new
+  `profile` constructor option (also `--profile <name>` on the CLI and
+  `BETTERWRIGHT_PROFILE` for the MCP server) selects a persistent profile at
+  `browser/profiles/<name>`; different names run concurrently, each fully
+  logged in, while the same name still serializes behind the ephemeral runtime
+  fallback. Omitting `profile` leaves `browser/profile` and every login in it
+  untouched — no migration. The vault, artifacts, CloakBrowser binary cache,
+  and per-home session-daemon socket stay shared across profiles. Names are
+  validated against path traversal and reserved device names.
+
 ## [1.5.0] - 2026-07-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -285,6 +285,23 @@ The security model — what the sandbox removes, why the metadata floor cannot
 be lifted, and where it does *not* claim to be a boundary — is in
 [docs/architecture.md](docs/architecture.md).
 
+All state lives under `$BETTERWRIGHT_HOME` (default `~/.betterwright`): the
+persistent browser profile at `browser/profile`, the credential `vault/`, and
+`artifacts/`. Only one process can own the default profile at a time, so a
+second concurrent run gets a signed-out ephemeral profile. To run unrelated
+work in parallel while each stays logged in, give each a **named profile** —
+an independent, separately-locked profile at `browser/profiles/<name>`:
+
+```js
+new BetterWright({ profile: "social" }); // holds the X / LinkedIn logins
+new BetterWright({ profile: "review" }); // reads and screenshots pages, concurrently
+```
+
+Omitting `profile` keeps the single default profile, unchanged. The vault and
+artifacts are shared across profiles. CLI: `--profile <name>`; MCP:
+`BETTERWRIGHT_PROFILE`. See
+[docs/architecture.md](docs/architecture.md#named-profiles).
+
 ## Docs
 
 | Start here | Capabilities | Under the hood |

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -224,8 +224,18 @@ async function makeBrowser(flags, { headless }: any = {}) {
   return new BetterWright({
     policy: new NetworkPolicy(policyOptionsFromFlags(flags)),
     headless: headless ?? !flags.has("--headed"),
+    ...(profileFromFlags() ? { profile: profileFromFlags() } : {}),
     ...cloakingFromFlags(flags),
   });
+}
+
+// The named browser profile for this invocation: `--profile <name>` selects an
+// independent, separately-locked profile at `browser/profiles/<name>` so
+// unrelated runs stay logged in concurrently; omitting it keeps the single
+// default profile. Shared with the daemon config below so the in-process
+// fallback and the daemon agree on which profile a run targets.
+function profileFromFlags() {
+  return flagValue(process.argv, "--profile") || undefined;
 }
 
 // Cloaking V2 flags shared by run/repl/agent. On by default; --no-cloak-v2
@@ -451,6 +461,7 @@ async function readSnippet(arg) {
 function daemonConfigFromFlags(flags) {
   return {
     headless: !flags.has("--headed"),
+    profile: profileFromFlags(),
     policy: {
       allowLoopback: !flags.has("--block-loopback"),
       allowPrivateNetwork: !flags.has("--block-private-network"),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,8 +138,10 @@ Everything lives under `$BETTERWRIGHT_HOME` (default `~/.betterwright`):
 ```
 ~/.betterwright/
 ├── browser/
-│   ├── profile/        persistent browser profile (cookies, logins)
-│   └── runtime/        ephemeral profiles when the main one is locked
+│   ├── profile/        default persistent browser profile (cookies, logins)
+│   ├── profiles/       named persistent profiles, one directory per name
+│   │   └── <name>/     e.g. profiles/social, profiles/review
+│   └── runtime/        ephemeral profiles when a profile is locked (shared)
 ├── vault/
 │   ├── vault.key       owner-only local encryption key
 │   ├── vault.enc       authenticated AES-256-GCM record table
@@ -148,6 +150,41 @@ Everything lives under `$BETTERWRIGHT_HOME` (default `~/.betterwright`):
 └── artifacts/          screenshots, downloads, spilled output (quota-managed)
     └── downloads/
 ```
+
+### Named profiles
+
+By default a home has exactly one persistent profile, at `browser/profile`.
+Only one process can own it at a time; a second concurrent worker gets an
+isolated ephemeral profile from `browser/runtime` (a signed-out browser) rather
+than corrupting the profile. That safety trade means concurrency and logged-in
+state are mutually exclusive on the default profile.
+
+Passing `profile: "<name>"` to the constructor (or `--profile <name>` on the
+CLI, or `BETTERWRIGHT_PROFILE` for the MCP server) selects an independent
+persistent profile at `browser/profiles/<name>` with the same internal layout
+and **its own lock** (`browser/profiles/<name>.betterwright-lock`, a sibling of
+the profile directory). Because the lock is per-profile, two BetterWright
+instances on *different* names run at the same time, each fully logged in;
+two instances on the *same* name still serialize, and the second falls back to
+an ephemeral runtime profile exactly as the single default profile does today.
+Omitting `profile` leaves `browser/profile` — and every existing login in it —
+untouched: there is no migration.
+
+Names are validated as a strict allowlist (letters, digits, `.`, `-`, `_`,
+starting with a letter or digit; no path separators, `..`, absolute paths, or
+Windows reserved device names) so a name can never escape `browser/profiles/`.
+They are as case-sensitive as the underlying filesystem.
+
+Only the profile directory and its lock are scoped. The **vault, the
+`artifacts/` directory, the CloakBrowser binary cache, and the session-daemon
+socket are shared across every profile in a home** — so a credential saved once
+is reachable from any profile. The daemon socket in particular stays per-home
+(`<home>/daemon.sock`, with the temp-dir fallback below): the profile rides in
+the daemon's config signature rather than the socket path, so a nested profile
+name can never push the socket over the unix-socket length limit. One daemon
+holds one profile at a time; a client that requests a different profile than the
+running daemon holds falls back to a private in-process browser scoped to the
+profile it asked for, so cross-profile concurrency always works.
 
 The separately licensed CloakBrowser binary is cached by its official wrapper,
 not copied into BetterWright's package or home directory. `betterwright setup`

--- a/docs/attach-mode.md
+++ b/docs/attach-mode.md
@@ -46,6 +46,27 @@ To sign in manually, start one headed run, complete the login in the visible
 browser window, then keep using the normal persistent profile. For model-safe
 credential filling, prefer the trusted [credential API](credentials.md).
 
+### Named profiles for concurrency
+
+The single-owner rule above means concurrency and logged-in state are otherwise
+mutually exclusive: a second concurrent run of the default profile gets a
+signed-out ephemeral browser. To run unrelated work in parallel while each
+stays logged in, give each its own named profile:
+
+```js
+new BetterWright({ profile: "social" }); // holds the X / LinkedIn logins
+new BetterWright({ profile: "review" }); // reads and screenshots pages
+```
+
+Each name is an independent persistent profile at `$BETTERWRIGHT_HOME/browser/
+profiles/<name>` with its own lock, so `social` and `review` run at the same
+time without sharing a cookie jar and without either being signed out. The same
+name still serializes with the ephemeral fallback. Omitting `profile` keeps the
+default `browser/profile`, unchanged. The vault is shared across profiles, so a
+credential saved from one profile is usable from every profile. The CLI
+equivalent is `--profile <name>`; for MCP, set `BETTERWRIGHT_PROFILE`. See
+[architecture.md](architecture.md#named-profiles).
+
 ## Managed-browser enforcement
 
 These legacy settings are rejected instead of silently choosing a normal

--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -52,6 +52,7 @@ export const VALUE_FLAGS = new Set([
   "--model-id",
   "--platform",
   "--port",
+  "--profile",
   "--protocol",
   "--provider",
   "--public-host",

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -104,6 +104,9 @@ result. Globals include page, snapshot, screenshot, credentials, human.
 
 Options:
   --session <name>       which persistent session to use (default "default")
+  --profile <name>       named persistent profile at browser/profiles/<name>
+                         (default: the shared browser/profile); different names
+                         run concurrently, each with its own logins
   --headed               show the browser window
   --close                close the session after this call
   --approve-downloads    allow downloads for this one run

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ import { defaultHome } from "./home.js";
 import { defaultLiveViewListen } from "./live-view.js";
 import { loadLiveViewConfig } from "./live-view-config.js";
 import { NetworkPolicy } from "./policy.js";
+import { profileDirFor, resolveProfileName } from "./profile-name.js";
 import { listSkills, skillHintsForPages } from "./skills.js";
 import { createLocalCredentialVault } from "./vault.js";
 
@@ -195,6 +196,7 @@ function stealthDriverAvailable() {
 /** A persistent, policy-guarded Playwright browser. */
 export class BetterWright {
   declare home: string;
+  declare profile: string | null;
   declare policy: NetworkPolicy;
   declare vault: any;
   declare credentialCapture: boolean;
@@ -235,6 +237,15 @@ export class BetterWright {
   /**
    * @param {object} [options]
    * @param {string} [options.home] state directory (default ~/.betterwright)
+   * @param {string} [options.profile] named persistent browser profile inside
+   *   the home. Omit it (the default) to keep the single `browser/profile`
+   *   directory unchanged. A name selects an independent, separately-locked
+   *   profile at `browser/profiles/<name>`, so different names run
+   *   concurrently, each fully logged in; the same name still serializes with
+   *   the ephemeral fallback. The vault, artifacts, and browser binary cache
+   *   stay shared across profiles. Names allow letters, digits, ".", "-", and
+   *   "_" (no path separators or "..") and are case-sensitive to the extent
+   *   the filesystem is.
    * @param {NetworkPolicy} [options.policy] network policy
    * @param {object|false|null} [options.vault] custom vault with
    *   `handleRequest(action, payload, origin)`, or false/null to disable the
@@ -300,6 +311,10 @@ export class BetterWright {
    */
   constructor(options: any = {}) {
     this.home = options.home || defaultHome();
+    // null == the default `browser/profile`; a validated name scopes the
+    // profile directory and its lock without touching the shared vault,
+    // artifacts, or binary cache. Throws TypeError on an invalid name.
+    this.profile = resolveProfileName(options.profile);
     this.policy = options.policy || new NetworkPolicy();
     if (Object.hasOwn(options, "vault")) {
       const vault = options.vault;
@@ -398,8 +413,12 @@ export class BetterWright {
     for (const dir of [root, artifacts, downloads, runtime]) {
       fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
     }
+    // Only the profile directory (and, derived from it, its lock) is scoped by
+    // name: default -> `browser/profile`, a name -> `browser/profiles/<name>`.
+    // The runtime, artifacts, and downloads directories above stay shared, so
+    // ephemeral fallbacks and saved files are common to every profile.
     return {
-      profileDir: path.join(root, "profile"),
+      profileDir: profileDirFor(root, this.profile),
       runtimeDir: runtime,
       artifactsDir: artifacts,
       downloadsDir: downloads,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -237,6 +237,17 @@ export function normalizeDaemonConfig(config: any = {}) {
   return {
     protocol: DAEMON_PROTOCOL,
     headless: config.headless !== false,
+    // The named browser profile (see src/profile-name.ts). It rides in the
+    // config signature, not the socket path: the daemon socket stays per-home
+    // (`<home>/daemon.sock`, with the temp-dir fallback for long homes) so the
+    // vault, artifacts, and binary cache remain shared, and adding a profile
+    // never pushes the socket over the 104/108-byte limit. A daemon holds one
+    // browser, hence one profile; a client that asks for a different profile
+    // sees a signature mismatch and — rather than run on the wrong profile —
+    // falls back to a private in-process browser scoped to the profile it asked
+    // for. Concurrency across profiles therefore always works; only daemon-side
+    // session persistence is limited to one profile per home at a time.
+    profile: config.profile ? String(config.profile) : null,
     policy: {
       allowLoopback: policy.allowLoopback !== false,
       allowPrivateNetwork: policy.allowPrivateNetwork !== false,
@@ -266,6 +277,7 @@ export async function createBrowserFromDaemonConfig(config) {
   return new BetterWright({
     policy: new NetworkPolicy(normalized.policy),
     headless: normalized.headless,
+    ...(normalized.profile ? { profile: normalized.profile } : {}),
     cloakV2: normalized.cloak.cloakV2,
     upstreamProxy: normalized.cloak.upstreamProxy || undefined,
     geoip: normalized.cloak.geoip,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -443,6 +443,13 @@ export async function runMcpServer(env = process.env, options: any = {}) {
     policy: policyFromEnv(env),
     headless: headlessFromEnv(env),
     downloadPolicy,
+    // Named browser profile (see docs/architecture.md): an independent,
+    // separately-locked profile at browser/profiles/<name> so parallel MCP
+    // servers on one home stay logged in without serializing. Unset keeps the
+    // single default profile.
+    ...(String(env.BETTERWRIGHT_PROFILE || "").trim()
+      ? { profile: String(env.BETTERWRIGHT_PROFILE).trim() }
+      : {}),
     // Identity must match egress geography (see docs/getting-started.md):
     // a headless server whose exit IP sits in another country needs these
     // pinned or geo-sensitive sites challenge every run.

--- a/src/profile-name.ts
+++ b/src/profile-name.ts
@@ -1,0 +1,104 @@
+// Named browser profiles inside one BetterWright home.
+//
+// A home has always held exactly one persistent profile at `browser/profile`.
+// That is still the default, byte-for-byte: an existing install keeps using
+// that directory with no migration. A caller that wants more than one
+// logged-in identity in the same home passes a profile *name*; each name is an
+// independent persistent profile at `browser/profiles/<name>` with the same
+// internal layout and, via `profileLockDirFor`, its own sibling lock. Only the
+// profile directory and its lock are scoped — the vault, artifacts, the
+// CloakBrowser binary cache, and the session-daemon socket stay shared across
+// profiles, so a credential saved once is reachable from every profile.
+//
+// The name becomes a path segment and a lock-directory basename, so it is
+// validated hard: a value that could contain a path separator, "..", or an
+// absolute path would let a caller read or lock a directory outside
+// `browser/profiles/`. Validation is an allowlist rather than a blocklist for
+// exactly that reason.
+
+import path from "node:path";
+
+// Names Windows reserves for character devices regardless of extension. A
+// profile directory named for one is unusable there, so reject them on every
+// platform to keep a home portable between operating systems.
+const RESERVED_NAMES = new Set([
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  ...Array.from({ length: 9 }, (_, i) => `com${i + 1}`),
+  ...Array.from({ length: 9 }, (_, i) => `lpt${i + 1}`),
+]);
+
+// Deliberately strict allowlist: an ASCII letter or digit first — so "..", a
+// leading ".", and a leading "-" are all rejected — then letters, digits, dot,
+// dash, or underscore. No path separators, no whitespace, nothing a shell or
+// filesystem treats specially. The cap keeps the nested profile path (and the
+// `<name>.betterwright-lock` directory beside it) comfortably short.
+const PROFILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+export const MAX_PROFILE_NAME_LENGTH = 64;
+
+/** A profile name that collides with a Windows reserved device name. */
+export function isReservedProfileName(name: string) {
+  return RESERVED_NAMES.has(String(name).toLowerCase());
+}
+
+/**
+ * Validate and normalize a profile name.
+ *
+ * Returns `null` for "no name given" (`undefined` or `null`); the caller then
+ * uses the default `browser/profile`. Any name that is *present but invalid*
+ * throws a `TypeError`, so a bad name is a clear failure at construction rather
+ * than a surprising path — or a path-traversal — later.
+ *
+ * Case sensitivity follows the filesystem: the name is used verbatim as a
+ * directory segment, so "Social" and "social" are two profiles on a
+ * case-sensitive volume (typical Linux) and one on a case-insensitive volume
+ * (default macOS, Windows). BetterWright does not fold case itself, because
+ * doing so would rename directories out from under an existing install.
+ */
+export function resolveProfileName(name: unknown): string | null {
+  if (name === undefined || name === null) return null;
+  if (typeof name !== "string") {
+    throw new TypeError("profile must be a string.");
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new TypeError("profile must not be empty.");
+  }
+  if (trimmed.length > MAX_PROFILE_NAME_LENGTH) {
+    throw new TypeError(
+      `profile must be at most ${MAX_PROFILE_NAME_LENGTH} characters.`,
+    );
+  }
+  if (!PROFILE_NAME_PATTERN.test(trimmed)) {
+    throw new TypeError(
+      `invalid profile name ${JSON.stringify(name)}: use letters, digits, ` +
+        '".", "-", or "_", starting with a letter or digit (no path ' +
+        'separators, "..", or absolute paths).',
+    );
+  }
+  if (isReservedProfileName(trimmed)) {
+    throw new TypeError(
+      `profile name ${JSON.stringify(trimmed)} is reserved by the operating system.`,
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * The persistent profile directory for a browser root (`<home>/browser`).
+ *
+ *  - No name (`undefined`/`null`): the historical default `<root>/profile`,
+ *    unchanged so existing logins keep working.
+ *  - A validated name: `<root>/profiles/<name>`, a sibling tree with the same
+ *    internal layout and, through `profileLockDirFor`, its own lock.
+ *
+ * Throws `TypeError` on an invalid name (see {@link resolveProfileName}).
+ */
+export function profileDirFor(root: string, name?: unknown): string {
+  const resolved = resolveProfileName(name);
+  return resolved === null
+    ? path.join(root, "profile")
+    : path.join(root, "profiles", resolved);
+}

--- a/tests/node/profiles.test.mjs
+++ b/tests/node/profiles.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { BetterWright } from "../../dist/src/index.js";
+import {
+  acquireProfileLock,
+  profileLockDirFor,
+  releaseProfileLockDir,
+} from "../../dist/src/profile-lock.js";
+import {
+  isReservedProfileName,
+  MAX_PROFILE_NAME_LENGTH,
+  profileDirFor,
+  resolveProfileName,
+} from "../../dist/src/profile-name.js";
+import { makeTempDir } from "./helpers/temp-dir.mjs";
+
+// --- Name validation -------------------------------------------------------
+
+test("resolveProfileName returns null when no profile is given", () => {
+  assert.equal(resolveProfileName(undefined), null);
+  assert.equal(resolveProfileName(null), null);
+});
+
+test("resolveProfileName accepts ordinary names and trims surrounding space", () => {
+  for (const name of ["social", "review", "work-1", "a.b_c", "Social", "X"]) {
+    assert.equal(resolveProfileName(name), name);
+  }
+  assert.equal(resolveProfileName("  social  "), "social");
+  // "console" merely starts with a reserved name; it is not itself reserved.
+  assert.equal(resolveProfileName("console"), "console");
+});
+
+test("resolveProfileName rejects traversal, separators, and absolute paths", () => {
+  for (const bad of [
+    "",
+    "   ",
+    "..",
+    ".",
+    "a/b",
+    "a\\b",
+    "/abs",
+    "../escape",
+    "./x",
+    ".hidden",
+    "-flag",
+    "a/../b",
+    "profiles/x",
+    "a b",
+    "a\tb",
+    "a\u0000b",
+  ]) {
+    assert.throws(
+      () => resolveProfileName(bad),
+      TypeError,
+      `should reject ${JSON.stringify(bad)}`,
+    );
+  }
+});
+
+test("resolveProfileName rejects OS-reserved device names on every platform", () => {
+  for (const bad of ["con", "CON", "nul", "Nul", "com1", "LPT9", "aux", "prn"]) {
+    assert.ok(isReservedProfileName(bad));
+    assert.throws(() => resolveProfileName(bad), TypeError);
+  }
+});
+
+test("resolveProfileName rejects non-strings and over-long names", () => {
+  assert.throws(() => resolveProfileName(5), TypeError);
+  assert.throws(() => resolveProfileName({}), TypeError);
+  assert.throws(
+    () => resolveProfileName("a".repeat(MAX_PROFILE_NAME_LENGTH + 1)),
+    TypeError,
+  );
+  assert.equal(
+    resolveProfileName("a".repeat(MAX_PROFILE_NAME_LENGTH)).length,
+    MAX_PROFILE_NAME_LENGTH,
+  );
+});
+
+// --- Path layout -----------------------------------------------------------
+
+test("profileDirFor keeps the default profile path byte-for-byte", () => {
+  const root = path.join("home", "browser");
+  // Exactly the value the client computed before named profiles existed.
+  assert.equal(profileDirFor(root), path.join(root, "profile"));
+  assert.equal(profileDirFor(root, undefined), path.join(root, "profile"));
+  assert.equal(profileDirFor(root, null), path.join(root, "profile"));
+});
+
+test("profileDirFor nests named profiles under profiles/<name>", () => {
+  const root = path.join("home", "browser");
+  assert.equal(profileDirFor(root, "social"), path.join(root, "profiles", "social"));
+  assert.equal(profileDirFor(root, "review"), path.join(root, "profiles", "review"));
+  assert.throws(() => profileDirFor(root, "a/b"), TypeError);
+});
+
+// --- Lock behaviour: default unchanged -------------------------------------
+
+test("the default profile uses the historical lock location", () => {
+  const browser = makeTempDir("bw-profiles-");
+  const runtime = path.join(browser, "runtime");
+  const def = profileDirFor(browser);
+  assert.equal(def, path.join(browser, "profile"));
+
+  const lock = acquireProfileLock(def, runtime);
+  try {
+    assert.equal(lock.ephemeral, false);
+    assert.equal(lock.profileDir, path.join(browser, "profile"));
+    assert.equal(lock.lockDir, profileLockDirFor(path.join(browser, "profile")));
+  } finally {
+    releaseProfileLockDir(lock);
+  }
+});
+
+// --- Lock behaviour: concurrent DIFFERENT profiles -------------------------
+
+test("different named profiles hold independent locks and run concurrently", () => {
+  const browser = makeTempDir("bw-profiles-");
+  const runtime = path.join(browser, "runtime");
+  const social = profileDirFor(browser, "social");
+  const review = profileDirFor(browser, "review");
+  assert.equal(social, path.join(browser, "profiles", "social"));
+
+  const a = acquireProfileLock(social, runtime);
+  const b = acquireProfileLock(review, runtime);
+  try {
+    // Neither falls back: both own their own persistent profile at once, so a
+    // logged-in "social" and a logged-in "review" run side by side.
+    assert.equal(a.ephemeral, false);
+    assert.equal(b.ephemeral, false);
+    assert.equal(a.profileDir, social);
+    assert.equal(b.profileDir, review);
+    assert.notEqual(a.lockDir, b.lockDir);
+    assert.ok(fs.existsSync(a.lockDir));
+    assert.ok(fs.existsSync(b.lockDir));
+    assert.ok(fs.existsSync(social));
+    assert.ok(fs.existsSync(review));
+  } finally {
+    releaseProfileLockDir(a);
+    releaseProfileLockDir(b);
+  }
+});
+
+// --- Lock behaviour: concurrent SAME profile -------------------------------
+
+test("the same named profile still serializes with the ephemeral fallback", () => {
+  const browser = makeTempDir("bw-profiles-");
+  const runtime = path.join(browser, "runtime");
+  const social = profileDirFor(browser, "social");
+
+  const first = acquireProfileLock(social, runtime);
+  const second = acquireProfileLock(social, runtime);
+  try {
+    assert.equal(first.ephemeral, false);
+    assert.equal(first.profileDir, social);
+    // The contended second instance gets an isolated ephemeral profile under
+    // the SHARED runtime dir — exactly how the default profile behaves today,
+    // so a named profile is never corrupted by concurrent same-name use.
+    assert.equal(second.ephemeral, true);
+    assert.notEqual(second.profileDir, social);
+    assert.ok(second.profileDir.startsWith(runtime));
+    assert.match(second.warning, /temporary profile without saved logins/);
+  } finally {
+    releaseProfileLockDir(first);
+    releaseProfileLockDir(second);
+  }
+});
+
+// --- Client layer: shared vs scoped ----------------------------------------
+
+test("BetterWright scopes only the profile directory; vault, artifacts, runtime stay shared", async () => {
+  const home = makeTempDir("bw-profiles-home-");
+  const def = new BetterWright({ home });
+  const social = new BetterWright({ home, profile: "social" });
+  const review = new BetterWright({ home, profile: "review" });
+  try {
+    const c0 = def._workerConfig();
+    const cs = social._workerConfig();
+    const cr = review._workerConfig();
+
+    // Default is byte-for-byte the historical path; names nest under profiles/.
+    assert.equal(c0.profileDir, path.join(home, "browser", "profile"));
+    assert.equal(cs.profileDir, path.join(home, "browser", "profiles", "social"));
+    assert.equal(cr.profileDir, path.join(home, "browser", "profiles", "review"));
+    assert.notEqual(cs.profileDir, cr.profileDir);
+
+    // Everything else is shared across profiles.
+    for (const key of ["runtimeDir", "artifactsDir", "downloadsDir"]) {
+      assert.equal(cs[key], c0[key]);
+      assert.equal(cr[key], c0[key]);
+    }
+    // The vault is shared: same encrypted store regardless of profile, so a
+    // credential saved once is reachable from every profile.
+    assert.equal(def.vault.dir, path.join(home, "vault"));
+    assert.equal(social.vault.dir, def.vault.dir);
+    assert.equal(review.vault.dir, def.vault.dir);
+  } finally {
+    await def.close();
+    await social.close();
+    await review.close();
+  }
+});
+
+test("BetterWright rejects an invalid profile name at construction", () => {
+  const home = makeTempDir("bw-profiles-home-");
+  for (const bad of ["a/b", "..", "/abs", "", "con"]) {
+    assert.throws(() => new BetterWright({ home, profile: bad }), TypeError);
+  }
+});

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -66,6 +66,7 @@ const options: BetterWrightOptions = {
   browser: "cloak",
   headless: "auto",
   downloadPolicy: "ask",
+  profile: "social",
 };
 const browser = new BetterWright(options);
 const vaultOptions: LocalCredentialVaultOptions = { home: "/tmp/betterwright-types" };

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -25,6 +25,20 @@ export type {
 
 export interface BetterWrightOptions {
   home?: string;
+  /**
+   * Named persistent browser profile inside the home. Omit it (the default) to
+   * keep the single `browser/profile` directory unchanged. A name selects an
+   * independent, separately-locked profile at `browser/profiles/<name>`, so
+   * different names run concurrently — each fully logged in — while the same
+   * name still serializes behind the ephemeral fallback. The vault, artifacts,
+   * and CloakBrowser binary cache stay shared across profiles.
+   *
+   * Names allow letters, digits, ".", "-", and "_", must start with a letter
+   * or digit, and cannot contain path separators or "..". They are as
+   * case-sensitive as the underlying filesystem. An invalid name throws a
+   * `TypeError` at construction.
+   */
+  profile?: string;
   policy?: NetworkPolicy;
   /** Custom credential backend, or false/null to disable the built-in vault. */
   vault?: CredentialVault | false | null;


### PR DESCRIPTION
# Named, lockable browser profiles in one BetterWright home

## The limitation

All BetterWright state lives under `$BETTERWRIGHT_HOME`, and a home has exactly
**one** persistent browser profile at `browser/profile`. Per
`docs/attach-mode.md`, only one process may own it at a time; a second
concurrent worker receives an isolated ephemeral profile from `browser/runtime`
rather than corrupting the persistent one.

That is the right safety behaviour, but it makes **concurrency and logged-in
state mutually exclusive**. A second concurrent run gets an ephemeral profile —
a signed-out browser. So any host that wants to run browser work in parallel
must serialize every run behind one global lock, even when the runs touch
completely unrelated sites and unrelated accounts.

## Why it matters

The framing is *concurrency vs. logged-in state*. Today you can have one or the
other, never both. A host running, say, a "social" worker that holds the
X/LinkedIn logins and a "review" worker that reads and screenshots pages cannot
run them at the same time without one of them being silently signed out.

## The feature

Named profiles inside one home. A caller picks a profile by name; each name is
an independent persistent profile with its own lock. Different names run
concurrently, each fully logged in. The same name still serializes with the
existing ephemeral fallback.

```js
new BetterWright({ profile: "social" }); // holds the X / LinkedIn logins
new BetterWright({ profile: "review" }); // reads and screenshots, concurrently
```

- **Library:** new `profile?: string` option on the `BetterWright`
  constructor, alongside `home`.
- **CLI:** `--profile <name>` on `run` / `repl` / `agent`.
- **MCP:** `BETTERWRIGHT_PROFILE` environment variable (matching how
  `BETTERWRIGHT_TIMEZONE` / `BETTERWRIGHT_LOCALE` are already read).

## Default behaviour is unchanged

**Omitting `profile` changes nothing.** The default profile directory stays
`browser/profile`, byte-for-byte, with the same lock at
`browser/profile.betterwright-lock`. There is **no migration, move, or copy** of
any existing profile — an install with cookies in `browser/profile/` keeps using
exactly that directory. This is covered by tests
(`profileDirFor keeps the default profile path byte-for-byte`,
`the default profile uses the historical lock location`).

## How it works

- `src/profile-name.ts` resolves a name to a directory: no name →
  `browser/profile` (unchanged); a name → `browser/profiles/<name>`.
- The profile **lock is already derived from the profile directory**
  (`profileLockDirFor(profileDir)` → `<profileDir>.betterwright-lock`), so
  scoping the directory scopes the lock for free. `acquireProfileLock` and its
  ephemeral-runtime fallback are untouched — same-profile contention behaves
  exactly as before.
- Only the profile directory and its lock are scoped. The **vault, `artifacts/`,
  the CloakBrowser binary cache, and `browser/runtime/` stay shared**, so a
  credential saved once is reachable from any profile.

### Scope decisions called out in the brief

- **Vault is not scoped.** `createLocalCredentialVault({ home })` still keys off
  the home only, so a credential saved from one profile is usable from every
  profile. Verified in
  `BetterWright scopes only the profile directory; vault, artifacts, runtime stay shared`.
- **Daemon socket stays per-home.** The session daemon holds one browser (hence
  one profile). Rather than derive a per-profile socket path — which risks the
  104/108-byte `sun_path` limit that `docs/architecture.md` documents, and which
  the brief explicitly wants avoided — the profile rides in the daemon's
  **config signature** (`normalizeDaemonConfig`). A daemon serves one profile at
  a time; a client that requests a different profile than the running daemon
  holds sees a signature mismatch and falls back to a private in-process browser
  **scoped to the profile it asked for**. So cross-profile concurrency always
  works; only daemon-side session persistence is limited to one profile per home
  at a time. This keeps the socket path length invariant and never runs a client
  on the wrong profile.
- **Name validation is a strict allowlist**, not a blocklist: letters, digits,
  `.`, `-`, `_`, must start with a letter or digit, max 64 chars. That rejects
  path separators, `..`, absolute paths, leading dots/dashes, whitespace, and
  NUL by construction; Windows reserved device names (`CON`, `NUL`, `COM1`…) are
  rejected on every platform for portability. An invalid name throws a
  `TypeError` at construction. A name can never escape `browser/profiles/`.
- **Case sensitivity is explicit:** names are used verbatim as a directory
  segment, so they are as case-sensitive as the filesystem — two profiles on a
  case-sensitive volume, one on a case-insensitive one. BetterWright does not
  fold case itself (that would rename directories out from under an install).

## No changes to security-sensitive behaviour

No changes to network policy, download policy, or credential handling. The guard
proxy, the network floor, redaction, and the vault API are untouched. The diff
adds one small pure module, threads one option through the client / CLI / MCP /
daemon-config, and updates docs and tests.

## Tests

- New `tests/node/profiles.test.mjs`: name validation (traversal, separators,
  absolute paths, reserved names, NUL, over-long, non-string), default path
  byte-for-byte, named-path layout, **concurrent different profiles** (both hold
  independent locks, neither falls back), **concurrent same profile** (second
  gets the ephemeral fallback), and the shared-vs-scoped split at the client
  layer.
- One additive line in `tests/types/package.test.ts` exercises the new
  `profile` field against the published declarations.
- The existing suite passes unmodified (`npm run release:check`: lint,
  typecheck, `check:build`, unit tests, `test:types`, `check:package`).

## Docs

- `docs/architecture.md` — State-on-disk tree now shows `browser/profiles/`,
  plus a "Named profiles" subsection covering the lock model, the shared-vs-
  scoped split, and the deliberate per-home daemon-socket decision.
- `docs/attach-mode.md` — a "Named profiles for concurrency" subsection.
- `README.md` and `CHANGELOG.md` updated.

## Verification on this branch

Run against upstream `main` at `dadc775`:

- `tests/node/profiles.test.mjs` — 12/12 pass.
- `npm run lint`, `npm run typecheck`, `npm run test:types`, `npm run check:build` — clean.
- `npm run release:check` — 616 pass, 1 fail: `vault.test.mjs` →
  `simultaneous stale-lock recovery cannot unlink a fresh writer lock`
  (`VAULT_LOCK_TIMEOUT`). That test **also fails on pristine `main`** on the same
  machine, and this diff touches no vault code — it looks like a load-sensitive
  lock-timeout flake on a busy host, not a regression here.