### PR TITLE
Ship the Windows x64 Chromium fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ step from what it sees, in a browser that must still be there next turn:
 | [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
 | [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel — no extra dependency |
 | [**Cloaking V2**](docs/cloaking-v2.md) | Coherent native fingerprint: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; live reCAPTCHA v3 returns 0.9 headed and headless |
-| [**Native Chromium fork**](docs/chromium-fork.md) | Optional BetterWright-built Chromium: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. Auto-detected at `~/.betterwright/chromium/`; platforms without an artifact (Windows) stay on managed CloakBrowser |
+| [**Native Chromium fork**](docs/chromium-fork.md) | Optional BetterWright-built Chromium: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. Auto-detected at `~/.betterwright/chromium/` on macOS arm64, Linux x64, and Windows x64 |
 | [**Skill packs**](docs/skills.md) | Per-site and per-password-manager guidance the host agent reads on demand — surfaced automatically when an open page matches |
 | [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time |
 | [**Operator guidance**](docs/agent-prompt.md) | `betterwright skill` / `agentSystemPrompt()` — decisive action on authorized tasks, with optional confirmation/spending guardrails |
@@ -239,7 +239,7 @@ step from what it sees, in a browser that must still be there next turn:
 ## Install
 
 Requires **Node.js 22+**. Setup downloads the browser (~200 MB, once) — the
-Chromium fork on macOS arm64 / Linux x64, CloakBrowser elsewhere — never as an
+Chromium fork on macOS arm64 / Linux x64 / Windows x64, CloakBrowser elsewhere — never as an
 npm lifecycle side effect, so installs stay predictable with `--ignore-scripts`.
 
 ```bash

--- a/SETUP.md
+++ b/SETUP.md
@@ -61,11 +61,11 @@ client it does not know), or when you want to do it deliberately.
 3. **Download the managed browser** (one-time, ~200 MB):
 
    ```bash
-   betterwright setup     # Chromium fork on mac/linux + Cloak fallback
+   betterwright setup     # Chromium fork on supported hosts + Cloak fallback
    # or: betterwright update   # fork only (switches default away from Cloak)
    ```
 
-   On macOS arm64 / Linux x64, setup/update fetch the pinned Chromium fork
+   On macOS arm64 / Linux x64 / Windows x64, setup/update fetch the pinned Chromium fork
    (SHA-256 verified) into `~/.betterwright/chromium/`. Elsewhere (and with
    `--cloak-only`), the CloakBrowser wrapper downloads its signed binary from
    CloakHQ. npm installation itself has no hidden browser-download lifecycle

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -462,7 +462,7 @@ async function cmdSetup(flags, { quiet = false }: any = {}) {
     console.log("\nSetup complete. Run `betterwright doctor` to confirm.");
     if (!cloakOnly) {
       console.log(
-        "On macOS arm64 / Linux x64, doctor should report browser: chromium-fork after update/setup.",
+        "On macOS arm64 / Linux x64 / Windows x64, doctor should report browser: chromium-fork after update/setup.",
       );
     }
   }

--- a/docs/attach-mode.md
+++ b/docs/attach-mode.md
@@ -2,7 +2,7 @@
 
 BetterWright launches its managed browser — the [Chromium
 fork](chromium-fork.md) when its artifact is installed (macOS arm64 / Linux
-x64), CloakBrowser otherwise. Headed and headless runs use the same persistent
+x64 / Windows x64), CloakBrowser otherwise. Headed and headless runs use the same persistent
 profile, fingerprint identity, network floor, download controls, and browser
 worker. There is no stock-Chromium fallback and no ordinary-Chrome CDP attach
 mode.

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -2,10 +2,10 @@
 
 BetterWright can run the pinned BetterWright Chromium 150 fork while keeping
 its public `run()`, `human.*`, `captcha.*`, snapshot, policy, proxy, and vault
-APIs unchanged. On macOS arm64 and Linux x64, `betterwright setup` /
-`betterwright update` download the fork into the zero-config discovery root;
-CloakBrowser remains the fallback when no artifact is present (and the only
-path on Windows today).
+APIs unchanged. On macOS arm64, Linux x64, and Windows x64,
+`betterwright setup` / `betterwright update` download the fork into the
+zero-config discovery root; CloakBrowser remains the fallback when no artifact
+is present.
 
 ## Install / update
 
@@ -46,8 +46,7 @@ artifacts/
   win-x64/chrome.exe
 ```
 
-Only macOS arm64 and Linux x64 are built and runtime-tested. Windows is reserved
-for a future verified artifact.
+macOS arm64, Linux x64, and Windows x64 are built and runtime-tested.
 
 `BETTERWRIGHT_CHROMIUM_PATH` takes precedence over
 `BETTERWRIGHT_CHROMIUM_ROOT`. Configured paths must be absolute and must exist;
@@ -58,17 +57,18 @@ BetterWright fails closed instead of silently falling back to another browser.
 With neither variable set, BetterWright checks the default root
 `~/.betterwright/chromium/` for the current platform's artifact. Found → the
 fork runs with no configuration at all. Not found (or no artifact shipped for
-the platform, e.g. Windows) → managed CloakBrowser, exactly as before.
+the platform) → managed CloakBrowser, exactly as before.
 
 ```text
 ~/.betterwright/chromium/
   mac-arm64/Chromium.app/Contents/MacOS/Chromium
   linux-x64/chrome          (+ fonts/ttf/ for the macOS-metric font set)
+  win-x64/chrome.exe
 ```
 
 This makes mixed fleets trivial: run `betterwright update` (or `setup`) on
-Linux and macOS hosts, `betterwright setup --cloak-only` on Windows, and every
-machine picks the right backend with the same configuration. Set
+macOS arm64, Linux x64, and Windows x64 hosts, and every machine picks the
+right backend with the same configuration. Set
 `BETTERWRIGHT_CHROMIUM_ROOT=off` (or `BETTERWRIGHT_CHROMIUM_PATH=off`) to force
 the managed path on a host that has the artifact installed.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,8 +62,8 @@ new BetterWright version is adopted.
 
 ### Managed CloakBrowser backend
 
-On platforms without a public fork artifact (Windows today), or when you pass
-`--cloak-only`, launches use CloakBrowser. `betterwright setup` asks the
+On platforms without a public fork artifact, or when you pass `--cloak-only`,
+launches use CloakBrowser. `betterwright setup` asks the
 pinned official wrapper to fetch the correct binary directly from CloakHQ's
 release source and verify the published checksums with its pinned Ed25519
 signature before extraction. BetterWright ships the wrapper integration, not
@@ -87,7 +87,7 @@ doctor` reports both versions. For a reproducible deployment, set a full
 `CLOAKBROWSER_VERSION`; to keep an already installed build from checking for a
 newer stable build, set `CLOAKBROWSER_AUTO_UPDATE=false`.
 
-### Native Chromium fork (default on macOS arm64 / Linux x64)
+### Native Chromium fork (default on macOS arm64 / Linux x64 / Windows x64)
 
 `betterwright setup` and `betterwright update` download BetterWright's own
 Chromium build into `~/.betterwright/chromium/` (SHA-256 verified from the
@@ -111,8 +111,7 @@ Resolution order:
 2. Zero-config discovery at `~/.betterwright/chromium/<platform>/`: if the
    artifact for this platform exists there, it is used automatically
    (this is what `update` / default `setup` populate).
-3. Otherwise the managed CloakBrowser backend. Platforms with no shipped
-   artifact (Windows) always land here.
+3. Otherwise the managed CloakBrowser backend.
 
 Force the managed path even with an artifact installed:
 
@@ -162,9 +161,8 @@ opened that directory, falling back to Cloak fails closed
 hosts, or delete `browser/profile` when switching backends (saved site
 logins in that profile are lost).
 
-A typical split: **Linux and macOS hosts get the fork artifact, Windows hosts
-run `betterwright setup` and stay on CloakBrowser** — one config, no branching
-in your deployment code.
+macOS arm64, Linux x64, and Windows x64 hosts all get the fork artifact with
+one config and no platform branching in deployment code.
 
 ## Your first run
 

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -25,8 +25,8 @@ new BetterWright({
 ```
 
 The `browser` option is not how you choose a browser: when the [Chromium
-fork](chromium-fork.md) artifact is installed (macOS arm64 / Linux x64), it is
-used automatically, with managed CloakBrowser as the fallback. Headed and
+fork](chromium-fork.md) artifact is installed (macOS arm64 / Linux x64 /
+Windows x64), it is used automatically, with managed CloakBrowser as the fallback. Headed and
 headless modes keep BetterWright's persistent profile and policy while reducing
 common stock-browser automation signals; they do not guarantee undetectability.
 

--- a/src/chromium-fork-install.ts
+++ b/src/chromium-fork-install.ts
@@ -3,7 +3,7 @@
 // and by default `betterwright setup` on platforms that ship an artifact.
 //
 // Pattern matches Playwright/Cloak: the npm package is the driver; the
-// ~200 MB browser zip is fetched from a pinned GitHub Release and verified
+// browser zip is fetched from a pinned GitHub Release and verified
 // with SHA-256 before extract. Apple-licensed fonts are intentionally not
 // in the public zip (see scripts/assemble-mac-fonts.sh).
 
@@ -90,11 +90,18 @@ function downloadToFile(url, destPath, { redirectsLeft = 5 }: any = {}) {
   });
 }
 
-function extractZip(zipPath, destDir) {
+function extractZip(
+  zipPath,
+  destDir,
+  {
+    platform = process.platform,
+    spawn = spawnSync,
+  } = {},
+) {
   fs.mkdirSync(destDir, { recursive: true, mode: 0o755 });
-  if (process.platform === "darwin") {
+  if (platform === "darwin") {
     // ditto preserves macOS app bundle metadata better than unzip.
-    const result = spawnSync(
+    const result = spawn(
       "ditto",
       ["-x", "-k", zipPath, destDir],
       { encoding: "utf8" },
@@ -106,20 +113,27 @@ function extractZip(zipPath, destDir) {
     }
     return;
   }
-  const result = spawnSync("unzip", ["-oq", zipPath, "-d", destDir], {
+
+  const command = platform === "win32" ? "tar.exe" : "unzip";
+  const args = platform === "win32"
+    ? ["-xf", zipPath, "-C", destDir]
+    : ["-oq", zipPath, "-d", destDir];
+  const result = spawn(command, args, {
     encoding: "utf8",
   });
   if (result.status !== 0) {
     throw new Error(
-      `unzip failed: ${result.stderr || result.stdout || "unknown error"}`,
+      `${command} extract failed: ${result.stderr || result.stdout || "unknown error"}`,
     );
   }
 }
 
+export const _extractZipForTest = extractZip;
+
 /**
  * Install (or refresh) the Chromium fork for this platform into
  * `~/.betterwright/chromium`. Returns `{ binary, root, skipped }` where
- * `skipped` is set when this platform has no public artifact (e.g. Windows).
+ * `skipped` is set when this platform has no public artifact.
  *
  * `download` / `extract` are injectable for unit tests.
  */

--- a/src/chromium-fork.ts
+++ b/src/chromium-fork.ts
@@ -77,6 +77,11 @@ export const CHROMIUM_FORK_ASSETS = Object.freeze({
     sha256:
       "45ffef258415057d70b71639424dc681284babf533939d32375f99585a136d31",
   }),
+  "win32-x64": Object.freeze({
+    name: "betterwright-chromium-win-x64.zip",
+    sha256:
+      "977cb811fdc7198723865b741b24da329128d5d1d519f5599e2b4cb1b9dadafa",
+  }),
 });
 
 function configuredValue(value) {
@@ -96,7 +101,7 @@ export function defaultChromiumForkRoot({ home = os.homedir() } = {}) {
  *     configured-but-missing binary is an error).
  *  2. The default root (~/.betterwright/chromium) — if the artifact for this
  *     platform exists there, use it silently. Platforms without a shipped
- *     artifact (e.g. Windows) fall through to managed CloakBrowser.
+ *     artifact fall through to managed CloakBrowser.
  *  3. Either variable set to "off" forces the managed CloakBrowser path.
  */
 export function resolveChromiumForkBinary({

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -60,7 +60,7 @@ Safe to re-run: it reports what is already done and changes only what is not.`,
 
   setup: `Usage: betterwright setup [options]
 
-Download the managed browser (~200 MB, once). On macOS arm64 and Linux x64
+Download the managed browser (once). On macOS arm64, Linux x64, and Windows x64
 this installs BetterWright's Chromium fork into ~/.betterwright/chromium/ and
 the CloakBrowser binary as a fallback; elsewhere, CloakBrowser alone.
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -83,6 +83,16 @@ export async function cloakRuntime() {
   }
 }
 
+/** Missing adjacent fonts only expose host fontconfig on Linux. */
+export function missingForkFontsWarning({
+  chromiumFork,
+  chromiumForkFonts,
+  platform = process.platform,
+}) {
+  if (platform !== "linux" || !chromiumFork || chromiumForkFonts) return null;
+  return "fork binary has no fonts/ttf beside it; host fontconfig will leak (Linux tell). Deploy the macOS-metric font bundle next to chrome.";
+}
+
 /** Build the readiness report `betterwright doctor` prints. */
 export async function doctorReport() {
   const core = resolveCoreDir();
@@ -108,10 +118,10 @@ export async function doctorReport() {
   }
   const browser = chromiumFork ? "chromium-fork" : "cloak";
   const chromiumForkFonts = chromiumFork ? forkFontsDir(chromiumFork) : null;
-  const chromiumForkFontsWarning =
-    chromiumFork && !chromiumForkFonts
-      ? "fork binary has no fonts/ttf beside it; host fontconfig will leak (Linux tell). Deploy the macOS-metric font bundle next to chrome."
-      : null;
+  const chromiumForkFontsWarning = missingForkFontsWarning({
+    chromiumFork,
+    chromiumForkFonts,
+  });
   const ready =
     workerOk &&
     version === PINNED_PLAYWRIGHT_VERSION &&
@@ -305,7 +315,7 @@ export function doctorChecks(
   } else if (report.chromium_fork_error) {
     add("Browser", "Chromium fork", "fail", report.chromium_fork_error, "Run `betterwright update`, or unset BETTERWRIGHT_CHROMIUM_PATH/ROOT.");
   } else {
-    add("Browser", "Chromium fork", "warn", "not installed — using CloakBrowser", "Run `betterwright update` for the fork (macOS arm64 / Linux x64 only).");
+    add("Browser", "Chromium fork", "warn", "not installed — using CloakBrowser", "Run `betterwright update` for the fork (macOS arm64 / Linux x64 / Windows x64).");
   }
   add(
     "Browser",

--- a/tests/node/chromium-fork-install.test.ts
+++ b/tests/node/chromium-fork-install.test.ts
@@ -10,12 +10,13 @@ import {
   CHROMIUM_FORK_RELEASE_TAG,
 } from "../../dist/src/chromium-fork.js";
 import {
+  _extractZipForTest,
   chromiumForkAssetForHost,
   installChromiumFork,
 } from "../../dist/src/chromium-fork-install.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
-test("public fork assets are pinned for mac-arm64 and linux-x64", () => {
+test("public fork assets are pinned for mac-arm64, linux-x64, and win32-x64", () => {
   assert.equal(CHROMIUM_FORK_RELEASE_TAG, `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}`);
   assert.equal(
     chromiumForkAssetForHost({ platform: "darwin", arch: "arm64" })?.name,
@@ -25,21 +26,61 @@ test("public fork assets are pinned for mac-arm64 and linux-x64", () => {
     chromiumForkAssetForHost({ platform: "linux", arch: "x64" })?.name,
     "betterwright-chromium-linux-x64.zip",
   );
-  assert.equal(chromiumForkAssetForHost({ platform: "win32", arch: "x64" }), null);
+  assert.equal(
+    chromiumForkAssetForHost({ platform: "win32", arch: "x64" })?.name,
+    "betterwright-chromium-win-x64.zip",
+  );
   for (const asset of Object.values<any>(CHROMIUM_FORK_ASSETS)) {
     assert.match(asset.sha256, /^[a-f0-9]{64}$/);
   }
 });
 
-test("installChromiumFork skips platforms without a public artifact", async () => {
+test("installChromiumFork skips unsupported platforms without a public artifact", async () => {
   const result = await installChromiumFork({
-    platform: "win32",
-    arch: "x64",
+    platform: "linux",
+    arch: "arm64",
     home: "/tmp/bw-home",
     log() {},
   });
   assert.match(result.skipped, /No public Chromium fork artifact/);
   assert.equal(result.binary, null);
+});
+
+test("Windows fork extraction uses the built-in tar executable", () => {
+  const calls = [];
+  const destDir = makeTempDir("bw-fork-extract-");
+  try {
+    _extractZipForTest("C:\\tmp\\fork.zip", destDir, {
+      platform: "win32",
+      spawn: (command, args, options) => {
+        calls.push({ command, args, options });
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    assert.deepEqual(calls, [{
+      command: "tar.exe",
+      args: ["-xf", "C:\\tmp\\fork.zip", "-C", destDir],
+      options: { encoding: "utf8" },
+    }]);
+  } finally {
+    fs.rmSync(destDir, { recursive: true, force: true });
+  }
+});
+
+test("Windows fork extraction reports tar failures", () => {
+  const destDir = makeTempDir("bw-fork-extract-fail-");
+  try {
+    assert.throws(
+      () =>
+        _extractZipForTest("C:\\tmp\\fork.zip", destDir, {
+          platform: "win32",
+          spawn: () => ({ status: 2, stdout: "", stderr: "bad archive" }),
+        }),
+      /tar\.exe extract failed: bad archive/,
+    );
+  } finally {
+    fs.rmSync(destDir, { recursive: true, force: true });
+  }
 });
 
 test("installChromiumFork short-circuits when already installed", async () => {
@@ -62,19 +103,19 @@ test("installChromiumFork short-circuits when already installed", async () => {
   assert.match(logs.join("\n"), /already installed/);
 });
 
-test("installChromiumFork downloads, verifies SHA-256, and extracts", async () => {
+test("installChromiumFork downloads, verifies, and installs the Windows layout", async () => {
   const home = makeTempDir("bw-fork-home-");
   const payload = Buffer.from("betterwright-chromium-test-zip");
   const sha256 = createHash("sha256").update(payload).digest("hex");
   const assets = {
-    "linux-x64": { name: "test-linux.zip", sha256 },
+    "win32-x64": { name: "test-windows.zip", sha256 },
   };
-  const binaryRel = path.join("linux-x64", "chrome");
+  const binaryRel = path.join("win-x64", "chrome.exe");
   let downloadedUrl = null;
 
   try {
     const result = await installChromiumFork({
-      platform: "linux",
+      platform: "win32",
       arch: "x64",
       home,
       force: true,
@@ -93,12 +134,12 @@ test("installChromiumFork downloads, verifies SHA-256, and extracts", async () =
     });
     assert.equal(
       downloadedUrl,
-      `https://github.com/BetterWright/betterwright/releases/download/${CHROMIUM_FORK_RELEASE_TAG}/test-linux.zip`,
+      `https://github.com/BetterWright/betterwright/releases/download/${CHROMIUM_FORK_RELEASE_TAG}/test-windows.zip`,
     );
     assert.equal(result.alreadyInstalled, false);
     assert.equal(
       result.binary,
-      path.join(home, ".betterwright", "chromium", "linux-x64", "chrome"),
+      path.join(home, ".betterwright", "chromium", "win-x64", "chrome.exe"),
     );
     assert.ok(fs.existsSync(result.binary));
   } finally {

--- a/tests/node/chromium-fork.test.ts
+++ b/tests/node/chromium-fork.test.ts
@@ -41,7 +41,6 @@ test("default root discovers a deployed artifact (zero-config fork)", () => {
 });
 
 test("platforms without a deployed artifact fall back to managed CloakBrowser", () => {
-  // Windows: layout exists but no artifact shipped.
   assert.equal(
     resolveChromiumForkBinary({
       env: {},
@@ -134,7 +133,7 @@ test("explicit Chromium fork path wins and must be absolute", () => {
   );
 });
 
-test("artifact root resolves native macOS and Linux layouts", () => {
+test("artifact root resolves native macOS, Linux, and Windows layouts", () => {
   assert.equal(
     resolveChromiumForkBinary({
       env: { BETTERWRIGHT_CHROMIUM_ROOT: "/opt/betterwright" },
@@ -159,6 +158,15 @@ test("artifact root resolves native macOS and Linux layouts", () => {
       existsSync: present,
     }),
     path.join("/opt/betterwright", "linux-x64", "chrome"),
+  );
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: { BETTERWRIGHT_CHROMIUM_ROOT: "/opt/betterwright" },
+      platform: "win32",
+      arch: "x64",
+      existsSync: present,
+    }),
+    path.join("/opt/betterwright", "win-x64", "chrome.exe"),
   );
 });
 

--- a/tests/node/onboard.test.ts
+++ b/tests/node/onboard.test.ts
@@ -9,6 +9,7 @@ import test from "node:test";
 import {
   doctorChecks,
   formatDoctorChecks,
+  missingForkFontsWarning,
   modelReadiness,
   modelSetupHint,
   preferredModelId,
@@ -285,6 +286,42 @@ test("doctor checks translate a raw report into fixable lines", () => {
   const failures = broken.filter((check) => check.status === "fail");
   assert.ok(failures.length >= 2);
   assert.ok(failures.every((check) => check.fix));
+});
+
+test("doctor only warns about missing fork font bundles on Linux", () => {
+  const chromiumFork = "/x/fork/chrome";
+  assert.match(
+    missingForkFontsWarning({
+      chromiumFork,
+      chromiumForkFonts: null,
+      platform: "linux",
+    }),
+    /fontconfig/,
+  );
+  assert.equal(
+    missingForkFontsWarning({
+      chromiumFork,
+      chromiumForkFonts: null,
+      platform: "win32",
+    }),
+    null,
+  );
+  assert.equal(
+    missingForkFontsWarning({
+      chromiumFork,
+      chromiumForkFonts: null,
+      platform: "darwin",
+    }),
+    null,
+  );
+  assert.equal(
+    missingForkFontsWarning({
+      chromiumFork,
+      chromiumForkFonts: "/x/fork/fonts",
+      platform: "linux",
+    }),
+    null,
+  );
 });
 
 test("doctor output groups checks and marks each status", () => {


### PR DESCRIPTION
## Summary

- add the verified Windows x64 Chromium 150 artifact to BetterWright's pinned release manifest
- install Windows zip artifacts with the built-in `tar.exe`, with focused success and failure coverage
- make the fork the zero-config default on supported Windows hosts and update CLI/docs
- keep the fontconfig bundle warning Linux-only so Windows doctor output reflects DirectWrite correctly

No new production dependency is added. CloakBrowser remains the explicit/fallback backend when the fork is disabled or absent.

## Verification

- `npm run release:check` (655 tests, 650 passed, 5 skipped, 0 failed)
- Windows native validation on `testbench`: V8 inspector 441/441, headless/headed fork probes, setContent, attach, identity, BetterWright E2E, and live reCAPTCHA v3 score 0.9
- fresh public GitHub release download, SHA-256 validation, built-in Windows extraction, and launch smoke
- current BetterWright default-backend E2E passed headless and headed with `navigator.webdriver === false`
- Windows `betterwright doctor --json`: `browser: chromium-fork`, `ready: true`

Artifact: `betterwright-chromium-win-x64.zip` on `chromium-150.0.7871.129`
SHA-256: `977cb811fdc7198723865b741b24da329128d5d1d519f5599e2b4cb1b9dadafa`