### PR TITLE
Fix dormant CAPTCHA detection in modern auth flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Managed Cloak sessions now allow native service-worker registration, matching
+  the Chromium-fork path and ordinary Chrome behavior while keeping all worker
+  traffic behind the policy guard proxy.
+- Dormant CAPTCHA providers preloaded in hidden or zero-size iframes no longer
+  appear as active challenges. A visible widget or blocking verification prompt
+  is still detected and follows the existing solve/handoff flow.
+
 ### Added
 
 - Named browser profiles: `profile` on the `BetterWright` constructor,

--- a/docs/cloaking-v2.md
+++ b/docs/cloaking-v2.md
@@ -26,6 +26,7 @@ hardware, automation markers, and client hints.
 | Timezone | `--fingerprint-timezone`, so `Intl` and `Date` agree |
 | GPU, plugins, hardware | CloakBrowser source-level fingerprint patches |
 | JavaScript APIs | Left native; no replacement getters or functions |
+| Service workers | Allowed natively on both managed-browser backends; traffic still crosses the policy guard |
 
 That last row is important. Fresh stock Chrome 150 leaves `chrome.runtime`
 unavailable to ordinary web pages and can initially enumerate zero speech
@@ -92,6 +93,11 @@ Interactive CAPTCHA issuance is a separate gate. In the current public-demo
 runs, Turnstile remained at `processing` without a token in both modes, while
 reCAPTCHA v2 escalated to an image grid that requires vision. The report prints
 `tokenIssued` explicitly so those outcomes cannot be mistaken for a pass.
+
+Sites frequently preload invisible Enterprise CAPTCHA providers before a form
+is submitted. BetterWright reports those frames only after their iframe becomes
+visible or the page presents an explicit blocking verification prompt, so a
+dormant provider cannot derail an otherwise normal signup or login flow.
 
 ## Configuration
 

--- a/src/captcha-solver.ts
+++ b/src/captcha-solver.ts
@@ -130,12 +130,14 @@ export function classifyChallengeStage(metadata: any = {}) {
       url: stringValue(frame.url),
       title: stringValue(frame.title),
       text: stringValue(frame.text),
+      visible: typeof frame.visible === "boolean" ? frame.visible : null,
     })),
     {
       kind: "main",
       url: stringValue(main.url ?? input.url),
       title: stringValue(main.title ?? input.title),
       text: stringValue(main.text ?? input.text),
+      visible: true,
     },
   ];
 
@@ -145,6 +147,10 @@ export function classifyChallengeStage(metadata: any = {}) {
   let source = sources[sources.length - 1];
 
   for (const candidate of sources) {
+    // Sites preload dormant CAPTCHA providers in hidden iframes. They are not
+    // an interactive stage until the frame becomes visible or the host page
+    // presents an explicit blocking prompt.
+    if (candidate.kind === "frame" && candidate.visible === false) continue;
     const text = normalizedText(`${candidate.title}\n${candidate.text}`);
     const url = candidate.url.toLowerCase();
     const parsed = parsedUrl(candidate.url);

--- a/src/challenges.ts
+++ b/src/challenges.ts
@@ -74,6 +74,7 @@ function normalizeSource(value, kind, index = null, fallback: any = {}) {
     title: stringValue(source.title ?? fallback.title),
     text: stringValue(source.text ?? fallback.text),
     completed: source.completed === true,
+    visible: typeof source.visible === "boolean" ? source.visible : null,
   };
 }
 
@@ -116,6 +117,14 @@ function explicitInvisible(url) {
 }
 
 function challengeUrlSignal(source, includeInvisible = false) {
+  // Provider widgets are commonly preloaded in zero-size/hidden iframes long
+  // before a site asks the user to verify anything. Treating their URL alone
+  // as an active challenge derails normal forms and makes agents attempt a
+  // CAPTCHA that has not been issued. Visible prompt text can still identify
+  // a real escalation through genericTextSignal below.
+  if (!includeInvisible && source.kind === "frame" && source.visible === false) {
+    return null;
+  }
   const parsed = parsedUrl(source.url);
   if (!parsed) return null;
 
@@ -189,6 +198,7 @@ function searchProviderTextSignal(main) {
 }
 
 function genericTextSignal(source) {
+  if (source.kind === "frame" && source.visible === false) return null;
   const title = normalizedText(source.title);
   const body = normalizedText(source.text);
   const text = `${title} ${body}`.trim();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1561,7 +1561,11 @@ async function ensureBrowser(config) {
         args: launchArgs,
         contextOptions: {
           acceptDownloads: true,
-          serviceWorkers: "block",
+          // Service workers are normal browser behavior and many modern apps
+          // (including authentication flows) depend on registration succeeding.
+          // The SOCKS guard remains the network security boundary for worker
+          // traffic, so allowing them does not bypass policy enforcement.
+          serviceWorkers: "allow",
         },
         launchOptions: {
           downloadsPath: launchConfig.downloadsDir,
@@ -3888,6 +3892,29 @@ async function collectFrameMetadata(page) {
       .filter((frame) => frame !== page.mainFrame())
       .slice(0, 24)
       .map(async (frame) => {
+        const presentation = await frame
+          .frameElement()
+          .then(async (element) => {
+            try {
+              return await element.evaluate((iframe) => {
+                const rect = iframe.getBoundingClientRect();
+                const style = getComputedStyle(iframe);
+                return {
+                  visible:
+                    rect.width > 0 &&
+                    rect.height > 0 &&
+                    style.display !== "none" &&
+                    style.visibility !== "hidden" &&
+                    Number(style.opacity || "1") > 0,
+                  width: rect.width,
+                  height: rect.height,
+                };
+              });
+            } finally {
+              await element.dispose().catch(() => {});
+            }
+          })
+          .catch(() => null);
         const frameText = (
           await frame
             .locator("body")
@@ -3904,6 +3931,9 @@ async function collectFrameMetadata(page) {
         return {
           url: frame.url(),
           text: frameText,
+          visible: presentation?.visible ?? null,
+          width: presentation?.width ?? null,
+          height: presentation?.height ?? null,
           completed:
             checked ||
             /verification (?:complete|successful)|success!|you are verified/i.test(
@@ -4257,8 +4287,9 @@ async function detectCaptchaOnPage(page) {
     type: challenge?.type,
   });
   const widgets = [];
-  for (const frame of page.frames()) {
-    if (frame === page.mainFrame()) continue;
+  const childFrames = page.frames().filter((frame) => frame !== page.mainFrame());
+  for (const [index, frame] of childFrames.entries()) {
+    if (metadata.frames[index]?.visible === false) continue;
     const url = frame.url() || "";
     for (const [provider, pattern] of Object.entries(WIDGET_FRAME_PATTERNS)) {
       if (pattern.test(url)) {

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -97,6 +97,45 @@ test("navigate and read the title", opts, async () => {
   }
 });
 
+test("managed Cloak sessions preserve native service-worker behavior", opts, async () => {
+  const site = await listen((request, response) => {
+    if (request.url === "/sw.js") {
+      response.writeHead(200, {
+        "content-type": "application/javascript",
+        "service-worker-allowed": "/",
+      });
+      response.end("self.addEventListener('fetch', () => {});");
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><title>Service worker fixture</title>");
+  });
+  const bw = new BetterWright({
+    home: tempHome(),
+    policy: new NetworkPolicy(),
+    headless: true,
+  });
+  try {
+    const result = await bw.run(`
+      await page.goto(${JSON.stringify(site.origin)});
+      return page.evaluate(async () => {
+        const registration = await navigator.serviceWorker.register('/sw.js');
+        await navigator.serviceWorker.ready;
+        return {
+          scope: registration.scope,
+          active: Boolean(registration.active),
+        };
+      });
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.active, true);
+    assert.equal(result.result.scope, `${site.origin}/`);
+  } finally {
+    await bw.close();
+    await site.close();
+  }
+});
+
 test("page summaries identify the active tab", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/captcha-solver.test.ts
+++ b/tests/node/captcha-solver.test.ts
@@ -27,6 +27,22 @@ test("classifies reCAPTCHA anchor as checkbox", () => {
   assert.equal(result.needsVision, false);
 });
 
+test("does not classify hidden dormant provider frames as active stages", () => {
+  const result = classifyChallengeStage({
+    main: { url: "https://shop.example/signup" },
+    frames: [
+      {
+        url: "https://www.google.com/recaptcha/enterprise/anchor?k=site-key",
+        text: "Verify you are human",
+        visible: false,
+      },
+    ],
+  });
+  assert.equal(result.stage, CAPTCHA_STAGES.NONE);
+  assert.equal(result.autoSolvable, false);
+  assert.equal(result.needsVision, false);
+});
+
 test("classifies reCAPTCHA bframe as image grid", () => {
   const result = classifyChallengeStage({
     main: { url: "https://shop.example/checkout" },

--- a/tests/node/challenges.test.ts
+++ b/tests/node/challenges.test.ts
@@ -251,6 +251,22 @@ test("ignores explicitly invisible provider frames without a blocking prompt", (
   }
 });
 
+test("ignores hidden dormant provider frames even without an invisible URL marker", () => {
+  for (const url of [
+    "https://www.google.com/recaptcha/enterprise/anchor?k=key",
+    "https://newassets.hcaptcha.com/captcha/v1/build/static/hcaptcha.html#frame=challenge",
+    "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0",
+  ]) {
+    assert.equal(
+      detectBotChallenge({
+        main: { url: "https://example.com/signup" },
+        frames: [{ url, visible: false, text: "Verify you are human" }],
+      }),
+      null,
+    );
+  }
+});
+
 test("uses visible frame text to report an interactive challenge from an invisible widget", () => {
   for (const [url, provider] of [
     ["https://www.google.com/recaptcha/api2/anchor?k=key&size=invisible", "recaptcha"],


### PR DESCRIPTION
## Summary

- ignore hidden or zero-size CAPTCHA provider iframes until they become interactive
- propagate iframe visibility into challenge detection and solver stage classification
- allow native service workers in managed Cloak sessions while retaining the guard proxy as the network security boundary
- cover dormant Enterprise reCAPTCHA and managed service-worker behavior with regression tests

## Root cause

Modern signup pages such as Reddit preload Enterprise reCAPTCHA in a hidden iframe. BetterWright previously treated the provider URL alone as proof of an active challenge, so an agent could abandon a normal form and enter CAPTCHA handling before a challenge existed. The managed Cloak backend also blocked service workers even though the Chromium-fork backend allowed them, creating a web-visible behavior difference and potentially breaking modern authentication flows.

This change records iframe layout visibility and excludes hidden provider frames from challenge detection and stage classification. Visible widgets and explicit blocking verification prompts continue through the existing solve or handoff flow.

A separate Reddit network-security block observed during diagnosis is controlled by Reddit and exit-network reputation; this patch does not claim to bypass server-side abuse controls.

## Validation

- `npm run lint` (passes with four pre-existing benchmark warnings)
- `npm run typecheck`
- `npm run check:build`
- `npm run test:types`
- `npm run check:package`
- targeted challenge and solver unit tests: 31 passed
- managed service-worker browser regression test: passed
- full unit run: 647 passed, 5 skipped, with two unrelated timing failures; both failing tests passed immediately when rerun in isolation