### PR TITLE
Release BetterWright 1.5.1 beta

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,6 +82,25 @@ jobs:
       - name: Test managed CloakBrowser headed mode
         if: steps.existing.outputs.published != 'true'
         run: xvfb-run -a env BETTERWRIGHT_CLOAK_E2E=1 BETTERWRIGHT_CHROMIUM_ROOT=off node --test tests/node/cloak.test.js
+      - name: Select npm distribution tag
+        if: steps.existing.outputs.published != 'true'
+        id: npm_tag
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
+              echo "Prerelease package versions must use a GitHub prerelease." >&2
+              exit 1
+            fi
+            echo "tag=beta" >> "$GITHUB_OUTPUT"
+          else
+            if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+              echo "Stable package versions cannot use a GitHub prerelease." >&2
+              exit 1
+            fi
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish to npm with provenance
         if: steps.existing.outputs.published != 'true'
-        run: npm publish --access public --tag latest
+        run: npm publish --access public --tag "${{ steps.npm_tag.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.5.1-beta.0] - 2026-07-26
+
 ### Fixed
 
 - Managed Cloak sessions now allow native service-worker registration, matching

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.5.0
+generated_by: betterwright@1.5.1-beta.0
 ---
 
 # Browser tool: BetterWright

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.5.0",
+      "version": "1.5.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- version BetterWright as `1.5.1-beta.0`
- publish the merged dormant-CAPTCHA and service-worker fixes as a GitHub prerelease
- keep prerelease npm packages on the `beta` distribution tag instead of replacing `latest`
- refresh the generated BetterWright skill metadata for the beta version

## Release impact

This packages the fixes merged in #71. Hidden or zero-size CAPTCHA provider frames no longer interrupt ordinary signup and login flows, while visible challenges and explicit blocking prompts continue through the existing solve or handoff flow. Managed Cloak sessions also preserve native service-worker behavior behind the network guard.

The npm workflow now fails closed when GitHub release type and SemVer stability disagree. Prerelease versions publish under `beta`; stable versions continue under `latest`.

## Validation

- `npm run release:check`
- 649 runnable unit tests passed; 5 opt-in live CAPTCHA tests skipped
- type declarations passed
- package smoke test passed for `betterwright-1.5.1-beta.0.tgz`
