### PR TITLE
Release BetterWright 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Releases before 1.1.3 predate this file; their notes live on the
   appear as active challenges. A visible widget or blocking verification prompt
   is still detected and follows the existing solve/handoff flow.
 
+### Changed
+
+- Completed the repository-wide TypeScript migration for build and release
+  scripts, tests, benchmarks, and shipped examples. Published examples now live
+  under `examples/typescript/*.ts` and are type-checked against the public
+  declarations; runtime package exports remain ordinary JavaScript.
+
 ### Added
 
 - The pinned BetterWright Chromium 150 fork now ships for Windows x64 in
@@ -308,6 +315,7 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
+[1.5.1]: https://github.com/BetterWright/betterwright/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/BetterWright/betterwright/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/BetterWright/betterwright/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/BetterWright/betterwright/compare/v1.3.0...v1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
-## [1.5.1-beta.0] - 2026-07-26
+## [1.5.1] - 2026-07-28
 
 ### Fixed
 
@@ -22,6 +22,13 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ### Added
 
+- The pinned BetterWright Chromium 150 fork now ships for Windows x64 in
+  addition to macOS arm64 and Linux x64. `betterwright setup` and
+  `betterwright update` verify and install the Windows artifact using the
+  built-in `tar.exe`, then select it as the zero-configuration default.
+  CloakBrowser remains the explicit or automatic fallback when the fork is
+  disabled or absent. Windows doctor output also avoids the Linux-only
+  fontconfig warning because Windows uses DirectWrite.
 - Named browser profiles: `profile` on the `BetterWright` constructor,
   `--profile <name>` on the CLI, and `BETTERWRIGHT_PROFILE` for the MCP server
   and any shell (the flag wins). A

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.5.1-beta.0
+generated_by: betterwright@1.5.1
 ---
 
 # Browser tool: BetterWright

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.5.1-beta.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.5.1-beta.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.5.1-beta.0",
+  "version": "1.5.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- promote `1.5.1-beta.0` to stable `1.5.1`
- retain the beta's dormant-CAPTCHA, service-worker, and named-profile changes
- include CuriosityOS's merged Windows x64 Chromium-fork work from #70
- record the Windows artifact, built-in `tar.exe` extraction, zero-config selection, CloakBrowser fallback, and platform-correct doctor behavior in the stable changelog
- record the post-1.5.0 TypeScript migration of build/release scripts, tests, benchmarks, and shipped examples
- refresh package, lockfile, and generated skill version metadata together

## Integration audit

The beta tag `v1.5.1-beta.0` is an ancestor of current `main`. PR #70 was brought up to date through merge commit `248debb`, whose second parent is the beta release commit `8836b81`, before CuriosityOS merged it as `165aaba`. The final tree therefore includes both lines without dropping the beta fixes.

The original Windows feature patch and its merged delta have the same patch ID, and the final merge tree is the clean union of both parents.

## Validation

- `npm ci`
- `npm run release:check`
  - 657 tests: 652 passed, 5 opt-in live tests skipped, 0 failed
  - type declarations passed
  - package smoke test passed for `betterwright-1.5.1.tgz`
- `node scripts/check-versions.js --tag v1.5.1`
