### PR TITLE
pi: honor BETTERWRIGHT_PROFILE for a separate persistent identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ new BetterWright({ profile: "review" }); // the reading account, concurrently
 Omitting `profile` keeps the single default profile, unchanged. The vault and
 artifacts are shared across profiles, so a credential saved once fills
 anywhere. CLI: `--profile <name>` or `BETTERWRIGHT_PROFILE`, which the MCP
-server reads too. See
+server and the Pi extension read too. See
 [docs/sessions.md](docs/sessions.md#sessions-vs-profiles).
 
 ## Docs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ ephemeral profile from `browser/runtime` (a signed-out browser) rather than
 corrupting it.
 
 `profile: "<name>"` (CLI `--profile <name>` or `BETTERWRIGHT_PROFILE`, which
-the MCP server reads too) selects a **separate identity**: an independent persistent profile at
+the MCP server and the Pi extension read too) selects a **separate identity**: an independent persistent profile at
 `browser/profiles/<name>`, with its own cookie jar, its own lock
 (`browser/profiles/<name>.betterwright-lock`, a sibling of the directory), its
 own [session daemon](sessions.md), and its own `exec` transcripts. Two

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -64,7 +64,8 @@ betterwright close --all     # stops every profile's daemon
 ```
 
 `BETTERWRIGHT_PROFILE=social` sets the identity for a whole shell (and is the
-only way to set it for the MCP server); `--profile` beats it. Both run at once
+only way to set it for the MCP server and the Pi extension); `--profile`
+beats it. Both run at once
 and both stay signed in, because each profile locks its own directory under
 `$BETTERWRIGHT_HOME/browser/profiles/`. Two runs of the *same*
 profile still serialize: the second gets an isolated, signed-out ephemeral

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -8,6 +8,7 @@ import {
   piImageContent,
   piPrimaryImageArtifact,
 } from "./pi.js";
+import { resolveProfileName } from "./profile-name.js";
 import { agentSystemPrompt } from "./prompt.js";
 import { piBrowserToolParameters, piLoginToolParameters } from "./tool-schemas.js";
 
@@ -125,7 +126,7 @@ function normalizedMaxSteps(value) {
   return parsed;
 }
 
-function resolvedBrowserOptions(options) {
+function resolvedBrowserOptions(options, profile) {
   const timeout = envPositiveInteger("BETTERWRIGHT_PI_TIMEOUT_SECONDS", 0);
   const downloadPolicy = String(
     process.env.BETTERWRIGHT_PI_DOWNLOAD_POLICY || "",
@@ -136,6 +137,7 @@ function resolvedBrowserOptions(options) {
     ...(options || {}),
     ...(timeout ? { defaultTimeout: timeout } : {}),
     ...(downloadPolicy ? { downloadPolicy } : {}),
+    ...(profile ? { profile } : {}),
   };
 }
 
@@ -412,6 +414,15 @@ export function createPiExtension(options: any = {}) {
     const startUrl = normalizedStartUrl(
       options.startUrl ?? process.env.BETTERWRIGHT_PI_START_URL,
     );
+    // Same identity knob as the CLI and MCP server: a named profile is a
+    // separate persistent cookie jar with its own lock, so two Pi sessions
+    // with different profiles run concurrently, both signed in. Resolved
+    // eagerly so an invalid name surfaces at extension load, not as a
+    // mysteriously signed-out browser later.
+    const profile = resolveProfileName(
+      String(options.profile ?? process.env.BETTERWRIGHT_PROFILE ?? "").trim() ||
+        undefined,
+    );
     let browser = options.browser || null;
     let startPromise = null;
     let pendingStartWarning = "";
@@ -447,7 +458,9 @@ export function createPiExtension(options: any = {}) {
 
     async function getBrowser() {
       if (!browser)
-        browser = new BetterWright(resolvedBrowserOptions(options.browserOptions));
+        browser = new BetterWright(
+          resolvedBrowserOptions(options.browserOptions, profile),
+        );
       if (startUrl && !startPromise) {
         startPromise = browser
           .run(

--- a/tests/node/pi-extension.test.ts
+++ b/tests/node/pi-extension.test.ts
@@ -432,6 +432,20 @@ test("native Pi extension reports invalid configuration and recovers from start 
     () => createPiExtension({ startUrl: "file:///tmp/page.html" })(new FakePi()),
     /http or https/,
   );
+  // Profile names become path segments; an invalid one must fail at
+  // extension load (option or BETTERWRIGHT_PROFILE env), not at first browse.
+  assert.throws(
+    () => createPiExtension({ profile: "../escape" })(new FakePi()),
+    /profile/i,
+  );
+  process.env.BETTERWRIGHT_PROFILE = "bad name";
+  try {
+    assert.throws(() => createPiExtension({})(new FakePi()), /profile/i);
+  } finally {
+    delete process.env.BETTERWRIGHT_PROFILE;
+  }
+  // A valid name is accepted (identity wiring is covered by resolvedBrowserOptions).
+  createPiExtension({ browser: new FakeBrowser({}), profile: "work" })(new FakePi());
 
   const { dir, screenshot } = await fixture();
   const browser = new FakeBrowser({ startFails: true, screenshot });

--- a/types/pi-extension.d.ts
+++ b/types/pi-extension.d.ts
@@ -12,6 +12,7 @@ export interface PiExtensionOptions {
   closeBrowserOnShutdown?: boolean;
   guardrails?: Guardrails;
   maxSteps?: number;
+  profile?: string;
   requireEvidence?: boolean;
   session?: string;
   startUrl?: string;


### PR DESCRIPTION

The CLI and the MCP server both read `BETTERWRIGHT_PROFILE` so two processes
on one home can run as different signed-in identities; the docs describe the
env var as setting "the identity for a whole shell". The Pi extension
silently ignored it — so a second concurrent Pi session always contended for
the default profile and fell over to the ephemeral, signed-out fallback,
with no way to opt into a named persistent profile.

Resolve the profile eagerly (`options.profile` over the env var, mirroring
the MCP server's `profileFromEnv` semantics) so an invalid name fails at
extension load rather than as a mysteriously signed-out browser later, and
pass it to the constructed BetterWright alongside the other env-resolved
options. The three doc references to "which the MCP server reads too" now
include the Pi extension.

## Testing

* `npm run release:check` green.
* Unit tests: an invalid profile (path-escaping name, via option and via
  env) throws at extension load; a valid name is accepted.
* Verified live: two concurrent Pi sessions on one machine, one on the
  default profile, one with `BETTERWRIGHT_PROFILE=scratch` — no lock
  contention, both persistent, vault shared across both.
