### PR TITLE
Optimize Linux Chromium RAM and CPU use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Changed
+
+- The Linux x64 Chromium fork now uses file-backed FontDataService transport
+  and a four-renderer soft limit. These reduce summed Chromium PSS by at least
+  25% at 1, 5, 10, and 20 same-site tabs in the validated four-vCPU workload,
+  while preserving full Site Isolation, process locks, fingerprint output,
+  and an explicit `--renderer-process-limit` override.
+
 ## [1.5.1] - 2026-07-28
 
 ### Fixed

--- a/docs/chromium-fork-patches.md
+++ b/docs/chromium-fork-patches.md
@@ -1,4 +1,4 @@
-# Chromium Fork Fingerprint Patch Set
+# Chromium Fork Patch Set
 
 Build-side patches for the pinned BetterWright Chromium 150 fork. The JS
 layer (`src/fork-identity.ts`) already masks UA, UA-CH, `navigator.platform`,
@@ -116,7 +116,77 @@ the rendered buffer. Must be stable per profile and distinct per seed.
   Georgia 307 / Palatino 307 / Avenir Next 304) instead of collapsing to one
   fallback.
 
-## 8. Build flags
+## 8. Linux font-data file sharing
+
+Apply `patches/chromium-150/font-data-file-sharing.patch` from the Chromium
+source root. It was validated at Chromium
+`e69b30bba288603e514cffb4c79c359cac68e923` and Skia
+`bee4c917220040e147f14964635ff92ce6c5a3f6`. It makes Skia's
+FontConfig-backed typefaces expose their backing file identity, allowing
+`FontDataService` to send renderers a read-only font file handle instead of
+copying the complete font into an anonymous shared region. TTC indices,
+variation coordinates, synthetic styles, fallback for non-file-backed
+typefaces, and renderer-side per-file mapping remain unchanged.
+
+This is especially important with the bundled Mac-compatible TTC collection:
+the old fallback kept large direct font mappings alongside deleted
+`/tmp/.org.chromium.*` copies. Validate with:
+
+```bash
+autoninja -C out/LinuxSelective chrome font_data_service_unittests
+out/LinuxSelective/font_data_service_unittests \
+  --test-launcher-bot-mode --gtest_color=no
+```
+
+The focused test must report file-handle results on Linux while the explicit
+memory-fallback tests continue to report valid shared regions. Resource
+benchmarks must use summed Chromium PSS and verify that process counts, tab
+counts, font metrics, canvas/audio hashes, and live detector verdicts remain
+unchanged.
+
+## 9. Linux renderer soft limit
+
+Apply `patches/chromium-150/renderer-process-soft-limit.patch` from the
+Chromium source root. The patch makes four the Linux fork's default **soft**
+renderer-process limit, retaining an explicit `--renderer-process-limit`
+override for diagnostics or higher-capacity deployments. The default is set
+through `RenderProcessHost::SetMaxRendererProcessCount()` during Linux startup,
+the same global-override path as the command-line switch. Do not implement it
+only through `ContentBrowserClient::GetMaxRendererProcessCountOverride()`:
+Chromium 150's `RemoveRendererProcessLimit` feature can bypass calculated or
+embedder limits while deliberately preserving explicit/global overrides.
+
+This does not disable Site Isolation or remove process locks. Once four
+renderer hosts exist, Chromium's existing `GetExistingProcessHost()` path may
+reuse only a suitable renderer; distinct locked sites, origins, profiles,
+storage partitions, and cross-origin-isolated contexts still receive separate
+processes and may exceed the soft limit. The result is bounded same-site
+process sharing. On hosts where more same-site renderer parallelism is more
+important than memory, override the default with
+`BETTERWRIGHT_CHROMIUM_ARGS=--renderer-process-limit=N`.
+
+The exact compiled Linux artifact reduced summed Chromium PSS by 29.62%,
+29.81%, 25.96%, and 28.50% at 1/5/10/20 X.com tabs versus the PGO control.
+Concurrent deterministic throughput changed by +0.55% to +1.42%, while live
+CPU-seconds per 1,000 operations improved by 1.55% to 8.67%. Validate all of
+the following on any rebuilt artifact:
+
+- Six distinct test sites still create at least six site-locked renderers when
+  the configured soft limit is four.
+- Same-site tabs begin sharing only after the limit, while all tabs retain
+  independent page lifecycle and DOM state.
+- Summed Chromium PSS is measured at 1, 5, 10, and 20 tabs against a build
+  without this patch; do not use summed RSS.
+- Concurrent fixed-content responsiveness, live-site CPU, headed/headless
+  fingerprints, detector verdicts, and open/use/close lifecycle checks pass.
+
+Chromium's own `SitePerProcessBrowserTest.MainFrameProcessReuseWhenOverLimit`
+and `SubframeProcessReuseWhenOverLimit` cover the security invariant: even
+with a limit of one, different sites remain in different processes while
+eligible same-site documents may reuse a process. The deliberate stability
+tradeoff is that co-resident same-site tabs share renderer crash/debugger fate.
+
+## 10. Build flags
 
 `out/LinuxStatic` builds with `proprietary_codecs=true`,
 `ffmpeg_branding="Chrome"`, `is_component_build=false`, `target_cpu="x64"`.

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -16,10 +16,12 @@ betterwright setup           # fork (when shipped) + CloakBrowser fallback
 betterwright setup --cloak-only
 ```
 
-Artifacts come from the GitHub Release tag `chromium-<version>` (see
-`CHROMIUM_FORK_RELEASE_TAG` / `CHROMIUM_FORK_ASSETS` in
-`src/chromium-fork.ts`). Each zip is SHA-256 pinned in that manifest before
-extract. Apple-licensed fonts are **not** in the public zip.
+Artifacts come from a revisioned GitHub Release tag such as
+`chromium-<version>-r2` (see `CHROMIUM_FORK_RELEASE_TAG` /
+`CHROMIUM_FORK_ASSETS` in `src/chromium-fork.ts`). Revisioning keeps older
+published BetterWright packages bound to their original immutable assets.
+Each zip is SHA-256 pinned in the manifest before extract. Apple-licensed
+fonts are **not** in the public zip.
 
 ## Runtime Selection
 

--- a/patches/chromium-150/font-data-file-sharing.patch
+++ b/patches/chromium-150/font-data-file-sharing.patch
@@ -1,0 +1,134 @@
+diff --git a/components/services/font_data/BUILD.gn b/components/services/font_data/BUILD.gn
+index 2305b75361..6b0cf621f8 100644
+--- a/components/services/font_data/BUILD.gn
++++ b/components/services/font_data/BUILD.gn
+@@ -30,6 +30,24 @@ source_set("lib") {
+   public_deps = [ "//skia" ]
+ }
+ 
++test("font_data_service_unittests") {
++  sources = [ "font_data_service_impl_unittest.cc" ]
++  deps = [
++    ":lib",
++    "//base",
++    "//base/test:test_support",
++    "//components/services/font_data/public/mojom",
++    "//mojo/core/test:run_all_unittests",
++    "//mojo/public/cpp/bindings",
++    "//mojo/public/cpp/system",
++    "//skia",
++    "//testing/gtest",
++    "//ui/gfx",
++  ]
++
++  data_deps = [ "//third_party/test_fonts" ]
++}
++
+ source_set("unit_tests") {
+   testonly = true
+   sources = [ "font_data_service_impl_unittest.cc" ]
+diff --git a/components/services/font_data/font_data_service_impl.cc b/components/services/font_data/font_data_service_impl.cc
+index 4917c5780e..b8500a4334 100644
+--- a/components/services/font_data/font_data_service_impl.cc
++++ b/components/services/font_data/font_data_service_impl.cc
+@@ -121,12 +121,6 @@ std::tuple<base::File, uint64_t> FontDataServiceImpl::GetFileHandle(
+   typeface.getResourceName(&font_path);
+   base::UmaHistogramBoolean("Chrome.FontDataService.EmptyPathOnGetFileHandle",
+                             font_path.isEmpty());
+-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
+-  // TODO(crbug.com/463411679): `getResourceName()` is not implemented for
+-  // Linux nor ChromeOS, so the returned file will always be invalid and a
+-  // memory region will be shared instead.
+-  CHECK(font_path.isEmpty());
+-#endif  // BUILDFLAG(IS_LINUX)
+   if (font_path.isEmpty()) {
+     return {};
+   }
+diff --git a/components/services/font_data/font_data_service_impl_unittest.cc b/components/services/font_data/font_data_service_impl_unittest.cc
+index 67971d6712..21f9fa97cd 100644
+--- a/components/services/font_data/font_data_service_impl_unittest.cc
++++ b/components/services/font_data/font_data_service_impl_unittest.cc
+@@ -208,18 +208,10 @@ TEST_F(FontDataServiceImplUnitTest, MatchFamilyName) {
+   font_service_->MatchFamilyName(
+       family_name, CreateTypefaceStyle(400, 5, mojom::TypefaceSlant::kRoman),
+       &out_result);
+-#if BUILDFLAG(IS_WIN)
+   EXPECT_EQ(impl_.GetCacheSizeForTesting(), 0u);
+   EXPECT_TRUE(out_result->typeface_data->is_font_file());
+   EXPECT_TRUE(
+       out_result->typeface_data->get_font_file()->file_handle.IsValid());
+-#else
+-  // For now, on Linux/ChromeOS we always hit the memory region fallback, and
+-  // therefore also adds to the cache.
+-  EXPECT_EQ(impl_.GetCacheSizeForTesting(), 1u);
+-  EXPECT_TRUE(out_result->typeface_data->is_region());
+-  EXPECT_TRUE(out_result->typeface_data->get_region().IsValid());
+-#endif
+ }
+ 
+ TEST_F(FontDataServiceImplUnitTest, MatchFamilyNameMemoryCacheSize) {
+@@ -339,15 +331,9 @@ TEST_F(FontDataServiceImplUnitTest, LegacyMakeTypefaceNullFamilyName) {
+   font_service_->LegacyMakeTypeface(
+       std::nullopt, CreateTypefaceStyle(400, 5, mojom::TypefaceSlant::kRoman),
+       &out_result);
+-#if BUILDFLAG(IS_WIN)
+   EXPECT_TRUE(out_result->typeface_data->is_font_file());
+   EXPECT_TRUE(
+       out_result->typeface_data->get_font_file()->file_handle.IsValid());
+-#else
+-  // For now, on Linux/ChromeOS we always hit the memory region fallback.
+-  EXPECT_TRUE(out_result->typeface_data->is_region());
+-  EXPECT_TRUE(out_result->typeface_data->get_region().IsValid());
+-#endif
+ }
+ 
+ #if BUILDFLAG(IS_WIN)
+diff --git a/third_party/skia/src/ports/SkFontConfigTypeface.h b/third_party/skia/src/ports/SkFontConfigTypeface.h
+index 6ea63cb..d657faf 100644
+--- a/third_party/skia/src/ports/SkFontConfigTypeface.h
++++ b/third_party/skia/src/ports/SkFontConfigTypeface.h
+@@ -65,6 +65,7 @@ protected:
+     }
+ 
+     void onGetFontDescriptor(SkFontDescriptor*, bool*) const override;
++    int onGetResourceName(SkString* resourceName) const override;
+     std::unique_ptr<SkStreamAsset> onOpenStream(int* ttcIndex) const override;
+ 
+     void onGetFamilyName(SkString* familyName) const override {
+diff --git a/third_party/skia/src/ports/SkFontMgr_FontConfigInterface.cpp b/third_party/skia/src/ports/SkFontMgr_FontConfigInterface.cpp
+index 16e3a2b..c1c46da 100644
+--- a/third_party/skia/src/ports/SkFontMgr_FontConfigInterface.cpp
++++ b/third_party/skia/src/ports/SkFontMgr_FontConfigInterface.cpp
+@@ -27,6 +27,13 @@ std::unique_ptr<SkStreamAsset> SkTypeface_FCI::onOpenStream(int* ttcIndex) const
+     return std::unique_ptr<SkStreamAsset>(fFCI->openStream(this->getIdentity()));
+ }
+ 
++int SkTypeface_FCI::onGetResourceName(SkString* resourceName) const {
++    if (resourceName) {
++        *resourceName = fIdentity.fString;
++    }
++    return 1;
++}
++
+ void SkTypeface_FCI::onGetFontDescriptor(SkFontDescriptor* desc, bool* serialize) const {
+     SkTypeface_proxy::onGetFontDescriptor(desc, serialize);
+     SkString name;
+diff --git a/third_party/skia/tests/FCITest.cpp b/third_party/skia/tests/FCITest.cpp
+index 603a8ba..02a3f36 100644
+--- a/third_party/skia/tests/FCITest.cpp
++++ b/third_party/skia/tests/FCITest.cpp
+@@ -114,6 +114,14 @@ DEF_TEST(FontConfigInterface_MatchStyleNamedInstance, reporter) {
+                 return;
+             }
+ 
++            SkString resource_from_typeface;
++            REPORTER_ASSERT(reporter,
++                            typeface->getResourceName(&resource_from_typeface) == 1,
++                            "Matched font should expose its backing resource.");
++            REPORTER_ASSERT(reporter,
++                            resource_from_typeface == resultIdentity.fString,
++                            "Matched font's resource should match the FontConfig identity.");
++
+             SkString family_from_typeface;
+             typeface->getFamilyName(&family_from_typeface);
+ 

--- a/patches/chromium-150/renderer-process-soft-limit.patch
+++ b/patches/chromium-150/renderer-process-soft-limit.patch
@@ -1,0 +1,20 @@
+diff --git a/content/browser/browser_main_loop.cc b/content/browser/browser_main_loop.cc
+index 90ee66b3e9..5357126f65 100644
+--- a/content/browser/browser_main_loop.cc
++++ b/content/browser/browser_main_loop.cc
+@@ -607,6 +607,15 @@ int BrowserMainLoop::EarlyInitialization() {
+     if (base::StringToSizeT(limit_string, &process_limit)) {
+       RenderProcessHost::SetMaxRendererProcessCount(process_limit);
+     }
++#if BUILDFLAG(IS_LINUX)
++  } else {
++    // BrowserBox sandboxes have four vCPUs. Chromium's memory-derived default
++    // allows dozens of renderers in an 8 GiB sandbox, duplicating substantial
++    // same-site V8 and Blink state without adding useful CPU parallelism. This
++    // remains a soft limit: Site Isolation creates another site-locked process
++    // whenever no existing renderer is suitable.
++    RenderProcessHost::SetMaxRendererProcessCount(4u);
++#endif
+   }
+ 
+   if (parts_)

--- a/src/chromium-fork.ts
+++ b/src/chromium-fork.ts
@@ -60,7 +60,7 @@ export const PLATFORM_LAYOUT = Object.freeze({
 });
 
 /** GitHub release that hosts the per-platform fork zip artifacts. */
-export const CHROMIUM_FORK_RELEASE_TAG = `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}`;
+export const CHROMIUM_FORK_RELEASE_TAG = `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}-r2`;
 
 /**
  * Public download manifest for `betterwright update` / default `setup`.
@@ -75,7 +75,7 @@ export const CHROMIUM_FORK_ASSETS = Object.freeze({
   "linux-x64": Object.freeze({
     name: "betterwright-chromium-linux-x64.zip",
     sha256:
-      "45ffef258415057d70b71639424dc681284babf533939d32375f99585a136d31",
+      "676249346f0fd91e8b2768190efbb958cc20239bedacd6c53d541882a57bf4a0",
   }),
   "win32-x64": Object.freeze({
     name: "betterwright-chromium-win-x64.zip",

--- a/tests/node/chromium-fork-install.test.ts
+++ b/tests/node/chromium-fork-install.test.ts
@@ -17,7 +17,10 @@ import {
 import { makeTempDir } from "./helpers/temp-dir.js";
 
 test("public fork assets are pinned for mac-arm64, linux-x64, and win32-x64", () => {
-  assert.equal(CHROMIUM_FORK_RELEASE_TAG, `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}`);
+  assert.equal(
+    CHROMIUM_FORK_RELEASE_TAG,
+    `chromium-${BETTERWRIGHT_CHROMIUM_VERSION}-r2`,
+  );
   assert.equal(
     chromiumForkAssetForHost({ platform: "darwin", arch: "arm64" })?.name,
     "betterwright-chromium-mac-arm64.zip",


### PR DESCRIPTION
## Summary

- add the validated Linux FontDataService file-handle transport patch
- set the fork's Linux renderer soft limit to four while preserving explicit overrides and Site Isolation
- move browser downloads to the immutable `chromium-150.0.7871.129-r2` release and pin the optimized Linux zip
- document memory, CPU, process-isolation, and same-site crash-fate tradeoffs

## Validated results

Exact compiled-binary summed Chromium PSS versus the PGO control:

| Tabs | Before | Final | Reduction |
|---:|---:|---:|---:|
| 1 | 735.1 MiB | 517.4 MiB | 29.62% |
| 5 | 1039.8 MiB | 729.8 MiB | 29.81% |
| 10 | 1420.6 MiB | 1051.9 MiB | 25.96% |
| 20 | 2148.2 MiB | 1536.1 MiB | 28.50% |

Concurrent fixed-content throughput changed by +0.55% to +1.42%; live CPU-seconds per 1,000 operations improved by 1.55% to 8.67%. Six distinct sites still created six site-locked renderers with a soft limit of four. Headed/headless fingerprint and seven-site detector comparisons had zero regressions.

## Release artifact

- Release: https://github.com/BetterWright/betterwright/releases/tag/chromium-150.0.7871.129-r2
- Linux zip SHA-256: `676249346f0fd91e8b2768190efbb958cc20239bedacd6c53d541882a57bf4a0`
- Nested Chromium SHA-256: `33bf82d29d0b23aec71b2292597913b98a10b5d20e178e5cb7d9090d0e6ecc65`
- The original release remains untouched, so already-published packages retain valid pins.

## Verification

- `npm run release:check` — 652 passed, 5 skipped, 0 failed
- actual 223 MB Linux zip passed SHA-256, `unzip -t`, runtime manifest, headless launch, and real installer extraction tests
- macOS arm64 and Windows x64 release assets are byte-identical to the previous release
