### PR TITLE
Release BetterWright 1.5.2

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   publish:
+    if: startsWith(github.event.release.tag_name, 'v')
     name: Publish trusted package
     runs-on: ubuntu-latest
     environment: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-30
+
 ### Changed
 
 - The Linux x64 Chromium fork now uses file-backed FontDataService transport
@@ -16,6 +18,11 @@ Releases before 1.1.3 predate this file; their notes live on the
   25% at 1, 5, 10, and 20 same-site tabs in the validated four-vCPU workload,
   while preserving full Site Isolation, process locks, fingerprint output,
   and an explicit `--renderer-process-limit` override.
+
+### Fixed
+
+- Chromium-only GitHub Releases no longer start the npm publishing job; only
+  package release tags beginning with `v` may enter Trusted Publishing.
 
 ## [1.5.1] - 2026-07-28
 
@@ -323,6 +330,7 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
+[1.5.2]: https://github.com/BetterWright/betterwright/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/BetterWright/betterwright/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/BetterWright/betterwright/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/BetterWright/betterwright/compare/v1.3.1...v1.4.0

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.5.1
+generated_by: betterwright@1.5.2
 ---
 
 # Browser tool: BetterWright

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- bump BetterWright and the lockfile to 1.5.2
- release the Linux Chromium RAM/CPU optimizations from #76
- stamp the packaged browser skill with 1.5.2
- prevent Chromium-only GitHub Releases from entering the npm publish job

## Verification

- `npm run release:check`
- 652 unit tests passed, 5 skipped, 0 failed
- package smoke test: `betterwright-1.5.2.tgz`, 102 files
- version/tag check: `node scripts/check-versions.js --tag v1.5.2`
- optimized Chromium r2 release and public SHA manifest already verified
