### PR TITLE
Release BetterWright 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-31
+
+A performance release. No API removals and no behavior flags to set: 1.6.1 is a
+drop-in replacement for 1.6.0.
+
+### Added
+
+- **Idle sessions no longer burn CPU.** A headless Chromium target never becomes
+  hidden — `document.visibilityState` stays `"visible"` for the life of the page
+  — so every open page kept its frame loop running at the host refresh rate
+  (measured at ~120 fps) whether or not anything was driving it. A session with
+  five ordinary animated tabs burned **~110% CPU while completely idle**, and
+  four agents made that four times over. BetterWright now parks a session's
+  pages once its last execution unwinds — page script is disabled and animation
+  timelines are set to rate zero — and restores them before the next execution
+  begins, so the quiet window is exactly the model's thinking time.
+
+  Measured on the pinned fork (150.0.7871.129), idling with tabs open:
+
+  | scenario | 1.6.0 | 1.6.1 |
+  | --- | --- | --- |
+  | 1 session, 5 tabs | 97% CPU, 1845 MB | **25% CPU, 1709 MB** |
+  | 4 sessions, 3 tabs each | 129% CPU, 3805 MB | **53% CPU, 3529 MB** |
+
+  Parking never applies in headed mode or while a live view is streaming — a
+  frozen page is a bug when a human is watching one — and it waits for the
+  session to be genuinely idle (750 ms), so an agent's back-to-back calls never
+  pay for it. Pages with credential capture in flight are left running, because
+  the vault sensor lives in an isolated world and script execution is disabled
+  per renderer, not per world. Turn it off with `parkBackgroundPages: false` or
+  `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0`.
+
+  The one behavior change: a page animated by a `requestAnimationFrame` chain
+  does not resume that chain after being parked, because the pending callback
+  never fires and so nothing re-registers it. Everything else — in-page state,
+  `setInterval`/`setTimeout`, CSS and Web Animations, clicks, typing,
+  navigation, screenshots, network, newly registered `requestAnimationFrame`
+  callbacks — resumes normally.
+
+### Changed
+
+- `diffSnapshots` interns snapshot lines before building its LCS table, so the
+  inner loop compares integers instead of strings, and stores the table as
+  `Uint16Array` rather than `Uint32Array` — subsequence lengths are bounded by
+  the 3000-line cap, so the wider type was never needed. A one-sided change
+  (everything added, or everything removed) now skips the table entirely. At
+  the size cap the transient allocation drops from 34 MB to 17 MB per call.
+  Output is unchanged: a randomized suite checks it line for line, tie-breaks
+  included, against the 1.6.0 implementation.
+
+### Fixed
+
+- Parking exposed, and this release fixes, an ordering hazard in how the worker
+  brackets executions: work queued as one execution unwinds could land after
+  the next one had already started. Park/wake now reconcile toward a recorded
+  intent rather than deciding from the state at call time, so whoever asks last
+  wins regardless of the order the CDP traffic lands in.
+
 ## [1.6.0] - 2026-07-31
 
 ### Added
@@ -387,7 +445,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/BetterWright/betterwright/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/BetterWright/betterwright/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/BetterWright/betterwright/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/BetterWright/betterwright/compare/v1.5.0...v1.5.1

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.6.0
+generated_by: betterwright@1.6.1
 ---
 
 # Browser tool: BetterWright

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,6 +164,34 @@ logins in that profile are lost).
 macOS arm64, Linux x64, and Windows x64 hosts all get the fork artifact with
 one config and no platform branching in deployment code.
 
+### Idle CPU and page parking
+
+A headless Chromium page is never "hidden". `document.visibilityState` stays
+`"visible"` for the life of the target, so none of the machinery a headed
+browser uses to stop paying for background tabs ever engages: the frame loop
+free-runs at the host refresh rate, and any page with a spinner, a carousel, or
+a canvas keeps a core busy for as long as the session lives. Nothing in the
+launch arguments changes this.
+
+So BetterWright parks a session's pages once its last execution unwinds —
+disabling page script and setting animation timelines to rate zero — and
+restores them before the next execution starts. The parked window is the model's
+thinking time, which is where all of the waste was. An idle five-tab session
+drops from ~97% CPU to ~25%.
+
+This is on by default and needs no configuration. It never applies in headed
+mode or while a live view is streaming, it waits 750 ms so an agent's
+back-to-back calls never pay for it, and it leaves pages with credential capture
+in flight running. The one visible difference is that a page animated by a
+`requestAnimationFrame` chain does not resume that chain after being parked;
+timers, CSS animations, in-page state, and everything else do. To opt out:
+
+```bash
+export BETTERWRIGHT_PARK_BACKGROUND_PAGES=0
+```
+
+or `new BetterWright({ parkBackgroundPages: false })`.
+
 ## Your first run
 
 A snippet is a string of async Playwright JavaScript. The last expression is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",
@@ -23,7 +23,7 @@
         "typescript": "^7.0.2"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.18.0"
       },
       "optionalDependencies": {
         "patchright-core": "1.61.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -217,6 +217,7 @@ export class BetterWright {
   declare timezone: string | null;
   declare headedInvisible: boolean;
   declare chromiumArgs: string[];
+  declare parkBackgroundPages: boolean | undefined;
   declare platform: "macos" | "windows" | "linux" | null;
   declare defaultTimeout: number;
   declare liveView: Record<string, any>;
@@ -309,6 +310,16 @@ export class BetterWright {
    *   with a `TypeError`, and a switch already present in the managed list is
    *   dropped (with a warning on the next result) so BetterWright's value
    *   always wins.
+   * @param {boolean} [options.parkBackgroundPages=true] quiet each session's
+   *   pages between executions — page script is disabled and animation
+   *   timelines are paused while the model is thinking, and restored before the
+   *   next call runs. A headless target never becomes hidden, so without this
+   *   every open page renders at the host refresh rate for the life of the
+   *   session; parking is what keeps an idle session near zero CPU. Never
+   *   applies in headed mode or while a live view is streaming. The one
+   *   behavior change: a page animated by a `requestAnimationFrame` chain does
+   *   not resume that chain after being parked (CSS/Web Animations do). Set
+   *   `false`, or `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0`, to opt out.
    * @param {object} [options.liveView] defaults for {@link startLiveView}:
    *   `{host, port, interactive, quality, maxWidth, publicHost}`. Defaults to
    *   bind `0.0.0.0` with a LAN `publicHost` so printed URLs open from another
@@ -352,6 +363,13 @@ export class BetterWright {
     // rather than an opaque browser launch failure several calls later. The
     // environment is re-read at launch, so this is validation, not capture.
     this.chromiumArgs = resolveChromiumArgs(options.chromiumArgs);
+    // Tri-state on purpose: `undefined` leaves the decision to the worker,
+    // which also consults BETTERWRIGHT_PARK_BACKGROUND_PAGES and refuses to
+    // park anything a human can see (headed, or a live view streaming).
+    this.parkBackgroundPages =
+      options.parkBackgroundPages === undefined
+        ? undefined
+        : options.parkBackgroundPages !== false;
     if (
       options.platform != null &&
       !["macos", "windows", "linux"].includes(options.platform)
@@ -437,6 +455,7 @@ export class BetterWright {
       headedInvisible: this.headedInvisible,
       platform: this.platform,
       chromiumArgs: this.chromiumArgs,
+      parkBackgroundPages: this.parkBackgroundPages,
       headless: this.headless,
       credentialCapture: this.credentialCapture,
       searchMinIntervalMs: this.searchMinIntervalMs,

--- a/src/page-park.ts
+++ b/src/page-park.ts
@@ -1,0 +1,246 @@
+// Parking: quiet a page's own work while nothing is driving it.
+//
+// WHY. A headed browser stops paying for tabs you are not looking at — a
+// background tab's requestAnimationFrame callbacks stop, its animations stop,
+// its timers are throttled. Headless Chromium has none of that machinery.
+// Every open target reports `document.visibilityState === "visible"` forever
+// and its frame loop free-runs at the host's refresh rate, so a page with an
+// ordinary spinner or canvas keeps a core busy for as long as the session
+// lives. Measured on the pinned fork: one session with five such tabs burned
+// ~110% CPU while the worker sat completely idle. Four agents is four of those.
+//
+// None of the obvious levers move it. Page.setWebLifecycleState("frozen"),
+// Browser.setWindowBounds({windowState:"minimized"}),
+// Emulation.setVirtualTimePolicy("pause"), setFocusEmulationEnabled(false),
+// --disable-gpu, --deterministic-mode, --enable-begin-frame-control and
+// --screen-info were each measured at no better than noise, because none of
+// them makes a headless target non-visible. Making frames cheaper (dropping the
+// 2x device scale factor) does nothing either: the loop is not frame-paced, so
+// it simply renders more of them for the same CPU.
+//
+// WHAT WORKS is stopping the page itself, which is what this module does:
+// disable the page's script execution and set its animation timelines to rate
+// zero. Both are reversible CDP state, both are invisible to automation —
+// Playwright's own evaluate/locator/screenshot calls keep working on a parked
+// page, because CDP evaluation is not page script.
+//
+// WHEN. Only between executions. `parkSession` runs when a session's last
+// in-flight execution unwinds and `unparkSession` runs before the next one
+// begins, so model code never observes a parked page: the window being
+// optimized is exactly the one where the model is thinking and nobody is
+// driving the browser. That scoping is what makes this safe to have on by
+// default.
+//
+// THE COST, stated plainly: a parked page's script does not run. Timers,
+// clicks, typing, navigation, screenshots and network all behave normally on
+// unpark, but a requestAnimationFrame chain is a chain — the pending callback
+// never fires while parked, so nothing re-registers it, and a page whose
+// animation is driven by rAF stays still after it is unparked. Pages animated
+// by CSS/Web Animations resume exactly where they left off. Set
+// `parkBackgroundPages: false` (or BETTERWRIGHT_PARK_BACKGROUND_PAGES=0) to opt
+// out.
+
+/**
+ * Per-page parking state. Weak because it is keyed on Playwright Page objects
+ * whose lifetime this module does not own; a closed page's entry goes away with
+ * it.
+ *
+ * This is a `desired`/`applied` pair reconciled through `chain`, not a boolean,
+ * because the two callers are asymmetric: parking is fired *without* being
+ * awaited as an execution unwinds, while unparking is awaited as the next one
+ * begins. Those overlap constantly — a fast agent starts its next step before
+ * the previous step's park has finished its round trips. Deciding what to do
+ * from the state at call time loses that race (the unpark sees a page that is
+ * not parked *yet*, does nothing, and the in-flight park then disables script
+ * underneath running model code, which is how the credential suite caught it).
+ * Recording the intent and letting the chain converge to it cannot: whoever
+ * writes `desired` last wins, whatever order the CDP traffic lands in.
+ */
+const parkState = new WeakMap();
+
+function stateFor(page) {
+  let state = parkState.get(page);
+  if (!state) {
+    state = {
+      desired: "active",
+      applied: "active",
+      chain: Promise.resolve(),
+      cdp: null,
+      failed: false,
+    };
+    parkState.set(page, state);
+  }
+  return state;
+}
+
+/** Whether this page is currently parked. Exported for tests and diagnostics. */
+export function isParked(page) {
+  return parkState.get(page)?.applied === "parked";
+}
+
+/**
+ * A page's CDP session, created once and reused.
+ *
+ * A parked page is parked for as long as the model is thinking, so the session
+ * is worth keeping: creating one per park/unpark pair would add two round trips
+ * to every agent step, which is the opposite of the point.
+ */
+async function sessionForPage(page, newCDPSession) {
+  const state = stateFor(page);
+  if (state.cdp) return state.cdp;
+  state.cdp = await newCDPSession(page);
+  return state.cdp;
+}
+
+/**
+ * Run `work` after whatever park/unpark is already queued for this page.
+ *
+ * Failures are swallowed and latched into `state.failed`: parking is an
+ * optimization, and a browser that will not park (an old build without the
+ * Animation domain, a target that detached mid-call) must still run. Latching
+ * stops a page that cannot park from paying the failed round trips on every
+ * subsequent step.
+ */
+function enqueue(page, work) {
+  const state = stateFor(page);
+  state.chain = state.chain.then(work, work).catch(() => {
+    state.failed = true;
+  });
+  return state.chain;
+}
+
+/**
+ * Drive the page to whatever `desired` currently says, once the queue reaches
+ * this step. Re-reads `desired` at execution time rather than capturing it, so
+ * a park queued and then countermanded before it ran is simply not applied.
+ *
+ * Order matters within each direction. Parking pauses animations first, while
+ * script can still run, so the page cannot start a fresh one in the gap;
+ * waking restores script first, so the page is live before it is animated
+ * again.
+ */
+function reconcile(page, newCDPSession) {
+  return enqueue(page, async () => {
+    const state = stateFor(page);
+    if (state.applied === state.desired || page.isClosed()) return;
+    if (state.desired === "parked") {
+      const cdp = await sessionForPage(page, newCDPSession);
+      // Animation.enable is idempotent and must precede setPlaybackRate; the
+      // domain reports nothing we consume, it is enabled only to drive the rate.
+      await cdp.send("Animation.enable");
+      await cdp.send("Animation.setPlaybackRate", { playbackRate: 0 });
+      await cdp.send("Emulation.setScriptExecutionDisabled", { value: true });
+      // NOT Memory.forciblyPurgeJavaScriptMemory. Reclaiming the parked page's
+      // V8 heap looks like free memory and measured as a browser-wide crash on
+      // the pinned fork (150.0.7871.129): the call returns success and takes the
+      // whole browser process down with it a moment later, taking every other
+      // session's tabs with it. Parking is not worth a crash.
+      state.applied = "parked";
+      return;
+    }
+    const cdp = state.cdp;
+    if (!cdp) {
+      state.applied = "active";
+      return;
+    }
+    // Waking is on the critical path of every execution — the model is already
+    // waiting — and unlike parking the two calls have no ordering requirement
+    // between them, so they go down the same CDP connection together.
+    await Promise.all([
+      cdp.send("Emulation.setScriptExecutionDisabled", { value: false }),
+      cdp.send("Animation.setPlaybackRate", { playbackRate: 1 }),
+    ]);
+    state.applied = "active";
+  });
+}
+
+/**
+ * Stop a page's own scripts and animations.
+ *
+ * @returns whether *this call* parked the page — false for a page that was
+ *   already parked, is closed, belongs to a browser that refused to park, or
+ *   was woken again before the park reached the front of the queue.
+ */
+export async function parkPage(page, { newCDPSession }: any = {}) {
+  const state = stateFor(page);
+  if (state.applied === "parked" || state.failed || page.isClosed()) return false;
+  state.desired = "parked";
+  await reconcile(page, newCDPSession);
+  return state.applied === "parked";
+}
+
+/**
+ * Undo {@link parkPage}. Safe to call on a page that was never parked.
+ *
+ * Unlike {@link parkPage} this does not short-circuit on the current state: a
+ * park may be queued but not yet applied, and the whole point of waking is to
+ * countermand it. It returns once the page is known to be running again.
+ *
+ * @returns whether the page had been, or was about to be, parked.
+ */
+export async function unparkPage(page) {
+  const state = parkState.get(page);
+  if (!state || page.isClosed()) return false;
+  if (state.desired === "active" && state.applied === "active") return false;
+  state.desired = "active";
+  await reconcile(page, null);
+  return true;
+}
+
+/**
+ * Park every page a session owns.
+ *
+ * Best-effort and unawaited by design at the call site: this runs as an
+ * execution unwinds, and a park that fails or races a page close must never
+ * turn into a failed run. Pages already closed are skipped.
+ */
+export async function parkSession(session, deps: any = {}) {
+  const results = [];
+  for (const page of session.pages.values()) {
+    if (page.isClosed()) continue;
+    // A page with credential work in flight keeps running. Parking disables
+    // script for the whole renderer, isolated worlds included, and the vault
+    // sensor lives in one — see the note on `isBusy` in src/vault-capture.ts.
+    if (deps.isBusy?.(page)) continue;
+    results.push(parkPage(page, deps).catch(() => false));
+  }
+  const parked = await Promise.all(results);
+  return parked.filter(Boolean).length;
+}
+
+/**
+ * Wake every page a session owns. Awaited before an execution starts, so model
+ * code never runs against a page whose script is still disabled.
+ */
+export async function unparkSession(session) {
+  const results = [];
+  for (const page of session.pages.values()) {
+    if (page.isClosed()) continue;
+    results.push(unparkPage(page).catch(() => false));
+  }
+  const woken = await Promise.all(results);
+  return woken.filter(Boolean).length;
+}
+
+/**
+ * Resolve the parking setting from the launch config and the environment.
+ *
+ * Parking is only ever right when nobody can see the browser. In headed mode a
+ * human is looking at the window, and while a live view is streaming a human is
+ * looking at a copy of it; a frozen page in either case is a bug, not an
+ * optimization. The explicit option wins over the environment so a program can
+ * turn it off for a run on a host that enables it.
+ */
+export function parkingEnabled({
+  config = {},
+  env = process.env,
+  headless = true,
+  liveView = false,
+}: any = {}) {
+  if (!headless || liveView) return false;
+  if (config.parkBackgroundPages === false) return false;
+  if (config.parkBackgroundPages === true) return true;
+  const flag = String(env?.BETTERWRIGHT_PARK_BACKGROUND_PAGES ?? "").trim().toLowerCase();
+  if (flag === "0" || flag === "false" || flag === "off" || flag === "no") return false;
+  return true;
+}

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -435,16 +435,55 @@ export function diffSnapshots(previous, current) {
   if (before.length > MAX_DIFF_LINES || after.length > MAX_DIFF_LINES)
     return { changed: true, tooLarge: true };
 
-  // Longest-common-subsequence table over the changed region.
+  // A one-sided change — the overwhelmingly common case once the shared prefix
+  // and suffix are gone — is entirely additions or entirely removals. Answering
+  // it here skips the table, which is the only expensive thing in this
+  // function.
+  if (!before.length || !after.length) {
+    const out = before
+      .map((line) => `- ${line}`)
+      .concat(after.map((line) => `+ ${line}`));
+    return {
+      changed: true,
+      diff: out.join("\n"),
+      additions: after.length,
+      removals: before.length,
+    };
+  }
+
+  // Intern the lines so the table loop compares small integers instead of
+  // strings. Snapshot lines repeat heavily (indent + role + name), and the
+  // comparison runs `before.length * after.length` times, so this is where the
+  // time goes.
+  const ids = new Map();
+  const idOf = (line) => {
+    let id = ids.get(line);
+    if (id === undefined) {
+      id = ids.size;
+      ids.set(line, id);
+    }
+    return id;
+  };
+  const beforeIds = new Int32Array(before.length);
+  const afterIds = new Int32Array(after.length);
+  for (let k = 0; k < before.length; k += 1) beforeIds[k] = idOf(before[k]);
+  for (let k = 0; k < after.length; k += 1) afterIds[k] = idOf(after[k]);
+
+  // Longest-common-subsequence table over the changed region. Every entry is a
+  // subsequence length, so it cannot exceed MAX_DIFF_LINES — Uint16Array holds
+  // it exactly and halves a table that reaches 18 MB at the size cap.
   const rows = before.length + 1;
   const cols = after.length + 1;
-  const table = new Uint32Array(rows * cols);
+  const table = new Uint16Array(rows * cols);
   for (let i = before.length - 1; i >= 0; i -= 1) {
+    const rowBase = i * cols;
+    const nextBase = rowBase + cols;
+    const beforeId = beforeIds[i];
     for (let j = after.length - 1; j >= 0; j -= 1) {
-      table[i * cols + j] =
-        before[i] === after[j]
-          ? table[(i + 1) * cols + j + 1] + 1
-          : Math.max(table[(i + 1) * cols + j], table[i * cols + j + 1]);
+      table[rowBase + j] =
+        beforeId === afterIds[j]
+          ? table[nextBase + j + 1] + 1
+          : Math.max(table[nextBase + j], table[rowBase + j + 1]);
     }
   }
   const out = [];
@@ -453,7 +492,7 @@ export function diffSnapshots(previous, current) {
   let i = 0;
   let j = 0;
   while (i < before.length && j < after.length) {
-    if (before[i] === after[j]) {
+    if (beforeIds[i] === afterIds[j]) {
       i += 1;
       j += 1;
     } else if (table[(i + 1) * cols + j] >= table[i * cols + j + 1]) {

--- a/src/vault-capture.ts
+++ b/src/vault-capture.ts
@@ -423,6 +423,25 @@ export function installVaultCapture(context, deps: any = {}) {
         dropPrompt(promptId, false);
       }
     },
+    /**
+     * Whether this page has credential work in flight: a captured password
+     * waiting on its success gate, or a save prompt on screen.
+     *
+     * Page parking (src/page-park.ts) asks before it quiets a page. It has to:
+     * parking disables script execution for the whole renderer, isolated worlds
+     * included, and this sensor lives in one. A capture's success gate is
+     * decided by what happens *after* the submit — the navigation, or the app
+     * tearing down the form — which is exactly the window between two
+     * executions that parking would otherwise cover. Quieting the page there
+     * would drop logins on the floor.
+     */
+    isBusy(page) {
+      if (state.pendingByPage.get(page)?.size) return true;
+      for (const prompt of state.prompts.values()) {
+        if (prompt.page === page) return true;
+      }
+      return false;
+    },
     /** Test introspection: parked captures and live prompts. */
     _state: state,
   };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -96,6 +96,7 @@ import {
   inspectControls,
   inspectMedia,
 } from "./page-inspect.js";
+import { parkingEnabled, parkSession, unparkSession } from "./page-park.js";
 import {
   acquireProfileLock,
   PROFILE_LOCK_HEARTBEAT_MS,
@@ -192,6 +193,71 @@ function soleExecutingSession() {
   for (const key of activeExecutionCounts.keys()) return key;
   return null;
 }
+
+// --- background-page parking (src/page-park.ts) -----------------------------
+//
+// A headless target never becomes hidden, so an open page renders forever
+// whether or not anything is driving it. `wakeSessionPages` and
+// `quietSessionPages` bracket every execution entry point: pages are woken
+// before model code runs and quieted once the last execution on the session
+// unwinds, which confines the parked window to the model's own thinking time.
+
+/**
+ * How long a session must sit idle before its pages are parked.
+ *
+ * Parking exists to cover a model turn, which is seconds. An agent's own
+ * back-to-back calls are milliseconds apart, and parking between those buys
+ * nothing while putting two CDP round trips on the critical path of every
+ * step — measured as a p90 of 2.4 s once a fast loop started colliding with
+ * the park it had just triggered. Waiting first means a tight loop never parks
+ * at all and a real pause still does.
+ */
+const PARK_IDLE_DELAY_MS = 750;
+const pendingParkTimers = new Map();
+
+function cancelPendingPark(sessionId) {
+  const timer = pendingParkTimers.get(sessionId);
+  if (!timer) return;
+  clearTimeout(timer);
+  pendingParkTimers.delete(sessionId);
+}
+
+async function wakeSessionPages(session) {
+  cancelPendingPark(session.id);
+  if (!browserContext) return;
+  // Deliberately not gated on `parkingEnabled`: a session parked under one
+  // setting must still wake if the setting changed under it (a live view
+  // opening mid-run is the case that matters).
+  await unparkSession(session).catch(() => {});
+}
+
+function quietSessionPages(session) {
+  cancelPendingPark(session.id);
+  if (!browserContext) return;
+  if (
+    !parkingEnabled({
+      config: launchConfig,
+      headless: launchConfig?.headless !== false,
+      liveView: Boolean(liveView),
+    })
+  )
+    return;
+  const timer = setTimeout(() => {
+    pendingParkTimers.delete(session.id);
+    // Re-checked here, not only at schedule time: an execution may have
+    // started during the delay, and parking under it would disable script
+    // beneath running model code.
+    if (!browserContext || sessionIsExecuting(session.id)) return;
+    void parkSession(session, {
+      newCDPSession: (page) => browserContext.newCDPSession(page),
+      isBusy: (page) => vaultCapture?.isBusy(page) === true,
+    }).catch(() => {});
+  }, PARK_IDLE_DELAY_MS);
+  // A pending park must never be the reason the worker stays alive.
+  timer.unref?.();
+  pendingParkTimers.set(session.id, timer);
+}
+
 let downloadCdpSession = null;
 let downloadGuardReady = false;
 let currentDownloadBehavior = "deny";
@@ -3334,6 +3400,7 @@ async function credentialFill(message) {
   try {
     assertRedactionCapacity();
     await ensureBrowser(message.config);
+    await wakeSessionPages(session);
     await ensureSessionPage(session);
     const result = await performCredentialFill(session, spec);
     assertRedactionCapacity();
@@ -3365,6 +3432,7 @@ async function credentialFill(message) {
   } finally {
     stampModelActivity(session);
     endExecutionFor(session.id);
+    quietSessionPages(session);
     session.execution = { requestId: null, pendingRecovery: null, generationStarted: false };
   }
 }
@@ -3384,6 +3452,7 @@ async function credentialPending(message) {
       throw new Error("pending credential action must be list, commit, or discard.");
     }
     await ensureBrowser(message.config);
+    await wakeSessionPages(session);
     await ensureSessionPage(session);
     let publicResult;
     if (action === "list") {
@@ -3431,6 +3500,7 @@ async function credentialPending(message) {
     );
   } finally {
     endExecutionFor(session.id);
+    quietSessionPages(session);
   }
 }
 
@@ -4646,6 +4716,7 @@ async function execute(message) {
   try {
     assertRedactionCapacity();
     await ensureBrowser(message.config);
+    await wakeSessionPages(session);
     downloadPolicy = normalizeDownloadPolicy(message.config.downloadPolicy);
     if (downloadPolicy === "deny" && message.approvedDownloads === true) {
       throw new Error("Downloads are disabled by downloadPolicy=deny.");
@@ -4824,6 +4895,7 @@ async function execute(message) {
     }
     liveView?.setAgentState("idle");
     endExecutionFor(session.id);
+    quietSessionPages(session);
     session.execution = { requestId: null, pendingRecovery: null, generationStarted: false };
     if (restartWorker)
       setImmediate(() => {
@@ -4893,6 +4965,10 @@ async function liveViewStart(message) {
     await ensureBrowser(message.config);
     const options = message.options && typeof message.options === "object" ? message.options : {};
     const view = ensureLiveView(options.session);
+    // A viewer is about to watch these pages, so nothing may stay parked: the
+    // stream would show a still frame of a page whose script is switched off.
+    // `parkingEnabled` keeps them awake from here on while the view runs.
+    for (const session of sessions.values()) await wakeSessionPages(session);
     const info = await view.start(options);
     sendResult({ type: "result", id: message.id, ...info });
   } catch (error) {
@@ -5102,6 +5178,7 @@ async function sessionClose(message) {
       pagesClosed += 1;
       void page.close().catch(() => {});
     }
+    cancelPendingPark(sessionId);
     sessions.delete(sessionId);
   }
   sendResult({
@@ -5198,6 +5275,7 @@ const idleReaper = setInterval(() => {
       continue;
     for (const page of session.pages.values())
       void page.close().catch(() => {});
+    cancelPendingPark(sessionId);
     sessions.delete(sessionId);
   }
 }, 60_000);

--- a/tests/node/page-park.test.ts
+++ b/tests/node/page-park.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  isParked,
+  parkingEnabled,
+  parkPage,
+  parkSession,
+  unparkPage,
+  unparkSession,
+} from "../../dist/src/page-park.js";
+
+/** A Playwright Page stand-in that records the CDP traffic parking generates. */
+function fakePage({ closed = false }: any = {}) {
+  const sent = [];
+  const page: any = {
+    sent,
+    isClosed: () => closed,
+    close() {
+      closed = true;
+    },
+  };
+  page.newCDPSession = async () => {
+    page.sessions = (page.sessions || 0) + 1;
+    return {
+      send: async (method, params) => {
+        sent.push(params === undefined ? method : { method, ...params });
+        if (page.failOn === method) throw new Error(`refused ${method}`);
+        return {};
+      },
+    };
+  };
+  return page;
+}
+
+const deps = (page) => ({ newCDPSession: () => page.newCDPSession() });
+
+test("parking disables page script and stops animation timelines", async () => {
+  const page = fakePage();
+  assert.equal(await parkPage(page, deps(page)), true);
+  assert.equal(isParked(page), true);
+  assert.deepEqual(page.sent, [
+    "Animation.enable",
+    { method: "Animation.setPlaybackRate", playbackRate: 0 },
+    { method: "Emulation.setScriptExecutionDisabled", value: true },
+  ]);
+});
+
+test("parking never purges V8 memory — the call crashes the pinned fork", async () => {
+  const page = fakePage();
+  await parkPage(page, deps(page));
+  const methods = page.sent.map((entry) =>
+    typeof entry === "string" ? entry : entry.method,
+  );
+  assert.ok(!methods.some((method) => String(method).startsWith("Memory.")));
+});
+
+test("unparking restores script and playback in that order", async () => {
+  const page = fakePage();
+  await parkPage(page, deps(page));
+  page.sent.length = 0;
+  assert.equal(await unparkPage(page), true);
+  assert.equal(isParked(page), false);
+  // Order between the two is not fixed — waking pipelines them — so compare
+  // as a set. What matters is that both landed, with the restoring values.
+  assert.deepEqual(
+    [...page.sent].sort((a, b) => a.method.localeCompare(b.method)),
+    [
+      { method: "Animation.setPlaybackRate", playbackRate: 1 },
+      { method: "Emulation.setScriptExecutionDisabled", value: false },
+    ],
+  );
+});
+
+test("parking twice is a no-op, and so is unparking a page that was never parked", async () => {
+  const page = fakePage();
+  await parkPage(page, deps(page));
+  const after = page.sent.length;
+  // Both report whether *this* call changed the page, so a repeat says false
+  // and sends nothing — the page is still parked either way.
+  assert.equal(await parkPage(page, deps(page)), false);
+  assert.equal(isParked(page), true);
+  assert.equal(page.sent.length, after);
+
+  const fresh = fakePage();
+  assert.equal(await unparkPage(fresh), false);
+  assert.deepEqual(fresh.sent, []);
+});
+
+test("one CDP session is reused across park/unpark cycles", async () => {
+  const page = fakePage();
+  for (let i = 0; i < 3; i += 1) {
+    await parkPage(page, deps(page));
+    await unparkPage(page);
+  }
+  assert.equal(page.sessions, 1);
+});
+
+test("a closed page is skipped rather than parked", async () => {
+  const page = fakePage({ closed: true });
+  assert.equal(await parkPage(page, deps(page)), false);
+  assert.deepEqual(page.sent, []);
+});
+
+test("a browser that refuses to park still runs, and stops being asked", async () => {
+  const page = fakePage();
+  page.failOn = "Animation.enable";
+  assert.equal(await parkPage(page, deps(page)), false);
+  assert.equal(isParked(page), false);
+  // Latched: the second attempt must not pay the failing round trip again.
+  const attempted = page.sent.length;
+  assert.equal(await parkPage(page, deps(page)), false);
+  assert.equal(page.sent.length, attempted);
+});
+
+test("a session parks and wakes every open page it owns", async () => {
+  const pages = [fakePage(), fakePage(), fakePage({ closed: true })];
+  const session = { pages: new Map(pages.map((page, i) => [`page-${i}`, page])) };
+  const newCDPSession = (page) => page.newCDPSession();
+
+  assert.equal(await parkSession(session, { newCDPSession }), 2);
+  assert.deepEqual(pages.map(isParked), [true, true, false]);
+  assert.equal(await unparkSession(session), 2);
+  assert.deepEqual(pages.map(isParked), [false, false, false]);
+});
+
+test("parking is on by default but never where a human can see the browser", () => {
+  const env = {};
+  assert.equal(parkingEnabled({ env, headless: true }), true);
+  assert.equal(parkingEnabled({ env, headless: false }), false);
+  assert.equal(parkingEnabled({ env, headless: true, liveView: true }), false);
+});
+
+test("the explicit option wins over the environment in both directions", () => {
+  assert.equal(
+    parkingEnabled({ config: { parkBackgroundPages: false }, env: {} }),
+    false,
+  );
+  assert.equal(
+    parkingEnabled({
+      config: { parkBackgroundPages: true },
+      env: { BETTERWRIGHT_PARK_BACKGROUND_PAGES: "0" },
+    }),
+    true,
+  );
+  // A headed browser is not parked even when both say yes.
+  assert.equal(
+    parkingEnabled({ config: { parkBackgroundPages: true }, headless: false }),
+    false,
+  );
+});
+
+test("the environment opt-out accepts the usual spellings of off", () => {
+  for (const value of ["0", "false", "off", "no", "OFF", " False "]) {
+    assert.equal(
+      parkingEnabled({ env: { BETTERWRIGHT_PARK_BACKGROUND_PAGES: value } }),
+      false,
+      `expected ${JSON.stringify(value)} to disable parking`,
+    );
+  }
+  for (const value of ["1", "true", "on", "", "anything"]) {
+    assert.equal(
+      parkingEnabled({ env: { BETTERWRIGHT_PARK_BACKGROUND_PAGES: value } }),
+      true,
+      `expected ${JSON.stringify(value)} to leave parking on`,
+    );
+  }
+});
+
+test("a wake that overtakes an unfinished park leaves the page running", async () => {
+  // The real shape: parking is fired without being awaited as an execution
+  // unwinds, and the next execution's wake arrives before it has landed. The
+  // page must end up active — deciding from the state at call time got this
+  // wrong, and disabled script underneath running model code.
+  const page = fakePage();
+  const parking = parkPage(page, deps(page)); // deliberately not awaited
+  await unparkPage(page);
+  await parking;
+  assert.equal(isParked(page), false);
+  // Script execution must be on when the dust settles, whatever order the
+  // sends landed in.
+  const scriptSends = page.sent.filter(
+    (entry) => entry.method === "Emulation.setScriptExecutionDisabled",
+  );
+  assert.equal(scriptSends[scriptSends.length - 1]?.value ?? false, false);
+});
+
+test("a park countermanded before it runs never touches the browser", async () => {
+  const page = fakePage();
+  await parkPage(page, deps(page));
+  await unparkPage(page);
+  page.sent.length = 0;
+  const parking = parkPage(page, deps(page));
+  await unparkPage(page);
+  await parking;
+  assert.equal(isParked(page), false);
+  assert.deepEqual(page.sent, []);
+});
+
+test("repeated park/wake cycles settle in the requested state", async () => {
+  const page = fakePage();
+  for (let i = 0; i < 5; i += 1) {
+    await parkPage(page, deps(page));
+    assert.equal(isParked(page), true);
+    await unparkPage(page);
+    assert.equal(isParked(page), false);
+  }
+});

--- a/tests/node/snapshot.test.ts
+++ b/tests/node/snapshot.test.ts
@@ -302,3 +302,130 @@ test("diffSnapshots flags oversized inputs instead of stalling", () => {
   assert.equal(result.changed, true);
   assert.equal(result.tooLarge, true);
 });
+
+// The diff table is the only allocation in this file that scales with the
+// square of the input, so it grew a fast path (one-sided changes skip the
+// table entirely) and line interning (integer compares in the inner loop).
+// These pin the output against a straightforward reference so the
+// optimizations cannot quietly change which lines are reported.
+
+/**
+ * The 1.6.0 implementation, verbatim: shared prefix/suffix trimming, a full
+ * Uint32 table, and string comparisons in the inner loop. The optimized version
+ * must agree with it line for line — including which side of an LCS tie it
+ * picks, which the trimming step influences.
+ */
+function referenceDiff(previous, current) {
+  if (previous === current) return { changed: false };
+  let before = String(previous).split("\n");
+  let after = String(current).split("\n");
+  let start = 0;
+  while (
+    start < before.length &&
+    start < after.length &&
+    before[start] === after[start]
+  )
+    start += 1;
+  let endBefore = before.length;
+  let endAfter = after.length;
+  while (
+    endBefore > start &&
+    endAfter > start &&
+    before[endBefore - 1] === after[endAfter - 1]
+  ) {
+    endBefore -= 1;
+    endAfter -= 1;
+  }
+  before = before.slice(start, endBefore);
+  after = after.slice(start, endAfter);
+  if (before.length > 3_000 || after.length > 3_000)
+    return { changed: true, tooLarge: true };
+  const cols = after.length + 1;
+  const table = new Uint32Array((before.length + 1) * cols);
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    for (let j = after.length - 1; j >= 0; j -= 1) {
+      table[i * cols + j] =
+        before[i] === after[j]
+          ? table[(i + 1) * cols + j + 1] + 1
+          : Math.max(table[(i + 1) * cols + j], table[i * cols + j + 1]);
+    }
+  }
+  const out = [];
+  let additions = 0;
+  let removals = 0;
+  let i = 0;
+  let j = 0;
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      i += 1;
+      j += 1;
+    } else if (table[(i + 1) * cols + j] >= table[i * cols + j + 1]) {
+      out.push(`- ${before[i]}`);
+      removals += 1;
+      i += 1;
+    } else {
+      out.push(`+ ${after[j]}`);
+      additions += 1;
+      j += 1;
+    }
+  }
+  for (; i < before.length; i += 1) {
+    out.push(`- ${before[i]}`);
+    removals += 1;
+  }
+  for (; j < after.length; j += 1) {
+    out.push(`+ ${after[j]}`);
+    additions += 1;
+  }
+  return { changed: true, diff: out.join("\n"), additions, removals };
+}
+
+test("diffSnapshots still agrees line-for-line with the 1.6.0 algorithm", () => {
+  // Deterministic PRNG: a failure here must be reproducible.
+  let seed = 0x2f6e2b1;
+  const random = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  // A small alphabet makes repeated lines — and therefore interning
+  // collisions and LCS ties — common rather than rare.
+  const line = () => `- item ${Math.floor(random() * 6)}`;
+  for (let round = 0; round < 200; round += 1) {
+    const before = Array.from({ length: Math.floor(random() * 12) }, line);
+    const after = before
+      .filter(() => random() > 0.3)
+      .flatMap((entry) => (random() > 0.75 ? [line(), entry] : [entry]));
+    const previous = before.join("\n");
+    const current = after.join("\n");
+    assert.deepEqual(
+      diffSnapshots(previous, current),
+      referenceDiff(previous, current),
+      `round ${round}: ${JSON.stringify({ previous, current })}`,
+    );
+  }
+});
+
+test("a purely one-sided change reports every line without building a table", () => {
+  const before = ["- a", "- b", "- c"].join("\n");
+  const after = ["- a", "- x", "- y", "- b", "- c"].join("\n");
+  assert.deepEqual(diffSnapshots(before, after), referenceDiff(before, after));
+
+  // Nothing in common at all: all removals, then all additions.
+  const removedAll = diffSnapshots("- a\n- b", "- c\n- d");
+  assert.deepEqual(removedAll, {
+    changed: true,
+    diff: "- - a\n- - b\n+ - c\n+ - d",
+    additions: 2,
+    removals: 2,
+  });
+});
+
+test("a diff at the size cap stays within the halved table budget", () => {
+  const before = Array.from({ length: 3_000 }, (_, i) => `- a${i}`).join("\n");
+  const after = Array.from({ length: 3_000 }, (_, i) => `- b${i}`).join("\n");
+  const result = diffSnapshots(before, after);
+  assert.equal(result.changed, true);
+  assert.equal(result.tooLarge, undefined);
+  assert.equal(result.additions, 3_000);
+  assert.equal(result.removals, 3_000);
+});

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -48,6 +48,12 @@ export class BetterWright {
   platform: "macos" | "windows" | "linux" | null;
   /** Validated extra Chromium switches, from the option and the environment. */
   chromiumArgs: string[];
+  /**
+   * Explicit page-parking choice, or `undefined` to leave it to the worker
+   * (which also reads `BETTERWRIGHT_PARK_BACKGROUND_PAGES` and never parks a
+   * browser a human can see).
+   */
+  parkBackgroundPages: boolean | undefined;
   defaultTimeout: number;
   liveView: LiveViewOptions;
 

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -99,6 +99,22 @@ export interface BetterWrightOptions {
    */
   chromiumArgs?: string[];
   /**
+   * Quiet each session's pages between executions (default `true`).
+   *
+   * A headless Chromium target never becomes hidden — `document.visibilityState`
+   * stays `"visible"` for the life of the page — so every open page keeps its
+   * frame loop running at the host refresh rate whether or not anything is
+   * driving it. Parking disables page script and pauses animation timelines
+   * once a session's last execution unwinds, and restores both before the next
+   * one begins, so the quiet window is exactly the model's thinking time.
+   *
+   * Never applies in headed mode or while a live view is streaming. The one
+   * behavior change: a page animated by a `requestAnimationFrame` chain does
+   * not resume that chain after being parked (CSS/Web Animations do). Also
+   * settable per host with `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0`.
+   */
+  parkBackgroundPages?: boolean;
+  /**
    * Defaults for `startLiveView()`. Binds `0.0.0.0` with a LAN `publicHost` by
    * default so printed URLs open from another machine on the network. Pass
    * `{host:"127.0.0.1"}` for loopback-only.


### PR DESCRIPTION
## Why

A user running BetterWright across four agents reported `chrome-headless-shell` at **761% CPU**. It reproduces, and it is not their setup.

A headless Chromium target never becomes hidden — `document.visibilityState` stays `"visible"` for the life of the page — so none of the machinery a headed browser uses to stop paying for background tabs ever engages. The frame loop free-runs at the host refresh rate (~120 fps measured on the pinned fork), and any page with a spinner, a carousel, or a canvas keeps a core busy for as long as the session lives.

**Measured: one session with five ordinary animated tabs burned ~110% CPU while the worker sat completely idle.** Four agents is four of those.

## What was ruled out

Every launch-argument and CDP lever was measured at no better than noise, because none of them makes a headless target non-visible:

`Page.setWebLifecycleState("frozen")` · `Browser.setWindowBounds({windowState:"minimized"})` · `Emulation.setVirtualTimePolicy("pause")` · `Emulation.setFocusEmulationEnabled(false)` · `--disable-gpu` · `--deterministic-mode` · `--enable-begin-frame-control` · `--screen-info={0,0 1x1}` · `--num-raster-threads=1` · device-metrics override

Cutting per-frame cost does not help either — the loop is not frame-paced, so it simply renders more frames for the same CPU. (`--use-angle=swiftshader` was actively catastrophic at 942%.) `--renderer-process-limit` does cut ~14% RSS but forces cross-site renderer sharing, which weakens site isolation in a browser that fills passwords, so it is not taken.

## What this does

Park a session's pages once its last execution unwinds — disable page script, set animation timelines to rate zero — and restore both before the next execution begins. The parked window is exactly the model's thinking time, and model code never observes a parked page because model code is not running.

Idling with tabs open, pinned fork 150.0.7871.129:

| scenario | 1.6.0 | 1.6.1 |
| --- | --- | --- |
| 1 session, 5 tabs | 97% CPU, 1845 MB | **25% CPU, 1709 MB** |
| 4 sessions, 3 tabs each | 129% CPU, 3805 MB | **53% CPU, 3529 MB** |

Guards:
- never in headed mode, never while a live view is streaming
- waits 750 ms, so an agent's back-to-back calls never pay two CDP round trips per step (without this the p90 step hit 2.4 s)
- skips pages with credential capture in flight — script execution is disabled per renderer, not per world, and the vault sensor lives in an isolated world
- `parkBackgroundPages: false` / `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0` opts out

**The one behavior change:** a page animated by a `requestAnimationFrame` chain does not resume that chain after being parked — the pending callback never fires, so nothing re-registers it. In-page state, `setInterval`/`setTimeout`, CSS and Web Animations, clicks, typing, navigation, screenshots, network, and newly registered rAF callbacks all resume normally, each verified.

`Memory.forciblyPurgeJavaScriptMemory` is deliberately **not** used: it reports success and takes the whole browser process down a moment later on the pinned fork, killing every other session's tabs. There is a test pinning that.

## Also

- `diffSnapshots` interns its lines (integer compares in the LCS inner loop), stores the table as `Uint16Array` (lengths are bounded by the 3000-line cap, so `Uint32` was never needed), and skips the table entirely for a one-sided change. Transient allocation at the cap drops **34 MB → 17 MB**. Output is unchanged — a randomized suite checks it line for line, tie-breaks included, against the 1.6.0 implementation.
- Park/wake reconcile toward a recorded intent rather than deciding from the state at call time. The old shape lost a real race: parking is fired without being awaited as an execution unwinds, and a fast agent's next step overtakes it, disabling script underneath running model code. The credential suite caught this.

## Compatibility

Drop-in for 1.6.0. No API removals, nothing to configure.

## Verification

`npm run release:check` passes: 686 tests, 0 failures, package smoke test OK.