### PR TITLE
bench: perf harness with per-action latency, guard-RPC, and iframe-tax baselines

### DIFF
--- a/benchmarks/perf/REPORT.md
+++ b/benchmarks/perf/REPORT.md
@@ -1,0 +1,290 @@
+# Round-trip cost: per-action latency, guard RPCs, challenge-scan overhead
+
+This harness measures the three round-trip costs that the current performance
+plan targets. Unlike the other benchmarks in this directory it touches **no
+external network at all** — every byte comes from `http.createServer` fixtures
+on loopback — so it is fully reproducible on any machine with the browser
+runtime installed, and the numbers describe BetterWright's own overhead rather
+than someone else's CDN.
+
+It exists to answer one question per phase of the plan, before and after:
+
+| Benchmark | Measures | Plan target |
+|---|---|---|
+| **A / A'.** Per-action latency | The floor cost of one agent action on a quiet page | Baseline for everything; Phase B's sandbox hoists move it |
+| **B.** Page load + guard RPC count | Stdio round-trips paid per page load | **Phase A** — worker-side guard decision cache |
+| **C.** Challenge-scan cost | What benign cross-site iframes add to *every* action | **Phase B** — staged challenge scan |
+
+## How to run
+
+```
+npm run build:harness
+node benchmarks/perf/run.js
+```
+
+Roughly 25 seconds. Flags:
+
+- `--quick` — 20/3/10 iterations instead of 100/10/30, and only the 10-frame
+  challenge scan. For editing the harness, not for numbers you intend to
+  record. Quick runs write under their own `<label>-quick-<sha>` key, so they
+  **cannot** overwrite a recorded full-fidelity baseline.
+- `--label <name>` — the results key prefix (default `baseline`). Results land
+  in `results.json` under `runs["<label>[-quick]-<short sha>"]`, **merged** with
+  what is already there, so a before and an after live side by side in one
+  file. Use `--label baseline` before a change and `--label phase-a` after it.
+- `--iframes <n>[,<n>...]` — frame counts for benchmark C (default `10,24`).
+- `--force` — replace an existing run under the same key. Without it the
+  harness **refuses** to overwrite a recorded run, and it checks this *before*
+  measuring anything, so a doomed invocation costs zero seconds.
+
+The harness needs the managed browser runtime (`betterwright setup`). It creates
+its own temp home, uses a stock `NetworkPolicy`, and runs with `vault: false` so
+host-side secret redaction does not add noise to every result envelope.
+
+Teardown (browser, six fixture listeners, temp home) lives in a named
+`shutdown()` reached from **both** the `finally` block and a `SIGINT` handler.
+`finally` alone does not cover Ctrl-C — Node's default SIGINT disposition kills
+the process outright and the pending `await` never resumes — which is why the
+signal handler is explicit. Verified: `SIGINT` mid-run exits 130 and leaves no
+`betterwright-perf-*` profile in `os.tmpdir()`.
+
+## What each benchmark actually does
+
+### A / A'. Per-action latency
+
+Loads a fixture page with no subresources and no frames, then executes
+`return page.title()` 100 times (5 warmup iterations discarded), timing each
+`bw.run()` call end to end from the host process.
+
+This is the floor every agent action pays regardless of what the page contains:
+client to worker stdio RPC, sandbox realm creation, snippet compile, execute,
+challenge scan, envelope build, response. A trivial snippet on a quiet page
+isolates that scaffolding from any real work.
+
+It is measured **twice**: once at the start of the session (A) and once between
+the two challenge-scan runs (A'). Benchmark C otherwise sits at the far end of a
+long session — after ~110 executes, 11 page loads, and a grown `session.events`
+/ `session.artifacts` — and any per-session drift would be charged entirely to
+the iframes. The reported iframe tax is derived from the **adjacent** pair,
+`C − A'`, and `session_drift` records `A' − A` so the drift is a number rather
+than a silent bias.
+
+### B. Page-load wall time + guard RPC count
+
+One fixture page pulls **50 subresources spread round-robin across 4 distinct
+`127.0.0.1:<port>` origins**. Distinct ports matter: they are distinct guard
+cache keys, which is precisely the case Phase A's worker-side LRU has to handle.
+
+Three things make each measured load honest:
+
+1. **Everything is `no-store` and the document URL is cache-busted per load.**
+2. **Every fixture server counts its own requests** (`fixture_requests_per_load`)
+   and the run **fails** if any measured load is not exactly 51 (1 document +
+   50 subresources). Without this the only evidence that subresources were
+   re-fetched would be the guard count — the very number under test. If a
+   Chromium change or a header edit ever let the memory cache serve
+   `/asset/N.gif`, the guard count would collapse and read as a Phase A win.
+3. **All keep-alive sockets are dropped between loads**
+   (`server.closeAllConnections()`), so every measured load is connection-cold
+   and the SOCKS proxy's per-connection guards appear as a full n=10 series
+   instead of a single confounded warmup sample.
+
+The `about:blank` teardown navigation is followed by a **250 ms settle before**
+`guard.reset()`, not only after the timed load. Tearing down the previous
+document emits trailing guard RPCs; resetting the counter the instant `goto`
+returns attributed those stragglers to the next load, which is what made the
+count drift run to run.
+
+Guard RPCs are counted **without modifying `src/`**, at the **stdio RPC
+boundary** rather than at `policy.check`:
+
+```js
+const original = bw._serviceRpc.bind(bw);
+bw._serviceRpc = (message, child) => {
+  if (message?.method === "guard") { /* bucket by message.payload.resourceType */ }
+  return original(message, child);
+};
+```
+
+Wrapping `_serviceRpc` rather than `policy.check` matters for two reasons. It
+counts **one per round-trip under any batching scheme** — the plan keeps a
+`guardBatch` RPC on the table, and a `policy.check` counter would still report N
+for a batch of N and hide the entire win. And it exposes `payload.resourceType`,
+which is what lets the count be **bucketed**, which it must be:
+
+- **`guard_rpcs_per_load.route`** — the `context.route("**/*")` interception
+  (`src/worker.ts:1393`): one RPC per HTTP request. Exactly
+  `subresources + 1`, and genuinely invariant.
+- **`guard_rpcs_per_load.transport`** — the SOCKS guard proxy's per-connection
+  guards: one hostname check (`resourceType: "transport"`,
+  `src/guard-proxy.ts:517`) plus one per resolved IP
+  (`"transport-address"`, `:546`). **Connection-scoped and inherently
+  variable**, because Chromium decides how many sockets to open and when.
+
+Totalling the two produces a scalar that drifts ±12% while looking exact. It is
+still reported as `.total`, but the two buckets are the numbers to read.
+
+There is also a **liveness assertion**: if the warmup load records zero route
+guards, the run throws. Otherwise a refactor that moves the check off
+`_serviceRpc` would report 0 guard RPCs, and a broken hook would look exactly
+like a total Phase A win.
+
+### C. Challenge-scan cost
+
+Identical snippet to benchmark A (`return page.title()`, 30 iterations, 3
+warmup) against a page embedding **N benign iframes**, each with a real body of
+prose so per-frame text extraction has something to extract. Nothing on the page
+is a challenge. Measured at **N = 10 and N = 24** (24 is the hard cap in
+`collectFrameMetadata`, `src/worker.ts:3973`), so frame scaling is measured data
+rather than extrapolation.
+
+The frames are served from **distinct loopback hostnames** (`127.0.0.2`,
+`127.0.0.3`) while the parent is on `127.0.0.1`. This is load-bearing:
+Chromium's site isolation keys on scheme + eTLD+1 and **ignores the port**, so
+same-host different-port frames would share the parent's renderer process and
+their frame walks would be cheap same-process CDP. Distinct IPs are distinct
+sites, so these are real OOPIFs with their own targets — which is what an
+ad-heavy page actually looks like. The harness **asserts** it: after navigation
+it reads `page.frames()` and fails unless all N children are attached and all N
+are cross-site with the parent.
+
+`detectSessionChallenges` runs unconditionally on every execute. **C minus A' is
+therefore the per-action tax that benign iframes impose today** — reported as
+`derived.iframe_overhead.frames_<n>`.
+
+## Baseline results
+
+`baseline-52a577d` — 2026-08-03, BetterWright 1.6.2, Node v26.5.0, linux-x64,
+8 CPUs, commit `52a577d` (`perf/bench-harness`, before any Phase A/B change).
+
+| Metric | p50 | p95 | mean | stdev |
+|---|---|---|---|---|
+| **A.** Per-action latency (n=100) | **7.60 ms** | 11.31 ms | 7.93 ms | 1.85 ms |
+| **A'.** Per-action latency, late-session (n=100) | **6.45 ms** | 8.56 ms | 6.37 ms | 1.17 ms |
+| **B.** Page-load wall time (n=10) | **715.8 ms** | 756.6 ms | 720.2 ms | 15.7 ms |
+| **B.** In-page navigation time (n=10) | 695 ms | 728 ms | 697.5 ms | 13.6 ms |
+| **C.** Per-action, 10 cross-site iframes (n=30) | **36.68 ms** | 46.45 ms | 35.95 ms | 5.03 ms |
+| **C.** Per-action, 24 cross-site iframes (n=30) | **60.57 ms** | 71.16 ms | 61.10 ms | 4.76 ms |
+
+| Guard RPCs per load (n=10) | p50 | min | max | mean |
+|---|---|---|---|---|
+| **`route`** — one per HTTP request | **51** | 51 | 51 | 51 |
+| **`transport`** — per-connection hostname + IP | **44** | 36 | 48 | 42.8 |
+| `total` | 95 | 87 | 99 | 93.8 |
+
+| Assertion | Value |
+|---|---|
+| Fixture requests per load (n=10) | **51** — min 51, max 51 (enforced) |
+| Route guard RPCs per subresource | 1.02 |
+
+| Derived (against the adjacent A' control) | Value |
+|---|---|
+| **Iframe tax per action, 10 frames (p50)** | **+30.23 ms** (3.02 ms/frame) |
+| Iframe tax per action, 10 frames (p95) | +37.89 ms |
+| **Iframe tax per action, 24 frames (p50)** | **+54.12 ms** (2.26 ms/frame) |
+| Iframe tax per action, 24 frames (p95) | +62.60 ms |
+| Session drift (A' − A, p50) | −1.15 ms (−15.1%) |
+
+### Reading the baseline
+
+**Route guards: 51 per load for 50 subresources, and this one *is* exact.**
+50 subresources + 1 document = 51 stdio round-trips, min = max = 51 across all
+10 loads in both recorded runs, with the fixture independently confirming 51
+requests were served. Every one of those is a synchronous pipe round-trip to the
+client process for what `src/client.ts:686` resolves as pure sync CPU. This is
+the cleanest Phase A signal in the file: **treat any movement in the `route`
+series as real.**
+
+**Transport guards: ~43 per connection-cold load, and this one is *not*
+exact — by nature.** Every measured load drops all keep-alive sockets first, so
+each pays the SOCKS proxy's per-connection cost afresh: one hostname guard plus
+one per resolved IP, issued serially (`src/guard-proxy.ts:546`). The observed
+range is 36–48 across 10 loads in both recorded runs, because Chromium decides
+how many sockets to open to each of the four origins and when. **Do not read a
+±6 move here as a regression** — compare p50 and mean across ≥10 loads.
+Phase A targets both buckets, and a real ad-heavy page with many origins and
+short-lived connections looks much more like this row than like a keep-alive
+steady state, which is why every measured load is deliberately connection-cold.
+
+An earlier version of this harness reported the two buckets summed as a single
+"51, zero variance" invariant. That was wrong: the sum drifts ±12% run to run,
+and the doc instructed the reviewer to read that drift as signal.
+
+**Benign iframes cost 6–9x the entire base action.** 36.7 ms at 10 frames and
+60.6 ms at 24 versus a 6.45 ms floor: iframes that contain nothing but prose make
+every single agent action **six to nine times slower**, purely through the
+unconditional frame walk, and it is paid on *every* execute whether or not a
+challenge exists. This is the Phase B target.
+
+**The frame cost is sublinear in frame count, and the two measured points say
+how sublinear.** 10 frames cost +30.2 ms (3.02 ms/frame); 24 frames cost
++54.1 ms (2.26 ms/frame). A 2.4x frame count buys a 1.8x tax — the ~25%
+per-frame discount is `collectFrameMetadata`'s `Promise.all` overlapping the ~5
+CDP round-trips *across* frames, while they stay sequential *within* a frame
+(`src/worker.ts:3973`). So do not divide the tax by frames and call it a
+per-frame round-trip cost, and do not extrapolate 10 frames to 24 — the harness
+measures both points, and `--iframes` takes any list. At the 24-frame cap the
+frame walk is still roughly **8x the entire rest of the action**.
+
+**Per-action latency itself is already tight** at 6.5–7.6 ms p50 on a quiet
+page. Phase B's sandbox hoists (realm script, `compileCode` heuristic) are
+chipping at a small number; expect single-digit-percent movement here, and do
+not read a 1 ms shift as a win.
+
+## Variance
+
+The full battery was run twice back to back on an otherwise idle machine
+(`baseline-52a577d` and `repeat-52a577d`, both in `results.json`):
+
+| Metric | baseline | repeat | delta |
+|---|---|---|---|
+| Per-action p50 (A) | 7.60 ms | 7.45 ms | −2.0% |
+| Per-action p50 (A') | 6.45 ms | 6.34 ms | −1.7% |
+| Page-load wall p50 | 715.8 ms | 715.2 ms | −0.1% |
+| Route guard RPCs / load | 51 (51–51) | 51 (51–51) | 0 |
+| Transport guard RPCs / load | 44 p50, 42.8 mean (36–48) | 42 p50, 42.8 mean (36–48) | 0% on the mean |
+| Fixture requests / load | 51 | 51 | 0 |
+| 10-iframe p50 | 36.68 ms | 33.92 ms | −7.5% |
+| 24-iframe p50 | 60.57 ms | 60.70 ms | +0.2% |
+| Iframe tax p50, 10 frames | 30.23 ms | 27.58 ms | −8.8% |
+| Iframe tax p50, 24 frames | 54.12 ms | 54.36 ms | +0.4% |
+
+Caveats when comparing runs:
+
+- **The `route` guard count is exact**, not statistical: min = max = 51 in both
+  runs, cross-checked against the fixture's own request counter. Treat *any*
+  change as real.
+- **The `transport` guard count is statistical.** It ranged 36–48 per load in
+  both runs; the p50 moved 44 to 42 while the mean was identical at 42.8.
+  Compare p50/mean over the full n=10 series; a single-load reading means
+  nothing.
+- **p50s are reliable to a few percent, except the 10-frame scan; p95s are not
+  reliable at all.** The 10-iframe p95 moved 46.5 to 40.4 ms between two
+  identical runs. Compare p50s; treat a p95 delta under ~30% as noise.
+- **Per-session drift is real and is now measured, not assumed.** `A' − A` was
+  −15.1% and −14.9% in the two runs: the late-session A' is consistently
+  *faster*, not slower — JIT warmup dominates any session-state growth over a
+  run this size. Because the tax is derived from `C − A'`, this makes the
+  reported tax slightly *larger* than the old `C − A` form did, and correctly
+  so. If a future run shows `session_drift` swinging positive by more than a
+  few percent, the iframe tax for that run is suspect.
+- **The iframe tax carries ~9% run-to-run spread at 10 frames and <1% at 24.**
+  It is a difference of two measurements, so it inherits both their variances,
+  and the 24-frame figure is the steadier of the two. A Phase B win needs to be
+  much larger than 9% to count — which, given it should remove most of the 30
+  ms, it will be.
+- **Page-load wall time is dominated by the fixture**, not by BetterWright: 695
+  of the 716 ms is in-page navigation including `networkidle` settling. Do not
+  expect Phase A to move this number much even if it removes 50 RPCs; the RPC
+  *counts* are the metrics that matter there, and wall time is context.
+- Only run this on an idle machine. A browser build, a test suite, or a video
+  call in the background will swamp the per-action numbers.
+
+## Files
+
+- [`run.ts`](run.ts) — the harness. Compiled to `run.js` by `npm run
+  build:harness`; the emitted `.js` is gitignored (`benchmarks/*/*.js`), same as
+  every other harness here.
+- [`results.json`](results.json) — all recorded runs, keyed by
+  `<label>[-quick]-<short sha>`, each with its own metadata and config block.
+  Schema `betterwright-perf-results-v2`.

--- a/benchmarks/perf/results.json
+++ b/benchmarks/perf/results.json
@@ -1,0 +1,316 @@
+{
+  "schema_version": "betterwright-perf-results-v2",
+  "benchmark": "round-trip cost: per-action latency, page-load guard RPCs, challenge-scan overhead",
+  "fixture": "local http.createServer only — no external network",
+  "defined_in": "run.ts",
+  "runs": {
+    "baseline-52a577d": {
+      "metadata": {
+        "label": "baseline",
+        "date": "2026-08-03T02:45:38.020Z",
+        "commit": "52a577d",
+        "branch": "perf/bench-harness",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.6,
+        "p95_ms": 11.31,
+        "mean_ms": 7.93,
+        "stdev_ms": 1.85,
+        "min_ms": 4.9,
+        "max_ms": 17.4
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.45,
+        "p95_ms": 8.56,
+        "mean_ms": 6.37,
+        "stdev_ms": 1.17,
+        "min_ms": 4.15,
+        "max_ms": 9.57
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -1.15,
+        "p50_delta_pct": -15.13
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 715.76,
+          "p95_ms": 756.58,
+          "mean_ms": 720.17,
+          "stdev_ms": 15.71,
+          "min_ms": 698.55,
+          "max_ms": 756.58
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 695,
+          "p95_ms": 728,
+          "mean_ms": 697.5,
+          "stdev_ms": 13.59,
+          "min_ms": 680,
+          "max_ms": 728
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 51,
+            "mean": 51,
+            "min": 51,
+            "max": 51
+          },
+          "transport": {
+            "count": 10,
+            "p50": 44,
+            "mean": 42.8,
+            "min": 36,
+            "max": 48
+          },
+          "total": {
+            "count": 10,
+            "p50": 95,
+            "mean": 93.8,
+            "min": 87,
+            "max": 99
+          }
+        },
+        "route_guard_rpcs_per_subresource": 1.02,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 51,
+          "guard_rpcs_transport": 46,
+          "fixture_requests": 51,
+          "wall_ms": 734.54
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 36.68,
+          "p95_ms": 46.45,
+          "mean_ms": 35.95,
+          "stdev_ms": 5.03,
+          "min_ms": 28.03,
+          "max_ms": 47.59
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 60.57,
+          "p95_ms": 71.16,
+          "mean_ms": 61.1,
+          "stdev_ms": 4.76,
+          "min_ms": 53.78,
+          "max_ms": 77.16
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 30.23,
+            "p95_ms": 37.89,
+            "per_frame_p50_ms": 3.02
+          },
+          "frames_24": {
+            "p50_ms": 54.12,
+            "p95_ms": 62.6,
+            "per_frame_p50_ms": 2.26
+          }
+        }
+      }
+    },
+    "repeat-52a577d": {
+      "metadata": {
+        "label": "repeat",
+        "date": "2026-08-03T02:46:08.972Z",
+        "commit": "52a577d",
+        "branch": "perf/bench-harness",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.45,
+        "p95_ms": 10.63,
+        "mean_ms": 7.49,
+        "stdev_ms": 1.49,
+        "min_ms": 4.79,
+        "max_ms": 12.06
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.34,
+        "p95_ms": 8.73,
+        "mean_ms": 6.54,
+        "stdev_ms": 1.2,
+        "min_ms": 4.39,
+        "max_ms": 11.03
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -1.11,
+        "p50_delta_pct": -14.9
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 715.19,
+          "p95_ms": 744.25,
+          "mean_ms": 718.58,
+          "stdev_ms": 9.67,
+          "min_ms": 707.68,
+          "max_ms": 744.25
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 691,
+          "p95_ms": 724,
+          "mean_ms": 695.1,
+          "stdev_ms": 10.77,
+          "min_ms": 686,
+          "max_ms": 724
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 51,
+            "mean": 51,
+            "min": 51,
+            "max": 51
+          },
+          "transport": {
+            "count": 10,
+            "p50": 42,
+            "mean": 42.8,
+            "min": 36,
+            "max": 48
+          },
+          "total": {
+            "count": 10,
+            "p50": 93,
+            "mean": 93.8,
+            "min": 87,
+            "max": 99
+          }
+        },
+        "route_guard_rpcs_per_subresource": 1.02,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 51,
+          "guard_rpcs_transport": 42,
+          "fixture_requests": 51,
+          "wall_ms": 727.58
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 33.92,
+          "p95_ms": 40.36,
+          "mean_ms": 34.45,
+          "stdev_ms": 4.26,
+          "min_ms": 27.78,
+          "max_ms": 47.9
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 60.7,
+          "p95_ms": 68.52,
+          "mean_ms": 61.45,
+          "stdev_ms": 3.76,
+          "min_ms": 54.88,
+          "max_ms": 69.27
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 27.58,
+            "p95_ms": 31.63,
+            "per_frame_p50_ms": 2.76
+          },
+          "frames_24": {
+            "p50_ms": 54.36,
+            "p95_ms": 59.79,
+            "per_frame_p50_ms": 2.27
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/perf/run.ts
+++ b/benchmarks/perf/run.ts
@@ -1,0 +1,761 @@
+#!/usr/bin/env node
+// BetterWright round-trip benchmark. Measures the three costs the perf plan
+// (docs: "eliminate per-request IPC and per-action CDP round-trips") targets,
+// against a purely LOCAL http fixture so the numbers describe BetterWright's
+// own overhead rather than the internet:
+//
+//   A. per-action latency  — `run()` of a trivial snippet on a loaded static
+//      page. This is the floor every agent action pays: client→worker stdio
+//      RPC, sandbox realm + compile, execute, challenge scan, envelope build.
+//      Measured TWICE — once at the start of the session and once between the
+//      two iframe benchmarks — so per-session drift is quantified rather than
+//      silently charged to the iframes.
+//   B. page-load wall time + guard RPC count — one page pulling ~50
+//      subresources across 4 distinct `127.0.0.1:<port>` origins. Distinct
+//      ports mean distinct guard cache keys, which is what Phase A's worker
+//      side LRU has to cope with. The guard-RPC counters are the Phase A
+//      target metric: today every subresource costs at least one stdio
+//      round-trip, and every fresh connection costs several more.
+//   C. challenge-scan cost — the same trivial snippet, but on a page with N
+//      benign CROSS-SITE iframes. `detectSessionChallenges` walks every frame
+//      on every execute, so C − A' is the per-action frame-walk tax Phase B
+//      removes. Measured at 10 and 24 frames (24 = the hard cap in
+//      `collectFrameMetadata`) so the scaling is data, not extrapolation.
+//
+// Run it:
+//     npm run build:harness
+//     node benchmarks/perf/run.js [--quick] [--label <name>] [--iframes 10,24]
+//
+// Results are merged into results.json under
+// `runs["<label>[-quick]-<short sha>"]`, so a baseline run and a post-PR run
+// sit side by side in one file and a `--quick` smoke run can never overwrite a
+// recorded full-fidelity baseline. Nothing here touches the external network,
+// so it is reproducible on any machine with the browser runtime installed
+// (`betterwright setup`).
+
+import { execFileSync } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BetterWright, NetworkPolicy } from "../../dist/src/index.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RESULTS = path.join(HERE, "results.json");
+
+const argv = process.argv.slice(2);
+const has = (name) => argv.includes(name);
+const flag = (name, fallback) => {
+  const index = argv.indexOf(name);
+  return index !== -1 && argv[index + 1] !== undefined ? argv[index + 1] : fallback;
+};
+
+// `--quick` trades statistical confidence for a ~4x faster smoke run. Use it
+// while editing the harness; use the defaults for anything you record. Quick
+// runs get their own results key so they cannot clobber a real baseline.
+const QUICK = has("--quick");
+const LABEL = String(flag("--label", "baseline"));
+const FORCE = has("--force");
+
+const ACTION_ITERS = QUICK ? 20 : 100;
+const ACTION_WARMUP = 5;
+const LOAD_ITERS = QUICK ? 3 : 10;
+const LOAD_WARMUP = 1;
+const CHALLENGE_ITERS = QUICK ? 10 : 30;
+const CHALLENGE_WARMUP = 3;
+
+const SUBRESOURCE_COUNT = 50; // spread across ORIGIN_COUNT servers
+const ORIGIN_COUNT = 4;
+// Every measured /heavy load must produce exactly this many fixture requests:
+// the document itself plus every subresource. Asserted, not assumed — see
+// `fixture_requests_per_load`.
+const EXPECTED_FIXTURE_REQUESTS = SUBRESOURCE_COUNT + 1;
+
+// `collectFrameMetadata` (src/worker.ts) hard-caps the walk at 24 frames, so 24
+// is the worst case the product can reach and 10 is the plan's stated scenario.
+const IFRAME_COUNTS = has("--iframes")
+  ? String(flag("--iframes", "10"))
+      .split(",")
+      .map((n) => Number(n.trim()))
+      .filter((n) => Number.isInteger(n) && n > 0)
+  : QUICK
+    ? [10]
+    : [10, 24];
+if (!IFRAME_COUNTS.length)
+  throw new Error("--iframes needs at least one positive integer, e.g. --iframes 10,24");
+const MAX_IFRAMES = Math.max(...IFRAME_COUNTS);
+
+// Benchmark C's frames must be CROSS-SITE, not just cross-port: Chromium's site
+// isolation keys on scheme + eTLD+1 and ignores the port, so `127.0.0.1:A` and
+// `127.0.0.1:B` share one renderer and their frame walks are cheap in-process
+// CDP. Distinct loopback IPs are distinct sites, so these frames become real
+// OOPIFs with their own targets — which is what an ad-heavy page actually
+// looks like. 127.0.0.0/8 is entirely local on Linux, so binding these needs no
+// setup.
+const FRAME_HOSTS = ["127.0.0.2", "127.0.0.3"];
+
+// ---------------------------------------------------------------- statistics
+
+function quantile(sorted, q) {
+  if (!sorted.length) return null;
+  // Nearest-rank. With n=100 that makes p95 the 95th slowest sample, which is
+  // the reading people expect from a latency table.
+  const rank = Math.min(sorted.length - 1, Math.ceil(q * sorted.length) - 1);
+  return sorted[Math.max(0, rank)];
+}
+
+function round(value) {
+  return value === null || value === undefined ? null : Math.round(value * 100) / 100;
+}
+
+function stats(values) {
+  const v = values.filter((x) => Number.isFinite(x)).sort((a, b) => a - b);
+  if (!v.length) return null;
+  const mean = v.reduce((a, b) => a + b, 0) / v.length;
+  const variance = v.reduce((a, b) => a + (b - mean) ** 2, 0) / v.length;
+  return {
+    count: v.length,
+    p50_ms: round(quantile(v, 0.5)),
+    p95_ms: round(quantile(v, 0.95)),
+    mean_ms: round(mean),
+    stdev_ms: round(Math.sqrt(variance)),
+    min_ms: round(v[0]),
+    max_ms: round(v[v.length - 1]),
+  };
+}
+
+function countStats(values) {
+  const v = values.filter((x) => Number.isFinite(x)).sort((a, b) => a - b);
+  if (!v.length) return null;
+  return {
+    count: v.length,
+    p50: quantile(v, 0.5),
+    mean: round(v.reduce((a, b) => a + b, 0) / v.length),
+    min: v[0],
+    max: v[v.length - 1],
+  };
+}
+
+const log = (line) => process.stderr.write(`${line}\n`);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ------------------------------------------------------------------ fixtures
+
+// 1x1 transparent GIF. Small enough that transfer time is noise and the cost
+// being measured is purely per-request: guard RPC + route interception.
+const PIXEL = Buffer.from(
+  "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+  "base64",
+);
+
+function iframeBody(index) {
+  // Enough text that `innerText` extraction is not free — a frame-scan sample
+  // with an empty body would understate the cost the plan is chasing.
+  const paragraph =
+    "This is a benign iframe with ordinary prose in it, present only so the " +
+    "per-frame text extraction has something to extract and the measurement " +
+    "reflects a realistic embedded document rather than an empty one. ";
+  return (
+    `<!doctype html><meta charset="utf-8"><title>Frame ${index}</title>` +
+    `<body><h1>Benign frame ${index}</h1><p>${paragraph.repeat(6)}</p></body>`
+  );
+}
+
+async function startFixtureServer(indexOfServer, refs, host = "127.0.0.1") {
+  // Request counting is the only thing that turns "no-store means every load
+  // re-fetches all 50 subresources" from an assumption into an assertion. The
+  // guard-RPC count is the number under test, so it cannot also be the evidence
+  // that the requests happened — that reasoning is circular.
+  let measured = 0;
+  let total = 0;
+
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url || "/", `http://${host}`);
+    const pathname = url.pathname;
+    total++;
+    if (pathname === "/heavy" || pathname.startsWith("/asset/")) measured++;
+    // Everything is no-store so each load re-fetches every subresource. Cache
+    // hits would silently collapse the guard-RPC count and make the page-load
+    // benchmark measure nothing.
+    const nocache = { "cache-control": "no-store, no-cache, must-revalidate" };
+
+    if (pathname === "/static") {
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(
+        '<!doctype html><meta charset="utf-8"><title>Static fixture</title>' +
+          "<body><h1>Static fixture</h1><p>No subresources, no frames.</p></body>",
+      );
+      return;
+    }
+
+    if (pathname === "/heavy") {
+      // Subresources are dealt round-robin across every fixture origin, so the
+      // load crosses ORIGIN_COUNT distinct host:port guard keys.
+      const origins = refs.origins;
+      const parts = [];
+      for (let i = 0; i < SUBRESOURCE_COUNT; i++) {
+        const origin = origins[i % origins.length];
+        parts.push(
+          i % 5 === 0
+            ? `<script src="${origin}/asset/${i}.js"></script>`
+            : `<img alt="" width="1" height="1" src="${origin}/asset/${i}.gif">`,
+        );
+      }
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(
+        '<!doctype html><meta charset="utf-8"><title>Heavy fixture</title>' +
+          `<body><h1>Heavy fixture</h1>${parts.join("")}</body>`,
+      );
+      return;
+    }
+
+    if (pathname === "/frames") {
+      const wanted = Math.max(0, Number(url.searchParams.get("n") || MAX_IFRAMES));
+      const frameOrigins = refs.frameOrigins;
+      const frames = [];
+      for (let i = 0; i < wanted; i++) {
+        const origin = frameOrigins[i % frameOrigins.length];
+        frames.push(
+          `<iframe title="f${i}" width="200" height="80" src="${origin}/frame/${i}"></iframe>`,
+        );
+      }
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(
+        '<!doctype html><meta charset="utf-8"><title>Frames fixture</title>' +
+          `<body><h1>Frames fixture</h1>${frames.join("")}</body>`,
+      );
+      return;
+    }
+
+    if (pathname.startsWith("/frame/")) {
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(iframeBody(pathname.slice("/frame/".length)));
+      return;
+    }
+
+    if (pathname.endsWith(".js")) {
+      response.writeHead(200, { ...nocache, "content-type": "application/javascript" });
+      response.end(`/* asset ${pathname} on server ${indexOfServer} */\n`);
+      return;
+    }
+
+    if (pathname.endsWith(".gif")) {
+      response.writeHead(200, { ...nocache, "content-type": "image/gif" });
+      response.end(PIXEL);
+      return;
+    }
+
+    response.writeHead(404, nocache);
+    response.end("not found");
+  });
+
+  server.listen(0, host);
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  return {
+    origin: `http://${host}:${port}`,
+    host,
+    port,
+    resetHits() {
+      measured = 0;
+      total = 0;
+    },
+    hits() {
+      return { measured, total };
+    },
+    // Dropping keep-alive sockets between loads is what makes every measured
+    // load pay the SOCKS proxy's per-connection guards, instead of only the
+    // first one paying them (n=1) and the rest hiding them.
+    dropConnections() {
+      server.closeAllConnections?.();
+    },
+    async close() {
+      server.closeAllConnections?.();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+// -------------------------------------------------------------- measurements
+
+async function timedRun(bw, code) {
+  const start = performance.now();
+  const result = await bw.run(code);
+  const elapsed = performance.now() - start;
+  if (!result?.ok) throw new Error(`snippet failed: ${result?.error || "unknown error"}`);
+  return { elapsed, result };
+}
+
+const TRIVIAL = "return page.title()";
+
+async function measurePerAction(bw, origin, tag) {
+  log(`\n[${tag}] per-action latency, 0 frames — ${ACTION_WARMUP} warmup + ${ACTION_ITERS} iterations`);
+  const goto = await timedRun(
+    bw,
+    `await page.goto(${JSON.stringify(`${origin}/static`)}); return page.title()`,
+  );
+  log(`    loaded ${origin}/static in ${goto.elapsed.toFixed(0)}ms`);
+  for (let i = 0; i < ACTION_WARMUP; i++) await timedRun(bw, TRIVIAL);
+  const samples = [];
+  for (let i = 0; i < ACTION_ITERS; i++) {
+    const { elapsed } = await timedRun(bw, TRIVIAL);
+    samples.push(elapsed);
+    if ((i + 1) % 25 === 0) log(`    ${i + 1}/${ACTION_ITERS}`);
+  }
+  return stats(samples);
+}
+
+async function measurePageLoad(bw, origin, guard, servers) {
+  log(
+    `\n[B] page load + guard RPCs — ${LOAD_WARMUP} warmup + ${LOAD_ITERS} loads, ${SUBRESOURCE_COUNT} subresources / ${ORIGIN_COUNT} origins`,
+  );
+  const wall = [];
+  const inner = [];
+  const routeRpcs = [];
+  const transportRpcs = [];
+  const fixtureRequests = [];
+  // The warmup load is discarded: it is the only one whose renderer, socket
+  // pool and worker state have never seen this fixture. It is reported as
+  // `first_load` with n=1 and is NOT a headline metric.
+  let firstLoad = null;
+
+  for (let i = 0; i < LOAD_WARMUP + LOAD_ITERS; i++) {
+    // Cache-busting query string on top of no-store: belt and braces, since a
+    // repeat of the identical URL is the one thing that could let the browser
+    // skip the request entirely.
+    const url = `${origin}/heavy?load=${i}-${Date.now()}`;
+    // about:blank first so each measurement starts from a torn-down document
+    // rather than a warm one that may reuse subresources.
+    await timedRun(bw, "await page.goto('about:blank'); return 'reset'");
+    // Drop every keep-alive socket so the next load is connection-cold. Without
+    // this, only the first load pays the SOCKS proxy's per-connection guards
+    // and the connection-scoped cost is an n=1 anecdote.
+    for (const server of servers) server.dropConnections();
+    // Settle BEFORE the reset, not only after: tearing down the previous
+    // document produces trailing guard RPCs, and resetting the counter the
+    // instant `goto` returns attributes those stragglers to the next load. That
+    // is what made the steady-state count drift 51 -> 61 between runs.
+    await sleep(250);
+    guard.reset();
+    for (const server of servers) server.resetHits();
+
+    const start = performance.now();
+    const { result } = await timedRun(
+      bw,
+      `const t0 = Date.now();
+       await page.goto(${JSON.stringify(url)}, { waitUntil: 'load' });
+       await page.waitForLoadState('networkidle').catch(() => {});
+       return Date.now() - t0;`,
+    );
+    const elapsed = performance.now() - start;
+    // Guard RPCs are serviced on the host as the worker asks; the last few can
+    // land microtasks after networkidle resolves. A short settle keeps the
+    // count honest without meaningfully inflating it.
+    await sleep(250);
+    const counts = guard.count();
+    const requests = servers.reduce((sum, server) => sum + server.hits().measured, 0);
+
+    if (i < LOAD_WARMUP) {
+      // Liveness: if a refactor moves the guard off `_serviceRpc`, the counter
+      // reads 0 and a broken hook looks exactly like a total Phase A win.
+      if (!counts.route)
+        throw new Error(
+          "guard counter never fired: the client._serviceRpc hook is stale (no method === 'guard' RPCs observed)",
+        );
+      firstLoad = {
+        note: "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+        guard_rpcs_route: counts.route,
+        guard_rpcs_transport: counts.transport,
+        fixture_requests: requests,
+        wall_ms: round(elapsed),
+      };
+      log(
+        `    warmup load: ${elapsed.toFixed(0)}ms wall, ${counts.route} route + ${counts.transport} transport guard RPCs, ${requests} fixture requests`,
+      );
+      continue;
+    }
+
+    // The core assumption of this benchmark, asserted rather than assumed: if
+    // the memory cache ever starts serving `/asset/N.gif`, the guard count
+    // collapses and would otherwise read as a Phase A win.
+    if (requests !== EXPECTED_FIXTURE_REQUESTS)
+      throw new Error(
+        `fixture served ${requests} requests on load ${i - LOAD_WARMUP + 1}, expected ${EXPECTED_FIXTURE_REQUESTS} ` +
+          `(1 document + ${SUBRESOURCE_COUNT} subresources). Something is serving subresources from cache; ` +
+          "the guard-RPC counts for this run are not comparable.",
+      );
+
+    wall.push(elapsed);
+    inner.push(Number(result.result));
+    routeRpcs.push(counts.route);
+    transportRpcs.push(counts.transport);
+    fixtureRequests.push(requests);
+    log(
+      `    load ${i - LOAD_WARMUP + 1}/${LOAD_ITERS}: ${elapsed.toFixed(0)}ms wall, ${result.result}ms in-page, ` +
+        `${counts.route} route + ${counts.transport} transport guard RPCs, ${requests} fixture requests`,
+    );
+  }
+
+  const routeMean = routeRpcs.length
+    ? routeRpcs.reduce((a, b) => a + b, 0) / routeRpcs.length
+    : null;
+  return {
+    wall_time: stats(wall),
+    navigation_time: stats(inner),
+    guard_rpcs_per_load: {
+      note:
+        "route = context.route('**/*') interception, one per HTTP request, exact. " +
+        "transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; " +
+        "connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+      route: countStats(routeRpcs),
+      transport: countStats(transportRpcs),
+      total: countStats(routeRpcs.map((n, i) => n + transportRpcs[i])),
+    },
+    route_guard_rpcs_per_subresource:
+      routeMean === null ? null : round(routeMean / SUBRESOURCE_COUNT),
+    fixture_requests_per_load: countStats(fixtureRequests),
+    first_load: firstLoad,
+  };
+}
+
+async function measureChallengeScan(bw, origin, frameCount) {
+  log(
+    `\n[C${frameCount}] challenge-scan cost — ${frameCount} benign cross-site iframes, ${CHALLENGE_WARMUP} warmup + ${CHALLENGE_ITERS} iterations`,
+  );
+  const url = `${origin}/frames?n=${frameCount}`;
+  await timedRun(
+    bw,
+    `await page.goto(${JSON.stringify(url)}, { waitUntil: 'load' }); return page.title()`,
+  );
+
+  // Verify the frames really are attached and really are cross-site. Same-site
+  // frames would share the parent's renderer, and the measurement would be a
+  // floor rather than the number it claims to be.
+  const probe = await timedRun(
+    bw,
+    `const frames = await page.frames();
+     const urls = [];
+     for (const frame of frames) urls.push(await frame.url());
+     return { count: urls.length, urls };`,
+  );
+  const urls = (probe.result.result?.urls || []) as string[];
+  const mainHost = new URL(url).hostname;
+  const childHosts = urls
+    .slice(1)
+    .map((u) => {
+      try {
+        return new URL(u).hostname;
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+  const crossSite = childHosts.filter((h) => h !== mainHost).length;
+  if (childHosts.length !== frameCount)
+    throw new Error(
+      `expected ${frameCount} child frames, saw ${childHosts.length} (${urls.join(", ")})`,
+    );
+  if (crossSite !== frameCount)
+    throw new Error(
+      `expected all ${frameCount} child frames to be cross-site with ${mainHost}, only ${crossSite} were`,
+    );
+  log(`    ${frameCount} child frames attached, all cross-site (${[...new Set(childHosts)].join(", ")})`);
+
+  for (let i = 0; i < CHALLENGE_WARMUP; i++) await timedRun(bw, TRIVIAL);
+  const samples = [];
+  for (let i = 0; i < CHALLENGE_ITERS; i++) {
+    const { elapsed } = await timedRun(bw, TRIVIAL);
+    samples.push(elapsed);
+    if ((i + 1) % 10 === 0) log(`    ${i + 1}/${CHALLENGE_ITERS}`);
+  }
+  return {
+    frames: frameCount,
+    cross_site_frames: crossSite,
+    ...stats(samples),
+  };
+}
+
+// ------------------------------------------------------------------ plumbing
+
+// Counts guard RPCs at the stdio RPC boundary rather than at `policy.check`.
+// Two reasons: (1) it counts one per round-trip under any future batching
+// scheme (the plan keeps a `guardBatch` RPC on the table, and a `policy.check`
+// counter would still report N for a batch of N and hide the whole win);
+// (2) it lets the count be bucketed by `payload.resourceType`, which matters
+// because two very different populations arrive here:
+//   - route guards   — one per HTTP request from `context.route("**/*")`;
+//                      exactly (subresources + 1) and deterministic.
+//   - transport guards — the SOCKS proxy's per-connection hostname
+//                      (`resourceType: "transport"`) and per-resolved-IP
+//                      (`"transport-address"`) checks; nondeterministic,
+//                      because Chromium decides when to open a socket.
+// Totalling them produces a scalar that drifts +-12% while looking exact.
+function instrumentGuard(bw) {
+  const original = bw._serviceRpc.bind(bw);
+  const counts = { route: 0, transport: 0 };
+  bw._serviceRpc = (message, child) => {
+    if (message?.method === "guard") {
+      const type = message.payload?.resourceType;
+      if (type === "transport" || type === "transport-address") counts.transport++;
+      else counts.route++;
+    }
+    return original(message, child);
+  };
+  return {
+    reset() {
+      counts.route = 0;
+      counts.transport = 0;
+    },
+    count() {
+      return { ...counts };
+    },
+    restore() {
+      delete bw._serviceRpc;
+    },
+  };
+}
+
+function gitInfo() {
+  const git = (args) => {
+    try {
+      return execFileSync("git", args, { cwd: HERE, encoding: "utf8" }).trim();
+    } catch {
+      return null;
+    }
+  };
+  return {
+    commit: git(["rev-parse", "--short", "HEAD"]),
+    branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: !!git(["status", "--porcelain"]),
+  };
+}
+
+function readResults() {
+  let existing: any = {};
+  if (fs.existsSync(RESULTS)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(RESULTS, "utf8")) || {};
+    } catch {
+      // A corrupt or hand-edited file must not lose the run that just
+      // finished; keep it aside instead of overwriting it silently.
+      const backup = `${RESULTS}.bak`;
+      fs.copyFileSync(RESULTS, backup);
+      log(`\nresults.json was unparseable; copied to ${backup} and starting fresh.`);
+      existing = {};
+    }
+  }
+  return existing;
+}
+
+// Refuse to silently replace a recorded run. Checked BEFORE any measurement so
+// a doomed invocation costs zero seconds, and again in writeResults so a
+// concurrent writer cannot slip past. `--quick` also gets its own key suffix,
+// so a smoke run can never land on top of a full-fidelity baseline.
+function assertKeyFree(key, existing = readResults()) {
+  if (!existing.runs?.[key]) return;
+  if (!FORCE)
+    throw new Error(
+      `results.json already has a run under "${key}" (recorded ${existing.runs[key]?.metadata?.date}). ` +
+        "Overwriting it would destroy a recorded baseline. Re-run with a different --label, " +
+        "or pass --force to replace it deliberately.",
+    );
+  log(`warning: --force given; the existing run "${key}" will be replaced.`);
+}
+
+function writeResults(key, payload) {
+  const existing = readResults();
+  assertKeyFree(key, existing);
+  const merged = {
+    schema_version: "betterwright-perf-results-v2",
+    benchmark: "round-trip cost: per-action latency, page-load guard RPCs, challenge-scan overhead",
+    fixture: "local http.createServer only — no external network",
+    defined_in: "run.ts",
+    runs: { ...(existing.runs || {}), [key]: payload },
+  };
+  fs.writeFileSync(RESULTS, `${JSON.stringify(merged, null, 2)}\n`);
+}
+
+async function main() {
+  const git = gitInfo();
+  const key = `${LABEL}${QUICK ? "-quick" : ""}-${git.commit || "unknown"}`;
+  assertKeyFree(key);
+
+  const servers = [];
+  const frameServers = [];
+  const refs = { origins: [], frameOrigins: [] };
+  let bw = null;
+  let guard = null;
+  let home = null;
+  let shuttingDown = false;
+
+  // Teardown lives in a named function so it can be reached from BOTH the
+  // `finally` below and a SIGINT handler. `finally` alone does not cover
+  // Ctrl-C: Node's default SIGINT disposition kills the process outright, the
+  // pending `await` never resumes, and every aborted run leaves a
+  // `betterwright-perf-*` browser profile in os.tmpdir().
+  async function shutdown() {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    // Every teardown step is independently guarded: a failed bw.close() must
+    // not leave six http servers listening and a temp home on disk.
+    try {
+      guard?.restore();
+    } catch {
+      /* the wrap is harness-local; failing to unwrap cannot affect results */
+    }
+    try {
+      await bw?.close();
+    } catch (error) {
+      log(`warning: bw.close() failed: ${error}`);
+    }
+    for (const server of [...servers, ...frameServers]) {
+      try {
+        await server.close();
+      } catch {
+        /* a server that already errored out is already gone */
+      }
+    }
+    if (home) {
+      try {
+        fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      } catch {
+        /* leaving a temp dir behind is not worth failing the run over */
+      }
+      home = null;
+    }
+  }
+
+  const onSigint = () => {
+    log("\ninterrupted; tearing down browser, servers and temp home...");
+    void shutdown().finally(() => {
+      process.off("SIGINT", onSigint);
+      process.kill(process.pid, "SIGINT");
+    });
+  };
+  process.on("SIGINT", onSigint);
+
+  try {
+    for (let i = 0; i < ORIGIN_COUNT; i++) servers.push(await startFixtureServer(i, refs));
+    refs.origins = servers.map((s) => s.origin);
+    for (const [i, host] of FRAME_HOSTS.entries())
+      frameServers.push(await startFixtureServer(100 + i, refs, host));
+    refs.frameOrigins = frameServers.map((s) => s.origin);
+    log(`fixture origins: ${refs.origins.join(", ")}`);
+    log(`frame origins:   ${refs.frameOrigins.join(", ")}`);
+
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-perf-"));
+    bw = new BetterWright({
+      home,
+      // Stock NetworkPolicy: loopback is allowed by default, and an unmodified
+      // policy is what Phase A's `cacheable` flag will key on, so the baseline
+      // must be measured through the same object shape.
+      policy: new NetworkPolicy(),
+      headless: true,
+      // The vault is irrelevant here and its host-side redaction would add
+      // noise to every result envelope.
+      vault: false,
+    });
+    guard = instrumentGuard(bw);
+
+    const origin = refs.origins[0];
+    // A, then B, then C at each frame count with a fresh 0-frame control (A')
+    // measured BETWEEN the two C runs. The iframe tax is derived from the
+    // adjacent pair (C - A'), so monotonic per-session drift is measured
+    // instead of being charged to the iframes.
+    const perAction = await measurePerAction(bw, origin, "A");
+    const pageLoad = await measurePageLoad(bw, origin, guard, [...servers, ...frameServers]);
+
+    const challenges = [];
+    let perActionAfter = null;
+    for (const [i, frameCount] of IFRAME_COUNTS.entries()) {
+      challenges.push(await measureChallengeScan(bw, origin, frameCount));
+      if (i === 0) perActionAfter = await measurePerAction(bw, origin, "A'");
+    }
+    if (!perActionAfter) perActionAfter = await measurePerAction(bw, origin, "A'");
+
+    const drift =
+      perAction && perActionAfter ? round(perActionAfter.p50_ms - perAction.p50_ms) : null;
+    const driftPct =
+      perAction?.p50_ms && drift !== null ? round((drift / perAction.p50_ms) * 100) : null;
+
+    const iframeOverhead = {};
+    for (const c of challenges) {
+      iframeOverhead[`frames_${c.frames}`] = {
+        p50_ms: round(c.p50_ms - perActionAfter.p50_ms),
+        p95_ms: round(c.p95_ms - perActionAfter.p95_ms),
+        per_frame_p50_ms: round((c.p50_ms - perActionAfter.p50_ms) / c.frames),
+      };
+    }
+
+    const payload = {
+      metadata: {
+        label: LABEL,
+        date: new Date().toISOString(),
+        commit: git.commit,
+        branch: git.branch,
+        working_tree_dirty: git.dirty,
+        node: process.version,
+        platform: `${process.platform}-${process.arch}`,
+        cpus: os.cpus()?.length ?? null,
+        quick_mode: QUICK,
+        betterwright_version: JSON.parse(
+          fs.readFileSync(path.resolve(HERE, "..", "..", "package.json"), "utf8"),
+        ).version,
+      },
+      config: {
+        action_iterations: ACTION_ITERS,
+        action_warmup: ACTION_WARMUP,
+        load_iterations: LOAD_ITERS,
+        load_warmup: LOAD_WARMUP,
+        challenge_iterations: CHALLENGE_ITERS,
+        challenge_warmup: CHALLENGE_WARMUP,
+        subresources: SUBRESOURCE_COUNT,
+        origins: ORIGIN_COUNT,
+        iframe_counts: IFRAME_COUNTS,
+        frame_hosts: FRAME_HOSTS,
+        connections_dropped_between_loads: true,
+        snippet: TRIVIAL,
+      },
+      per_action_latency: perAction,
+      per_action_latency_after: perActionAfter,
+      session_drift: {
+        note: "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        p50_delta_ms: drift,
+        p50_delta_pct: driftPct,
+      },
+      page_load: pageLoad,
+      challenge_scan: challenges,
+      derived: {
+        // The headline Phase B number: what N benign cross-site iframes add to
+        // every single agent action, purely through the unconditional frame
+        // walk. Derived against the ADJACENT 0-frame control, not against the
+        // A measured at the other end of the session.
+        iframe_overhead: iframeOverhead,
+      },
+    };
+    writeResults(key, payload);
+
+    log(`\n=== ${key} ===`);
+    log(`per-action p50/p95:     ${perAction?.p50_ms}ms / ${perAction?.p95_ms}ms`);
+    log(`per-action p50 (A'):    ${perActionAfter?.p50_ms}ms  (session drift ${drift >= 0 ? "+" : ""}${drift}ms, ${driftPct}%)`);
+    log(`page-load wall p50:     ${pageLoad.wall_time?.p50_ms}ms`);
+    log(`route guard RPCs/load:  ${pageLoad.guard_rpcs_per_load.route?.p50} (p50), min ${pageLoad.guard_rpcs_per_load.route?.min} max ${pageLoad.guard_rpcs_per_load.route?.max}`);
+    log(`transport guard/load:   ${pageLoad.guard_rpcs_per_load.transport?.p50} (p50), min ${pageLoad.guard_rpcs_per_load.transport?.min} max ${pageLoad.guard_rpcs_per_load.transport?.max}`);
+    log(`fixture requests/load:  ${pageLoad.fixture_requests_per_load?.p50} (asserted ${EXPECTED_FIXTURE_REQUESTS})`);
+    for (const c of challenges)
+      log(`${String(c.frames).padStart(2)}-iframe page p50/p95: ${c.p50_ms}ms / ${c.p95_ms}ms  (tax +${iframeOverhead[`frames_${c.frames}`].p50_ms}ms, ${iframeOverhead[`frames_${c.frames}`].per_frame_p50_ms}ms/frame)`);
+    log(`\nresults.json updated: ${RESULTS}`);
+  } finally {
+    process.off("SIGINT", onSigint);
+    await shutdown();
+  }
+}
+
+main().catch((error) => {
+  log(`\nbenchmark failed: ${error?.stack || error}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds `benchmarks/perf/` — a regression harness for the round-trip performance work (PR-0 of the perf program). No `src/` changes.

Measures three signals against local HTTP fixtures (no external network):

- **Per-action latency** — `run()` of a trivial snippet, 100 iterations, p50/p95, with an adjacent late-session control to cancel JIT drift.
- **Page-load guard RPCs** — counted at the client `_serviceRpc` boundary (survives future batching), bucketed into `route` (the `context.route("**/*")` population — exactly 1:1 with requests, min=max=51 on the fixture) vs `transport` (SOCKS per-connection guards, connection-cold on every measured load). Fixture servers count their own requests and the run fails if any load isn't exactly 51, ruling out browser-cache contamination.
- **Challenge-scan tax** — per-action latency with N genuinely cross-site OOPIF iframes (extra loopback IPs, asserted cross-site), measured at N=10 and N=24.

### 1.6.2 baseline (`baseline-52a577d`)

| Metric | p50 |
|---|---|
| Per-action latency (quiet page) | 7.60 ms |
| Route guard RPCs / 51-request load | 51 (exact) |
| Transport guard RPCs / load | ~44 |
| Iframe tax, 10 frames | +30.2 ms |
| Iframe tax, 24 frames | +54.1 ms |

The route-RPC count and iframe tax are the regression signals for the follow-up PRs (worker-side guard decision cache; gated/batched challenge scan).

Harness details: liveness assertion on the RPC hook (a stale hook fails the run instead of reporting a fake win), SIGINT-safe teardown, refuses to overwrite a recorded results key without `--force`, `--quick` mode records under a separate key.

## Test plan

- `npm run build:harness` compiles clean; `npm run lint` / `npm run typecheck` clean.
- Three full runs end-to-end with all assertions passing; run-to-run agreement within noise bounds documented in `benchmarks/perf/REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)