### PR TITLE
perf: worker-side guard decision cache + parallel IP validation (−97% guard RPCs/load)

### DIFF
--- a/benchmarks/perf/REPORT.md
+++ b/benchmarks/perf/REPORT.md
@@ -280,6 +280,96 @@ Caveats when comparing runs:
 - Only run this on an idle machine. A browser build, a test suite, or a video
   call in the background will swamp the per-action numbers.
 
+## Phase A results
+
+`phase-a-cee1d46` and `phase-a-repeat-cee1d46` — 2026-08-03, same machine, Node
+v26.5.0, linux-x64, 8 CPUs, branch `perf/guard-cache`: worker-side guard
+decision cache (`src/guard-url.ts`) plus parallel resolved-IP validation
+(`src/guard-proxy.ts`). Two full-fidelity runs back to back, for the same reason
+the baseline has a `repeat`.
+
+| Metric (p50) | baseline | phase-a | repeat | delta |
+|---|---|---|---|---|
+| **A.** Per-action latency (n=100) | 7.60 ms | 7.36 ms | 7.35 ms | −3.2% |
+| **A'.** Per-action latency, late-session (n=100) | 6.45 ms | 6.19 ms | 6.50 ms | ±noise |
+| **B.** Page-load wall time (n=10) | 715.8 ms | 713.8 ms | 716.2 ms | −0.3% |
+| **B.** In-page navigation time (n=10) | 695 ms | 691 ms | 689 ms | −0.7% |
+| **C.** Per-action, 10 cross-site iframes (n=30) | 36.68 ms | 35.41 ms | 33.31 ms | ±noise (−3.5% / −9.2%) |
+| **C.** Per-action, 24 cross-site iframes (n=30) | 60.57 ms | 66.08 ms | 60.28 ms | see below |
+
+| Guard RPCs per load (n=10) | baseline p50 | phase-a p50 | baseline mean | phase-a mean | delta (mean) |
+|---|---|---|---|---|---|
+| **`route`** — one per HTTP request | **51** (51–51) | **1** (1–6) | 51 | 2.0 | **−96.1%** |
+| **`transport`** — per-connection hostname + IP | **44** (36–48) | **0** (0–3) | 42.8 | 0.8 | **−98.1%** |
+| `total` | 95 | 1 | 93.8 | 2.8 | −97.0% |
+
+| Assertion | baseline | phase-a |
+|---|---|---|
+| Fixture requests per load (n=10) | **51** — min 51, max 51 | **51** — min 51, max 51 (enforced) |
+| Route guard RPCs per subresource | 1.02 | **0.04** |
+| Warmup (cold-cache) load: route / transport | 51 / 46 | 6 / 5 — repeat 5 / 3 |
+
+| Derived (against the adjacent A' control) | baseline | phase-a | repeat |
+|---|---|---|---|
+| Iframe tax per action, 10 frames (p50) | +30.23 ms | +29.22 ms | +26.81 ms |
+| Iframe tax per action, 24 frames (p50) | +54.12 ms | +59.89 ms | +53.78 ms |
+| Session drift (A' − A, p50) | −15.1% | −15.9% | −11.6% |
+
+### Reading Phase A
+
+**The route bucket — the one the baseline called "exact, treat any movement as
+real" — went from a flat 51 to a p50 of 1, and the fixture still served exactly
+51 requests on every measured load.** That cross-check is the whole reason to
+believe the number: the subresources were genuinely re-fetched, the guard simply
+stopped costing a stdio round-trip. The steady-state 1 is the cache-busted
+document, which is a `fullUrl` check and therefore *never* cacheable by
+construction — so 1/load is the floor this design can reach, and it reaches it.
+The mean of 2.0 rather than 1.0 is the 5 s TTL amortising: a load cycle is
+~1.25 s, so roughly every fourth load re-pays first contact (loads 4 and 8 in the
+first run). That is the TTL doing its job against mutable `allowHosts`, not a
+miss. Cold-cache cost is 5–6 route RPCs, and tracing the payload URLs shows why
+it is 5–6 and not a fixed 5: one document plus one miss per distinct origin
+(4), plus occasionally one *duplicate* miss when two same-origin subresources
+are in flight before the first RPC resolves. There is no single-flight
+coalescing, so concurrent first contacts to one key can each miss. It is bounded
+by connection concurrency, costs at most a handful of RPCs once per key per TTL,
+and is worth noting rather than fixing now.
+
+**Two caveats keep the transport row honest.** Its collapse to a p50 of 0 is
+real but this fixture flatters its *shape*: every origin is a literal IP, so
+`transportUrl(host, port)` and `transportUrl(address, port)` produce the same
+cache key, which makes the per-IP `transport-address` check a guaranteed hit —
+zero of them appear in a traced load. Against a real hostname with N A-records
+the keys differ, so first contact costs 1 + N and every repeat contact costs 0;
+still a collapse, just not to zero on the first connection. And **the parallel
+IP validation is not measured by this harness at all** — loopback resolves to a
+single address, so there is nothing to overlap, and the cache turns the check
+into a hit regardless. That half of Phase A needs a multi-A-record target to
+show up anywhere, and no number in this table is evidence for or against it.
+
+**Wall time did not move, exactly as the baseline predicted, and per-action
+latency is flat-to-marginally-better.** 715.8 → 713.8/716.2 ms: 50 removed
+round-trips are invisible against ~695 ms of fixture navigation and `networkidle`
+settling, which is why the counts and not the clock are the Phase A metrics. The
+~3% dip in A is within the ±2% the baseline records for repeated runs; do not
+bank it.
+
+**Neither challenge-scan row carries a Phase A signal — both are noise.** Phase A
+touches nothing in `collectChallengeMetadata` or `collectFrameMetadata`, so any
+movement here is run-to-run spread, and the two rows are quoted as ranges rather
+than deltas for that reason. C24 is the one that needed a second run: the first
+Phase A run put the 24-frame page at 66.08 ms, +9.1% over baseline — outside the
+±0.4% spread the Variance section claims for that metric. The repeat came back at
+60.28 ms against a 60.57 ms baseline (−0.5%). Across the four recorded full runs
+the 24-frame p50 has spanned 60.28–66.08 ms and the 10-frame p50 has spanned
+33.31–36.68 ms — **~10% for both, so the earlier claim that the 24-frame figure
+is the steadier of the two challenge-scan points (<1%) is wrong** until more runs
+say otherwise. The C10 arms straddle that whole band (−3.5% for the first run,
+−9.2% for the repeat, and +1.1% if the means are compared instead), which is why
+no single delta is quoted. Phase B is graded on these metrics, so treat
+60.3–60.6 ms and 33.3–36.7 ms as its baselines and require a win far larger than
+10%.
+
 ## Files
 
 - [`run.ts`](run.ts) — the harness. Compiled to `run.js` by `npm run

--- a/benchmarks/perf/REPORT.md
+++ b/benchmarks/perf/REPORT.md
@@ -1,0 +1,290 @@
+# Round-trip cost: per-action latency, guard RPCs, challenge-scan overhead
+
+This harness measures the three round-trip costs that the current performance
+plan targets. Unlike the other benchmarks in this directory it touches **no
+external network at all** — every byte comes from `http.createServer` fixtures
+on loopback — so it is fully reproducible on any machine with the browser
+runtime installed, and the numbers describe BetterWright's own overhead rather
+than someone else's CDN.
+
+It exists to answer one question per phase of the plan, before and after:
+
+| Benchmark | Measures | Plan target |
+|---|---|---|
+| **A / A'.** Per-action latency | The floor cost of one agent action on a quiet page | Baseline for everything; Phase B's sandbox hoists move it |
+| **B.** Page load + guard RPC count | Stdio round-trips paid per page load | **Phase A** — worker-side guard decision cache |
+| **C.** Challenge-scan cost | What benign cross-site iframes add to *every* action | **Phase B** — staged challenge scan |
+
+## How to run
+
+```
+npm run build:harness
+node benchmarks/perf/run.js
+```
+
+Roughly 25 seconds. Flags:
+
+- `--quick` — 20/3/10 iterations instead of 100/10/30, and only the 10-frame
+  challenge scan. For editing the harness, not for numbers you intend to
+  record. Quick runs write under their own `<label>-quick-<sha>` key, so they
+  **cannot** overwrite a recorded full-fidelity baseline.
+- `--label <name>` — the results key prefix (default `baseline`). Results land
+  in `results.json` under `runs["<label>[-quick]-<short sha>"]`, **merged** with
+  what is already there, so a before and an after live side by side in one
+  file. Use `--label baseline` before a change and `--label phase-a` after it.
+- `--iframes <n>[,<n>...]` — frame counts for benchmark C (default `10,24`).
+- `--force` — replace an existing run under the same key. Without it the
+  harness **refuses** to overwrite a recorded run, and it checks this *before*
+  measuring anything, so a doomed invocation costs zero seconds.
+
+The harness needs the managed browser runtime (`betterwright setup`). It creates
+its own temp home, uses a stock `NetworkPolicy`, and runs with `vault: false` so
+host-side secret redaction does not add noise to every result envelope.
+
+Teardown (browser, six fixture listeners, temp home) lives in a named
+`shutdown()` reached from **both** the `finally` block and a `SIGINT` handler.
+`finally` alone does not cover Ctrl-C — Node's default SIGINT disposition kills
+the process outright and the pending `await` never resumes — which is why the
+signal handler is explicit. Verified: `SIGINT` mid-run exits 130 and leaves no
+`betterwright-perf-*` profile in `os.tmpdir()`.
+
+## What each benchmark actually does
+
+### A / A'. Per-action latency
+
+Loads a fixture page with no subresources and no frames, then executes
+`return page.title()` 100 times (5 warmup iterations discarded), timing each
+`bw.run()` call end to end from the host process.
+
+This is the floor every agent action pays regardless of what the page contains:
+client to worker stdio RPC, sandbox realm creation, snippet compile, execute,
+challenge scan, envelope build, response. A trivial snippet on a quiet page
+isolates that scaffolding from any real work.
+
+It is measured **twice**: once at the start of the session (A) and once between
+the two challenge-scan runs (A'). Benchmark C otherwise sits at the far end of a
+long session — after ~110 executes, 11 page loads, and a grown `session.events`
+/ `session.artifacts` — and any per-session drift would be charged entirely to
+the iframes. The reported iframe tax is derived from the **adjacent** pair,
+`C − A'`, and `session_drift` records `A' − A` so the drift is a number rather
+than a silent bias.
+
+### B. Page-load wall time + guard RPC count
+
+One fixture page pulls **50 subresources spread round-robin across 4 distinct
+`127.0.0.1:<port>` origins**. Distinct ports matter: they are distinct guard
+cache keys, which is precisely the case Phase A's worker-side LRU has to handle.
+
+Three things make each measured load honest:
+
+1. **Everything is `no-store` and the document URL is cache-busted per load.**
+2. **Every fixture server counts its own requests** (`fixture_requests_per_load`)
+   and the run **fails** if any measured load is not exactly 51 (1 document +
+   50 subresources). Without this the only evidence that subresources were
+   re-fetched would be the guard count — the very number under test. If a
+   Chromium change or a header edit ever let the memory cache serve
+   `/asset/N.gif`, the guard count would collapse and read as a Phase A win.
+3. **All keep-alive sockets are dropped between loads**
+   (`server.closeAllConnections()`), so every measured load is connection-cold
+   and the SOCKS proxy's per-connection guards appear as a full n=10 series
+   instead of a single confounded warmup sample.
+
+The `about:blank` teardown navigation is followed by a **250 ms settle before**
+`guard.reset()`, not only after the timed load. Tearing down the previous
+document emits trailing guard RPCs; resetting the counter the instant `goto`
+returns attributed those stragglers to the next load, which is what made the
+count drift run to run.
+
+Guard RPCs are counted **without modifying `src/`**, at the **stdio RPC
+boundary** rather than at `policy.check`:
+
+```js
+const original = bw._serviceRpc.bind(bw);
+bw._serviceRpc = (message, child) => {
+  if (message?.method === "guard") { /* bucket by message.payload.resourceType */ }
+  return original(message, child);
+};
+```
+
+Wrapping `_serviceRpc` rather than `policy.check` matters for two reasons. It
+counts **one per round-trip under any batching scheme** — the plan keeps a
+`guardBatch` RPC on the table, and a `policy.check` counter would still report N
+for a batch of N and hide the entire win. And it exposes `payload.resourceType`,
+which is what lets the count be **bucketed**, which it must be:
+
+- **`guard_rpcs_per_load.route`** — the `context.route("**/*")` interception
+  (`src/worker.ts:1393`): one RPC per HTTP request. Exactly
+  `subresources + 1`, and genuinely invariant.
+- **`guard_rpcs_per_load.transport`** — the SOCKS guard proxy's per-connection
+  guards: one hostname check (`resourceType: "transport"`,
+  `src/guard-proxy.ts:517`) plus one per resolved IP
+  (`"transport-address"`, `:546`). **Connection-scoped and inherently
+  variable**, because Chromium decides how many sockets to open and when.
+
+Totalling the two produces a scalar that drifts ±12% while looking exact. It is
+still reported as `.total`, but the two buckets are the numbers to read.
+
+There is also a **liveness assertion**: if the warmup load records zero route
+guards, the run throws. Otherwise a refactor that moves the check off
+`_serviceRpc` would report 0 guard RPCs, and a broken hook would look exactly
+like a total Phase A win.
+
+### C. Challenge-scan cost
+
+Identical snippet to benchmark A (`return page.title()`, 30 iterations, 3
+warmup) against a page embedding **N benign iframes**, each with a real body of
+prose so per-frame text extraction has something to extract. Nothing on the page
+is a challenge. Measured at **N = 10 and N = 24** (24 is the hard cap in
+`collectFrameMetadata`, `src/worker.ts:3973`), so frame scaling is measured data
+rather than extrapolation.
+
+The frames are served from **distinct loopback hostnames** (`127.0.0.2`,
+`127.0.0.3`) while the parent is on `127.0.0.1`. This is load-bearing:
+Chromium's site isolation keys on scheme + eTLD+1 and **ignores the port**, so
+same-host different-port frames would share the parent's renderer process and
+their frame walks would be cheap same-process CDP. Distinct IPs are distinct
+sites, so these are real OOPIFs with their own targets — which is what an
+ad-heavy page actually looks like. The harness **asserts** it: after navigation
+it reads `page.frames()` and fails unless all N children are attached and all N
+are cross-site with the parent.
+
+`detectSessionChallenges` runs unconditionally on every execute. **C minus A' is
+therefore the per-action tax that benign iframes impose today** — reported as
+`derived.iframe_overhead.frames_<n>`.
+
+## Baseline results
+
+`baseline-52a577d` — 2026-08-03, BetterWright 1.6.2, Node v26.5.0, linux-x64,
+8 CPUs, commit `52a577d` (`perf/bench-harness`, before any Phase A/B change).
+
+| Metric | p50 | p95 | mean | stdev |
+|---|---|---|---|---|
+| **A.** Per-action latency (n=100) | **7.60 ms** | 11.31 ms | 7.93 ms | 1.85 ms |
+| **A'.** Per-action latency, late-session (n=100) | **6.45 ms** | 8.56 ms | 6.37 ms | 1.17 ms |
+| **B.** Page-load wall time (n=10) | **715.8 ms** | 756.6 ms | 720.2 ms | 15.7 ms |
+| **B.** In-page navigation time (n=10) | 695 ms | 728 ms | 697.5 ms | 13.6 ms |
+| **C.** Per-action, 10 cross-site iframes (n=30) | **36.68 ms** | 46.45 ms | 35.95 ms | 5.03 ms |
+| **C.** Per-action, 24 cross-site iframes (n=30) | **60.57 ms** | 71.16 ms | 61.10 ms | 4.76 ms |
+
+| Guard RPCs per load (n=10) | p50 | min | max | mean |
+|---|---|---|---|---|
+| **`route`** — one per HTTP request | **51** | 51 | 51 | 51 |
+| **`transport`** — per-connection hostname + IP | **44** | 36 | 48 | 42.8 |
+| `total` | 95 | 87 | 99 | 93.8 |
+
+| Assertion | Value |
+|---|---|
+| Fixture requests per load (n=10) | **51** — min 51, max 51 (enforced) |
+| Route guard RPCs per subresource | 1.02 |
+
+| Derived (against the adjacent A' control) | Value |
+|---|---|
+| **Iframe tax per action, 10 frames (p50)** | **+30.23 ms** (3.02 ms/frame) |
+| Iframe tax per action, 10 frames (p95) | +37.89 ms |
+| **Iframe tax per action, 24 frames (p50)** | **+54.12 ms** (2.26 ms/frame) |
+| Iframe tax per action, 24 frames (p95) | +62.60 ms |
+| Session drift (A' − A, p50) | −1.15 ms (−15.1%) |
+
+### Reading the baseline
+
+**Route guards: 51 per load for 50 subresources, and this one *is* exact.**
+50 subresources + 1 document = 51 stdio round-trips, min = max = 51 across all
+10 loads in both recorded runs, with the fixture independently confirming 51
+requests were served. Every one of those is a synchronous pipe round-trip to the
+client process for what `src/client.ts:686` resolves as pure sync CPU. This is
+the cleanest Phase A signal in the file: **treat any movement in the `route`
+series as real.**
+
+**Transport guards: ~43 per connection-cold load, and this one is *not*
+exact — by nature.** Every measured load drops all keep-alive sockets first, so
+each pays the SOCKS proxy's per-connection cost afresh: one hostname guard plus
+one per resolved IP, issued serially (`src/guard-proxy.ts:546`). The observed
+range is 36–48 across 10 loads in both recorded runs, because Chromium decides
+how many sockets to open to each of the four origins and when. **Do not read a
+±6 move here as a regression** — compare p50 and mean across ≥10 loads.
+Phase A targets both buckets, and a real ad-heavy page with many origins and
+short-lived connections looks much more like this row than like a keep-alive
+steady state, which is why every measured load is deliberately connection-cold.
+
+An earlier version of this harness reported the two buckets summed as a single
+"51, zero variance" invariant. That was wrong: the sum drifts ±12% run to run,
+and the doc instructed the reviewer to read that drift as signal.
+
+**Benign iframes cost 6–9x the entire base action.** 36.7 ms at 10 frames and
+60.6 ms at 24 versus a 6.45 ms floor: iframes that contain nothing but prose make
+every single agent action **six to nine times slower**, purely through the
+unconditional frame walk, and it is paid on *every* execute whether or not a
+challenge exists. This is the Phase B target.
+
+**The frame cost is sublinear in frame count, and the two measured points say
+how sublinear.** 10 frames cost +30.2 ms (3.02 ms/frame); 24 frames cost
++54.1 ms (2.26 ms/frame). A 2.4x frame count buys a 1.8x tax — the ~25%
+per-frame discount is `collectFrameMetadata`'s `Promise.all` overlapping the ~5
+CDP round-trips *across* frames, while they stay sequential *within* a frame
+(`src/worker.ts:3973`). So do not divide the tax by frames and call it a
+per-frame round-trip cost, and do not extrapolate 10 frames to 24 — the harness
+measures both points, and `--iframes` takes any list. At the 24-frame cap the
+frame walk is still roughly **8x the entire rest of the action**.
+
+**Per-action latency itself is already tight** at 6.5–7.6 ms p50 on a quiet
+page. Phase B's sandbox hoists (realm script, `compileCode` heuristic) are
+chipping at a small number; expect single-digit-percent movement here, and do
+not read a 1 ms shift as a win.
+
+## Variance
+
+The full battery was run twice back to back on an otherwise idle machine
+(`baseline-52a577d` and `repeat-52a577d`, both in `results.json`):
+
+| Metric | baseline | repeat | delta |
+|---|---|---|---|
+| Per-action p50 (A) | 7.60 ms | 7.45 ms | −2.0% |
+| Per-action p50 (A') | 6.45 ms | 6.34 ms | −1.7% |
+| Page-load wall p50 | 715.8 ms | 715.2 ms | −0.1% |
+| Route guard RPCs / load | 51 (51–51) | 51 (51–51) | 0 |
+| Transport guard RPCs / load | 44 p50, 42.8 mean (36–48) | 42 p50, 42.8 mean (36–48) | 0% on the mean |
+| Fixture requests / load | 51 | 51 | 0 |
+| 10-iframe p50 | 36.68 ms | 33.92 ms | −7.5% |
+| 24-iframe p50 | 60.57 ms | 60.70 ms | +0.2% |
+| Iframe tax p50, 10 frames | 30.23 ms | 27.58 ms | −8.8% |
+| Iframe tax p50, 24 frames | 54.12 ms | 54.36 ms | +0.4% |
+
+Caveats when comparing runs:
+
+- **The `route` guard count is exact**, not statistical: min = max = 51 in both
+  runs, cross-checked against the fixture's own request counter. Treat *any*
+  change as real.
+- **The `transport` guard count is statistical.** It ranged 36–48 per load in
+  both runs; the p50 moved 44 to 42 while the mean was identical at 42.8.
+  Compare p50/mean over the full n=10 series; a single-load reading means
+  nothing.
+- **p50s are reliable to a few percent, except the 10-frame scan; p95s are not
+  reliable at all.** The 10-iframe p95 moved 46.5 to 40.4 ms between two
+  identical runs. Compare p50s; treat a p95 delta under ~30% as noise.
+- **Per-session drift is real and is now measured, not assumed.** `A' − A` was
+  −15.1% and −14.9% in the two runs: the late-session A' is consistently
+  *faster*, not slower — JIT warmup dominates any session-state growth over a
+  run this size. Because the tax is derived from `C − A'`, this makes the
+  reported tax slightly *larger* than the old `C − A` form did, and correctly
+  so. If a future run shows `session_drift` swinging positive by more than a
+  few percent, the iframe tax for that run is suspect.
+- **The iframe tax carries ~9% run-to-run spread at 10 frames and <1% at 24.**
+  It is a difference of two measurements, so it inherits both their variances,
+  and the 24-frame figure is the steadier of the two. A Phase B win needs to be
+  much larger than 9% to count — which, given it should remove most of the 30
+  ms, it will be.
+- **Page-load wall time is dominated by the fixture**, not by BetterWright: 695
+  of the 716 ms is in-page navigation including `networkidle` settling. Do not
+  expect Phase A to move this number much even if it removes 50 RPCs; the RPC
+  *counts* are the metrics that matter there, and wall time is context.
+- Only run this on an idle machine. A browser build, a test suite, or a video
+  call in the background will swamp the per-action numbers.
+
+## Files
+
+- [`run.ts`](run.ts) — the harness. Compiled to `run.js` by `npm run
+  build:harness`; the emitted `.js` is gitignored (`benchmarks/*/*.js`), same as
+  every other harness here.
+- [`results.json`](results.json) — all recorded runs, keyed by
+  `<label>[-quick]-<short sha>`, each with its own metadata and config block.
+  Schema `betterwright-perf-results-v2`.

--- a/benchmarks/perf/results.json
+++ b/benchmarks/perf/results.json
@@ -311,6 +311,314 @@
           }
         }
       }
+    },
+    "phase-a-cee1d46": {
+      "metadata": {
+        "label": "phase-a",
+        "date": "2026-08-03T03:11:06.944Z",
+        "commit": "cee1d46",
+        "branch": "perf/guard-cache",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.36,
+        "p95_ms": 10.73,
+        "mean_ms": 7.64,
+        "stdev_ms": 1.52,
+        "min_ms": 4.69,
+        "max_ms": 11.75
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.19,
+        "p95_ms": 8.03,
+        "mean_ms": 6.23,
+        "stdev_ms": 1.26,
+        "min_ms": 4.24,
+        "max_ms": 11.36
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -1.17,
+        "p50_delta_pct": -15.9
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 713.77,
+          "p95_ms": 750.38,
+          "mean_ms": 722.31,
+          "stdev_ms": 16.74,
+          "min_ms": 699.05,
+          "max_ms": 750.38
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 691,
+          "p95_ms": 726,
+          "mean_ms": 699.8,
+          "stdev_ms": 16.23,
+          "min_ms": 679,
+          "max_ms": 726
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 1,
+            "mean": 2,
+            "min": 1,
+            "max": 6
+          },
+          "transport": {
+            "count": 10,
+            "p50": 0,
+            "mean": 0.8,
+            "min": 0,
+            "max": 3
+          },
+          "total": {
+            "count": 10,
+            "p50": 1,
+            "mean": 2.8,
+            "min": 1,
+            "max": 9
+          }
+        },
+        "route_guard_rpcs_per_subresource": 0.04,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 6,
+          "guard_rpcs_transport": 5,
+          "fixture_requests": 51,
+          "wall_ms": 754.11
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 35.41,
+          "p95_ms": 45.04,
+          "mean_ms": 36.34,
+          "stdev_ms": 5.35,
+          "min_ms": 30.64,
+          "max_ms": 57.45
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 66.08,
+          "p95_ms": 79.12,
+          "mean_ms": 67.01,
+          "stdev_ms": 6.18,
+          "min_ms": 57.02,
+          "max_ms": 82.59
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 29.22,
+            "p95_ms": 37.01,
+            "per_frame_p50_ms": 2.92
+          },
+          "frames_24": {
+            "p50_ms": 59.89,
+            "p95_ms": 71.09,
+            "per_frame_p50_ms": 2.5
+          }
+        }
+      }
+    },
+    "phase-a-repeat-cee1d46": {
+      "metadata": {
+        "label": "phase-a-repeat",
+        "date": "2026-08-03T03:13:44.196Z",
+        "commit": "cee1d46",
+        "branch": "perf/guard-cache",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.35,
+        "p95_ms": 9.26,
+        "mean_ms": 7.3,
+        "stdev_ms": 1.46,
+        "min_ms": 4.26,
+        "max_ms": 13.81
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.5,
+        "p95_ms": 8.77,
+        "mean_ms": 6.53,
+        "stdev_ms": 1.28,
+        "min_ms": 4.29,
+        "max_ms": 11.4
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -0.85,
+        "p50_delta_pct": -11.56
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 716.24,
+          "p95_ms": 725.62,
+          "mean_ms": 715.59,
+          "stdev_ms": 8.17,
+          "min_ms": 700.72,
+          "max_ms": 725.62
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 689,
+          "p95_ms": 704,
+          "mean_ms": 692.4,
+          "stdev_ms": 7.34,
+          "min_ms": 681,
+          "max_ms": 704
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 1,
+            "mean": 2,
+            "min": 1,
+            "max": 6
+          },
+          "transport": {
+            "count": 10,
+            "p50": 0,
+            "mean": 0.9,
+            "min": 0,
+            "max": 4
+          },
+          "total": {
+            "count": 10,
+            "p50": 1,
+            "mean": 2.9,
+            "min": 1,
+            "max": 10
+          }
+        },
+        "route_guard_rpcs_per_subresource": 0.04,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 5,
+          "guard_rpcs_transport": 3,
+          "fixture_requests": 51,
+          "wall_ms": 725.65
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 33.31,
+          "p95_ms": 46.22,
+          "mean_ms": 34.23,
+          "stdev_ms": 4.8,
+          "min_ms": 27.1,
+          "max_ms": 49.49
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 60.28,
+          "p95_ms": 71.96,
+          "mean_ms": 61.54,
+          "stdev_ms": 5.52,
+          "min_ms": 52.15,
+          "max_ms": 79.37
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 26.81,
+            "p95_ms": 37.45,
+            "per_frame_p50_ms": 2.68
+          },
+          "frames_24": {
+            "p50_ms": 53.78,
+            "p95_ms": 63.19,
+            "per_frame_p50_ms": 2.24
+          }
+        }
+      }
     }
   }
 }

--- a/benchmarks/perf/results.json
+++ b/benchmarks/perf/results.json
@@ -1,0 +1,316 @@
+{
+  "schema_version": "betterwright-perf-results-v2",
+  "benchmark": "round-trip cost: per-action latency, page-load guard RPCs, challenge-scan overhead",
+  "fixture": "local http.createServer only — no external network",
+  "defined_in": "run.ts",
+  "runs": {
+    "baseline-52a577d": {
+      "metadata": {
+        "label": "baseline",
+        "date": "2026-08-03T02:45:38.020Z",
+        "commit": "52a577d",
+        "branch": "perf/bench-harness",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.6,
+        "p95_ms": 11.31,
+        "mean_ms": 7.93,
+        "stdev_ms": 1.85,
+        "min_ms": 4.9,
+        "max_ms": 17.4
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.45,
+        "p95_ms": 8.56,
+        "mean_ms": 6.37,
+        "stdev_ms": 1.17,
+        "min_ms": 4.15,
+        "max_ms": 9.57
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -1.15,
+        "p50_delta_pct": -15.13
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 715.76,
+          "p95_ms": 756.58,
+          "mean_ms": 720.17,
+          "stdev_ms": 15.71,
+          "min_ms": 698.55,
+          "max_ms": 756.58
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 695,
+          "p95_ms": 728,
+          "mean_ms": 697.5,
+          "stdev_ms": 13.59,
+          "min_ms": 680,
+          "max_ms": 728
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 51,
+            "mean": 51,
+            "min": 51,
+            "max": 51
+          },
+          "transport": {
+            "count": 10,
+            "p50": 44,
+            "mean": 42.8,
+            "min": 36,
+            "max": 48
+          },
+          "total": {
+            "count": 10,
+            "p50": 95,
+            "mean": 93.8,
+            "min": 87,
+            "max": 99
+          }
+        },
+        "route_guard_rpcs_per_subresource": 1.02,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 51,
+          "guard_rpcs_transport": 46,
+          "fixture_requests": 51,
+          "wall_ms": 734.54
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 36.68,
+          "p95_ms": 46.45,
+          "mean_ms": 35.95,
+          "stdev_ms": 5.03,
+          "min_ms": 28.03,
+          "max_ms": 47.59
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 60.57,
+          "p95_ms": 71.16,
+          "mean_ms": 61.1,
+          "stdev_ms": 4.76,
+          "min_ms": 53.78,
+          "max_ms": 77.16
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 30.23,
+            "p95_ms": 37.89,
+            "per_frame_p50_ms": 3.02
+          },
+          "frames_24": {
+            "p50_ms": 54.12,
+            "p95_ms": 62.6,
+            "per_frame_p50_ms": 2.26
+          }
+        }
+      }
+    },
+    "repeat-52a577d": {
+      "metadata": {
+        "label": "repeat",
+        "date": "2026-08-03T02:46:08.972Z",
+        "commit": "52a577d",
+        "branch": "perf/bench-harness",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.45,
+        "p95_ms": 10.63,
+        "mean_ms": 7.49,
+        "stdev_ms": 1.49,
+        "min_ms": 4.79,
+        "max_ms": 12.06
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.34,
+        "p95_ms": 8.73,
+        "mean_ms": 6.54,
+        "stdev_ms": 1.2,
+        "min_ms": 4.39,
+        "max_ms": 11.03
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -1.11,
+        "p50_delta_pct": -14.9
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 715.19,
+          "p95_ms": 744.25,
+          "mean_ms": 718.58,
+          "stdev_ms": 9.67,
+          "min_ms": 707.68,
+          "max_ms": 744.25
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 691,
+          "p95_ms": 724,
+          "mean_ms": 695.1,
+          "stdev_ms": 10.77,
+          "min_ms": 686,
+          "max_ms": 724
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 51,
+            "mean": 51,
+            "min": 51,
+            "max": 51
+          },
+          "transport": {
+            "count": 10,
+            "p50": 42,
+            "mean": 42.8,
+            "min": 36,
+            "max": 48
+          },
+          "total": {
+            "count": 10,
+            "p50": 93,
+            "mean": 93.8,
+            "min": 87,
+            "max": 99
+          }
+        },
+        "route_guard_rpcs_per_subresource": 1.02,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 51,
+          "guard_rpcs_transport": 42,
+          "fixture_requests": 51,
+          "wall_ms": 727.58
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 33.92,
+          "p95_ms": 40.36,
+          "mean_ms": 34.45,
+          "stdev_ms": 4.26,
+          "min_ms": 27.78,
+          "max_ms": 47.9
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 60.7,
+          "p95_ms": 68.52,
+          "mean_ms": 61.45,
+          "stdev_ms": 3.76,
+          "min_ms": 54.88,
+          "max_ms": 69.27
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 27.58,
+            "p95_ms": 31.63,
+            "per_frame_p50_ms": 2.76
+          },
+          "frames_24": {
+            "p50_ms": 54.36,
+            "p95_ms": 59.79,
+            "per_frame_p50_ms": 2.27
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/perf/run.ts
+++ b/benchmarks/perf/run.ts
@@ -1,0 +1,761 @@
+#!/usr/bin/env node
+// BetterWright round-trip benchmark. Measures the three costs the perf plan
+// (docs: "eliminate per-request IPC and per-action CDP round-trips") targets,
+// against a purely LOCAL http fixture so the numbers describe BetterWright's
+// own overhead rather than the internet:
+//
+//   A. per-action latency  — `run()` of a trivial snippet on a loaded static
+//      page. This is the floor every agent action pays: client→worker stdio
+//      RPC, sandbox realm + compile, execute, challenge scan, envelope build.
+//      Measured TWICE — once at the start of the session and once between the
+//      two iframe benchmarks — so per-session drift is quantified rather than
+//      silently charged to the iframes.
+//   B. page-load wall time + guard RPC count — one page pulling ~50
+//      subresources across 4 distinct `127.0.0.1:<port>` origins. Distinct
+//      ports mean distinct guard cache keys, which is what Phase A's worker
+//      side LRU has to cope with. The guard-RPC counters are the Phase A
+//      target metric: today every subresource costs at least one stdio
+//      round-trip, and every fresh connection costs several more.
+//   C. challenge-scan cost — the same trivial snippet, but on a page with N
+//      benign CROSS-SITE iframes. `detectSessionChallenges` walks every frame
+//      on every execute, so C − A' is the per-action frame-walk tax Phase B
+//      removes. Measured at 10 and 24 frames (24 = the hard cap in
+//      `collectFrameMetadata`) so the scaling is data, not extrapolation.
+//
+// Run it:
+//     npm run build:harness
+//     node benchmarks/perf/run.js [--quick] [--label <name>] [--iframes 10,24]
+//
+// Results are merged into results.json under
+// `runs["<label>[-quick]-<short sha>"]`, so a baseline run and a post-PR run
+// sit side by side in one file and a `--quick` smoke run can never overwrite a
+// recorded full-fidelity baseline. Nothing here touches the external network,
+// so it is reproducible on any machine with the browser runtime installed
+// (`betterwright setup`).
+
+import { execFileSync } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BetterWright, NetworkPolicy } from "../../dist/src/index.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RESULTS = path.join(HERE, "results.json");
+
+const argv = process.argv.slice(2);
+const has = (name) => argv.includes(name);
+const flag = (name, fallback) => {
+  const index = argv.indexOf(name);
+  return index !== -1 && argv[index + 1] !== undefined ? argv[index + 1] : fallback;
+};
+
+// `--quick` trades statistical confidence for a ~4x faster smoke run. Use it
+// while editing the harness; use the defaults for anything you record. Quick
+// runs get their own results key so they cannot clobber a real baseline.
+const QUICK = has("--quick");
+const LABEL = String(flag("--label", "baseline"));
+const FORCE = has("--force");
+
+const ACTION_ITERS = QUICK ? 20 : 100;
+const ACTION_WARMUP = 5;
+const LOAD_ITERS = QUICK ? 3 : 10;
+const LOAD_WARMUP = 1;
+const CHALLENGE_ITERS = QUICK ? 10 : 30;
+const CHALLENGE_WARMUP = 3;
+
+const SUBRESOURCE_COUNT = 50; // spread across ORIGIN_COUNT servers
+const ORIGIN_COUNT = 4;
+// Every measured /heavy load must produce exactly this many fixture requests:
+// the document itself plus every subresource. Asserted, not assumed — see
+// `fixture_requests_per_load`.
+const EXPECTED_FIXTURE_REQUESTS = SUBRESOURCE_COUNT + 1;
+
+// `collectFrameMetadata` (src/worker.ts) hard-caps the walk at 24 frames, so 24
+// is the worst case the product can reach and 10 is the plan's stated scenario.
+const IFRAME_COUNTS = has("--iframes")
+  ? String(flag("--iframes", "10"))
+      .split(",")
+      .map((n) => Number(n.trim()))
+      .filter((n) => Number.isInteger(n) && n > 0)
+  : QUICK
+    ? [10]
+    : [10, 24];
+if (!IFRAME_COUNTS.length)
+  throw new Error("--iframes needs at least one positive integer, e.g. --iframes 10,24");
+const MAX_IFRAMES = Math.max(...IFRAME_COUNTS);
+
+// Benchmark C's frames must be CROSS-SITE, not just cross-port: Chromium's site
+// isolation keys on scheme + eTLD+1 and ignores the port, so `127.0.0.1:A` and
+// `127.0.0.1:B` share one renderer and their frame walks are cheap in-process
+// CDP. Distinct loopback IPs are distinct sites, so these frames become real
+// OOPIFs with their own targets — which is what an ad-heavy page actually
+// looks like. 127.0.0.0/8 is entirely local on Linux, so binding these needs no
+// setup.
+const FRAME_HOSTS = ["127.0.0.2", "127.0.0.3"];
+
+// ---------------------------------------------------------------- statistics
+
+function quantile(sorted, q) {
+  if (!sorted.length) return null;
+  // Nearest-rank. With n=100 that makes p95 the 95th slowest sample, which is
+  // the reading people expect from a latency table.
+  const rank = Math.min(sorted.length - 1, Math.ceil(q * sorted.length) - 1);
+  return sorted[Math.max(0, rank)];
+}
+
+function round(value) {
+  return value === null || value === undefined ? null : Math.round(value * 100) / 100;
+}
+
+function stats(values) {
+  const v = values.filter((x) => Number.isFinite(x)).sort((a, b) => a - b);
+  if (!v.length) return null;
+  const mean = v.reduce((a, b) => a + b, 0) / v.length;
+  const variance = v.reduce((a, b) => a + (b - mean) ** 2, 0) / v.length;
+  return {
+    count: v.length,
+    p50_ms: round(quantile(v, 0.5)),
+    p95_ms: round(quantile(v, 0.95)),
+    mean_ms: round(mean),
+    stdev_ms: round(Math.sqrt(variance)),
+    min_ms: round(v[0]),
+    max_ms: round(v[v.length - 1]),
+  };
+}
+
+function countStats(values) {
+  const v = values.filter((x) => Number.isFinite(x)).sort((a, b) => a - b);
+  if (!v.length) return null;
+  return {
+    count: v.length,
+    p50: quantile(v, 0.5),
+    mean: round(v.reduce((a, b) => a + b, 0) / v.length),
+    min: v[0],
+    max: v[v.length - 1],
+  };
+}
+
+const log = (line) => process.stderr.write(`${line}\n`);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ------------------------------------------------------------------ fixtures
+
+// 1x1 transparent GIF. Small enough that transfer time is noise and the cost
+// being measured is purely per-request: guard RPC + route interception.
+const PIXEL = Buffer.from(
+  "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+  "base64",
+);
+
+function iframeBody(index) {
+  // Enough text that `innerText` extraction is not free — a frame-scan sample
+  // with an empty body would understate the cost the plan is chasing.
+  const paragraph =
+    "This is a benign iframe with ordinary prose in it, present only so the " +
+    "per-frame text extraction has something to extract and the measurement " +
+    "reflects a realistic embedded document rather than an empty one. ";
+  return (
+    `<!doctype html><meta charset="utf-8"><title>Frame ${index}</title>` +
+    `<body><h1>Benign frame ${index}</h1><p>${paragraph.repeat(6)}</p></body>`
+  );
+}
+
+async function startFixtureServer(indexOfServer, refs, host = "127.0.0.1") {
+  // Request counting is the only thing that turns "no-store means every load
+  // re-fetches all 50 subresources" from an assumption into an assertion. The
+  // guard-RPC count is the number under test, so it cannot also be the evidence
+  // that the requests happened — that reasoning is circular.
+  let measured = 0;
+  let total = 0;
+
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url || "/", `http://${host}`);
+    const pathname = url.pathname;
+    total++;
+    if (pathname === "/heavy" || pathname.startsWith("/asset/")) measured++;
+    // Everything is no-store so each load re-fetches every subresource. Cache
+    // hits would silently collapse the guard-RPC count and make the page-load
+    // benchmark measure nothing.
+    const nocache = { "cache-control": "no-store, no-cache, must-revalidate" };
+
+    if (pathname === "/static") {
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(
+        '<!doctype html><meta charset="utf-8"><title>Static fixture</title>' +
+          "<body><h1>Static fixture</h1><p>No subresources, no frames.</p></body>",
+      );
+      return;
+    }
+
+    if (pathname === "/heavy") {
+      // Subresources are dealt round-robin across every fixture origin, so the
+      // load crosses ORIGIN_COUNT distinct host:port guard keys.
+      const origins = refs.origins;
+      const parts = [];
+      for (let i = 0; i < SUBRESOURCE_COUNT; i++) {
+        const origin = origins[i % origins.length];
+        parts.push(
+          i % 5 === 0
+            ? `<script src="${origin}/asset/${i}.js"></script>`
+            : `<img alt="" width="1" height="1" src="${origin}/asset/${i}.gif">`,
+        );
+      }
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(
+        '<!doctype html><meta charset="utf-8"><title>Heavy fixture</title>' +
+          `<body><h1>Heavy fixture</h1>${parts.join("")}</body>`,
+      );
+      return;
+    }
+
+    if (pathname === "/frames") {
+      const wanted = Math.max(0, Number(url.searchParams.get("n") || MAX_IFRAMES));
+      const frameOrigins = refs.frameOrigins;
+      const frames = [];
+      for (let i = 0; i < wanted; i++) {
+        const origin = frameOrigins[i % frameOrigins.length];
+        frames.push(
+          `<iframe title="f${i}" width="200" height="80" src="${origin}/frame/${i}"></iframe>`,
+        );
+      }
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(
+        '<!doctype html><meta charset="utf-8"><title>Frames fixture</title>' +
+          `<body><h1>Frames fixture</h1>${frames.join("")}</body>`,
+      );
+      return;
+    }
+
+    if (pathname.startsWith("/frame/")) {
+      response.writeHead(200, { ...nocache, "content-type": "text/html; charset=utf-8" });
+      response.end(iframeBody(pathname.slice("/frame/".length)));
+      return;
+    }
+
+    if (pathname.endsWith(".js")) {
+      response.writeHead(200, { ...nocache, "content-type": "application/javascript" });
+      response.end(`/* asset ${pathname} on server ${indexOfServer} */\n`);
+      return;
+    }
+
+    if (pathname.endsWith(".gif")) {
+      response.writeHead(200, { ...nocache, "content-type": "image/gif" });
+      response.end(PIXEL);
+      return;
+    }
+
+    response.writeHead(404, nocache);
+    response.end("not found");
+  });
+
+  server.listen(0, host);
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  return {
+    origin: `http://${host}:${port}`,
+    host,
+    port,
+    resetHits() {
+      measured = 0;
+      total = 0;
+    },
+    hits() {
+      return { measured, total };
+    },
+    // Dropping keep-alive sockets between loads is what makes every measured
+    // load pay the SOCKS proxy's per-connection guards, instead of only the
+    // first one paying them (n=1) and the rest hiding them.
+    dropConnections() {
+      server.closeAllConnections?.();
+    },
+    async close() {
+      server.closeAllConnections?.();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+// -------------------------------------------------------------- measurements
+
+async function timedRun(bw, code) {
+  const start = performance.now();
+  const result = await bw.run(code);
+  const elapsed = performance.now() - start;
+  if (!result?.ok) throw new Error(`snippet failed: ${result?.error || "unknown error"}`);
+  return { elapsed, result };
+}
+
+const TRIVIAL = "return page.title()";
+
+async function measurePerAction(bw, origin, tag) {
+  log(`\n[${tag}] per-action latency, 0 frames — ${ACTION_WARMUP} warmup + ${ACTION_ITERS} iterations`);
+  const goto = await timedRun(
+    bw,
+    `await page.goto(${JSON.stringify(`${origin}/static`)}); return page.title()`,
+  );
+  log(`    loaded ${origin}/static in ${goto.elapsed.toFixed(0)}ms`);
+  for (let i = 0; i < ACTION_WARMUP; i++) await timedRun(bw, TRIVIAL);
+  const samples = [];
+  for (let i = 0; i < ACTION_ITERS; i++) {
+    const { elapsed } = await timedRun(bw, TRIVIAL);
+    samples.push(elapsed);
+    if ((i + 1) % 25 === 0) log(`    ${i + 1}/${ACTION_ITERS}`);
+  }
+  return stats(samples);
+}
+
+async function measurePageLoad(bw, origin, guard, servers) {
+  log(
+    `\n[B] page load + guard RPCs — ${LOAD_WARMUP} warmup + ${LOAD_ITERS} loads, ${SUBRESOURCE_COUNT} subresources / ${ORIGIN_COUNT} origins`,
+  );
+  const wall = [];
+  const inner = [];
+  const routeRpcs = [];
+  const transportRpcs = [];
+  const fixtureRequests = [];
+  // The warmup load is discarded: it is the only one whose renderer, socket
+  // pool and worker state have never seen this fixture. It is reported as
+  // `first_load` with n=1 and is NOT a headline metric.
+  let firstLoad = null;
+
+  for (let i = 0; i < LOAD_WARMUP + LOAD_ITERS; i++) {
+    // Cache-busting query string on top of no-store: belt and braces, since a
+    // repeat of the identical URL is the one thing that could let the browser
+    // skip the request entirely.
+    const url = `${origin}/heavy?load=${i}-${Date.now()}`;
+    // about:blank first so each measurement starts from a torn-down document
+    // rather than a warm one that may reuse subresources.
+    await timedRun(bw, "await page.goto('about:blank'); return 'reset'");
+    // Drop every keep-alive socket so the next load is connection-cold. Without
+    // this, only the first load pays the SOCKS proxy's per-connection guards
+    // and the connection-scoped cost is an n=1 anecdote.
+    for (const server of servers) server.dropConnections();
+    // Settle BEFORE the reset, not only after: tearing down the previous
+    // document produces trailing guard RPCs, and resetting the counter the
+    // instant `goto` returns attributes those stragglers to the next load. That
+    // is what made the steady-state count drift 51 -> 61 between runs.
+    await sleep(250);
+    guard.reset();
+    for (const server of servers) server.resetHits();
+
+    const start = performance.now();
+    const { result } = await timedRun(
+      bw,
+      `const t0 = Date.now();
+       await page.goto(${JSON.stringify(url)}, { waitUntil: 'load' });
+       await page.waitForLoadState('networkidle').catch(() => {});
+       return Date.now() - t0;`,
+    );
+    const elapsed = performance.now() - start;
+    // Guard RPCs are serviced on the host as the worker asks; the last few can
+    // land microtasks after networkidle resolves. A short settle keeps the
+    // count honest without meaningfully inflating it.
+    await sleep(250);
+    const counts = guard.count();
+    const requests = servers.reduce((sum, server) => sum + server.hits().measured, 0);
+
+    if (i < LOAD_WARMUP) {
+      // Liveness: if a refactor moves the guard off `_serviceRpc`, the counter
+      // reads 0 and a broken hook looks exactly like a total Phase A win.
+      if (!counts.route)
+        throw new Error(
+          "guard counter never fired: the client._serviceRpc hook is stale (no method === 'guard' RPCs observed)",
+        );
+      firstLoad = {
+        note: "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+        guard_rpcs_route: counts.route,
+        guard_rpcs_transport: counts.transport,
+        fixture_requests: requests,
+        wall_ms: round(elapsed),
+      };
+      log(
+        `    warmup load: ${elapsed.toFixed(0)}ms wall, ${counts.route} route + ${counts.transport} transport guard RPCs, ${requests} fixture requests`,
+      );
+      continue;
+    }
+
+    // The core assumption of this benchmark, asserted rather than assumed: if
+    // the memory cache ever starts serving `/asset/N.gif`, the guard count
+    // collapses and would otherwise read as a Phase A win.
+    if (requests !== EXPECTED_FIXTURE_REQUESTS)
+      throw new Error(
+        `fixture served ${requests} requests on load ${i - LOAD_WARMUP + 1}, expected ${EXPECTED_FIXTURE_REQUESTS} ` +
+          `(1 document + ${SUBRESOURCE_COUNT} subresources). Something is serving subresources from cache; ` +
+          "the guard-RPC counts for this run are not comparable.",
+      );
+
+    wall.push(elapsed);
+    inner.push(Number(result.result));
+    routeRpcs.push(counts.route);
+    transportRpcs.push(counts.transport);
+    fixtureRequests.push(requests);
+    log(
+      `    load ${i - LOAD_WARMUP + 1}/${LOAD_ITERS}: ${elapsed.toFixed(0)}ms wall, ${result.result}ms in-page, ` +
+        `${counts.route} route + ${counts.transport} transport guard RPCs, ${requests} fixture requests`,
+    );
+  }
+
+  const routeMean = routeRpcs.length
+    ? routeRpcs.reduce((a, b) => a + b, 0) / routeRpcs.length
+    : null;
+  return {
+    wall_time: stats(wall),
+    navigation_time: stats(inner),
+    guard_rpcs_per_load: {
+      note:
+        "route = context.route('**/*') interception, one per HTTP request, exact. " +
+        "transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; " +
+        "connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+      route: countStats(routeRpcs),
+      transport: countStats(transportRpcs),
+      total: countStats(routeRpcs.map((n, i) => n + transportRpcs[i])),
+    },
+    route_guard_rpcs_per_subresource:
+      routeMean === null ? null : round(routeMean / SUBRESOURCE_COUNT),
+    fixture_requests_per_load: countStats(fixtureRequests),
+    first_load: firstLoad,
+  };
+}
+
+async function measureChallengeScan(bw, origin, frameCount) {
+  log(
+    `\n[C${frameCount}] challenge-scan cost — ${frameCount} benign cross-site iframes, ${CHALLENGE_WARMUP} warmup + ${CHALLENGE_ITERS} iterations`,
+  );
+  const url = `${origin}/frames?n=${frameCount}`;
+  await timedRun(
+    bw,
+    `await page.goto(${JSON.stringify(url)}, { waitUntil: 'load' }); return page.title()`,
+  );
+
+  // Verify the frames really are attached and really are cross-site. Same-site
+  // frames would share the parent's renderer, and the measurement would be a
+  // floor rather than the number it claims to be.
+  const probe = await timedRun(
+    bw,
+    `const frames = await page.frames();
+     const urls = [];
+     for (const frame of frames) urls.push(await frame.url());
+     return { count: urls.length, urls };`,
+  );
+  const urls = (probe.result.result?.urls || []) as string[];
+  const mainHost = new URL(url).hostname;
+  const childHosts = urls
+    .slice(1)
+    .map((u) => {
+      try {
+        return new URL(u).hostname;
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+  const crossSite = childHosts.filter((h) => h !== mainHost).length;
+  if (childHosts.length !== frameCount)
+    throw new Error(
+      `expected ${frameCount} child frames, saw ${childHosts.length} (${urls.join(", ")})`,
+    );
+  if (crossSite !== frameCount)
+    throw new Error(
+      `expected all ${frameCount} child frames to be cross-site with ${mainHost}, only ${crossSite} were`,
+    );
+  log(`    ${frameCount} child frames attached, all cross-site (${[...new Set(childHosts)].join(", ")})`);
+
+  for (let i = 0; i < CHALLENGE_WARMUP; i++) await timedRun(bw, TRIVIAL);
+  const samples = [];
+  for (let i = 0; i < CHALLENGE_ITERS; i++) {
+    const { elapsed } = await timedRun(bw, TRIVIAL);
+    samples.push(elapsed);
+    if ((i + 1) % 10 === 0) log(`    ${i + 1}/${CHALLENGE_ITERS}`);
+  }
+  return {
+    frames: frameCount,
+    cross_site_frames: crossSite,
+    ...stats(samples),
+  };
+}
+
+// ------------------------------------------------------------------ plumbing
+
+// Counts guard RPCs at the stdio RPC boundary rather than at `policy.check`.
+// Two reasons: (1) it counts one per round-trip under any future batching
+// scheme (the plan keeps a `guardBatch` RPC on the table, and a `policy.check`
+// counter would still report N for a batch of N and hide the whole win);
+// (2) it lets the count be bucketed by `payload.resourceType`, which matters
+// because two very different populations arrive here:
+//   - route guards   — one per HTTP request from `context.route("**/*")`;
+//                      exactly (subresources + 1) and deterministic.
+//   - transport guards — the SOCKS proxy's per-connection hostname
+//                      (`resourceType: "transport"`) and per-resolved-IP
+//                      (`"transport-address"`) checks; nondeterministic,
+//                      because Chromium decides when to open a socket.
+// Totalling them produces a scalar that drifts +-12% while looking exact.
+function instrumentGuard(bw) {
+  const original = bw._serviceRpc.bind(bw);
+  const counts = { route: 0, transport: 0 };
+  bw._serviceRpc = (message, child) => {
+    if (message?.method === "guard") {
+      const type = message.payload?.resourceType;
+      if (type === "transport" || type === "transport-address") counts.transport++;
+      else counts.route++;
+    }
+    return original(message, child);
+  };
+  return {
+    reset() {
+      counts.route = 0;
+      counts.transport = 0;
+    },
+    count() {
+      return { ...counts };
+    },
+    restore() {
+      delete bw._serviceRpc;
+    },
+  };
+}
+
+function gitInfo() {
+  const git = (args) => {
+    try {
+      return execFileSync("git", args, { cwd: HERE, encoding: "utf8" }).trim();
+    } catch {
+      return null;
+    }
+  };
+  return {
+    commit: git(["rev-parse", "--short", "HEAD"]),
+    branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: !!git(["status", "--porcelain"]),
+  };
+}
+
+function readResults() {
+  let existing: any = {};
+  if (fs.existsSync(RESULTS)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(RESULTS, "utf8")) || {};
+    } catch {
+      // A corrupt or hand-edited file must not lose the run that just
+      // finished; keep it aside instead of overwriting it silently.
+      const backup = `${RESULTS}.bak`;
+      fs.copyFileSync(RESULTS, backup);
+      log(`\nresults.json was unparseable; copied to ${backup} and starting fresh.`);
+      existing = {};
+    }
+  }
+  return existing;
+}
+
+// Refuse to silently replace a recorded run. Checked BEFORE any measurement so
+// a doomed invocation costs zero seconds, and again in writeResults so a
+// concurrent writer cannot slip past. `--quick` also gets its own key suffix,
+// so a smoke run can never land on top of a full-fidelity baseline.
+function assertKeyFree(key, existing = readResults()) {
+  if (!existing.runs?.[key]) return;
+  if (!FORCE)
+    throw new Error(
+      `results.json already has a run under "${key}" (recorded ${existing.runs[key]?.metadata?.date}). ` +
+        "Overwriting it would destroy a recorded baseline. Re-run with a different --label, " +
+        "or pass --force to replace it deliberately.",
+    );
+  log(`warning: --force given; the existing run "${key}" will be replaced.`);
+}
+
+function writeResults(key, payload) {
+  const existing = readResults();
+  assertKeyFree(key, existing);
+  const merged = {
+    schema_version: "betterwright-perf-results-v2",
+    benchmark: "round-trip cost: per-action latency, page-load guard RPCs, challenge-scan overhead",
+    fixture: "local http.createServer only — no external network",
+    defined_in: "run.ts",
+    runs: { ...(existing.runs || {}), [key]: payload },
+  };
+  fs.writeFileSync(RESULTS, `${JSON.stringify(merged, null, 2)}\n`);
+}
+
+async function main() {
+  const git = gitInfo();
+  const key = `${LABEL}${QUICK ? "-quick" : ""}-${git.commit || "unknown"}`;
+  assertKeyFree(key);
+
+  const servers = [];
+  const frameServers = [];
+  const refs = { origins: [], frameOrigins: [] };
+  let bw = null;
+  let guard = null;
+  let home = null;
+  let shuttingDown = false;
+
+  // Teardown lives in a named function so it can be reached from BOTH the
+  // `finally` below and a SIGINT handler. `finally` alone does not cover
+  // Ctrl-C: Node's default SIGINT disposition kills the process outright, the
+  // pending `await` never resumes, and every aborted run leaves a
+  // `betterwright-perf-*` browser profile in os.tmpdir().
+  async function shutdown() {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    // Every teardown step is independently guarded: a failed bw.close() must
+    // not leave six http servers listening and a temp home on disk.
+    try {
+      guard?.restore();
+    } catch {
+      /* the wrap is harness-local; failing to unwrap cannot affect results */
+    }
+    try {
+      await bw?.close();
+    } catch (error) {
+      log(`warning: bw.close() failed: ${error}`);
+    }
+    for (const server of [...servers, ...frameServers]) {
+      try {
+        await server.close();
+      } catch {
+        /* a server that already errored out is already gone */
+      }
+    }
+    if (home) {
+      try {
+        fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      } catch {
+        /* leaving a temp dir behind is not worth failing the run over */
+      }
+      home = null;
+    }
+  }
+
+  const onSigint = () => {
+    log("\ninterrupted; tearing down browser, servers and temp home...");
+    void shutdown().finally(() => {
+      process.off("SIGINT", onSigint);
+      process.kill(process.pid, "SIGINT");
+    });
+  };
+  process.on("SIGINT", onSigint);
+
+  try {
+    for (let i = 0; i < ORIGIN_COUNT; i++) servers.push(await startFixtureServer(i, refs));
+    refs.origins = servers.map((s) => s.origin);
+    for (const [i, host] of FRAME_HOSTS.entries())
+      frameServers.push(await startFixtureServer(100 + i, refs, host));
+    refs.frameOrigins = frameServers.map((s) => s.origin);
+    log(`fixture origins: ${refs.origins.join(", ")}`);
+    log(`frame origins:   ${refs.frameOrigins.join(", ")}`);
+
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-perf-"));
+    bw = new BetterWright({
+      home,
+      // Stock NetworkPolicy: loopback is allowed by default, and an unmodified
+      // policy is what Phase A's `cacheable` flag will key on, so the baseline
+      // must be measured through the same object shape.
+      policy: new NetworkPolicy(),
+      headless: true,
+      // The vault is irrelevant here and its host-side redaction would add
+      // noise to every result envelope.
+      vault: false,
+    });
+    guard = instrumentGuard(bw);
+
+    const origin = refs.origins[0];
+    // A, then B, then C at each frame count with a fresh 0-frame control (A')
+    // measured BETWEEN the two C runs. The iframe tax is derived from the
+    // adjacent pair (C - A'), so monotonic per-session drift is measured
+    // instead of being charged to the iframes.
+    const perAction = await measurePerAction(bw, origin, "A");
+    const pageLoad = await measurePageLoad(bw, origin, guard, [...servers, ...frameServers]);
+
+    const challenges = [];
+    let perActionAfter = null;
+    for (const [i, frameCount] of IFRAME_COUNTS.entries()) {
+      challenges.push(await measureChallengeScan(bw, origin, frameCount));
+      if (i === 0) perActionAfter = await measurePerAction(bw, origin, "A'");
+    }
+    if (!perActionAfter) perActionAfter = await measurePerAction(bw, origin, "A'");
+
+    const drift =
+      perAction && perActionAfter ? round(perActionAfter.p50_ms - perAction.p50_ms) : null;
+    const driftPct =
+      perAction?.p50_ms && drift !== null ? round((drift / perAction.p50_ms) * 100) : null;
+
+    const iframeOverhead = {};
+    for (const c of challenges) {
+      iframeOverhead[`frames_${c.frames}`] = {
+        p50_ms: round(c.p50_ms - perActionAfter.p50_ms),
+        p95_ms: round(c.p95_ms - perActionAfter.p95_ms),
+        per_frame_p50_ms: round((c.p50_ms - perActionAfter.p50_ms) / c.frames),
+      };
+    }
+
+    const payload = {
+      metadata: {
+        label: LABEL,
+        date: new Date().toISOString(),
+        commit: git.commit,
+        branch: git.branch,
+        working_tree_dirty: git.dirty,
+        node: process.version,
+        platform: `${process.platform}-${process.arch}`,
+        cpus: os.cpus()?.length ?? null,
+        quick_mode: QUICK,
+        betterwright_version: JSON.parse(
+          fs.readFileSync(path.resolve(HERE, "..", "..", "package.json"), "utf8"),
+        ).version,
+      },
+      config: {
+        action_iterations: ACTION_ITERS,
+        action_warmup: ACTION_WARMUP,
+        load_iterations: LOAD_ITERS,
+        load_warmup: LOAD_WARMUP,
+        challenge_iterations: CHALLENGE_ITERS,
+        challenge_warmup: CHALLENGE_WARMUP,
+        subresources: SUBRESOURCE_COUNT,
+        origins: ORIGIN_COUNT,
+        iframe_counts: IFRAME_COUNTS,
+        frame_hosts: FRAME_HOSTS,
+        connections_dropped_between_loads: true,
+        snippet: TRIVIAL,
+      },
+      per_action_latency: perAction,
+      per_action_latency_after: perActionAfter,
+      session_drift: {
+        note: "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        p50_delta_ms: drift,
+        p50_delta_pct: driftPct,
+      },
+      page_load: pageLoad,
+      challenge_scan: challenges,
+      derived: {
+        // The headline Phase B number: what N benign cross-site iframes add to
+        // every single agent action, purely through the unconditional frame
+        // walk. Derived against the ADJACENT 0-frame control, not against the
+        // A measured at the other end of the session.
+        iframe_overhead: iframeOverhead,
+      },
+    };
+    writeResults(key, payload);
+
+    log(`\n=== ${key} ===`);
+    log(`per-action p50/p95:     ${perAction?.p50_ms}ms / ${perAction?.p95_ms}ms`);
+    log(`per-action p50 (A'):    ${perActionAfter?.p50_ms}ms  (session drift ${drift >= 0 ? "+" : ""}${drift}ms, ${driftPct}%)`);
+    log(`page-load wall p50:     ${pageLoad.wall_time?.p50_ms}ms`);
+    log(`route guard RPCs/load:  ${pageLoad.guard_rpcs_per_load.route?.p50} (p50), min ${pageLoad.guard_rpcs_per_load.route?.min} max ${pageLoad.guard_rpcs_per_load.route?.max}`);
+    log(`transport guard/load:   ${pageLoad.guard_rpcs_per_load.transport?.p50} (p50), min ${pageLoad.guard_rpcs_per_load.transport?.min} max ${pageLoad.guard_rpcs_per_load.transport?.max}`);
+    log(`fixture requests/load:  ${pageLoad.fixture_requests_per_load?.p50} (asserted ${EXPECTED_FIXTURE_REQUESTS})`);
+    for (const c of challenges)
+      log(`${String(c.frames).padStart(2)}-iframe page p50/p95: ${c.p50_ms}ms / ${c.p95_ms}ms  (tax +${iframeOverhead[`frames_${c.frames}`].p50_ms}ms, ${iframeOverhead[`frames_${c.frames}`].per_frame_p50_ms}ms/frame)`);
+    log(`\nresults.json updated: ${RESULTS}`);
+  } finally {
+    process.off("SIGINT", onSigint);
+    await shutdown();
+  }
+}
+
+main().catch((error) => {
+  log(`\nbenchmark failed: ${error?.stack || error}`);
+  process.exitCode = 1;
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,8 +83,13 @@ The controls that hold even if a snippet found a way around the JS facades:
    DNS-rebinding and redirect-hop bypasses: Chromium never does a second,
    unguarded lookup. WebRTC is pinned to the proxy path so it can't send UDP
    around it.
-2. **The policy, failing closed.** `NetworkPolicy` answers every `guard`. If it
-   errors, the request is denied. Metadata endpoints can't be allowlisted.
+2. **The policy, failing closed.** `NetworkPolicy` answers every `guard` the
+   worker cannot serve from its short-lived (≤5 s) decision cache. Navigations,
+   documents, downloads and WebSocket upgrades always reach it, and only a stock
+   policy's host-scoped answers are ever reused — a `custom` hook, a subclass or
+   any other `check` implementation is asked every time (see
+   [network-policy.md](network-policy.md)). If it errors, the request is denied
+   and nothing is cached. Metadata endpoints can't be allowlisted.
 
 These are independent of the sandbox and of each other. See
 [network-policy.md](network-policy.md) for the metadata-endpoint rationale in

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -91,13 +91,25 @@ are both cached; a failed check never is.
 Only decisions from a stock `NetworkPolicy` with no `custom` hook are eligible —
 the client decides, per policy, whether its answers may be cached at all:
 
-- **Mutating `allowHosts` or `blockHosts` mid-session takes up to 5 seconds to
-  take effect** for a host the browser has already contacted. Hosts not yet seen
-  (and every host after the entry expires) use the new lists immediately.
 - **A `custom` hook, a `NetworkPolicy` subclass, or any other object with a
   `check` method is never cached.** Every request reaches your hook, so a policy
   that decides on `details`, time, or external state keeps working exactly as
   written.
+- **Installing a hook mid-session empties the cache**, so it governs hosts the
+  browser has already contacted rather than only new ones. The first check that
+  reaches the client after the change is what carries the flush, and navigations
+  are never cached — so in practice the next page load does it. A request to an
+  already-cached host with no such check in between falls back to the 5-second
+  expiry below.
+- **Mutating `allowHosts` or `blockHosts` mid-session takes up to 5 seconds to
+  take effect** for a host the browser has already contacted. Hosts not yet seen
+  (and every host after the entry expires) use the new lists immediately. Unlike
+  installing a hook, editing these lists does not change the *shape* of the
+  policy, so nothing in a decision marks it as changed and there is nothing for a
+  flush to key off — the expiry is the whole mechanism.
+
+If a change must apply immediately and you cannot wait for either, construct the
+policy the way you want it before the browser launches, or close the session.
 
 ## Why metadata endpoints are unliftable
 

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -81,6 +81,24 @@ new NetworkPolicy({ custom: onlyGetNavigations });
 An `allowed: true` returned from the hook still cannot reach a metadata endpoint
 — that floor is re-checked after the hook.
 
+## Decision caching
+
+A page pulling 200 subresources would otherwise ask the client 200 times about
+the same few hosts, so the worker keeps a short-lived cache of guard decisions,
+keyed by scheme + host + port and held for at most 5 seconds. Allows and denies
+are both cached; a failed check never is.
+
+Only decisions from a stock `NetworkPolicy` with no `custom` hook are eligible —
+the client decides, per policy, whether its answers may be cached at all:
+
+- **Mutating `allowHosts` or `blockHosts` mid-session takes up to 5 seconds to
+  take effect** for a host the browser has already contacted. Hosts not yet seen
+  (and every host after the entry expires) use the new lists immediately.
+- **A `custom` hook, a `NetworkPolicy` subclass, or any other object with a
+  `check` method is never cached.** Every request reaches your hook, so a policy
+  that decides on `details`, time, or external state keeps working exactly as
+  written.
+
 ## Why metadata endpoints are unliftable
 
 A server-side agent usually runs on a cloud instance whose metadata service

--- a/src/client.ts
+++ b/src/client.ts
@@ -673,6 +673,28 @@ export class BetterWright {
     return this._pending.get(executionId)?.child === child;
   }
 
+  /**
+   * Whether the worker may cache this policy's guard decisions by
+   * scheme/host/port. A stock `NetworkPolicy` running its own `check` with no
+   * `custom` hook is the only shape whose verdict depends on nothing but those
+   * three fields (src/policy.ts); anything that can consult `details`, time, or
+   * external state must be re-asked per request.
+   *
+   * Must be read per RPC, never memoized: `policy`, `policy.custom`, and
+   * `policy.check` are all public and mutable, so a hook installed — or a whole
+   * policy swapped in — after construction has to invalidate cacheability at
+   * once. Method identity is checked too, since `constructor` identity alone
+   * still admits an own-property `check` override and Proxy decorators.
+   */
+  get _policyCacheable() {
+    const policy = this.policy;
+    return (
+      policy?.constructor === NetworkPolicy &&
+      policy.check === NetworkPolicy.prototype.check &&
+      !policy.custom
+    );
+  }
+
   async _serviceRpc(message, child = this._process) {
     const requestId = String(message.requestId || "");
     let response;
@@ -683,7 +705,10 @@ export class BetterWright {
       let result;
       if (message.method === "guard") {
         const { url, ...details } = payload;
-        result = this.policy.check(url, details);
+        // Copy rather than annotate: policy.check may return a shared or frozen
+        // object, and `cacheable` is an envelope field, not part of the public
+        // NetworkDecision the policy produced.
+        result = { ...this.policy.check(url, details), cacheable: this._policyCacheable };
       } else if (message.method === "vault") {
         if (!this.vault)
           throw new Error(

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -30,6 +30,11 @@ import { profileLabel, resolveProfileName } from "./profile-name.js";
 const CONNECT_TIMEOUT_MS = 1_000;
 const SPAWN_WAIT_MS = 8_000;
 const HANDSHAKE_TIMEOUT_MS = 10_000;
+// Probe a freshly spawned daemon eagerly, then back off to the steady interval.
+// The deadline (SPAWN_WAIT_MS) is what bounds the wait; these only decide how
+// much of it a fast start has to sit through.
+const SPAWN_RETRY_MIN_MS = 25;
+const SPAWN_RETRY_MAX_MS = 100;
 // The daemon's stderr log is append-only across restarts; roll it over once it
 // gets large so a long-lived install cannot fill a disk with it.
 const LOG_ROTATE_BYTES = 4 * 1024 * 1024;
@@ -210,10 +215,12 @@ async function connectWithSpawn({ home, socketPath, cliPath, config, profile, sp
   }
   spawnDaemon({ home, cliPath, config, profile });
   const deadline = Date.now() + SPAWN_WAIT_MS;
+  let retryMs = SPAWN_RETRY_MIN_MS;
   while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 100));
     socket = await connectOnce(socketPath, 500);
     if (socket) return socket;
+    await new Promise((resolve) => setTimeout(resolve, retryMs));
+    retryMs = Math.min(retryMs * 2, SPAWN_RETRY_MAX_MS);
   }
   return null;
 }

--- a/src/guard-proxy.ts
+++ b/src/guard-proxy.ts
@@ -543,18 +543,27 @@ export function createGuardProxy(
 
     // Validate every answer, then connect to one of these exact literals. This
     // closes both redirect-hop and DNS-rebinding gaps: Chromium never performs a
-    // second target lookup outside this guarded worker.
-    for (const candidate of addresses) {
-      const decision = await guardUrl(
-        transportUrl(candidate.address, port),
-        {
-          method: "CONNECT",
-          resourceType: "transport-address",
-          resolvedFrom: host,
-        },
-        attribution,
-      );
-      if (!decision?.allowed) throw proxyBlockedError(decision?.reason);
+    // second target lookup outside this guarded worker. The checks are issued as
+    // one parallel wave but remain exhaustive: every address is decided before
+    // any connect, and failures are reported in address order — not settle order
+    // — so the error a caller sees does not depend on guard timing.
+    const decisions = await Promise.allSettled(
+      addresses.map((candidate) =>
+        guardUrl(
+          transportUrl(candidate.address, port),
+          {
+            method: "CONNECT",
+            resourceType: "transport-address",
+            resolvedFrom: host,
+          },
+          attribution,
+        ),
+      ),
+    );
+    for (const settled of decisions) {
+      if (settled.status === "rejected") throw settled.reason;
+      if (!settled.value?.allowed)
+        throw proxyBlockedError(settled.value?.reason);
     }
     return addresses;
   }

--- a/src/guard-url.ts
+++ b/src/guard-url.ts
@@ -1,0 +1,113 @@
+// The worker's network guard entrypoint: turns a URL into a policy decision by
+// asking the client over RPC, and caches the answers the client marks cacheable
+// so a page pulling hundreds of subresources does not pay a round trip each.
+//
+// This module holds no policy of its own — decisions come from the client, which
+// is the only process the policy and its custom hook live in.
+//
+// Security contract:
+//   - Cacheability is asserted by the client and only by the client, which sets
+//     `cacheable: true` solely for a stock NetworkPolicy with no custom hook —
+//     the one shape whose verdict is a pure function of scheme, host, and port.
+//     The worker never infers it: anything other than the literal `true`
+//     (absent, false, a truthy non-boolean) means do not cache.
+//   - Only host-scoped checks are cached. `fullUrl` checks (navigations,
+//     documents, downloads, websockets) carry a path and details no host key can
+//     represent, so they always reach the client.
+//   - The key reads the port the same way NetworkPolicy does — straight off the
+//     parsed URL (`src/policy.ts` check) — so two URLs share a key exactly when
+//     the policy cannot tell them apart. WHATWG parsing already erases a
+//     scheme's default port, which is why `https://h/` and `https://h:443/` are
+//     one entry; a port written into the key by any other route would have to
+//     re-derive that equivalence and could drift from it.
+//   - Failures are never cached. An RPC rejection propagates unchanged and
+//     leaves no entry, so the transport still fails closed on the next attempt.
+//   - allowHosts/blockHosts are public mutable arrays, so entries expire after
+//     `ttlMs` instead of living for the session.
+//   - The cache belongs to the guard it was created with. A worker process
+//     serves one BetterWright and therefore one policy, so decisions made under
+//     one policy can never answer for another.
+
+export const GUARD_CACHE_TTL_MS = 5_000;
+export const GUARD_CACHE_MAX = 2_048;
+
+const BROWSER_SCHEMES = new Set(["http:", "https:", "ws:", "wss:"]);
+
+type GuardDecision = { allowed: boolean; reason?: string };
+
+/**
+ * Build the worker's `guardUrl`, backed by a cache private to this instance.
+ *
+ * @param {object} options
+ * @param {Function} options.rpc `(method, payload, executeId) => Promise<any>`
+ * @param {Function} [options.now] clock source, for tests
+ * @param {number} [options.ttlMs] entry lifetime
+ * @param {number} [options.max] entry ceiling before the oldest is evicted
+ */
+export function createGuardUrl({
+  rpc,
+  now = Date.now,
+  ttlMs = GUARD_CACHE_TTL_MS,
+  max = GUARD_CACHE_MAX,
+}) {
+  const cache = new Map<string, { at: number; decision: GuardDecision }>();
+
+  function cacheGet(key) {
+    const hit = cache.get(key);
+    if (!hit) return null;
+    if (now() - hit.at > ttlMs) {
+      cache.delete(key);
+      return null;
+    }
+    return hit.decision;
+  }
+
+  function cacheSet(key, decision) {
+    if (cache.size >= max && !cache.has(key)) {
+      // Map iteration order is insertion order, so the first key is the oldest.
+      const oldest = cache.keys().next();
+      if (!oldest.done) cache.delete(oldest.value);
+    }
+    cache.set(key, { at: now(), decision });
+  }
+
+  return async function guardUrl(url, details, executeId): Promise<any> {
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return { allowed: false, reason: "invalid URL" };
+    }
+    const scheme = parsed.protocol.toLowerCase();
+    if (scheme === "about:" && url === "about:blank") return { allowed: true };
+    if (scheme === "data:" || scheme === "blob:") return { allowed: true };
+    if (!BROWSER_SCHEMES.has(scheme)) {
+      return {
+        allowed: false,
+        reason: `unsupported browser URL scheme: ${scheme}`,
+      };
+    }
+    const fullUrl = Boolean(
+      details?.isNavigation ||
+      details?.resourceType === "document" ||
+      details?.resourceType === "download" ||
+      scheme === "ws:" ||
+      scheme === "wss:",
+    );
+    const key = fullUrl
+      ? ""
+      : `${scheme}//${parsed.hostname.toLowerCase()}:${parsed.port}`;
+    if (key) {
+      // Copy on read: a caller must not be able to mutate a cached verdict.
+      const cached = cacheGet(key);
+      if (cached) return { ...cached };
+    }
+    const response = await rpc("guard", { url, ...details, fullUrl }, executeId);
+    if (key && response?.cacheable === true) {
+      const decision: GuardDecision = { allowed: response.allowed === true };
+      if (typeof response.reason === "string") decision.reason = response.reason;
+      cacheSet(key, decision);
+    }
+    return response;
+  };
+}

--- a/src/guard-url.ts
+++ b/src/guard-url.ts
@@ -22,8 +22,16 @@
 //     re-derive that equivalence and could drift from it.
 //   - Failures are never cached. An RPC rejection propagates unchanged and
 //     leaves no entry, so the transport still fails closed on the next attempt.
-//   - allowHosts/blockHosts are public mutable arrays, so entries expire after
-//     `ttlMs` instead of living for the session.
+//   - A response that is not cacheable empties the cache. Declining to write
+//     new entries would still leave the old ones answering for hosts the
+//     browser had already contacted, so a `custom` hook installed mid-session
+//     would govern only new hosts — which is not what "never cached" means.
+//     Any navigation is an uncacheable check, so a page load flushes.
+//   - allowHosts/blockHosts are public mutable arrays, and a mutation is
+//     invisible from here: the verdict shape is unchanged, so nothing in a
+//     response marks it. Those converge on `ttlMs` instead. The same bound
+//     covers the one case the flush above cannot see — an already-cached host
+//     re-checked with no uncacheable check in between.
 //   - The cache belongs to the guard it was created with. A worker process
 //     serves one BetterWright and therefore one policy, so decisions made under
 //     one policy can never answer for another.
@@ -103,10 +111,26 @@ export function createGuardUrl({
       if (cached) return { ...cached };
     }
     const response = await rpc("guard", { url, ...details, fullUrl }, executeId);
-    if (key && response?.cacheable === true) {
-      const decision: GuardDecision = { allowed: response.allowed === true };
-      if (typeof response.reason === "string") decision.reason = response.reason;
-      cacheSet(key, decision);
+    if (response?.cacheable === true) {
+      if (key) {
+        const decision: GuardDecision = { allowed: response.allowed === true };
+        if (typeof response.reason === "string") decision.reason = response.reason;
+        cacheSet(key, decision);
+      }
+    } else if (cache.size) {
+      // The client just said this policy is not cacheable, and every entry
+      // below was decided back when it was. Refusing to write new entries is
+      // not enough on its own: a `custom` hook installed mid-session — or a
+      // whole policy swapped in — has to govern the hosts already contacted,
+      // not just the ones that happen to be new. Drop them now instead of
+      // letting them answer for the rest of their TTL.
+      //
+      // Navigations, documents, downloads and websockets are never cacheable,
+      // so any page load reaches this and flushes. What it cannot reach is a
+      // request to an already-cached host made with no uncacheable check in
+      // between; that one still converges on `ttlMs`, the same bound as an
+      // allowHosts/blockHosts mutation.
+      cache.clear();
     }
     return response;
   };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -82,6 +82,7 @@ import {
   httpGetViaProxy,
   parseUpstreamProxy,
 } from "./guard-proxy.js";
+import { createGuardUrl } from "./guard-url.js";
 import {
   movePointer,
   pointInside,
@@ -485,30 +486,11 @@ function rpc(method, payload, executeId): Promise<any> {
   });
 }
 
-async function guardUrl(url, details, executeId): Promise<any> {
-  let scheme = "";
-  try {
-    scheme = new URL(url).protocol.toLowerCase();
-  } catch {
-    return { allowed: false, reason: "invalid URL" };
-  }
-  if (scheme === "about:" && url === "about:blank") return { allowed: true };
-  if (scheme === "data:" || scheme === "blob:") return { allowed: true };
-  if (!["http:", "https:", "ws:", "wss:"].includes(scheme)) {
-    return {
-      allowed: false,
-      reason: `unsupported browser URL scheme: ${scheme}`,
-    };
-  }
-  const fullUrl = Boolean(
-    details?.isNavigation ||
-    details?.resourceType === "document" ||
-    details?.resourceType === "download" ||
-    scheme === "ws:" ||
-    scheme === "wss:",
-  );
-  return rpc("guard", { url, ...details, fullUrl }, executeId);
-}
+// Scheme handling, the RPC, and the decision cache live in guard-url.ts: this
+// file is a process entrypoint, so keeping them out of it is what lets the
+// security contract be unit-tested. One instance per worker process — that is
+// one BetterWright, and so one policy.
+const guardUrl = createGuardUrl({ rpc });
 
 function transportExecuteId() {
   // Attribution for the transport guard. With several sessions executing at

--- a/tests/node/client.test.ts
+++ b/tests/node/client.test.ts
@@ -9,6 +9,7 @@ import {
   pendingCredentialRecovery,
 } from "../../dist/src/credential-constants.js";
 import { BetterWright, LocalCredentialVault } from "../../dist/src/index.js";
+import { NetworkPolicy } from "../../dist/src/policy.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
 test("the encrypted local credential vault is enabled by default and can be replaced or disabled", async () => {
@@ -405,5 +406,113 @@ test("CLOAKBROWSER_BINARY_PATH remains the only binary override", async () => {
     await browser.close();
     if (previous === undefined) delete process.env.CLOAKBROWSER_BINARY_PATH;
     else process.env.CLOAKBROWSER_BINARY_PATH = previous;
+  }
+});
+
+test("only a stock NetworkPolicy's guard decisions are marked cacheable", async () => {
+  // The worker caches a guard decision only when the client says it may, and
+  // the client may only say so for the one policy shape whose verdict depends
+  // on nothing but scheme, host, and port. Anything that can consult `details`,
+  // time, or external state — a custom hook, a subclass, a duck-typed object —
+  // must reach the policy on every request.
+  class TighterPolicy extends NetworkPolicy {}
+  const shared = Object.freeze({ allowed: true, reason: "shared verdict" });
+  const patchedCheck = new NetworkPolicy();
+  patchedCheck.check = () => shared;
+  const grafted = Object.create(NetworkPolicy.prototype);
+  grafted.custom = null;
+  grafted.check = () => shared;
+  const proxied = new Proxy(new NetworkPolicy(), {
+    get: (target, prop, receiver) =>
+      prop === "check"
+        ? () => shared
+        : Reflect.get(target, prop, receiver),
+  });
+  const cases = [
+    { name: "default policy", options: {}, cacheable: true },
+    { name: "stock NetworkPolicy", options: { policy: new NetworkPolicy() }, cacheable: true },
+    {
+      name: "custom hook",
+      options: { policy: new NetworkPolicy({ custom: () => shared }) },
+      cacheable: false,
+    },
+    { name: "subclass", options: { policy: new TighterPolicy() }, cacheable: false },
+    {
+      name: "duck-typed check",
+      options: { policy: { check: () => shared } },
+      cacheable: false,
+    },
+    // Exact-constructor identity alone would pass all three of these: an own
+    // property shadows the prototype's check, and a Proxy forwards constructor
+    // and custom to its target while intercepting check.
+    { name: "instance-patched check", options: { policy: patchedCheck }, cacheable: false },
+    { name: "grafted prototype", options: { policy: grafted }, cacheable: false },
+    { name: "proxy decorator", options: { policy: proxied }, cacheable: false },
+  ];
+
+  for (const item of cases) {
+    const bw = new BetterWright({ vault: false, ...item.options });
+    const sent = [];
+    bw._send = (message) => sent.push(message);
+    try {
+      assert.equal(bw._policyCacheable, item.cacheable, item.name);
+      await bw._serviceRpc({
+        requestId: "guard-1",
+        method: "guard",
+        payload: { url: "https://example.com/a", resourceType: "image", fullUrl: false },
+      });
+      const response = sent.at(-1);
+      assert.equal(response.ok, true, item.name);
+      assert.equal(response.result.cacheable, item.cacheable, item.name);
+      assert.equal(response.result.allowed, true, item.name);
+    } finally {
+      await bw.close();
+    }
+  }
+  // Annotating the decision must never write through to the policy's own object.
+  assert.deepEqual(shared, { allowed: true, reason: "shared verdict" });
+  assert.equal("cacheable" in shared, false);
+});
+
+test("cacheability follows mid-session policy mutation, not construction", async () => {
+  // `policy`, `policy.custom`, and `policy.check` are all public and mutable,
+  // and docs/network-policy.md advertises mid-session policy edits. A hook
+  // installed after construction must stop the worker caching immediately —
+  // memoizing the flag would keep serving pre-hook verdicts for up to the cache
+  // TTL, and forever for hosts that keep being refreshed as cacheable.
+  const guard = async (bw) => {
+    const sent = [];
+    bw._send = (message) => sent.push(message);
+    await bw._serviceRpc({
+      requestId: "guard-1",
+      method: "guard",
+      payload: { url: "https://example.com/a", resourceType: "image", fullUrl: false },
+    });
+    return sent.at(-1).result;
+  };
+
+  const policy = new NetworkPolicy();
+  const bw = new BetterWright({ vault: false, policy });
+  try {
+    assert.equal((await guard(bw)).cacheable, true);
+
+    policy.custom = () => ({ allowed: false, reason: "hook says no" });
+    const hooked = await guard(bw);
+    assert.equal(hooked.cacheable, false);
+    assert.equal(hooked.allowed, false);
+
+    policy.custom = null;
+    assert.equal((await guard(bw)).cacheable, true);
+
+    policy.check = () => ({ allowed: true, reason: "patched" });
+    assert.equal((await guard(bw)).cacheable, false);
+
+    bw.policy = new NetworkPolicy();
+    assert.equal((await guard(bw)).cacheable, true);
+
+    bw.policy = new NetworkPolicy({ custom: () => ({ allowed: true, reason: "swapped" }) });
+    assert.equal((await guard(bw)).cacheable, false);
+  } finally {
+    await bw.close();
   }
 });

--- a/tests/node/guard-proxy.test.ts
+++ b/tests/node/guard-proxy.test.ts
@@ -6,6 +6,7 @@ import { PassThrough } from "node:stream";
 import test from "node:test";
 
 import { createGuardProxy } from "../../dist/src/guard-proxy.js";
+import { createGuardUrl } from "../../dist/src/guard-url.js";
 
 const IPV6_ONE = "2001:db8:0:0:0:0:0:1";
 const IPV6_TWO = "2001:db8:0:0:0:0:0:2";
@@ -567,5 +568,245 @@ test("SOCKS5 replies preserve policy, reachability, and address errors", async (
         await proxy.close();
       }
     });
+  }
+});
+
+// --- Guard decision cache, driven through the proxy -------------------------
+//
+// These run the worker's real guardUrl (src/guard-url.ts) in front of the
+// proxy, so what is asserted is the shipped cache, not a stand-in: how many
+// times the client is actually consulted, and that caching never lets a
+// connection reach an address no live decision covered.
+
+const ALLOW = { allowed: true, cacheable: true };
+
+function cachedGuardProxy(
+  transport,
+  decide: (payload?: any) => any = () => ALLOW,
+  cacheOptions = {},
+) {
+  const rpcs = [];
+  const rpc = async (_method, payload) => {
+    rpcs.push(payload);
+    return decide(payload);
+  };
+  const proxy = createGuardProxy({
+    guardUrl: createGuardUrl({ rpc, ...cacheOptions }),
+    executeId: () => "guard-proxy-test",
+    transport,
+  });
+  return { proxy, rpcs, urls: () => rpcs.map((payload) => payload.url) };
+}
+
+function addressTransport(resolve, extra: Record<string, any> = {}) {
+  const dialed = [];
+  return {
+    dialed,
+    transport: {
+      lookup: async () => resolve(),
+      connect: async ({ host }) => {
+        dialed.push(host);
+        return new PassThrough();
+      },
+      delay: async () => {},
+      ...extra,
+    },
+  };
+}
+
+test("a first connection guards the host and every address, a second guards nothing", async () => {
+  const { dialed, transport } = addressTransport(() => [
+    { address: "192.0.2.1", family: 4 },
+    { address: "192.0.2.2", family: 4 },
+  ]);
+  const { proxy, rpcs, urls } = cachedGuardProxy(transport);
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "cached.test"), 0);
+    assert.deepEqual(urls(), [
+      "https://cached.test:443/",
+      "https://192.0.2.1:443/",
+      "https://192.0.2.2:443/",
+    ]);
+    assert.deepEqual(dialed, ["192.0.2.1"]);
+
+    assert.equal(await socksConnect(port, "cached.test"), 0);
+    assert.equal(rpcs.length, 3, "every decision must have been served from the cache");
+    assert.deepEqual(dialed, ["192.0.2.1", "192.0.2.1"]);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("decisions the client does not mark cacheable are re-asked every time", async () => {
+  for (const decision of [{ allowed: true }, { allowed: true, cacheable: false }]) {
+    const { transport } = addressTransport(() => [
+      { address: "192.0.2.1", family: 4 },
+      { address: "192.0.2.2", family: 4 },
+    ]);
+    const { proxy, rpcs } = cachedGuardProxy(transport, () => decision);
+    try {
+      const port = await proxy.ensure();
+      assert.equal(await socksConnect(port, "uncached.test"), 0);
+      assert.equal(rpcs.length, 3);
+      assert.equal(await socksConnect(port, "uncached.test"), 0);
+      assert.equal(
+        rpcs.length,
+        6,
+        `${JSON.stringify(decision)} must reach the client on every connection`,
+      );
+    } finally {
+      await proxy.close();
+    }
+  }
+});
+
+test("a rebound hostname is guarded again at its new address", async () => {
+  let resolved = [{ address: "192.0.2.1", family: 4 }];
+  const { dialed, transport } = addressTransport(() => resolved);
+  const { proxy, urls } = cachedGuardProxy(transport);
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "rebind.test"), 0);
+    assert.deepEqual(urls(), ["https://rebind.test:443/", "https://192.0.2.1:443/"]);
+
+    // The name is cached; the address it now resolves to is not, so the new
+    // literal is decided before anything connects to it.
+    resolved = [{ address: "198.51.100.7", family: 4 }];
+    assert.equal(await socksConnect(port, "rebind.test"), 0);
+    assert.deepEqual(urls(), [
+      "https://rebind.test:443/",
+      "https://192.0.2.1:443/",
+      "https://198.51.100.7:443/",
+    ]);
+    assert.deepEqual(dialed, ["192.0.2.1", "198.51.100.7"]);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("one blocked address blocks the connection, and the block is cached", async () => {
+  let clock = 1_000;
+  const { dialed, transport } = addressTransport(
+    () => [
+      { address: "192.0.2.1", family: 4 },
+      { address: "192.0.2.66", family: 4 },
+      { address: "192.0.2.3", family: 4 },
+    ],
+    { now: () => clock, failureCooldownMs: 1, failureBackoffBaseMs: 1 },
+  );
+  const { proxy, rpcs, urls } = cachedGuardProxy(transport, (payload) =>
+    payload.url.includes("192.0.2.66")
+      ? { allowed: false, reason: "test policy", cacheable: true }
+      : ALLOW,
+  );
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "mixed.test"), 2);
+    assert.deepEqual(
+      urls(),
+      [
+        "https://mixed.test:443/",
+        "https://192.0.2.1:443/",
+        "https://192.0.2.66:443/",
+        "https://192.0.2.3:443/",
+      ],
+      "validation stays exhaustive: every address is decided, even after a denial",
+    );
+    assert.deepEqual(dialed, [], "a denied address must stop the whole connection");
+
+    clock += 5;
+    assert.equal(await socksConnect(port, "mixed.test"), 2);
+    assert.equal(rpcs.length, 4, "the denial must be cached like any other decision");
+    assert.deepEqual(dialed, []);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a denial in address order wins over a rejection that settles first", async () => {
+  // The addresses are guarded in parallel, so the error a caller sees must come
+  // from address order rather than from whichever guard finished first.
+  const settleOrder = [];
+  const later = async (value) => {
+    await new Promise((resolve) => setImmediate(resolve));
+    settleOrder.push("first");
+    return value;
+  };
+  const { transport } = addressTransport(
+    () => [
+      { address: "192.0.2.1", family: 4 },
+      { address: "192.0.2.2", family: 4 },
+    ],
+    { failureBackoffBaseMs: 1 },
+  );
+  const { proxy } = cachedGuardProxy(transport, (payload) => {
+    if (payload.url.includes("192.0.2.1"))
+      return later({ allowed: false, reason: "test policy" });
+    if (payload.url.includes("192.0.2.2")) {
+      settleOrder.push("second");
+      throw new Error("guard RPC failed");
+    }
+    return { allowed: true };
+  });
+  try {
+    const port = await proxy.ensure();
+    // 2 is "blocked by policy"; 1 would mean the RPC rejection won the race.
+    assert.equal(await socksConnect(port, "ordered.test"), 2);
+    assert.deepEqual(settleOrder, ["second", "first"]);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a failed guard RPC is never cached, so the next attempt asks again", async () => {
+  let clock = 1_000;
+  let failNext = true;
+  const { dialed, transport } = addressTransport(() => [{ address: "192.0.2.1", family: 4 }], {
+    now: () => clock,
+    failureCooldownMs: 1,
+    failureBackoffBaseMs: 1,
+  });
+  const { proxy, rpcs } = cachedGuardProxy(transport, (payload) => {
+    if (payload.url.includes("192.0.2.1") && failNext) {
+      failNext = false;
+      throw new Error("guard RPC failed");
+    }
+    return ALLOW;
+  });
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "flaky.test"), 1);
+    assert.equal(rpcs.length, 2);
+    assert.deepEqual(dialed, []);
+
+    clock += 5;
+    assert.equal(await socksConnect(port, "flaky.test"), 0);
+    assert.equal(rpcs.length, 3, "the address must be re-decided, not remembered as failed");
+    assert.deepEqual(dialed, ["192.0.2.1"]);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("an expired decision is re-asked before the next connection", async () => {
+  let cacheClock = 0;
+  const { transport } = addressTransport(() => [{ address: "192.0.2.1", family: 4 }]);
+  const { proxy, rpcs } = cachedGuardProxy(transport, () => ALLOW, {
+    now: () => cacheClock,
+    ttlMs: 5_000,
+  });
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "ttl.test"), 0);
+    assert.equal(rpcs.length, 2);
+    cacheClock += 5_000;
+    assert.equal(await socksConnect(port, "ttl.test"), 0);
+    assert.equal(rpcs.length, 2);
+    cacheClock += 1;
+    assert.equal(await socksConnect(port, "ttl.test"), 0);
+    assert.equal(rpcs.length, 4, "both the host and its address must be re-decided");
+  } finally {
+    await proxy.close();
   }
 });

--- a/tests/node/guard-url.test.ts
+++ b/tests/node/guard-url.test.ts
@@ -376,3 +376,99 @@ test("a cached guard decides every URL exactly as NetworkPolicy.check does", asy
     }
   }
 });
+
+// A hook installed after the browser has already contacted a host is the case
+// that made "a custom policy is never cached" untrue: refusing to write new
+// entries still left the old ones answering. These pin the flush that fixes it,
+// and the bound on what the flush cannot reach.
+
+test("a custom hook installed mid-session governs hosts already cached", async () => {
+  // The clock never advances, so nothing here can be the TTL doing the work.
+  const clock = 0;
+  const policy = new NetworkPolicy();
+  const { bw, guardUrl, rpcCount } = clientGuard(policy, { now: () => clock, ttlMs: 5_000 });
+  try {
+    assert.equal((await guardUrl("https://seen.example/a", {}, "e1")).allowed, true);
+    assert.equal((await guardUrl("https://seen.example/b", {}, "e1")).allowed, true);
+    assert.equal(rpcCount(), 1, "the second check was served from the cache");
+
+    policy.custom = () => ({ allowed: false, reason: "custom deny" });
+
+    // Any navigation is an uncacheable check, so it reaches the client, comes
+    // back not-cacheable, and empties the cache.
+    const navigation = await guardUrl(
+      "https://elsewhere.example/page",
+      { isNavigation: true },
+      "e1",
+    );
+    assert.equal(navigation.allowed, false);
+
+    const revisited = await guardUrl("https://seen.example/c", {}, "e1");
+    assert.equal(revisited.allowed, false, "the hook now decides the cached host");
+    assert.match(revisited.reason, /custom deny/);
+  } finally {
+    await bw.close();
+  }
+});
+
+test("an uncacheable response empties the cache even for an unrelated host", async () => {
+  const clock = 0;
+  const { rpc, calls } = recordingRpc((payload) =>
+    payload.fullUrl ? { allowed: true } : { allowed: true, cacheable: true },
+  );
+  const guardUrl = createGuardUrl({ rpc, now: () => clock, ttlMs: 5_000 });
+
+  await guardUrl("https://a.example/1", {}, "e1");
+  await guardUrl("https://b.example/1", {}, "e1");
+  assert.equal(calls.length, 2);
+  await guardUrl("https://a.example/2", {}, "e1");
+  assert.equal(calls.length, 2, "both hosts are cached");
+
+  await guardUrl("https://c.example/page", { isNavigation: true }, "e1");
+  assert.equal(calls.length, 3);
+
+  await guardUrl("https://a.example/3", {}, "e1");
+  await guardUrl("https://b.example/2", {}, "e1");
+  assert.equal(calls.length, 5, "the flush dropped every entry, not just one");
+});
+
+test("a cacheable response never flushes: normal operation keeps its cache", async () => {
+  // The flush must key off cacheability, not off the check being full-URL — a
+  // stock policy answers navigations with cacheable:true, and a page load
+  // interleaves those with subresources constantly.
+  const clock = 0;
+  const policy = new NetworkPolicy();
+  const { bw, guardUrl, rpcCount } = clientGuard(policy, { now: () => clock, ttlMs: 5_000 });
+  try {
+    await guardUrl("https://keep.example/sub", {}, "e1");
+    assert.equal(rpcCount(), 1);
+    await guardUrl("https://keep.example/page", { isNavigation: true }, "e1");
+    assert.equal(rpcCount(), 2, "navigations always reach the client");
+    await guardUrl("https://keep.example/sub2", {}, "e1");
+    assert.equal(rpcCount(), 2, "the host entry survived the navigation");
+  } finally {
+    await bw.close();
+  }
+});
+
+test("without an uncacheable check in between, a new hook waits for the TTL", async () => {
+  // The honest bound: the flush needs a response to ride on. A host re-checked
+  // with nothing uncacheable in between converges on ttlMs, exactly like an
+  // allowHosts/blockHosts mutation.
+  let clock = 0;
+  const policy = new NetworkPolicy();
+  const { bw, guardUrl } = clientGuard(policy, { now: () => clock, ttlMs: 5_000 });
+  try {
+    assert.equal((await guardUrl("https://quiet.example/a", {}, "e1")).allowed, true);
+    policy.custom = () => ({ allowed: false, reason: "custom deny" });
+    assert.equal(
+      (await guardUrl("https://quiet.example/b", {}, "e1")).allowed,
+      true,
+      "still stale: nothing has reached the client to carry the flush",
+    );
+    clock += 5_001;
+    assert.equal((await guardUrl("https://quiet.example/c", {}, "e1")).allowed, false);
+  } finally {
+    await bw.close();
+  }
+});

--- a/tests/node/guard-url.test.ts
+++ b/tests/node/guard-url.test.ts
@@ -1,0 +1,378 @@
+// The worker's guard entrypoint and its decision cache. The cache is the one
+// place a network decision is reused instead of re-derived, so these tests pin
+// the security contract in src/guard-url.ts: only the client may declare a
+// decision cacheable, only host-scoped checks are eligible, failures are never
+// cached, and a cached answer is byte-identical to the one the policy would
+// have produced for that URL.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createGuardUrl } from "../../dist/src/guard-url.js";
+import { BetterWright } from "../../dist/src/index.js";
+import { NetworkPolicy } from "../../dist/src/policy.js";
+
+const ALLOWED = { allowed: true, cacheable: true };
+
+function recordingRpc(respond: (payload?: any, call?: number) => any = () => ALLOWED) {
+  const calls = [];
+  const rpc = async (method, payload, executeId) => {
+    calls.push({ method, payload, executeId });
+    const response = respond(payload, calls.length);
+    if (response instanceof Error) throw response;
+    return response;
+  };
+  return { rpc, calls };
+}
+
+// One BetterWright is the real client half of the guard RPC: the decision and
+// the `cacheable` flag both come from the shipped code path, not a stand-in.
+function clientGuard(policy, options: any = {}) {
+  const bw = new BetterWright({ policy, vault: false });
+  const sent = [];
+  let calls = 0;
+  bw._send = (message) => sent.push(message);
+  const rpc = async (method, payload, executeId) => {
+    calls += 1;
+    const requestId = `guard-${calls}`;
+    await bw._serviceRpc({ requestId, method, payload, id: executeId });
+    const response = sent.at(-1);
+    assert.equal(response.requestId, requestId);
+    if (!response.ok) throw new Error(response.error);
+    return response.result;
+  };
+  return {
+    bw,
+    guardUrl: createGuardUrl({ rpc, ...options }),
+    rpcCount: () => calls,
+  };
+}
+
+test("a cacheable decision answers later checks for the same scheme, host, and port", async () => {
+  const { rpc, calls } = recordingRpc();
+  const guardUrl = createGuardUrl({ rpc });
+
+  assert.deepEqual(await guardUrl("https://example.com/a", {}, "e1"), ALLOWED);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "guard");
+  assert.equal(calls[0].payload.fullUrl, false);
+
+  // Path, query, and details vary; the decision does not.
+  for (const url of [
+    "https://example.com/b?q=1",
+    "https://example.com/c#hash",
+    "https://EXAMPLE.COM/d",
+    "https://example.com:443/e",
+  ])
+    assert.equal((await guardUrl(url, { resourceType: "image" }, "e1")).allowed, true);
+  assert.equal(calls.length, 1, "same origin must not re-ask the client");
+
+  // A different scheme, host, or port is a different key.
+  for (const url of [
+    "http://example.com/a",
+    "https://other.example.com/a",
+    "https://example.com:8443/a",
+  ])
+    assert.equal((await guardUrl(url, {}, "e1")).allowed, true);
+  assert.equal(calls.length, 4);
+});
+
+test("only the client's literal cacheable:true is ever cached", async () => {
+  for (const cacheable of [undefined, false, null, 0, 1, "true", {}]) {
+    const { rpc, calls } = recordingRpc(() =>
+      cacheable === undefined ? { allowed: true } : { allowed: true, cacheable },
+    );
+    const guardUrl = createGuardUrl({ rpc });
+    for (let attempt = 0; attempt < 3; attempt += 1)
+      assert.equal((await guardUrl("https://example.com/", {}, "e1")).allowed, true);
+    assert.equal(
+      calls.length,
+      3,
+      `cacheable=${JSON.stringify(cacheable)} must not enable caching`,
+    );
+  }
+});
+
+test("a malformed or empty response is neither trusted nor cached", async () => {
+  for (const response of [null, undefined, "allowed", { cacheable: true }]) {
+    const { rpc, calls } = recordingRpc(() => response);
+    const guardUrl = createGuardUrl({ rpc });
+    const first = await guardUrl("https://example.com/", {}, "e1");
+    assert.notEqual(first?.allowed, true, "a malformed response must not allow");
+    await guardUrl("https://example.com/", {}, "e1");
+    // `{cacheable: true}` is cacheable by contract, but it caches a denial.
+    if (response && (response as any).cacheable === true) {
+      assert.equal(calls.length, 1);
+      assert.equal((await guardUrl("https://example.com/", {}, "e1")).allowed, false);
+    } else assert.equal(calls.length, 2);
+  }
+});
+
+test("denials are cached with their reason, and a cache hit cannot be mutated", async () => {
+  const denial = {
+    allowed: false,
+    reason: "host blocked by policy: example.com",
+    cacheable: true,
+  };
+  const { rpc, calls } = recordingRpc(() => denial);
+  const guardUrl = createGuardUrl({ rpc });
+
+  const first = await guardUrl("https://example.com/a", {}, "e1");
+  assert.equal(first.allowed, false);
+  const second: any = await guardUrl("https://example.com/b", {}, "e1");
+  assert.equal(calls.length, 1, "denials are cached too");
+  assert.deepEqual(second, { allowed: false, reason: denial.reason });
+
+  second.allowed = true;
+  second.reason = "tampered";
+  const third = await guardUrl("https://example.com/c", {}, "e1");
+  assert.deepEqual(third, { allowed: false, reason: denial.reason });
+  assert.equal(calls.length, 1);
+});
+
+test("a failed guard denies the request and leaves nothing cached", async () => {
+  const { rpc, calls } = recordingRpc((_payload, call) =>
+    call === 1 ? new Error("worker pipe closed") : ALLOWED,
+  );
+  const guardUrl = createGuardUrl({ rpc });
+
+  await assert.rejects(
+    () => guardUrl("https://example.com/a", {}, "e1"),
+    /worker pipe closed/,
+    "an RPC failure must propagate so the transport fails closed",
+  );
+  assert.equal((await guardUrl("https://example.com/a", {}, "e1")).allowed, true);
+  assert.equal(calls.length, 2, "the failed attempt must not have been cached");
+});
+
+test("full-URL checks never read or write the cache", async () => {
+  const fullUrlCases = [
+    { url: "https://example.com/page", details: { isNavigation: true } },
+    { url: "https://example.com/page", details: { resourceType: "document" } },
+    { url: "https://example.com/file.zip", details: { resourceType: "download" } },
+    { url: "wss://example.com/socket", details: {} },
+    { url: "ws://example.com/socket", details: {} },
+  ];
+  for (const { url, details } of fullUrlCases) {
+    const { rpc, calls } = recordingRpc();
+    const guardUrl = createGuardUrl({ rpc });
+    for (let attempt = 0; attempt < 3; attempt += 1) await guardUrl(url, details, "e1");
+    assert.equal(calls.length, 3, `${url} ${JSON.stringify(details)} must not be cached`);
+    assert.ok(calls.every((call) => call.payload.fullUrl === true));
+  }
+
+  // Nor may the two kinds answer for each other in either direction.
+  const subresourceFirst = recordingRpc();
+  const subresourceGuard = createGuardUrl({ rpc: subresourceFirst.rpc });
+  await subresourceGuard("https://example.com/img.png", { resourceType: "image" }, "e1");
+  await subresourceGuard("https://example.com/page", { isNavigation: true }, "e1");
+  assert.equal(subresourceFirst.calls.length, 2);
+
+  const navigationFirst = recordingRpc();
+  const navigationGuard = createGuardUrl({ rpc: navigationFirst.rpc });
+  await navigationGuard("https://example.com/page", { isNavigation: true }, "e1");
+  await navigationGuard("https://example.com/img.png", { resourceType: "image" }, "e1");
+  assert.equal(navigationFirst.calls.length, 2);
+});
+
+test("cached entries expire at the TTL", async () => {
+  let clock = 1_000;
+  const { rpc, calls } = recordingRpc();
+  const guardUrl = createGuardUrl({ rpc, now: () => clock, ttlMs: 5_000 });
+
+  await guardUrl("https://example.com/", {}, "e1");
+  clock += 5_000;
+  await guardUrl("https://example.com/", {}, "e1");
+  assert.equal(calls.length, 1, "an entry is live through the whole TTL");
+  clock += 1;
+  await guardUrl("https://example.com/", {}, "e1");
+  assert.equal(calls.length, 2, "an expired entry must re-ask the client");
+  // The refreshed entry starts a new TTL rather than inheriting the old one.
+  clock += 5_000;
+  await guardUrl("https://example.com/", {}, "e1");
+  assert.equal(calls.length, 2);
+});
+
+test("a policy change is picked up once the entry expires", async () => {
+  let clock = 0;
+  const policy = new NetworkPolicy({ allowPrivateNetwork: false, allowLoopback: false });
+  const { bw, guardUrl, rpcCount } = clientGuard(policy, { now: () => clock, ttlMs: 5_000 });
+  try {
+    assert.equal((await guardUrl("https://blocked.example/a", {}, "e1")).allowed, true);
+    policy.blockHosts.push("blocked.example");
+    assert.equal(
+      (await guardUrl("https://blocked.example/b", {}, "e1")).allowed,
+      true,
+      "the documented cost of caching: a mutation is invisible until the TTL",
+    );
+    assert.equal(rpcCount(), 1);
+
+    clock += 5_001;
+    const decision = await guardUrl("https://blocked.example/c", {}, "e1");
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /blocked by policy/);
+    assert.equal(rpcCount(), 2);
+  } finally {
+    await bw.close();
+  }
+});
+
+test("the cache is bounded and evicts the oldest entry first", async () => {
+  const { rpc, calls } = recordingRpc();
+  const guardUrl = createGuardUrl({ rpc, max: 3 });
+
+  for (const host of ["a", "b", "c"]) await guardUrl(`https://${host}.example/`, {}, "e1");
+  assert.equal(calls.length, 3);
+  // A hit at capacity evicts nothing.
+  await guardUrl("https://c.example/again", {}, "e1");
+  assert.equal(calls.length, 3);
+
+  // Eviction is by insertion order, not by use: a hit does not move an entry.
+  await guardUrl("https://d.example/", {}, "e1");
+  assert.equal(calls.length, 4);
+  for (const host of ["b", "c", "d"]) await guardUrl(`https://${host}.example/`, {}, "e1");
+  assert.equal(calls.length, 4, "newer entries must have survived");
+  await guardUrl("https://a.example/", {}, "e1");
+  assert.equal(calls.length, 5, "the oldest entry must have been evicted");
+});
+
+test("non-network URLs are decided without an RPC", async () => {
+  const { rpc, calls } = recordingRpc();
+  const guardUrl = createGuardUrl({ rpc });
+
+  assert.deepEqual(await guardUrl("about:blank", {}, "e1"), { allowed: true });
+  assert.deepEqual(await guardUrl("data:text/html,hi", {}, "e1"), { allowed: true });
+  assert.deepEqual(await guardUrl("blob:https://example.com/x", {}, "e1"), {
+    allowed: true,
+  });
+  assert.equal((await guardUrl("file:///etc/passwd", {}, "e1")).allowed, false);
+  assert.equal((await guardUrl("javascript:alert(1)", {}, "e1")).allowed, false);
+  assert.deepEqual(await guardUrl("not a url", {}, "e1"), {
+    allowed: false,
+    reason: "invalid URL",
+  });
+  assert.equal(calls.length, 0);
+});
+
+// --- Differential: the cache must never change a decision ------------------
+
+const vectorsPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+  "policy-vectors.json",
+);
+const { vectors } = JSON.parse(fs.readFileSync(vectorsPath, "utf8"));
+
+function policyOptions(snakeCase) {
+  return {
+    allowPrivateNetwork: snakeCase.allow_private_network,
+    allowLoopback: snakeCase.allow_loopback,
+    allowHosts: snakeCase.allow_hosts,
+    blockHosts: snakeCase.block_hosts,
+  };
+}
+
+const CACHEABLE_SCHEMES = new Set(["http:", "https:", "ws:", "wss:"]);
+
+function cacheEligible(url) {
+  try {
+    return CACHEABLE_SCHEMES.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
+test("a cached guard decides every URL exactly as NetworkPolicy.check does", async () => {
+  // Deterministic PRNG: a failure here must be reproducible.
+  let seed = 0x51f3a7d;
+  const random = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  const pick = (items) => items[Math.floor(random() * items.length)];
+
+  const hosts = [
+    ...new Set(
+      vectors
+        .filter((vector) => cacheEligible(vector.url))
+        .map((vector) => new URL(vector.url).hostname),
+    ),
+    "example.com",
+    "sub.example.com",
+    "notexample.com",
+    "127.0.0.1",
+    "169.254.169.254",
+    "10.1.2.3",
+    "[::1]",
+    "metadata.google.internal",
+  ];
+  const schemes = ["http:", "https:", "ws:", "wss:"];
+  const ports = ["", ":80", ":443", ":8080", ":8443"];
+  const paths = ["/", "/a", "/b?q=1", "/deep/path#frag"];
+  const detailSets = [
+    {},
+    { resourceType: "image" },
+    { resourceType: "xhr", method: "POST" },
+    { resourceType: "document" },
+    { resourceType: "download" },
+    { isNavigation: true },
+  ];
+
+  // Group by policy so each guard instance sees one policy, exactly as a worker
+  // process does.
+  const groups = new Map();
+  for (const vector of vectors) {
+    const key = JSON.stringify(vector.policy);
+    if (!groups.has(key)) groups.set(key, { options: policyOptions(vector.policy), urls: [] });
+    groups.get(key).urls.push(vector.url);
+  }
+
+  for (const [key, group] of groups) {
+    const reference = new NetworkPolicy(group.options);
+    const cached = clientGuard(new NetworkPolicy(group.options));
+    // Same client, same policy, caching disabled: the control arm.
+    const uncached = clientGuard(new NetworkPolicy(group.options), { ttlMs: -1 });
+    try {
+      // Only the schemes the guard forwards to the policy: about:/data:/blob:
+      // and unsupported schemes are decided in the worker before any RPC, and
+      // are covered by their own test above.
+      const stream = group.urls.filter(cacheEligible);
+      for (let index = 0; index < 200; index += 1)
+        stream.push(`${pick(schemes)}//${pick(hosts)}${pick(ports)}${pick(paths)}`);
+      // Revisit earlier URLs so the stream actually exercises hits.
+      for (let index = 0; index < 100; index += 1) stream.push(pick(stream));
+
+      for (const url of stream) {
+        const details = pick(detailSets);
+        const expected = reference.check(url, details);
+        for (const [name, arm] of [
+          ["cached", cached],
+          ["uncached", uncached],
+        ] as const) {
+          const actual: any = await arm.guardUrl(url, details, "diff");
+          assert.equal(
+            Boolean(actual?.allowed),
+            Boolean(expected.allowed),
+            `${name} ${key} ${url} ${JSON.stringify(details)}`,
+          );
+          assert.equal(
+            actual?.reason,
+            expected.reason,
+            `${name} ${key} ${url} ${JSON.stringify(details)}`,
+          );
+        }
+      }
+      assert.ok(
+        cached.rpcCount() < uncached.rpcCount(),
+        "the cache must actually be saving round trips",
+      );
+    } finally {
+      await cached.bw.close();
+      await uncached.bw.close();
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Phase A of the round-trip perf program. **Stacked on #87** (merge that first; this diff includes its commit until then).

Every browser connection previously paid a full stdio RPC round-trip to the client process per policy check — one per HTTP request (`context.route("**/*")`), plus one per hostname and one **serial** RPC per resolved IP in the SOCKS guard proxy. For a stock `NetworkPolicy`, those decisions depend only on scheme+host+port, so:

- **New `src/guard-url.ts`**: worker-side decision cache, 5s TTL, 2048-entry LRU, host-scoped checks only. Extracted from `worker.ts` so the invariants are unit-testable (worker.ts is a process entrypoint).
- **Client asserts cacheability per-RPC** via a getter requiring exact `NetworkPolicy` constructor identity, `check === NetworkPolicy.prototype.check`, and no `custom` hook. Adversarial review caught that a construction-time flag fails open when a custom hook is installed mid-session (`policy`/`custom` are public mutable fields) — the getter closes that, plus instance-patched `check` and Proxy-wrapped policies.
- **Never cached**: full-URL checks (navigations, documents, downloads, ws/wss), RPC failures (denied, uncached), anything without a literal `cacheable: true` from the client.
- **Parallel IP validation**: `guardedTransportAddresses` validates all resolved addresses in one wave (`Promise.allSettled` + address-order scan so errors stay deterministic) instead of serially; every address is still decided before any connect. DNS rebinding to a new IP is a cache miss → fresh RPC.
- Daemon connect: try immediately, then 25→100ms backoff, instead of a flat 100ms sleep first.

## Benchmarks (`benchmarks/perf`, vs `baseline-52a577d`)

| Guard RPCs / 51-request load | baseline p50 | phase-a p50 |
|---|---|---|
| route (per HTTP request) | 51 (exact) | **1** |
| transport (per connection) | 44 | **0** |
| total | 95 | **1** (−97%) |

Fixture servers independently count requests: all 51 still served on every measured load, so the collapse is RPC elimination, not caching artifacts. The steady-state 1 is the cache-busted document — a full-URL check, uncacheable by design. Per-action latency and wall time flat (fixture-dominated), as predicted.

## Tests

- `tests/node/guard-url.test.ts` (new): TTL boundaries via injected clock, insertion-order eviction, strict `cacheable === true` gating, fullUrl bypass in both directions, RPC-rejection non-caching, mid-session `blockHosts` mutation convergence, plus a seeded randomized **differential suite** asserting cached-path decisions === direct `NetworkPolicy.check` (allowed + reason) over the policy-vectors fixture.
- `tests/node/guard-proxy.test.ts`: 7 new tests wiring the real `createGuardUrl` into the proxy — first/second connection RPC counts, rebinding, exhaustive parallel validation with one denied IP, denial-beats-rejection ordering (fails under `Promise.all`), TTL re-guarding.
- `tests/node/client.test.ts`: cacheability table (stock / subclass / custom / duck-typed / instance-patched / grafted prototype / Proxy) + mid-session mutation flips.
- `npm run test:unit` 705 pass / 0 fail; typecheck, lint, test:types clean.

Docs: `docs/network-policy.md` gains a Decision caching section (≤5s convergence for mid-session allow/block mutations; custom policies never cached); `docs/architecture.md` guard-path paragraph updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)