### PR TITLE
perf: gated + batched challenge scan, sandbox compile hoists (−95% iframe tax)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Changed
+
+- Challenge detection is now staged. Every `run()` still reads the main frame's
+  title, text and provider response tokens, but the per-frame walk — one round
+  trip per frame, previously paid on every action — runs only when something
+  already points at a challenge: a provider URL, matching main or same-origin
+  frame text, a recent 403/429/503 document response, a challenge left
+  unresolved by the previous action, or an unreadable cross-origin frame.
+  Benign iframes no longer tax every agent action. `captcha.solve()` and
+  `captcha.detect()` are unchanged and always read every frame. See
+  "When detection runs" in `docs/captcha.md`, including the one accepted
+  limitation: a page with more than three opaque cross-origin frames where the
+  challenge is identifiable only by the text inside one of them.
+
 ## [1.6.2] - 2026-08-02
 
 A performance release. No API changes: 1.6.2 is a drop-in replacement for

--- a/benchmarks/perf/REPORT.md
+++ b/benchmarks/perf/REPORT.md
@@ -370,6 +370,234 @@ no single delta is quoted. Phase B is graded on these metrics, so treat
 60.3–60.6 ms and 33.3–36.7 ms as its baselines and require a win far larger than
 10%.
 
+## Phase B results
+
+`phase-b-51eebd0` and `phase-b-repeat-51eebd0` — 2026-08-03, same machine, Node
+v26.5.0, linux-x64, 8 CPUs, branch `perf/challenge-staging`: the staged
+challenge scan (`challengeScanNeeded` / `frameUrlLooksLikeChallenge` in
+`src/challenges.ts`, the two-stage `collectChallengeMetadata` in
+`src/worker.ts`) plus the two sandbox hoists (the realm factory `vm.Script`,
+`src/compile-code.ts`'s statement-first heuristic). Two full-fidelity runs back
+to back, same as every other recorded phase.
+
+**These two keys were re-recorded after code review** (`--force`), against the
+reviewed revision rather than the first cut. Four review fixes move numbers in
+this table and the reasoning below is written against the reviewed code:
+
+1. Stage 1 is **four concurrent reads**, not one evaluate — `page.title()`,
+   `locator("body").innerText()`, the token evaluate, and the frame-descriptor
+   walk — so one slow field can no longer blank the other three. Title and text
+   go back through Playwright's utility world, which page script cannot patch.
+2. Stage 2 reads each frame's text and checkbox state through **locators**, not
+   an in-page evaluate: two parallel round trips per frame instead of one, in
+   exchange for utility-world isolation and shadow-DOM piercing.
+3. The gate opens for **unread cross-origin frames** — any frame whose URL is
+   challenge-shaped, plus up to `CHALLENGE_UNREAD_FRAME_BUDGET` (3) of them
+   unconditionally. This is a detection fix, and it is why the C fixture's 10
+   and 24 frames still skip while a 1–3 frame page no longer does.
+4. Unmatched frames resolve their geometry through `frameElement()` instead of
+   borrowing a sibling descriptor.
+
+**Both keys carry the Phase A commit `51eebd0` because Phase B was still
+uncommitted when the runs were taken** (`working_tree_dirty: true`, as with
+every other run in the file). The key names the tree the run started from, not
+the code under test; the branch field is what distinguishes these two runs.
+
+| Metric (p50) | baseline | phase-a | phase-b | phase-b-repeat | delta |
+|---|---|---|---|---|---|
+| **A.** Per-action latency (n=100) | 7.60 ms | 7.36 ms | 7.56 ms | 7.50 ms | flat |
+| **A'.** Per-action latency, late-session (n=100) | 6.45 ms | 6.19 ms | 7.52 ms | 6.96 ms | **+0.5 to +1.1 ms** |
+| **B.** Page-load wall time (n=10) | 715.8 ms | 713.8 ms | 721.0 ms | 711.7 ms | ±noise, fixture-dominated |
+| **B.** In-page navigation time (n=10) | 695 ms | 691 ms | 697 ms | 686 ms | ±noise |
+| **C.** Per-action, 10 cross-site iframes (n=30) | 36.68 ms | 35.41 ms | **8.99 ms** | **8.64 ms** | **−74% to −76%** |
+| **C.** Per-action, 24 cross-site iframes (n=30) | 60.57 ms | 66.08 ms | **11.64 ms** | **9.38 ms** | **−81% to −86%** |
+
+The C rows are quoted against the **full recorded band** rather than one arm,
+because the Phase A section established that band as ~10% wide: C10 has spanned
+33.31–36.68 ms and C24 60.28–66.08 ms across the four pre-Phase-B runs.
+
+| Derived (against the adjacent A' control) | recorded band, 4 runs | phase-b | phase-b-repeat | delta |
+|---|---|---|---|---|
+| **Iframe tax per action, 10 frames (p50)** | +26.81 to +30.23 ms | **+1.47 ms** | **+1.68 ms** | **−94% to −95%** |
+| **Iframe tax per action, 24 frames (p50)** | +53.78 to +59.89 ms | **+4.12 ms** | **+2.42 ms** | **−92% to −96%** |
+| Per-frame cost, 10 frames | 2.68–3.02 ms | 0.15 ms | 0.17 ms | |
+| Per-frame cost, 24 frames | 2.24–2.50 ms | 0.17 ms | 0.10 ms | |
+| Session drift (A' − A, p50) | −11.6% to −15.9% | −0.5% | −7.2% | see below |
+
+| Control (Phase A metrics, untouched by Phase B) | phase-a | phase-b | phase-b-repeat |
+|---|---|---|---|
+| **`route`** guard RPCs / load | 1 p50, mean 2.0 (1–6) | 1 p50, mean 1.8 (1–5) | 1 p50, mean 1.9 (1–6) |
+| **`transport`** guard RPCs / load | 0 p50, mean 0.8 (0–3) | 0 p50, mean 0.9 (0–4) | 0 p50, mean 1.0 (0–4) |
+| Fixture requests / load | **51** (enforced) | **51** (enforced) | **51** (enforced) |
+
+### Reading Phase B
+
+**The iframe tax collapsed by an order of magnitude, and it cleared the recorded
+variance by roughly ten times that variance.** The Phase A section set the bar:
+"treat 60.3–60.6 ms and 33.3–36.7 ms as its baselines and require a win far
+larger than 10%." C24 went to 9.38–11.64 ms and C10 to 8.64–8.99 ms. The tax
+derived against the adjacent A' control fell from +54 ms to +2.4–4.1 ms at 24
+frames and from +30 ms to +1.5–1.7 ms at 10. The C10 arms agree to within
+0.35 ms; C24 spans 2.3 ms between arms, which is the widest disagreement in this
+table and is why that row is quoted as a band.
+
+**Frame-count scaling is now flat inside the noise, which is the shape the
+staging predicts.** The baseline's headline structural finding was a sublinear
+but steep 2.26–3.02 ms *per frame*; Phase B reports 0.10–0.17 ms per frame, and
+the 10-frame and 24-frame tax bands (+1.47/+1.68 and +2.42/+4.12) nearly
+overlap. A 2.4x frame count now buys ~1–2 ms, because no per-frame round trip is
+being made at all. **Do not read the residual as a per-frame cost** — it is
+dominated by the fixed part of stage 1 plus the in-page descriptor walk.
+
+**The residual tax is stage 1, and it is charged whether or not the gate
+fires.** Stage 1's descriptor evaluate still enumerates `iframe, frame` elements
+and computes `getBoundingClientRect` + `getComputedStyle` for each (up to
+`CHALLENGE_FRAME_LIMIT`), attempts `contentDocument` on each to collect the
+same-origin text the gate judges, and the worker still calls `page.frames()` and
+maps their URLs. That is one round trip plus in-page work, which is why it costs
+~0.15 ms/frame instead of the ~2.3–3.0 ms of the old per-frame CDP walk. It is
+also the floor this design can reach without giving the gate less to look at
+than the detector needs.
+
+**Per-action latency did not improve, and A' cost about a millisecond — that is
+the review's price and it is worth paying.** A's p50 is 7.56/7.50 ms against a
+7.35–7.60 ms pre-Phase-B band: flat. A' is 7.52/6.96 ms against 6.19–6.50 ms:
+up 0.5–1.1 ms, and the session-drift row moved with it (−0.5%/−7.2% against a
+prior −11.6% to −15.9%), which is the same fact seen from the other side — A'
+rose relative to A. The cause is structural, not noise: stage 1 issues four
+concurrent round trips per action where the pre-review cut issued one, so a
+per-action floor that was 6.2–6.5 ms is now ~7 ms. What that buys is that a page
+slow enough to lose one read no longer loses the other three — in particular an
+empty `tokens` would re-report an already-solved challenge and burn the solver's
+three-attempt budget — and that title and body text are read in Playwright's
+utility world, where page script cannot patch `innerText` to hide its own
+interstitial. Against a 30–54 ms frame-walk win, a ~1 ms floor is the right
+trade; against the pre-review cut's headline "−2% on A", it means **the sandbox
+hoists' contribution is no longer visible in this metric.** Do not quote an A
+win from this table.
+
+**Nothing in the Phase A control rows moved, which is the negative result this
+table needs.** Phase B touches no guard path, and `route`/`transport` stayed at
+a p50 of 1 and 0, means of 1.8–1.9 and 0.9–1.0, with the fixture still serving
+its enforced 51 requests per load. (The `route` mean of 2.9 seen in the
+pre-review Phase B run — one load costing 15 RPCs — did not recur; both arms
+here match Phase A's 1.9–2.0.)
+
+**Page-load wall time did not move and was not expected to.** 721.0 and 711.7 ms
+against 713.8–716.2 ms is inside the spread this file records for a metric that
+is ~690 ms of fixture navigation and `networkidle` settling.
+
+### Gate verification: the gate did not fire
+
+The tax collapsing is consistent with the gate skipping stage 2, but it is not
+*proof* of it — a stage 2 that ran and did nothing would look similar enough to
+be worth ruling out, and a detection regression would look like a win. So the
+gate was checked directly rather than inferred from the clock.
+
+**Trace (pre-review revision).** `dist/src/worker.js` was temporarily patched at
+two points — the `options.gate` call site in `collectChallengeMetadata` and the
+entry to `collectFrameMetadata` itself — to append one NDJSON record per gate
+decision and per stage-2 invocation under a `BW_GATE_TRACE` env var.
+`collectFrameMetadata` was instrumented as well as the gate because the gate's
+own return value only proves what happened at *that* call site; the entry
+counter catches stage 2 arriving by any other path (the captcha-solving paths
+call `collectChallengeMetadata` ungated by design). The harness was then run
+under `--quick --iframes 10,24`.
+
+| Instrumented quick run | Value |
+|---|---|
+| Gate decisions recorded | **90** |
+| … returning `true` (scan stage 2) | **0** |
+| … returning `false` (skip stage 2) | **90** |
+| … reached with no gate function (ungated path) | **0** |
+| **`collectFrameMetadata` invocations** | **0** |
+| Decisions on the 0-frame pages (A, A', B) | 60 — all skip |
+| Decisions on the 10-frame page | 15 — all skip |
+| Decisions on the 24-frame page | 15 — all skip |
+| Same-origin frame texts read by stage 1 | 0, on every decision |
+| Main-frame `<iframe>` descriptors seen by stage 1 | 0 / 10 / 24 |
+
+Two rows carry the argument. **Stage 2 ran zero times** across the whole
+battery, so the C rows above are measuring a page whose per-frame walk genuinely
+did not happen. And **stage 1 saw 10 and 24 iframe descriptors on the respective
+pages** — the skip was a decision taken with the frames in hand, not a blindness
+to frames that were never enumerated. The `sameOrigin: 0` row confirms the
+design assumption the fixture was built to exercise: the frames are cross-site
+OOPIFs, opaque to stage 1's evaluate, so all the gate ever learned about them
+was their URL.
+
+**Replay (reviewed revision).** That trace predates review fix 3, which changed
+what the gate is given: frames now carry a `readable` flag, and an unread frame
+opens the gate either on URL shape or on the unread-frame budget. The trace was
+therefore re-checked rather than assumed, by replaying the fixture's exact frame
+sets through the shipped `challengeScanNeeded` in `dist/`:
+
+| Fixture page | Unread cross-site frames | `challengeScanNeeded` |
+|---|---|---|
+| A / A' / B (`/static`, `/page`) | 0 | `false` |
+| C10 (`/frames?n=10`) | 10 | `false` |
+| C24 (`/frames?n=24`) | 24 | `false` |
+
+All three still skip: the fixture frame URLs (`http://127.0.0.{2,3}:<port>/frame/<n>`)
+match no provider and carry no challenge-shaped token, and 10 and 24 are both
+over the 3-frame unread budget. **A page with 1–3 such frames would now scan** —
+that is the detection fix working, and it means this fixture is measuring the
+frame-heavy case specifically. A 2-frame variant of the C fixture would show the
+gate opening and stage 2's new cost; the harness does not have one.
+
+**Positive control: the gate does fire.** An all-skip trace is also what a
+permanently-false gate would produce, so the bot-challenge integration tests in
+`tests/node/browser.test.js` are the counter-evidence. Against the reviewed
+build all 13 challenge/captcha tests pass, including
+`iframe-only bot challenges are detected` and the new
+`bot challenges in a cross-origin frame are detected` — an out-of-process
+`127.0.0.2` frame whose URL names no provider, which only the unread-frame
+budget can reach, and which the pre-review gate missed.
+
+The instrumentation was removed by rebuilding `dist/` from source; `grep` for
+`BW_GATE_TRACE` in `dist/src/worker.js` returns 0 matches. The instrumented
+`--quick` run was deliberately **not** kept in `results.json`: its numbers
+include a synchronous `appendFileSync` per gate decision, and a quick run is not
+full-fidelity anyway.
+
+### Caveats specific to Phase B
+
+- **This harness measures the benign frame-heavy case only.** A page that
+  carries a challenge — or merely 1–3 opaque cross-origin frames — now pays
+  stage 1 plus stage 2 on every execute. Stage 2 was also rewritten: two
+  parallel locator reads per frame (`innerText`, checkbox `count`) plus one
+  shared descriptor walk on the parent, against five sequential CDP round trips
+  before (`frameElement`, rect/style, `dispose`, `innerText`, checkbox count).
+  Challenged pages should be faster too, but **no number in this table is
+  evidence of that**. It would need a fixture with a provider frame, which the
+  harness does not have.
+- **The gate is a detection surface, and the benchmark cannot see detection
+  regressions.** A gate that wrongly skipped would show up here as a *larger*
+  win — which is exactly what happened before review: the pre-review C rows were
+  0.5–2.5 ms lower than these, and part of that gap was a gate that skipped
+  cross-origin challenge frames. What constrains it now is
+  `tests/node/challenge-scan-gate.test.ts` — which feeds the gate
+  production-fidelity inputs (same-origin frames with text, cross-origin frames
+  with a bare URL) and compares against the detector run over the **full** frame
+  metadata the old unconditional scan produced, asserting that the only
+  divergence is the documented over-budget unread-frame case — plus the 13
+  integration tests used as the positive control above. Read the win only
+  together with those.
+- **A constant background load was present for every run in this file.** A
+  `sunshine` process held ~150% CPU (of 8 cores) from 16:10 local on 2026-08-02
+  onward, which covers the baseline (02:45Z), Phase A (03:13Z) and Phase B
+  (04:51Z / 04:52Z) runs alike. Absolute millisecond figures here are therefore
+  *not* the idle-machine floor the "How to run" section asks for, but the load
+  was the same for every arm, so the cross-run comparisons — which is all the
+  deltas above claim — hold. Anyone re-recording an absolute baseline should do
+  it on a genuinely idle machine.
+- **The C rows are now small enough that A' precision starts to matter.** The
+  residual tax (1.5–4.1 ms) is of the same order as A's own stdev (1.6–2.4 ms).
+  It is still a p50 of 30 samples against a p50 of 100, so it is a real
+  central-tendency difference, but quote it as the band across both runs rather
+  than as any single figure — and note that A' itself moved this round, so the
+  derived tax is a difference of two numbers that both changed.
+
 ## Files
 
 - [`run.ts`](run.ts) — the harness. Compiled to `run.js` by `npm run

--- a/benchmarks/perf/results.json
+++ b/benchmarks/perf/results.json
@@ -619,6 +619,314 @@
           }
         }
       }
+    },
+    "phase-b-51eebd0": {
+      "metadata": {
+        "label": "phase-b",
+        "date": "2026-08-03T04:51:43.154Z",
+        "commit": "51eebd0",
+        "branch": "perf/challenge-staging",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.56,
+        "p95_ms": 10.9,
+        "mean_ms": 7.79,
+        "stdev_ms": 1.63,
+        "min_ms": 5,
+        "max_ms": 14.19
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 7.52,
+        "p95_ms": 11.06,
+        "mean_ms": 7.67,
+        "stdev_ms": 2.16,
+        "min_ms": 4.9,
+        "max_ms": 22.09
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -0.04,
+        "p50_delta_pct": -0.53
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 721.02,
+          "p95_ms": 741.96,
+          "mean_ms": 722.98,
+          "stdev_ms": 9.1,
+          "min_ms": 711.63,
+          "max_ms": 741.96
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 697,
+          "p95_ms": 715,
+          "mean_ms": 698.3,
+          "stdev_ms": 7.77,
+          "min_ms": 685,
+          "max_ms": 715
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 1,
+            "mean": 1.8,
+            "min": 1,
+            "max": 5
+          },
+          "transport": {
+            "count": 10,
+            "p50": 0,
+            "mean": 0.9,
+            "min": 0,
+            "max": 4
+          },
+          "total": {
+            "count": 10,
+            "p50": 1,
+            "mean": 2.7,
+            "min": 1,
+            "max": 9
+          }
+        },
+        "route_guard_rpcs_per_subresource": 0.04,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 5,
+          "guard_rpcs_transport": 3,
+          "fixture_requests": 51,
+          "wall_ms": 751.14
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 8.99,
+          "p95_ms": 11.83,
+          "mean_ms": 9.25,
+          "stdev_ms": 1.27,
+          "min_ms": 7.4,
+          "max_ms": 12.26
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 11.64,
+          "p95_ms": 14.32,
+          "mean_ms": 11.47,
+          "stdev_ms": 1.82,
+          "min_ms": 7.91,
+          "max_ms": 15.62
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 1.47,
+            "p95_ms": 0.77,
+            "per_frame_p50_ms": 0.15
+          },
+          "frames_24": {
+            "p50_ms": 4.12,
+            "p95_ms": 3.26,
+            "per_frame_p50_ms": 0.17
+          }
+        }
+      }
+    },
+    "phase-b-repeat-51eebd0": {
+      "metadata": {
+        "label": "phase-b-repeat",
+        "date": "2026-08-03T04:52:12.662Z",
+        "commit": "51eebd0",
+        "branch": "perf/challenge-staging",
+        "working_tree_dirty": true,
+        "node": "v26.5.0",
+        "platform": "linux-x64",
+        "cpus": 8,
+        "quick_mode": false,
+        "betterwright_version": "1.6.2"
+      },
+      "config": {
+        "action_iterations": 100,
+        "action_warmup": 5,
+        "load_iterations": 10,
+        "load_warmup": 1,
+        "challenge_iterations": 30,
+        "challenge_warmup": 3,
+        "subresources": 50,
+        "origins": 4,
+        "iframe_counts": [
+          10,
+          24
+        ],
+        "frame_hosts": [
+          "127.0.0.2",
+          "127.0.0.3"
+        ],
+        "connections_dropped_between_loads": true,
+        "snippet": "return page.title()"
+      },
+      "per_action_latency": {
+        "count": 100,
+        "p50_ms": 7.5,
+        "p95_ms": 12.33,
+        "mean_ms": 7.97,
+        "stdev_ms": 2.39,
+        "min_ms": 4.73,
+        "max_ms": 21.21
+      },
+      "per_action_latency_after": {
+        "count": 100,
+        "p50_ms": 6.96,
+        "p95_ms": 10.02,
+        "mean_ms": 7.26,
+        "stdev_ms": 1.41,
+        "min_ms": 4.73,
+        "max_ms": 13.99
+      },
+      "session_drift": {
+        "note": "A' minus A: monotonic per-session cost growth, measured so it is not charged to the iframes",
+        "p50_delta_ms": -0.54,
+        "p50_delta_pct": -7.2
+      },
+      "page_load": {
+        "wall_time": {
+          "count": 10,
+          "p50_ms": 711.66,
+          "p95_ms": 733.85,
+          "mean_ms": 714.05,
+          "stdev_ms": 12.3,
+          "min_ms": 694.79,
+          "max_ms": 733.85
+        },
+        "navigation_time": {
+          "count": 10,
+          "p50_ms": 686,
+          "p95_ms": 709,
+          "mean_ms": 689.7,
+          "stdev_ms": 10.7,
+          "min_ms": 673,
+          "max_ms": 709
+        },
+        "guard_rpcs_per_load": {
+          "note": "route = context.route('**/*') interception, one per HTTP request, exact. transport = the SOCKS proxy's per-connection hostname + per-resolved-IP guards; connection-scoped and therefore variable, since Chromium decides how many sockets to open.",
+          "route": {
+            "count": 10,
+            "p50": 1,
+            "mean": 1.9,
+            "min": 1,
+            "max": 6
+          },
+          "transport": {
+            "count": 10,
+            "p50": 0,
+            "mean": 1,
+            "min": 0,
+            "max": 4
+          },
+          "total": {
+            "count": 10,
+            "p50": 1,
+            "mean": 2.9,
+            "min": 1,
+            "max": 10
+          }
+        },
+        "route_guard_rpcs_per_subresource": 0.04,
+        "fixture_requests_per_load": {
+          "count": 10,
+          "p50": 51,
+          "mean": 51,
+          "min": 51,
+          "max": 51
+        },
+        "first_load": {
+          "note": "n=1 warmup load, discarded from the series; kept only as a sanity reading",
+          "guard_rpcs_route": 5,
+          "guard_rpcs_transport": 3,
+          "fixture_requests": 51,
+          "wall_ms": 710.59
+        }
+      },
+      "challenge_scan": [
+        {
+          "frames": 10,
+          "cross_site_frames": 10,
+          "count": 30,
+          "p50_ms": 8.64,
+          "p95_ms": 11.99,
+          "mean_ms": 9.01,
+          "stdev_ms": 1.49,
+          "min_ms": 6.8,
+          "max_ms": 12.42
+        },
+        {
+          "frames": 24,
+          "cross_site_frames": 24,
+          "count": 30,
+          "p50_ms": 9.38,
+          "p95_ms": 12.73,
+          "mean_ms": 9.74,
+          "stdev_ms": 1.87,
+          "min_ms": 7.05,
+          "max_ms": 13.55
+        }
+      ],
+      "derived": {
+        "iframe_overhead": {
+          "frames_10": {
+            "p50_ms": 1.68,
+            "p95_ms": 1.97,
+            "per_frame_p50_ms": 0.17
+          },
+          "frames_24": {
+            "p50_ms": 2.42,
+            "p95_ms": 2.71,
+            "per_frame_p50_ms": 0.1
+          }
+        }
+      }
     }
   }
 }

--- a/docs/captcha.md
+++ b/docs/captcha.md
@@ -180,6 +180,36 @@ When the challenge clears, verify the current application state before resuming.
 Replay the original action only if it is idempotent or the state proves it did
 not already complete; never duplicate a submission, purchase, or message.
 
+## When detection runs
+
+Every `run()` result is scanned for a challenge, but the scan is staged. Stage 1
+always reads the main frame — its title, its body text, its filled provider
+response fields, and the geometry and (same-origin) text of its child frames.
+Stage 2 reads every frame individually, which costs a round trip per frame and
+so runs only when something already points at a challenge:
+
+- a provider frame or main-document URL (reCAPTCHA, hCaptcha, Turnstile, the
+  Cloudflare challenge platform, Google `/sorry`, Bing challenge paths);
+- main-frame or same-origin-frame text that the detector matches;
+- a 403, 429 or 503 document response — main frame **or** subframe — within the
+  last 10 seconds;
+- a challenge still unresolved at the end of the previous `run()`;
+- any frame stage 1 could not read (cross-origin) whose URL is challenge-shaped
+  — the commercial vendors that do not name a provider in their frame URL
+  (DataDome, Arkose/FunCaptcha, AWS WAF, PerimeterX, GeeTest) as well as
+  self-hosted `…/captcha/…`, `…/challenge…`, `…/verify…` endpoints;
+- up to three unreadable cross-origin frames regardless of what their URLs say.
+
+`captcha.solve()` and `captcha.detect()` never stage: they always read every
+frame.
+
+**Accepted limitation.** A page carrying **more than three** cross-origin frames
+whose URLs are entirely unremarkable, where one of them is a challenge
+identifiable only by its text, is not detected automatically. Text is the only
+evidence in that case and reading it is exactly the per-frame cost the staging
+exists to avoid. Call `captcha.detect()` explicitly if you are working a page
+you expect to challenge you from an opaque embedded frame.
+
 ## Efficiency
 
 The solver adds no worker processes, ONNX/TensorFlow runtimes, or OCR binaries.

--- a/src/challenges.ts
+++ b/src/challenges.ts
@@ -75,6 +75,24 @@ function providerForPage(url) {
   return host || "unknown";
 }
 
+// Provider host/path shapes shared by the full detector (challengeUrlSignal)
+// and the cheap URL-only gate (frameUrlLooksLikeChallenge). Both must read the
+// same constants: a gate that misses a URL the detector would match turns into
+// a silent false negative once the frame scan is staged behind it.
+const GOOGLE_SORRY_PATH = /^\/sorry(?:\/|$)/;
+const BING_CHALLENGE_PATH = /\/(?:captcha|challenge|turing)(?:\/|$)/;
+const RECAPTCHA_FRAME_PATH = /\/recaptcha\/(?:api2|enterprise)\/(?:anchor|bframe)(?:\/|$)/;
+const HCAPTCHA_CHALLENGE_QUERY = /(?:^|[?&#])frame=challenge(?:[&#]|$)/;
+const HCAPTCHA_CHALLENGE_PATH = /(?:^|\/)(?:hcaptcha-)?challenge(?:\.html)?(?:\/|$)/;
+const HCAPTCHA_IMAGE_PROMPT =
+  /(?:please )?(?:click|select|choose) (?:all|each|every|the) (?:image|images|square|squares)\b/;
+const CLOUDFLARE_PLATFORM_PATH = "/cdn-cgi/challenge-platform/";
+const TURNSTILE_PATH = "/turnstile/";
+
+function isRecaptchaHost(host) {
+  return isGoogleHost(host) || hostIs(host, "recaptcha.net");
+}
+
 function explicitInvisible(url) {
   let decoded = stringValue(url).toLowerCase();
   try {
@@ -102,17 +120,15 @@ function challengeUrlSignal(source, includeInvisible = false) {
   const path = parsed.pathname.toLowerCase();
   const whole = `${path}${parsed.search}${parsed.hash}`.toLowerCase();
 
-  if (isGoogleHost(host) && /^\/sorry(?:\/|$)/.test(path)) {
+  if (isGoogleHost(host) && GOOGLE_SORRY_PATH.test(path)) {
     return { provider: "google", signal: "google_sorry_url", source };
   }
-  if (hostIs(host, "bing.com") && /\/(?:captcha|challenge|turing)(?:\/|$)/.test(path)) {
+  if (hostIs(host, "bing.com") && BING_CHALLENGE_PATH.test(path)) {
     return { provider: "bing", signal: "bing_challenge_url", source };
   }
 
-  const recaptchaHost = isGoogleHost(host) || hostIs(host, "recaptcha.net");
-  const recaptchaFrame = /\/recaptcha\/(?:api2|enterprise)\/(?:anchor|bframe)(?:\/|$)/.test(
-    path,
-  );
+  const recaptchaHost = isRecaptchaHost(host);
+  const recaptchaFrame = RECAPTCHA_FRAME_PATH.test(path);
   if (recaptchaHost && recaptchaFrame) {
     if (!includeInvisible && path.endsWith("/anchor") && explicitInvisible(source.url)) return null;
     return { provider: "recaptcha", signal: "recaptcha_frame_url", source };
@@ -121,20 +137,17 @@ function challengeUrlSignal(source, includeInvisible = false) {
   const hcaptchaFrameText = normalizedText(`${source.title}\n${source.text}`);
   const hcaptchaChallengeFrame =
     hostIs(host, "hcaptcha.com") &&
-    (/(?:^|[?&#])frame=challenge(?:[&#]|$)/.test(whole) ||
-      /(?:^|\/)(?:hcaptcha-)?challenge(?:\.html)?(?:\/|$)/.test(path) ||
-      (path.includes("/captcha/") &&
-        /(?:please )?(?:click|select|choose) (?:all|each|every|the) (?:image|images|square|squares)\b/.test(
-          hcaptchaFrameText,
-        )));
+    (HCAPTCHA_CHALLENGE_QUERY.test(whole) ||
+      HCAPTCHA_CHALLENGE_PATH.test(path) ||
+      (path.includes("/captcha/") && HCAPTCHA_IMAGE_PROMPT.test(hcaptchaFrameText)));
   if (hcaptchaChallengeFrame) {
     return { provider: "hcaptcha", signal: "hcaptcha_frame_url", source };
   }
 
-  const cloudflarePlatform = path.includes("/cdn-cgi/challenge-platform/");
+  const cloudflarePlatform = path.includes(CLOUDFLARE_PLATFORM_PATH);
   const turnstileFrame =
     hostIs(host, "challenges.cloudflare.com") &&
-    (cloudflarePlatform || path.includes("/turnstile/"));
+    (cloudflarePlatform || path.includes(TURNSTILE_PATH));
   if (turnstileFrame) {
     if (!includeInvisible && explicitInvisible(source.url)) return null;
     return { provider: "turnstile", signal: "turnstile_frame_url", source };
@@ -231,6 +244,64 @@ function challengeResult(main, match) {
   };
 }
 
+/**
+ * URL-only "this frame might be a challenge" test, built from the same provider
+ * host/path constants as `challengeUrlSignal`. It is deliberately broader than
+ * the detector — it cannot see frame text, visibility, or `size=invisible`, so
+ * it must never narrow past what a later full scan could match. Callers use it
+ * to decide whether the expensive per-frame scan is worth running at all.
+ */
+export function frameUrlLooksLikeChallenge(url) {
+  const parsed = parsedUrl(url);
+  if (!parsed) return false;
+  const host = parsed.hostname.toLowerCase();
+  const path = parsed.pathname.toLowerCase();
+  if (path.includes(CLOUDFLARE_PLATFORM_PATH)) return true;
+  if (hostIs(host, "challenges.cloudflare.com")) return true;
+  if (hostIs(host, "hcaptcha.com")) return true;
+  if (isGoogleHost(host) && GOOGLE_SORRY_PATH.test(path)) return true;
+  if (hostIs(host, "bing.com") && BING_CHALLENGE_PATH.test(path)) return true;
+  return isRecaptchaHost(host) && RECAPTCHA_FRAME_PATH.test(path);
+}
+
+// Gate-only shapes, deliberately outside `challengeUrlSignal`. The detector
+// names a provider from these frames only after reading their *text* (they end
+// up as `providerForPage`'s host fallback in genericTextSignal), so the URL
+// alone must never report a challenge — but it is exactly what the gate has to
+// judge, because these frames are cross-origin and their text costs a round
+// trip. Commercial vendors whose challenge frame URL names no provider the
+// detector knows:
+const VENDOR_CHALLENGE_HOSTS = [
+  "captcha-delivery.com", // DataDome
+  "datadome.co",
+  "arkoselabs.com", // Arkose Labs / FunCaptcha
+  "funcaptcha.com",
+  "awswaf.com", // AWS WAF Captcha
+  "px-cdn.net", // PerimeterX / HUMAN
+  "perimeterx.net",
+  "geetest.com",
+];
+// …plus any host or path that says "captcha" in the usual words, which is what
+// self-hosted challenge endpoints are almost always called. Separator-anchored
+// so `recaptcha.example.com` and `challenges.cloudflare.com.evil.test` — the
+// lookalikes `frameUrlLooksLikeChallenge` must reject — do not match a bare
+// substring.
+const CHALLENGE_URL_TOKEN =
+  /(?:^|[.\-/_])(?:captcha|challenge|turing|verify|human|bot[-_]?check)(?:[.\-/_]|$)/;
+
+/**
+ * Whether an unread frame's URL is challenge-shaped enough to be worth reading.
+ * Not a detection: it only decides whether the frame's text gets fetched at all.
+ */
+function frameUrlSuggestsChallenge(url) {
+  if (frameUrlLooksLikeChallenge(url)) return true;
+  const parsed = parsedUrl(url);
+  if (!parsed) return false;
+  const host = parsed.hostname.toLowerCase();
+  if (VENDOR_CHALLENGE_HOSTS.some((vendor) => hostIs(host, vendor))) return true;
+  return CHALLENGE_URL_TOKEN.test(`${host}${parsed.pathname.toLowerCase()}`);
+}
+
 export function isPublicSearchNavigation(url) {
   const parsed = parsedUrl(url);
   if (!parsed) return false;
@@ -267,6 +338,81 @@ export function detectBotChallenge(metadata: any = {}) {
     firstMatch(sources, challengeUrlSignal) ||
     firstMatch(sources, genericTextSignal);
   return match ? challengeResult(main, match) : null;
+}
+
+/**
+ * How long after a 403/429/503 main-document response the next scan still
+ * treats the page as possibly serving an interstitial.
+ */
+export const CHALLENGE_BLOCK_WINDOW_MS = 10_000;
+
+/**
+ * How many frames whose text the caller could not read the gate will pay to
+ * read anyway. Text is the only thing that identifies a challenge in a
+ * cross-origin frame whose URL names no provider, so up to this many unread
+ * frames force the scan unconditionally — the scan then costs less than the
+ * round trips the gate saves elsewhere. Past the budget only
+ * `frameUrlSuggestsChallenge` speaks for an unread frame, which is the one
+ * accepted narrowing in this design (see docs/captcha.md).
+ */
+export const CHALLENGE_UNREAD_FRAME_BUDGET = 3;
+
+/**
+ * Decide whether the caller should pay for a full per-frame challenge scan.
+ *
+ * Reading a frame costs a round trip each, so the scan runs only once something
+ * already points at a challenge. Every condition covers a way a challenge can
+ * exist that the others would miss, ordered cheapest first:
+ *
+ *   - `openProviders` — a challenge was still open after the previous scan.
+ *     Only a completed full scan may rewrite that set, so this both keeps
+ *     watching an unsolved challenge and guarantees the set drains once the
+ *     page clears.
+ *   - `blockedAt` — the site just answered a document with a block status, and
+ *     the interstitial it swapped in may not have rendered recognizable text
+ *     yet.
+ *   - a main or frame URL that `frameUrlLooksLikeChallenge` recognizes.
+ *   - `detectBotChallenge` over the main frame plus whatever `frames` carry.
+ *     Callers pass every frame the full scan would read, with as much of its
+ *     text and visibility as they already have; adding fields to a source can
+ *     only widen a match, never narrow it, so a "no" here is at least as
+ *     complete as the answer the reported metadata would have produced.
+ *   - frames the caller could not read at all (`readable !== true`). Their text
+ *     is exactly what the previous condition is missing, so they are judged on
+ *     URL shape and, up to `CHALLENGE_UNREAD_FRAME_BUDGET` of them, read
+ *     regardless. A frame the caller knows to be invisible is exempt: both
+ *     `challengeUrlSignal` and `genericTextSignal` drop `visible === false`
+ *     frames, so reading one could not change the reported metadata.
+ *
+ * Pure: the caller supplies `now` and the already-read frames, so the decision
+ * is reproducible from its inputs alone.
+ */
+export function challengeScanNeeded(state: any = {}) {
+  const input: any = isRecord(state) ? state : {};
+  const openProviders = input.openProviders;
+  const openCount = openProviders
+    ? (openProviders.size ?? openProviders.length ?? 0)
+    : 0;
+  if (openCount > 0) return true;
+
+  const blockedAt = typeof input.blockedAt === "number" ? input.blockedAt : 0;
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  if (blockedAt > 0 && now - blockedAt <= CHALLENGE_BLOCK_WINDOW_MS) return true;
+
+  const main = isRecord(input.main) ? input.main : {};
+  const frames = (Array.isArray(input.frames) ? input.frames : []).filter(isRecord);
+  if (frameUrlLooksLikeChallenge(main.url)) return true;
+  if (frames.some((frame: any) => frameUrlLooksLikeChallenge(frame.url))) return true;
+
+  const unread = frames.filter(
+    (frame: any) => frame.readable !== true && frame.visible !== false,
+  );
+  if (unread.length > 0 && unread.length <= CHALLENGE_UNREAD_FRAME_BUDGET) return true;
+  if (unread.some((frame: any) => frameUrlSuggestsChallenge(frame.url))) return true;
+
+  return Boolean(
+    detectBotChallenge({ main, frames, solvedProviders: input.solvedProviders }),
+  );
 }
 
 export { PUBLIC_SEARCH_BLOCK_ADVICE, SEARCH_CHALLENGE_ADVICE };

--- a/src/compile-code.ts
+++ b/src/compile-code.ts
@@ -1,0 +1,76 @@
+// Wrapping model code for the sandbox realm. A snippet is either an expression
+// whose value is the result, or a statement list that returns nothing, and the
+// only way to tell them apart is to try to parse each form.
+//
+// Contract this module has to keep, because callers see the difference:
+//   - Whichever form the plain "expression first, statements on SyntaxError"
+//     order would have compiled is the form that runs. Picking the other form
+//     for a snippet both forms accept would silently swap a snippet's value for
+//     `undefined`.
+//   - When neither form parses, the statement-form SyntaxError is the one that
+//     surfaces — that is the message callers have always been shown.
+//   - A non-SyntaxError (a resource limit, say) propagates immediately instead
+//     of being retried in the other form.
+//
+// The heuristic below only reorders the two attempts, so a miss costs the same
+// double compile as before and never changes the outcome.
+
+import vm from "node:vm";
+
+/**
+ * Leading tokens after which the expression wrapper is *guaranteed* to be a
+ * parse error, so the statement form can be tried first.
+ *
+ * All the listed keywords are reserved words, which no expression may start
+ * with. `let` is not reserved in sloppy mode — `let.x`, `let(1)`, `let + 1` and
+ * `let [a] = o` are all valid expressions — so it qualifies only when followed
+ * by an identifier start, the one shape where `(let foo …)` cannot parse.
+ *
+ * `in` and `instanceof` are the exception to that: they are the only binary
+ * operators spelled as identifier-shaped words, so `let in o` and
+ * `let instanceof X` parse as expressions over a global named `let` and must be
+ * left to the expression-first path — claiming them would swap their value for
+ * `undefined`.
+ *
+ * `function`, `class` and `import` are excluded on purpose: they are valid
+ * expressions whose completion value callers read.
+ */
+export const STATEMENT_ONLY_START =
+  /^\s*(?:(?:const|var|return|throw|if|for|while|switch|do|try)\b|let\s+(?!(?:in|instanceof)\b)[$_\p{ID_Start}])/u;
+
+export function compileExpressionForm(code) {
+  return new vm.Script(`(async () => (${code}\n))()`, {
+    filename: "browser-playwright-expression.js",
+  });
+}
+
+export function compileStatementForm(code) {
+  return new vm.Script(`(async () => {\n${code}\n})()`, {
+    filename: "browser-playwright-statements.js",
+  });
+}
+
+/** Compile a model snippet into the async wrapper the realm runs. */
+export function compileCode(code) {
+  if (STATEMENT_ONLY_START.test(code)) {
+    let statementError;
+    try {
+      return compileStatementForm(code);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      statementError = error;
+    }
+    try {
+      return compileExpressionForm(code);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      throw statementError;
+    }
+  }
+  try {
+    return compileExpressionForm(code);
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+    return compileStatementForm(code);
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -29,6 +29,7 @@ import {
   WIDGET_FRAME_PATTERNS,
 } from "./captcha-solver.js";
 import {
+  challengeScanNeeded,
   detectBotChallenge,
   isPublicSearchNavigation,
   PUBLIC_SEARCH_BLOCK_ADVICE,
@@ -52,6 +53,7 @@ import {
   managedCloakViewport,
 } from "./cloak.js";
 import { buildV2LaunchPlan, resolveGeoIdentity } from "./cloak-v2.js";
+import { compileCode } from "./compile-code.js";
 import {
   assertRotationPreservesMatchMode,
   MAX_PENDING_CREDENTIAL_ORIGINS,
@@ -619,6 +621,10 @@ function sessionFor(id) {
       nextDialog: null,
       awaitingAnswerSince: null,
       cursor: { x: 0, y: 0, initialized: false },
+      // Providers whose challenge was still unsolved at the end of the last
+      // execute. Non-empty forces the full frame scan on the next one; only a
+      // full scan writes this set, so it always drains once the page clears.
+      openChallengeProviders: new Set(),
       // State that belongs to the execute currently running on this session.
       // Per-session, not global: sessions run concurrently, so one execute's
       // teardown must not clear another's request id or pending credential.
@@ -1047,6 +1053,16 @@ async function handleDialog(page, dialog) {
   }
 }
 
+// Statuses sites use to hand back an interstitial instead of the page. Recorded
+// per page so the challenge scan can look at frames right after a block even
+// before the replacement document has rendered any recognizable text.
+// Subframe documents count too: an interstitial served into an embedded frame
+// is precisely the case the URL-only half of the gate cannot see.
+// How long a recorded block keeps forcing the scan is CHALLENGE_BLOCK_WINDOW_MS
+// in challenges.ts, where the gate that reads this timestamp lives.
+const CHALLENGE_BLOCK_STATUSES = new Set([403, 429, 503]);
+const lastBlockedDocumentAt = new WeakMap();
+
 function adoptPage(page, sessionId) {
   const session = sessionFor(sessionId);
   const id = pageId(page);
@@ -1087,6 +1103,20 @@ function adoptPage(page, sessionId) {
     });
     page.on("download", (download) => {
       trackDownload(page, download);
+    });
+    // Status first: it rejects every response but the handful worth inspecting,
+    // so ordinary page loads never touch request metadata.
+    page.on("response", (response) => {
+      if (!CHALLENGE_BLOCK_STATUSES.has(response.status())) return;
+      try {
+        const request = response.request();
+        if (request.resourceType() !== "document") return;
+        if (request.frame()?.page() !== page) return;
+      } catch {
+        // Service-worker and already-detached requests have no frame.
+        return;
+      }
+      lastBlockedDocumentAt.set(page, Date.now());
     });
     page.on("dialog", (dialog) => {
       void handleDialog(page, dialog);
@@ -1964,8 +1994,13 @@ function assertModelNavigationUrl(value) {
   }
 }
 
-function createRealm(context) {
-  const factories = new vm.Script(
+let realmFactoryScript = null;
+
+// The factory source is a constant template with no interpolation, so the parse
+// is realm-independent: compile on first use and reuse the script thereafter.
+function getRealmFactoryScript() {
+  if (realmFactoryScript) return realmFactoryScript;
+  realmFactoryScript = new vm.Script(
     `(() => {
     const PromiseCtor = Promise;
     const ErrorCtor = Error;
@@ -2055,7 +2090,12 @@ function createRealm(context) {
     return { adopt, installPage, make, makePages, makeTracked };
   })()`,
     { filename: "browser-playwright-realm.js" },
-  ).runInContext(context);
+  );
+  return realmFactoryScript;
+}
+
+function createRealm(context) {
+  const factories = getRealmFactoryScript().runInContext(context);
   return {
     context,
     cache: new WeakMap(),
@@ -3934,137 +3974,422 @@ async function summarizeSessionPages(session) {
   );
 }
 
-function compileCode(code) {
-  const expression = `(async () => (${code}\n))()`;
-  try {
-    return new vm.Script(expression, {
-      filename: "browser-playwright-expression.js",
-    });
-  } catch (error) {
-    if (!(error instanceof SyntaxError)) throw error;
-    return new vm.Script(`(async () => {\n${code}\n})()`, {
-      filename: "browser-playwright-statements.js",
-    });
-  }
-}
-
 async function enforceArtifactQuota(session) {
   pruneArtifactQuota(session);
 }
 
-async function collectFrameMetadata(page) {
-  return Promise.all(
-    page
-      .frames()
-      .filter((frame) => frame !== page.mainFrame())
-      .slice(0, 24)
-      .map(async (frame) => {
-        const presentation = await frame
-          .frameElement()
-          .then(async (element) => {
-            try {
-              return await element.evaluate((iframe) => {
-                const rect = iframe.getBoundingClientRect();
-                const style = getComputedStyle(iframe);
-                return {
-                  visible:
-                    rect.width > 0 &&
-                    rect.height > 0 &&
-                    style.display !== "none" &&
-                    style.visibility !== "hidden" &&
-                    Number(style.opacity || "1") > 0,
-                  width: rect.width,
-                  height: rect.height,
-                };
-              });
-            } finally {
-              await element.dispose().catch(() => {});
-            }
-          })
-          .catch(() => null);
-        const frameText = (
-          await frame
-            .locator("body")
-            .innerText({ timeout: 500 })
-            .catch(() => "")
-        ).slice(0, 10_000);
-        const checked = await frame
-          .locator(
-            '[aria-checked="true"], input[type="checkbox"]:checked, .recaptcha-checkbox-checked',
-          )
-          .count()
-          .then((count) => count > 0)
-          .catch(() => false);
-        return {
-          url: frame.url(),
-          text: frameText,
-          visible: presentation?.visible ?? null,
-          width: presentation?.width ?? null,
-          height: presentation?.height ?? null,
-          completed:
-            checked ||
-            /verification (?:complete|successful)|success!|you are verified/i.test(
-              frameText,
-            ),
-        };
-      }),
+const CHALLENGE_FRAME_LIMIT = 24;
+const CHALLENGE_MAIN_TEXT_LIMIT = 50_000;
+const CHALLENGE_FRAME_TEXT_LIMIT = 10_000;
+const CHALLENGE_MAIN_TEXT_TIMEOUT_MS = 750;
+const CHALLENGE_FRAME_TEXT_TIMEOUT_MS = 500;
+// The frame walk is work the main-frame read did not do before, so it gets its
+// own budget rather than borrowing the body-text one: a page slow enough to
+// lose the walk must still report its title, text and solved-provider tokens.
+const CHALLENGE_FRAME_WALK_TIMEOUT_MS = 750;
+// In-page ceiling for the same-origin text walk, so one slow frame layout
+// cannot spend the whole evaluate budget by itself.
+const CHALLENGE_WALK_BUDGET_MS = 250;
+const CHALLENGE_CHECKED_SELECTOR =
+  '[aria-checked="true"], input[type="checkbox"]:checked, .recaptcha-checkbox-checked';
+const CHALLENGE_COMPLETED_TEXT =
+  /verification (?:complete|successful)|success!|you are verified/i;
+// Navigation destroys the execution context a pending evaluate was scheduled
+// in. The locator APIs retry that internally, inside their own timeout;
+// `evaluate` surfaces it as a rejection, so it is retried once here to keep a
+// mid-scan navigation from blanking a field the old per-call reads kept.
+const CHALLENGE_EVALUATE_RETRY =
+  /execution context was destroyed|frame was detached|cannot find context/i;
+
+/**
+ * Filled challenge response fields, keyed by provider. Runs in the page's main
+ * world because the fields are page state, which is where this read has always
+ * lived.
+ */
+const readSolvedProvidersInPage = () => {
+  const read = (name) => {
+    const fields = [...document.querySelectorAll(`[name="${name}"]`)];
+    if (fields.length === 0) return "";
+    const values = fields.map((element) =>
+      typeof (element as HTMLInputElement).value === "string"
+        ? (element as HTMLInputElement).value.trim()
+        : "",
+    );
+    // A provider only counts as solved once every response field is filled;
+    // a partially populated multi-widget page is still an open challenge.
+    return values.every(Boolean) ? values[0] : "";
+  };
+  const tokens: Record<string, string> = {};
+  const recaptcha = read("g-recaptcha-response");
+  const hcaptcha = read("h-captcha-response");
+  const turnstile = read("cf-turnstile-response");
+  if (recaptcha) tokens.recaptcha = recaptcha;
+  if (hcaptcha) tokens.hcaptcha = hcaptcha;
+  if (turnstile) tokens.turnstile = turnstile;
+  // Generic local fixture / self-hosted widgets.
+  const generic = read("bw-captcha-response") || read("captcha-response");
+  if (generic) tokens.generic = generic;
+  return tokens;
+};
+
+/**
+ * Child-frame geometry, plus the text of the same-origin ones when the caller
+ * is about to gate on it. One evaluate for the whole document tree instead of a
+ * round trip per frame. Serialized into the page, so it closes over no worker
+ * scope; `contentDocument` reaches same-origin frames (including `srcdoc`) and
+ * nothing else, which is why cross-origin frames still cost stage 2.
+ */
+const readFrameWalkInPage = (options: any) => {
+  const deadline = performance.now() + options.walkBudgetMs;
+  const presentationOf = (element) => {
+    const rect = element.getBoundingClientRect();
+    const view = element.ownerDocument?.defaultView;
+    const style = view ? view.getComputedStyle(element) : null;
+    return {
+      visible:
+        rect.width > 0 &&
+        rect.height > 0 &&
+        (!style ||
+          (style.display !== "none" &&
+            style.visibility !== "hidden" &&
+            Number(style.opacity || "1") > 0)),
+      width: rect.width,
+      height: rect.height,
+    };
+  };
+  // Only this document's own children: a nested frame's descriptors are read
+  // from that frame, and an iframe inside a shadow root (which
+  // `querySelectorAll` does not reach) is resolved through its own element by
+  // the caller rather than by walking every element on the page.
+  const elements = [...document.querySelectorAll("iframe, frame")].slice(
+    0,
+    options.frameLimit,
   );
+  const iframes = elements.map((element) => ({
+    name: element.getAttribute("name") || element.getAttribute("id") || "",
+    src: (element as HTMLIFrameElement).src || "",
+    ...presentationOf(element),
+  }));
+
+  const sameOrigin = [];
+  if (options.wantFrameText) {
+    const queue = [document];
+    while (queue.length > 0 && sameOrigin.length < options.frameLimit) {
+      if (performance.now() > deadline) break;
+      const scope = queue.shift();
+      let nested = [];
+      try {
+        nested = [...scope.querySelectorAll("iframe, frame")];
+      } catch {
+        continue;
+      }
+      for (const element of nested) {
+        if (sameOrigin.length >= options.frameLimit) break;
+        if (performance.now() > deadline) break;
+        let inner = null;
+        try {
+          inner = element.contentDocument;
+        } catch {
+          inner = null;
+        }
+        if (!inner) continue;
+        const innerBody = inner.body;
+        sameOrigin.push({
+          url: inner.location ? String(inner.location.href) : "",
+          title: inner.title || "",
+          text:
+            typeof innerBody?.innerText === "string"
+              ? innerBody.innerText.slice(0, options.frameTextLimit)
+              : "",
+          visible: presentationOf(element).visible,
+        });
+        queue.push(inner);
+      }
+    }
+  }
+  return { iframes, sameOrigin };
+};
+
+/**
+ * Geometry of one frame element, read through the element itself. Duplicates
+ * `presentationOf` above because in-page functions are serialized and cannot
+ * share worker-scope helpers.
+ */
+const readFramePresentationInPage = (element) => {
+  const rect = element.getBoundingClientRect();
+  const view = element.ownerDocument?.defaultView;
+  const style = view ? view.getComputedStyle(element) : null;
+  return {
+    visible:
+      rect.width > 0 &&
+      rect.height > 0 &&
+      (!style ||
+        (style.display !== "none" &&
+          style.visibility !== "hidden" &&
+          Number(style.opacity || "1") > 0)),
+    width: rect.width,
+    height: rect.height,
+  };
+};
+
+function emptyFrameWalk() {
+  return { iframes: [], sameOrigin: [] };
+}
+
+async function evaluateOnce(target, fn, arg?) {
+  try {
+    return await target.evaluate(fn, arg);
+  } catch (error: any) {
+    if (!CHALLENGE_EVALUATE_RETRY.test(String(error?.message || ""))) throw error;
+    return target.evaluate(fn, arg);
+  }
+}
+
+// A hung page must degrade to the same empty value the old per-call `.catch()`
+// handlers produced, and must not leave a rejected evaluate unhandled once the
+// race is over.
+async function withChallengeTimeout(work, timeoutMs, fallback) {
+  let timer;
+  return Promise.race([
+    work,
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve(fallback), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
 }
 
 async function readSolvedProviders(page): Promise<Record<string, string>> {
-  return page
-    .evaluate(() => {
-      const tokens: Record<string, string> = {};
-      const read = (name) => {
-        const fields = [...document.querySelectorAll(`[name="${name}"]`)];
-        if (fields.length === 0) return "";
-        const values = fields.map((element) =>
-          typeof (element as HTMLInputElement).value === "string"
-            ? (element as HTMLInputElement).value.trim()
-            : "",
-        );
-        // A provider only counts as solved once every response field is filled;
-        // a partially populated multi-widget page is still an open challenge.
-        return values.every(Boolean) ? values[0] : "";
-      };
-      const recaptcha = read("g-recaptcha-response");
-      const hcaptcha = read("h-captcha-response");
-      const turnstile = read("cf-turnstile-response");
-      if (recaptcha) tokens.recaptcha = recaptcha;
-      if (hcaptcha) tokens.hcaptcha = hcaptcha;
-      if (turnstile) tokens.turnstile = turnstile;
-      // Generic local fixture / self-hosted widgets.
-      const generic = read("bw-captcha-response") || read("captcha-response");
-      if (generic) tokens.generic = generic;
-      return tokens;
-    })
-    .catch(() => ({}));
+  return evaluateOnce(page, readSolvedProvidersInPage).catch(() => ({}));
 }
 
-async function collectChallengeMetadata(page) {
-  let title = "";
-  let text = "";
-  let frames = [];
-  let tokens: Record<string, any> = {};
+async function readFrameWalk(target, options) {
+  return withChallengeTimeout(
+    evaluateOnce(target, readFrameWalkInPage, options).catch(() => emptyFrameWalk()),
+    CHALLENGE_FRAME_WALK_TIMEOUT_MS,
+    emptyFrameWalk(),
+  );
+}
+
+/**
+ * Text and solved-checkbox state of one frame. Both go through Playwright's
+ * locator APIs, which run in an isolated utility world: a page cannot hide its
+ * own prompt by patching `innerText`, nor declare its challenge solved by
+ * patching `querySelector`, and the CSS engine pierces open shadow roots the
+ * way a widget's own checkbox is usually rendered.
+ */
+async function readFrameSurface(frame) {
+  const [text, checked] = await Promise.all([
+    frame
+      .locator("body")
+      .innerText({ timeout: CHALLENGE_FRAME_TEXT_TIMEOUT_MS })
+      .catch(() => ""),
+    frame
+      .locator(CHALLENGE_CHECKED_SELECTOR)
+      .count()
+      .then((count) => count > 0)
+      .catch(() => false),
+  ]);
+  return { text: text.slice(0, CHALLENGE_FRAME_TEXT_LIMIT), checked };
+}
+
+function claimUnique(pool, matches) {
+  let found = null;
+  for (const entry of pool) {
+    if (entry.used || !matches(entry)) continue;
+    // Two candidates identify nothing: duplicate ad frames and duplicate
+    // widgets share both name and URL, and guessing between them would attach
+    // one frame's visibility to the other.
+    if (found) return null;
+    found = entry;
+  }
+  if (found) found.used = true;
+  return found;
+}
+
+// Playwright's `frame.name()` reports the frame element's name attribute and
+// falls back to its id, so both identify a frame exactly. `src` is the element
+// attribute, which only equals `frame.url()` while the frame has not navigated
+// itself. Anything left over is resolved through its own element instead of
+// being guessed at: a descriptor borrowed from a sibling could report
+// `visible: false`, and that is the one value that makes the detector drop a
+// real challenge.
+function matchFrameDescriptor(frame, pool) {
+  if (!pool.length) return null;
+  const name = frame.name();
+  const byName = name ? claimUnique(pool, (entry) => entry.name === name) : null;
+  if (byName) return byName;
+  const url = frame.url();
+  return url ? claimUnique(pool, (entry) => entry.src && entry.src === url) : null;
+}
+
+async function resolveFramePresentation(frame) {
+  return frame
+    .frameElement()
+    .then(async (element) => {
+      try {
+        return await element.evaluate(readFramePresentationInPage);
+      } finally {
+        await element.dispose().catch(() => {});
+      }
+    })
+    .catch(() => null);
+}
+
+// Stage 2 of the challenge scan: two parallel locator reads per frame instead
+// of the five sequential CDP round-trips (frameElement, rect/style, dispose,
+// innerText, checkbox count) this used to cost, with the geometry coming from
+// the parent's single descriptor walk. `mainDescriptors` is the main frame's
+// share of that, already collected by stage 1.
+async function collectFrameMetadata(page, childFrames, mainDescriptors) {
+  if (!childFrames.length) return [];
+  const mainFrame = page.mainFrame();
+  const parents = new Set();
+  for (const frame of childFrames) {
+    const parent = frame.parentFrame();
+    if (parent && parent !== mainFrame) parents.add(parent);
+  }
+  const surfaces = new Map();
+  const walks = new Map();
+  await Promise.all([
+    ...childFrames.map(async (frame) => {
+      surfaces.set(frame, await readFrameSurface(frame));
+    }),
+    ...[...parents].map(async (frame) => {
+      walks.set(
+        frame,
+        await readFrameWalk(frame, {
+          frameLimit: CHALLENGE_FRAME_LIMIT,
+          frameTextLimit: CHALLENGE_FRAME_TEXT_LIMIT,
+          wantFrameText: false,
+          walkBudgetMs: CHALLENGE_WALK_BUDGET_MS,
+        }),
+      );
+    }),
+  ]);
+
+  const pools = new Map();
+  const poolFor = (parent) => {
+    if (!parent) return [];
+    if (!pools.has(parent)) {
+      const source =
+        parent === mainFrame ? mainDescriptors : walks.get(parent)?.iframes;
+      pools.set(
+        parent,
+        (source || []).map((entry) => ({ ...entry, used: false })),
+      );
+    }
+    return pools.get(parent);
+  };
+
+  const presentations = new Map();
+  for (const frame of childFrames) {
+    presentations.set(
+      frame,
+      matchFrameDescriptor(frame, poolFor(frame.parentFrame())),
+    );
+  }
+  await Promise.all(
+    childFrames
+      .filter((frame) => !presentations.get(frame))
+      .map(async (frame) => {
+        presentations.set(frame, await resolveFramePresentation(frame));
+      }),
+  );
+
+  return childFrames.map((frame) => {
+    const surface = surfaces.get(frame) || { text: "", checked: false };
+    const presentation = presentations.get(frame) || null;
+    return {
+      url: frame.url(),
+      text: surface.text,
+      visible: presentation?.visible ?? null,
+      width: presentation?.width ?? null,
+      height: presentation?.height ?? null,
+      completed: surface.checked || CHALLENGE_COMPLETED_TEXT.test(surface.text),
+    };
+  });
+}
+
+// Stage 1 always runs; stage 2 runs only when `options.gate` says so. Without a
+// gate the full scan runs, which is what the captcha-solving paths need. The
+// returned shape is identical either way — a skipped stage 2 reports no frames,
+// exactly as a frame-free page does.
+//
+// The four stage-1 reads are issued together and degrade independently, so one
+// slow field cannot blank the others: an empty `tokens` in particular would
+// re-report a solved challenge and burn the solver's attempt budget.
+async function collectChallengeMetadata(page, options: any = {}) {
+  const [title, text, tokens, walk] = await Promise.all([
+    page.title().catch(() => ""),
+    page
+      .locator("body")
+      .innerText({ timeout: CHALLENGE_MAIN_TEXT_TIMEOUT_MS })
+      .catch(() => ""),
+    readSolvedProviders(page),
+    readFrameWalk(page, {
+      frameLimit: CHALLENGE_FRAME_LIMIT,
+      frameTextLimit: CHALLENGE_FRAME_TEXT_LIMIT,
+      // Frame text is only read when a gate will judge it; the full scan reads
+      // every frame itself and would otherwise pay for the same text twice.
+      wantFrameText: Boolean(options.gate),
+      walkBudgetMs: CHALLENGE_WALK_BUDGET_MS,
+    }),
+  ]);
+  const main = {
+    url: page.url(),
+    title,
+    text: text.slice(0, CHALLENGE_MAIN_TEXT_LIMIT),
+  };
+
+  let childFrames = [];
   try {
-    [title, text, frames, tokens] = await Promise.all([
-      page.title().catch(() => ""),
-      page.locator("body").innerText({ timeout: 750 }).catch(() => ""),
-      collectFrameMetadata(page),
-      readSolvedProviders(page),
-    ]);
+    childFrames = page
+      .frames()
+      .filter((frame) => frame !== page.mainFrame())
+      .slice(0, CHALLENGE_FRAME_LIMIT);
   } catch {
-    /* page may navigate mid-collect */
+    // A page that closed mid-scan still reports its main-frame metadata.
+  }
+
+  const scanFrames = options.gate
+    ? options.gate({ main, tokens, childFrames, sameOrigin: walk.sameOrigin })
+    : true;
+  const frames = scanFrames
+    ? await collectFrameMetadata(page, childFrames, walk.iframes)
+    : [];
+  return { main, frames, solvedProviders: Object.keys(tokens), tokens };
+}
+
+// The gate itself lives in challenges.ts so it cannot drift from the detector
+// it has to agree with; this only reads the per-page state it needs.
+//
+// Each frame stage 2 would scan contributes exactly one source. Same-origin
+// frames carry the text and visibility stage 1 already read, so the gate judges
+// them on the same evidence the full scan would. Cross-origin frames carry only
+// a URL and are flagged `readable: false`, which is what makes the gate treat
+// them as unknown rather than as benign.
+function challengeScanState(session, page, { main, tokens, childFrames, sameOrigin }) {
+  const readable = new Map();
+  for (const entry of sameOrigin || []) {
+    const queued = readable.get(entry.url);
+    if (queued) queued.push(entry);
+    else readable.set(entry.url, [entry]);
+  }
+  const frames = childFrames.map((frame) => {
+    const entry = readable.get(frame.url())?.shift();
+    return entry ? { ...entry, readable: true } : { url: frame.url(), readable: false };
+  });
+  // Anything the walk read that no live frame claimed is still evidence.
+  for (const queued of readable.values()) {
+    for (const entry of queued) frames.push({ ...entry, readable: true });
   }
   return {
-    main: {
-      url: page.url(),
-      title,
-      text: text.slice(0, 50_000),
-    },
+    openProviders: session.openChallengeProviders,
+    blockedAt: lastBlockedDocumentAt.get(page) || 0,
+    now: Date.now(),
+    main,
     frames,
     solvedProviders: Object.keys(tokens),
-    tokens,
   };
 }
 
@@ -4077,9 +4402,13 @@ async function detectSessionChallenges(session) {
     activePage && !activePage.isClosed()
       ? [activePage]
       : [...session.pages.values()].filter((page) => !page.isClosed()).slice(0, 1);
+  let scanned = false;
   for (const page of pages) {
     if (page.isClosed()) continue;
-    const metadata = await collectChallengeMetadata(page);
+    const metadata = await collectChallengeMetadata(page, {
+      gate: (surface) => challengeScanNeeded(challengeScanState(session, page, surface)),
+    });
+    scanned = true;
     const challenge = detectBotChallenge(metadata);
     if (challenge) {
       const classification = classifyChallengeStage({
@@ -4110,6 +4439,14 @@ async function detectSessionChallenges(session) {
       }
       challenges.push(reported);
     }
+  }
+  // Written only from a completed scan, and a scan that finds nothing writes an
+  // empty set — so a solved or navigated-away challenge always releases the
+  // gate instead of pinning every later execute on the full frame walk.
+  if (scanned) {
+    session.openChallengeProviders = new Set(
+      challenges.map((entry) => entry.provider).filter(Boolean),
+    );
   }
   return challenges;
 }

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -28,13 +28,16 @@ function tempHome() {
   return makeTempDir("betterwright-test-");
 }
 
-async function listen(handler) {
+// Chromium's site isolation keys on scheme + eTLD+1 and ignores the port, so a
+// caller that needs a genuinely cross-site frame has to pass a distinct
+// loopback address, not just a distinct port.
+async function listen(handler, host = "127.0.0.1") {
   const server = http.createServer(handler);
-  server.listen(0, "127.0.0.1");
+  server.listen(0, host);
   await once(server, "listening");
   const { port } = server.address() as AddressInfo;
   return {
-    origin: `http://127.0.0.1:${port}`,
+    origin: `http://${host}:${port}`,
     port,
     async close() {
       server.closeAllConnections?.();
@@ -1166,6 +1169,43 @@ test("iframe-only bot challenges are detected", opts, async () => {
     assert.equal(result.challenges?.[0]?.detectedIn, "frame");
   } finally {
     await bw.close();
+  }
+});
+
+// The staged scan reads same-origin frame text without a round trip, so the
+// srcdoc case above never exercises the hard half. A real out-of-process frame
+// is opaque to that read, and this one names no provider anywhere in its URL:
+// only the gate's unread-frame budget can reach it.
+test("bot challenges in a cross-origin frame are detected", opts, async () => {
+  const embed = await listen((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+    response.end("<!doctype html><body><h1>Verify you are human</h1></body>");
+  }, "127.0.0.2");
+  const site = await listen((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+    response.end(
+      `<!doctype html><body><h1>Checkout</h1>` +
+        `<iframe width="320" height="120" src="${embed.origin}/w/9f3.html"></iframe>` +
+        `</body>`,
+    );
+  });
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.goto(${JSON.stringify(site.origin)});
+      const frames = page.frames();
+      return frames.map(frame => frame.url());
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.ok(
+      result.result.some((url) => url.startsWith(embed.origin)),
+      `the challenge frame never attached: ${JSON.stringify(result.result)}`,
+    );
+    assert.equal(result.challenges?.[0]?.detectedIn, "frame");
+  } finally {
+    await bw.close();
+    await site.close();
+    await embed.close();
   }
 });
 

--- a/tests/node/challenge-scan-gate.test.ts
+++ b/tests/node/challenge-scan-gate.test.ts
@@ -1,0 +1,634 @@
+// The staged challenge scan: the per-frame walk costs a round trip per frame,
+// so it runs only when `challengeScanNeeded` says something already points at a
+// challenge. That makes the gate a detection surface — a gate narrower than the
+// detector is a silent false negative — so these tests pin it against
+// `detectBotChallenge` itself rather than against a hand-copied pattern list.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CHALLENGE_BLOCK_WINDOW_MS,
+  CHALLENGE_UNREAD_FRAME_BUDGET,
+  challengeScanNeeded,
+  detectBotChallenge,
+  frameUrlLooksLikeChallenge,
+} from "../../dist/src/challenges.js";
+
+const BENIGN_MAIN = {
+  url: "https://shop.example/checkout",
+  title: "Checkout",
+  text: "Review your order and choose a shipping method.",
+};
+
+// Every URL family `challengeUrlSignal` recognizes, written the way the real
+// providers serve them. The gate must accept all of these.
+const PROVIDER_URLS = [
+  // google /sorry, on .com and the country-code domains isGoogleHost accepts
+  "https://www.google.com/sorry/index?continue=https://www.google.com/search",
+  "https://google.com/sorry",
+  "https://www.google.com.sg/sorry/index?continue=search",
+  "https://www.google.co.uk/sorry/index",
+  "https://www.google.de/sorry/index",
+  "https://ipv4.google.com/sorry/index",
+  // bing challenge paths
+  "https://www.bing.com/captcha/challenge?id=1",
+  "https://www.bing.com/challenge",
+  "https://www.bing.com/turing/captcha/challenge",
+  // recaptcha anchor/bframe on both google and recaptcha.net
+  "https://www.google.com/recaptcha/api2/anchor?ar=1&k=site-key&size=normal",
+  "https://www.google.com/recaptcha/api2/bframe?hl=en&k=site-key",
+  "https://www.google.com/recaptcha/enterprise/anchor?ar=1&k=site-key",
+  "https://www.google.com/recaptcha/enterprise/bframe?k=site-key",
+  "https://www.recaptcha.net/recaptcha/api2/anchor?k=site-key",
+  "https://recaptcha.net/recaptcha/enterprise/bframe?k=site-key",
+  // invisible reCAPTCHA: the detector suppresses it, the gate must still allow
+  // the scan that would decide that
+  "https://www.google.com/recaptcha/api2/anchor?k=site-key&size=invisible",
+  // hcaptcha frames
+  "https://newassets.hcaptcha.com/captcha/v1/x/static/hcaptcha-challenge.html#frame=challenge",
+  "https://newassets.hcaptcha.com/captcha/v1/x/static/hcaptcha.html#frame=challenge",
+  "https://hcaptcha.com/challenge",
+  "https://assets.hcaptcha.com/captcha/v1/abc/static/hcaptcha-checkbox.html",
+  // turnstile + the cdn-cgi challenge platform, which any site may serve
+  "https://challenges.cloudflare.com/turnstile/v0/api.js",
+  "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/b/turnstile/if/ov2/av0/rcv/x",
+  "https://challenges.cloudflare.com/",
+  "https://shop.example/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1",
+];
+
+// Shapes that look like a provider to a substring check but are not one. A gate
+// that fires on these pays the full frame walk on ordinary ad-heavy pages,
+// which is the entire cost the staging exists to avoid.
+const BENIGN_URLS = [
+  "https://example.com/cdn-cgi-fake/challenge-platform/x",
+  "https://example.com/cdn-cgi/challenge-platform-fake/x",
+  "https://recaptcha.example.com/recaptcha/api2/anchor?k=1",
+  "https://hcaptcha.com.evil.test/challenge",
+  "https://challenges.cloudflare.com.evil.test/turnstile/v0/api.js",
+  "https://notgoogle.com/sorry/index",
+  "https://google.com.evil.test/sorry/index",
+  "https://notbing.com/captcha/challenge",
+  "https://example.com/turnstile/widget",
+  "https://example.com/sorry/index",
+  "https://www.google.com/search?q=jacket",
+  "https://www.google.com/recaptcha/api.js?render=site-key",
+  "https://www.google.com/recaptcha/api2/reload?k=site-key",
+  "https://www.bing.com/search?q=jacket",
+  "https://td.doubleclick.net/td/ga/rul?tid=G-1",
+  "https://www.youtube.com/embed/abc",
+  "https://static.example.com/ads/iframe.html",
+  "about:blank",
+  "",
+  "not a url",
+];
+
+// Frames that carry no challenge shape at all: ad, analytics and embed URLs,
+// plus the provider lookalikes that are not challenge-shaped either. More than
+// CHALLENGE_UNREAD_FRAME_BUDGET of them, so the budget rule is not what makes a
+// list of these skip the scan.
+const ORDINARY_FRAME_URLS = [
+  "https://td.doubleclick.net/td/ga/rul?tid=G-1",
+  "https://www.youtube.com/embed/abc",
+  "https://static.example.com/ads/iframe.html",
+  "https://recaptcha.example.com/recaptcha/api2/anchor?k=1",
+  "https://challenges.cloudflare.com.evil.test/turnstile/v0/api.js",
+  "https://google.com.evil.test/sorry/index",
+  "https://example.com/turnstile/widget",
+  "https://www.google.com/recaptcha/api.js?render=site-key",
+  "https://www.google.com/recaptcha/api2/reload?k=site-key",
+  "about:blank",
+  "",
+];
+
+// Cross-origin frames whose URL names no provider `challengeUrlSignal` knows,
+// but whose host or path is challenge-shaped. Their text is the only thing that
+// could identify them and reading it costs a round trip, so the gate has to
+// open on the URL alone.
+const CHALLENGE_SHAPED_URLS = [
+  "https://geo.captcha-delivery.com/captcha/?initialCid=x", // DataDome
+  "https://client-api.arkoselabs.com/fc/gt2/public_key/ABC", // Arkose / FunCaptcha
+  "https://us-east-1.captcha.awswaf.com/captcha.html", // AWS WAF
+  "https://captcha.px-cdn.net/w/abc", // PerimeterX / HUMAN
+  "https://api.geetest.com/gettype.php",
+  "https://verify.shop-cdn.example/gate.html", // self-hosted, vendor unknown
+  "https://verify.example.com/challenge",
+  "https://shop.example/security/verify.html",
+  "https://cdn.example/bot-check/index.html",
+];
+
+// A cross-origin frame is opaque to the stage-1 evaluate, so all the gate ever
+// learns about one is its URL — which is what `readable: false` records.
+function urlFrames(urls) {
+  return urls.map((url) => ({ url, readable: false }));
+}
+
+// The same-origin frames stage 1 could read in full.
+function readFrames(entries) {
+  return entries.map((entry) => ({ ...entry, readable: true }));
+}
+
+test("the gate accepts every provider URL family the detector recognizes", () => {
+  for (const url of PROVIDER_URLS) {
+    assert.equal(
+      frameUrlLooksLikeChallenge(url),
+      true,
+      `frameUrlLooksLikeChallenge must accept ${url}`,
+    );
+  }
+});
+
+test("the gate rejects provider lookalikes", () => {
+  for (const url of BENIGN_URLS) {
+    assert.equal(
+      frameUrlLooksLikeChallenge(url),
+      false,
+      `frameUrlLooksLikeChallenge must reject ${url}`,
+    );
+  }
+});
+
+// The load-bearing invariant: the gate may be broader than the detector but
+// never narrower. Asserted against the detector's own answer so the two cannot
+// drift when a provider pattern is added to only one of them.
+test("no URL the detector matches from a frame is rejected by the gate", () => {
+  for (const url of [...PROVIDER_URLS, ...BENIGN_URLS]) {
+    const detected = detectBotChallenge({
+      main: BENIGN_MAIN,
+      frames: [{ url, visible: true }],
+    });
+    if (detected?.detectedIn !== "frame") continue;
+    assert.equal(
+      frameUrlLooksLikeChallenge(url),
+      true,
+      `the detector matched ${url} from its URL but the gate would skip the scan`,
+    );
+  }
+});
+
+test("a provider frame URL asks for the full scan", () => {
+  for (const url of PROVIDER_URLS) {
+    assert.equal(
+      challengeScanNeeded({
+        openProviders: new Set(),
+        main: BENIGN_MAIN,
+        frames: urlFrames(["https://static.example.com/ads/iframe.html", url]),
+        solvedProviders: [],
+      }),
+      true,
+      `a ${url} frame must trigger the frame scan`,
+    );
+  }
+});
+
+test("a provider URL in the main frame asks for the full scan", () => {
+  assert.equal(
+    challengeScanNeeded({
+      openProviders: new Set(),
+      main: { url: "https://www.google.com/sorry/index", title: "", text: "" },
+      frames: [],
+    }),
+    true,
+  );
+});
+
+test("benign frames and clean main text skip the full scan", () => {
+  assert.equal(
+    challengeScanNeeded({
+      openProviders: new Set(),
+      blockedAt: 0,
+      now: 1_700_000_000_000,
+      main: BENIGN_MAIN,
+      frames: urlFrames(ORDINARY_FRAME_URLS),
+      solvedProviders: [],
+    }),
+    false,
+  );
+});
+
+// The class the URL-only gate would otherwise lose: a cross-origin challenge
+// frame served by a vendor `challengeUrlSignal` does not name, or by the site
+// itself. The old unconditional scan caught these on frame text alone.
+test("a challenge-shaped frame URL asks for the full scan", () => {
+  for (const url of CHALLENGE_SHAPED_URLS) {
+    assert.equal(
+      challengeScanNeeded({
+        openProviders: new Set(),
+        blockedAt: 0,
+        now: 1_700_000_000_000,
+        main: BENIGN_MAIN,
+        frames: urlFrames([...ORDINARY_FRAME_URLS, url]),
+        solvedProviders: [],
+      }),
+      true,
+      `an unread ${url} frame must trigger the frame scan`,
+    );
+  }
+  // None of them is reported as a provider by the detector's URL rules: the
+  // gate is allowed to be broader, and here it has to be.
+  for (const url of CHALLENGE_SHAPED_URLS) {
+    assert.equal(frameUrlLooksLikeChallenge(url), false, url);
+  }
+});
+
+// URL shape is only the fallback. A handful of unread frames are read outright,
+// because the scan that reads them costs less than the round trips the gate
+// saves on the pages that have none.
+test("a few unread frames are scanned whatever their URL says", () => {
+  const state = {
+    openProviders: new Set(),
+    blockedAt: 0,
+    now: 1_700_000_000_000,
+    main: BENIGN_MAIN,
+    solvedProviders: [],
+  };
+  const opaque = "https://cdn.partner.example/w/9f3.html";
+  for (let count = 1; count <= CHALLENGE_UNREAD_FRAME_BUDGET; count += 1) {
+    assert.equal(
+      challengeScanNeeded({ ...state, frames: urlFrames(Array(count).fill(opaque)) }),
+      true,
+      `${count} unread frames must be read rather than guessed at`,
+    );
+  }
+  // Past the budget the frames are judged on URL shape alone. This is the one
+  // accepted narrowing against the old unconditional scan.
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: urlFrames(Array(CHALLENGE_UNREAD_FRAME_BUDGET + 1).fill(opaque)),
+    }),
+    false,
+  );
+  // A frame stage 1 already read in full does not count as unread, however
+  // many of them there are.
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: readFrames([
+        { url: "https://shop.example/cart", title: "Cart", text: "2 items", visible: true },
+      ]),
+    }),
+    false,
+  );
+  // Nor does one the caller knows to be invisible — the detector drops those.
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: [{ url: opaque, readable: false, visible: false }],
+    }),
+    false,
+  );
+});
+
+test("a main document that is itself the interstitial asks for the full scan", () => {
+  // Cloudflare and Google replace the page and carry no provider frame at all,
+  // so nothing but the stage-1 title and text points at the challenge.
+  assert.equal(
+    challengeScanNeeded({
+      openProviders: new Set(),
+      main: {
+        url: "https://shop.example/checkout",
+        title: "Just a moment...",
+        text: "Checking your browser before accessing shop.example.",
+      },
+      frames: [],
+    }),
+    true,
+  );
+  assert.equal(
+    challengeScanNeeded({
+      openProviders: new Set(),
+      main: {
+        url: "https://www.google.com/search?q=jacket",
+        title: "",
+        text: "Our systems have detected unusual traffic from your computer network.",
+      },
+      frames: [],
+    }),
+    true,
+  );
+});
+
+test("an unresolved challenge from the previous scan forces the full scan", () => {
+  const state = {
+    openProviders: new Set(["recaptcha"]),
+    blockedAt: 0,
+    now: 1_700_000_000_000,
+    main: BENIGN_MAIN,
+    frames: urlFrames(ORDINARY_FRAME_URLS),
+    solvedProviders: [],
+  };
+  assert.equal(challengeScanNeeded(state), true);
+  // An array of providers reads the same as a Set: the gate must not depend on
+  // which collection the caller keeps its open providers in.
+  assert.equal(challengeScanNeeded({ ...state, openProviders: ["recaptcha"] }), true);
+  assert.equal(challengeScanNeeded({ ...state, openProviders: new Set() }), false);
+  assert.equal(challengeScanNeeded({ ...state, openProviders: [] }), false);
+});
+
+test("a recent blocked main document forces the full scan until the window lapses", () => {
+  const now = 1_700_000_000_000;
+  const base = {
+    openProviders: new Set(),
+    now,
+    main: BENIGN_MAIN,
+    frames: [],
+    solvedProviders: [],
+  };
+  assert.equal(challengeScanNeeded({ ...base, blockedAt: now }), true);
+  assert.equal(challengeScanNeeded({ ...base, blockedAt: now - 1 }), true);
+  assert.equal(
+    challengeScanNeeded({ ...base, blockedAt: now - CHALLENGE_BLOCK_WINDOW_MS }),
+    true,
+  );
+  assert.equal(
+    challengeScanNeeded({ ...base, blockedAt: now - CHALLENGE_BLOCK_WINDOW_MS - 1 }),
+    false,
+  );
+  // No block ever recorded: the epoch-zero default must not read as "just now".
+  assert.equal(challengeScanNeeded({ ...base, blockedAt: 0 }), false);
+  assert.equal(challengeScanNeeded(base), false);
+});
+
+test("a solved provider stops the main-frame text from forcing the scan", () => {
+  // The prompt names reCAPTCHA, so a filled `g-recaptcha-response` is the same
+  // provider the detector would have reported.
+  const main = {
+    url: "https://shop.example/checkout",
+    title: "Checkout",
+    text: "I'm not a robot",
+  };
+  assert.equal(challengeScanNeeded({ openProviders: new Set(), main, frames: [] }), true);
+  assert.equal(
+    challengeScanNeeded({
+      openProviders: new Set(),
+      main,
+      frames: [],
+      solvedProviders: ["recaptcha"],
+    }),
+    false,
+  );
+});
+
+// Self-hosted and srcdoc challenge frames name no provider in their URL, so
+// text is the only thing that identifies them. Stage 1 can read that text for
+// same-origin frames without a round trip, and the gate has to use it — this is
+// what keeps `iframe-only bot challenges are detected` true.
+test("a same-origin frame's text asks for the full scan on its own", () => {
+  const state = {
+    openProviders: new Set(),
+    blockedAt: 0,
+    now: 1_700_000_000_000,
+    main: { url: "about:blank", title: "", text: "" },
+    solvedProviders: [],
+  };
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: readFrames([
+        { url: "about:srcdoc", title: "", text: "Verify you are human", visible: true },
+      ]),
+    }),
+    true,
+  );
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: readFrames([
+        {
+          url: "https://shop.example/gate",
+          title: "",
+          text: "Press and hold to confirm you are human",
+          visible: true,
+        },
+      ]),
+    }),
+    true,
+  );
+  // Ordinary same-origin frames still skip the scan.
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: readFrames([
+        { url: "https://shop.example/cart-widget", title: "Cart", text: "2 items, $40", visible: true },
+      ]),
+    }),
+    false,
+  );
+  // An offscreen frame is not a challenge the user can be blocked by, which is
+  // the same rule the full scan applies.
+  assert.equal(
+    challengeScanNeeded({
+      ...state,
+      frames: readFrames([
+        { url: "about:srcdoc", title: "", text: "Verify you are human", visible: false },
+      ]),
+    }),
+    false,
+  );
+});
+
+test("the gate survives absent, partial, and hostile state", () => {
+  assert.equal(challengeScanNeeded(), false);
+  assert.equal(challengeScanNeeded(null), false);
+  assert.equal(challengeScanNeeded("nope" as any), false);
+  assert.equal(challengeScanNeeded({}), false);
+  assert.equal(challengeScanNeeded({ frames: "not-an-array" }), false);
+  assert.equal(challengeScanNeeded({ main: null, frames: [null, undefined, 7] }), false);
+  assert.equal(challengeScanNeeded({ openProviders: new Set(["x"]) }), true);
+});
+
+// The compatibility question that matters is whether skipping stage 2 loses a
+// challenge the *unconditional* scan would have reported — so the comparison is
+// against the full frame metadata that scan produced, while the gate is fed
+// only what production can give it: text and visibility for same-origin frames,
+// a bare URL for cross-origin ones.
+//
+// One escape is allowed, and the test pins its exact shape rather than hiding
+// it: a page carrying more than CHALLENGE_UNREAD_FRAME_BUDGET unread frames
+// whose URLs say nothing, where one of them turns out to hold the challenge.
+// Everything else must agree.
+test("skipping the scan only ever loses an over-budget unread frame", () => {
+  const mains = [
+    BENIGN_MAIN,
+    { url: "https://shop.example/", title: "Just a moment...", text: "Checking your browser before accessing shop.example." },
+    { url: "https://www.bing.com/search?q=a", title: "One last step", text: "Please solve the challenge below to continue" },
+    { url: "https://www.google.com/sorry/index", title: "", text: "" },
+    { url: "https://shop.example/", title: "", text: "I'm not a robot" },
+    { url: "", title: "", text: "" },
+  ];
+  const pool = [
+    ...PROVIDER_URLS,
+    ...ORDINARY_FRAME_URLS,
+    ...CHALLENGE_SHAPED_URLS,
+    "https://cdn.partner.example/w/9f3.html",
+    "https://shop.example/cart-widget",
+  ];
+  let seed = 0x9e3779b9;
+  const next = (bound) => {
+    seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+    return seed % bound;
+  };
+  // The limitation, stated concretely first so the randomized half below is
+  // measuring a real escape hatch and not an empty one: more opaque
+  // cross-origin frames than the budget, none of their URLs saying anything,
+  // one of them holding the challenge.
+  const opaque = Array.from({ length: CHALLENGE_UNREAD_FRAME_BUDGET + 2 }, (_, index) => ({
+    url: `https://cdn.partner.example/w/${index}.html`,
+    text: index === 2 ? "Verify you are human" : "Sponsored content",
+    visible: true,
+    readable: false,
+  }));
+  assert.equal(
+    challengeScanNeeded({
+      openProviders: new Set(),
+      blockedAt: 0,
+      now: 1_700_000_000_000,
+      main: BENIGN_MAIN,
+      frames: urlFrames(opaque.map((frame) => frame.url)),
+      solvedProviders: [],
+    }),
+    false,
+  );
+  assert.equal(
+    detectBotChallenge({ main: BENIGN_MAIN, frames: opaque })?.detectedIn,
+    "frame",
+  );
+
+  for (let round = 0; round < 4_000; round += 1) {
+    const main = mains[next(mains.length)];
+    // What the full scan would have produced: every frame, text and all.
+    const scanned = Array.from({ length: next(8) }, () => ({
+      url: pool[next(pool.length)],
+      text: next(3) === 0 ? "I'm not a robot" : "Sponsored content",
+      visible: next(4) !== 0,
+      readable: next(2) === 0,
+    }));
+    // What the gate actually gets: an unread frame contributes its URL only.
+    const offered = scanned.map((frame) =>
+      frame.readable
+        ? frame
+        : { url: frame.url, visible: frame.visible, readable: false },
+    );
+    const solvedProviders = next(4) === 0 ? ["recaptcha", "turnstile", "hcaptcha"] : [];
+    const state = { openProviders: new Set(), blockedAt: 0, now: 1_700_000_000_000, main, frames: offered, solvedProviders };
+    if (challengeScanNeeded(state)) continue;
+    const reported = detectBotChallenge({ main, frames: scanned, solvedProviders });
+    if (!reported) continue;
+    const where = JSON.stringify({ main, scanned, solvedProviders });
+    assert.equal(reported.detectedIn, "frame", `gate skipped a main-frame challenge: ${where}`);
+    assert.equal(
+      detectBotChallenge({
+        main,
+        frames: scanned.filter((frame) => frame.readable),
+        solvedProviders,
+      }),
+      null,
+      `gate skipped a challenge it had already been shown: ${where}`,
+    );
+    assert.ok(
+      scanned.filter((frame) => !frame.readable && frame.visible !== false).length >
+        CHALLENGE_UNREAD_FRAME_BUDGET,
+      `gate skipped an unread frame it had budget to read: ${where}`,
+    );
+  }
+});
+
+// The gate's own inputs, judged against what the post-gate detector sees. This
+// is the weaker but unconditional half: a skipped scan reports no frames at
+// all, so the envelope must be empty whenever the gate says no.
+test("skipping the scan never hides a challenge the envelope would have reported", () => {
+  const mains = [
+    BENIGN_MAIN,
+    { url: "https://shop.example/", title: "Just a moment...", text: "Checking your browser before accessing shop.example." },
+    { url: "https://www.bing.com/search?q=a", title: "One last step", text: "Please solve the challenge below to continue" },
+    { url: "https://www.google.com/sorry/index", title: "", text: "" },
+    { url: "https://shop.example/", title: "", text: "I'm not a robot" },
+    { url: "", title: "", text: "" },
+  ];
+  const pool = [...PROVIDER_URLS, ...BENIGN_URLS];
+  // Deterministic pseudo-random frame sets: a fixed seed keeps a failure
+  // reproducible from the assertion message alone.
+  let seed = 0x9e3779b9;
+  const next = (bound) => {
+    seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+    return seed % bound;
+  };
+  for (let round = 0; round < 2_000; round += 1) {
+    const main = mains[next(mains.length)];
+    const frames = Array.from({ length: next(6) }, () => ({
+      url: pool[next(pool.length)],
+      text: next(3) === 0 ? "I'm not a robot" : "Sponsored content",
+      visible: next(4) !== 0,
+    }));
+    const solvedProviders = next(4) === 0 ? ["recaptcha", "turnstile", "hcaptcha"] : [];
+    const state = { openProviders: new Set(), blockedAt: 0, now: 1_700_000_000_000, main, frames, solvedProviders };
+    if (challengeScanNeeded(state)) continue;
+    const reported = detectBotChallenge({ main, frames: [], solvedProviders });
+    assert.equal(
+      reported,
+      null,
+      `gate skipped the scan but the envelope would still report ${JSON.stringify({ main, frames, solvedProviders })}`,
+    );
+  }
+});
+
+// The gate's own state is the one way it can wedge: if `openProviders` were
+// ever written by a skipped scan, a page that solved its challenge would keep
+// paying for the full frame walk forever. This walks the loop worker.ts runs.
+test("open-provider state drains once the challenge clears", () => {
+  const step = (openProviders, page) => {
+    const scanned = challengeScanNeeded({
+      openProviders,
+      blockedAt: 0,
+      now: 1_700_000_000_000,
+      main: page.main,
+      frames: page.frames.map((frame) => ({ url: frame.url })),
+      solvedProviders: page.solvedProviders,
+    });
+    // Stage 2 is what supplies frame text and visibility; a skipped scan
+    // reports no frames at all.
+    const challenge = detectBotChallenge({
+      main: page.main,
+      frames: scanned ? page.frames : [],
+      solvedProviders: page.solvedProviders,
+    });
+    const next = new Set(challenge ? [challenge.provider] : []);
+    return { scanned, provider: challenge?.provider ?? null, next };
+  };
+
+  const challenged = {
+    main: BENIGN_MAIN,
+    frames: [
+      {
+        url: "https://www.google.com/recaptcha/api2/bframe?k=site-key",
+        text: "Select all images with traffic lights",
+        visible: true,
+      },
+    ],
+    solvedProviders: [],
+  };
+  const first = step(new Set(), challenged);
+  assert.equal(first.scanned, true);
+  assert.equal(first.provider, "recaptcha");
+
+  // Still unsolved: the open set keeps forcing the scan.
+  const second = step(first.next, challenged);
+  assert.equal(second.scanned, true);
+  assert.equal(second.provider, "recaptcha");
+
+  // Token filled. The scan still runs (the set is non-empty), finds nothing,
+  // and writes the empty set back.
+  const solved = { ...challenged, solvedProviders: ["recaptcha"] };
+  const third = step(second.next, solved);
+  assert.equal(third.scanned, true);
+  assert.equal(third.provider, null);
+  assert.equal(third.next.size, 0);
+
+  // Navigated away instead: same drain, no token needed.
+  const cleared = { main: BENIGN_MAIN, frames: [], solvedProviders: [] };
+  const fourth = step(second.next, cleared);
+  assert.equal(fourth.scanned, true);
+  assert.equal(fourth.next.size, 0);
+  assert.equal(step(fourth.next, cleared).scanned, false);
+});

--- a/tests/node/compile-code.test.ts
+++ b/tests/node/compile-code.test.ts
@@ -1,0 +1,310 @@
+// `compileCode` wraps a model snippet either as an expression (its value is the
+// result) or as a statement list (result `undefined`). The shipped code tries
+// the statement form first for snippets that cannot possibly be an expression,
+// which is a pure latency optimization — so every test here is differential
+// against the plain "expression first, statements on SyntaxError" order the
+// worker used before, comparing the *evaluated* result, not the chosen form.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import vm from "node:vm";
+
+import {
+  compileCode,
+  compileExpressionForm,
+  compileStatementForm,
+  STATEMENT_ONLY_START,
+} from "../../dist/src/compile-code.js";
+
+/** The algorithm the worker shipped before the statement-first heuristic. */
+function expressionFirstCompile(code) {
+  try {
+    return compileExpressionForm(code);
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+    return compileStatementForm(code);
+  }
+}
+
+// A global named `let` is legal — `let` is only reserved in strict mode — and
+// it is exactly what separates a `let` declaration from a member expression on
+// an identifier, so the corpus can reach both.
+function freshContext() {
+  return vm.createContext({
+    Array,
+    let: { foo: 42 },
+    letters: ["a", "b"],
+    constant: 10,
+    doThing: () => "did",
+    tryIt: () => "tried",
+    iffy: () => "iffed",
+    forth: 4,
+    whilst: 5,
+    switcher: 6,
+    returned: 7,
+    thrower: 8,
+    varName: 9,
+    o: { a: 1 },
+    log: () => {},
+  });
+}
+
+function describe(value) {
+  if (value === undefined) return "undefined";
+  if (typeof value === "function") return `function:${value.name}`;
+  try {
+    return JSON.stringify(value) ?? `nonjson:${String(value)}`;
+  } catch {
+    return `unserializable:${Object.prototype.toString.call(value)}`;
+  }
+}
+
+/** Compile with `compile`, run in a fresh realm, and describe what came out. */
+async function outcome(compile, code) {
+  let script;
+  try {
+    script = compile(code);
+  } catch (error: any) {
+    return `compile-${error.constructor.name}:${error.message}`;
+  }
+  try {
+    return `value:${describe(await script.runInContext(freshContext()))}`;
+  } catch (error: any) {
+    return `runtime-${error.constructor.name}:${error.message}`;
+  }
+}
+
+const CORPUS = [
+  // single expressions
+  "1 + 1",
+  '"a" + "b"',
+  "[1, 2, 3].map((x) => x * 2)",
+  "Promise.resolve(7)",
+  "await Promise.resolve(8)",
+  "o.a",
+  "null",
+  "undefined",
+  "",
+  "   ",
+  // object literals: the classic form-sensitive pair
+  "{a:1}",
+  "({a:1})",
+  "{ }",
+  "{a:1, b:{c:2}}",
+  // class and function expressions, which must stay expressions
+  "class A {}",
+  "class A { m() { return 1 } }",
+  "function f() { return 1 }",
+  "async function g() { return 3 }",
+  "function* h() {}",
+  "(function () { return 2 })()",
+  "(() => 5)()",
+  "(async () => 6)()",
+  "(async () => { const v = 1; return v + 1 })()",
+  // statement-only starts, one per keyword in the heuristic
+  "const a = 1",
+  "const a = 1; a",
+  "const a = 1;\nconst b = 2;\na + b",
+  "let x = 1",
+  "let x = 1; x",
+  "let\n  x = 1",
+  "var v = 3",
+  "var v = 3; v",
+  "return 42",
+  "return { a: 1 }",
+  "throw new Error('boom')",
+  "if (true) { log('x') }",
+  "if (1) 2; else 3",
+  "for (const n of [1, 2]) log(n)",
+  "for (let i = 0; i < 2; i += 1) log(i)",
+  "while (false) { log('x') }",
+  "switch (1) { case 1: break }",
+  "do { log('x') } while (false)",
+  "try { log('x') } catch { log('y') }",
+  "try { throw new Error('t') } catch (e) { }",
+  // `let` used as an ordinary identifier: valid in both forms, and only the
+  // expression form yields the value, so the heuristic must not claim these
+  "let.foo",
+  "let['foo']",
+  "let + ''",
+  "let",
+  "let.foo + 1",
+  "let\n.foo",
+  // `in` and `instanceof` are identifier-shaped binary operators, so these are
+  // expressions over the global `let` even though `let\s+<ident>` matches them
+  "let instanceof Array",
+  "let in o",
+  "let instanceof Array === false",
+  // `let` destructuring, where the expression form is also legal
+  "let [a] = [1]",
+  "let {a} = o",
+  "let{a}=o",
+  // near misses: identifiers that merely start with a keyword
+  "letters.length",
+  "constant + 1",
+  "doThing()",
+  "tryIt()",
+  "iffy()",
+  "forth + whilst",
+  "switcher",
+  "returned",
+  "thrower",
+  "varName",
+  // template literals, including ones spanning newlines
+  "`plain`",
+  "`line1\nline2`",
+  // Split so this corpus entry is not itself read as a mis-typed template.
+  `\`a$${"{1 + 1}b`"}`,
+  "const t = `line1\nline2`; t",
+  // comments before the keyword, which the `^\s*` anchor cannot see past
+  "// note\nconst a = 1; a",
+  "/* note */ const a = 1",
+  "/* note */ 1 + 1",
+  "\n\n  const a = 1",
+  "\t const a = 1",
+  // syntax errors: expression-only, statement-only, and both
+  "}}}bad",
+  "const ((",
+  "if (",
+  "let x = ",
+  "return",
+  "1 +",
+  "function (",
+  "const 1 = 2",
+  "await",
+];
+
+test("the heuristic never changes what a snippet evaluates to", async () => {
+  for (const code of CORPUS) {
+    assert.equal(
+      await outcome(compileCode, code),
+      await outcome(expressionFirstCompile, code),
+      `compileCode diverged from the expression-first order on ${JSON.stringify(code)}`,
+    );
+  }
+});
+
+test("the heuristic surfaces the same error when neither form parses", async () => {
+  for (const code of ["}}}bad", "const ((", "if (", "const 1 = 2"]) {
+    const shipped = await outcome(compileCode, code);
+    assert.match(shipped, /^compile-SyntaxError:/, `${code} should fail to compile`);
+    assert.equal(shipped, await outcome(expressionFirstCompile, code));
+  }
+});
+
+test("a non-SyntaxError from compilation is never retried in the other form", () => {
+  const failure = new RangeError("compilation budget exhausted");
+  const thrower = () => {
+    throw failure;
+  };
+  // Both branches of the heuristic must propagate immediately; the statement
+  // branch is the one the reordering added.
+  assert.equal(STATEMENT_ONLY_START.test("const a = 1"), true);
+  assert.equal(STATEMENT_ONLY_START.test("1 + 1"), false);
+  assert.throws(() => {
+    if (STATEMENT_ONLY_START.test("const a = 1")) thrower();
+  }, failure);
+});
+
+test("the heuristic only claims snippets whose expression form cannot parse", () => {
+  for (const code of CORPUS) {
+    if (!STATEMENT_ONLY_START.test(code)) continue;
+    assert.throws(
+      () => compileExpressionForm(code),
+      SyntaxError,
+      `${JSON.stringify(code)} is claimed by the heuristic but parses as an expression`,
+    );
+  }
+});
+
+test("the heuristic claims the statement starts it exists for", () => {
+  for (const code of [
+    "const a = 1",
+    "let x = 1",
+    // The `in`/`instanceof` exclusion is a word-boundary lookahead, so
+    // declarations whose name merely starts with those letters stay claimed.
+    "let index = 1",
+    "let instance = 2",
+    "let interface = 1",
+    "var v = 1",
+    "return 1",
+    "throw e",
+    "if (a) b",
+    "for (;;) {}",
+    "while (a) {}",
+    "switch (a) {}",
+    "do {} while (a)",
+    "try {} catch {}",
+  ]) {
+    assert.equal(STATEMENT_ONLY_START.test(code), true, `${code} should be claimed`);
+  }
+  // Expressions the heuristic must leave to the expression-first path.
+  for (const code of [
+    "function f() {}",
+    "class A {}",
+    "import('x')",
+    "let.foo",
+    "let [a] = [1]",
+    "let{a}=o",
+    "let in o",
+    "let instanceof Array",
+    "letters.length",
+    "constant",
+    "{a:1}",
+  ]) {
+    assert.equal(STATEMENT_ONLY_START.test(code), false, `${code} must not be claimed`);
+  }
+});
+
+// Randomized cross-product: the fixed corpus pins the shapes we reasoned about,
+// this pins the ones we did not, including snippets that mix a claimed prefix
+// with an expression tail.
+test("randomized snippets evaluate identically under both orders", async () => {
+  const heads = [
+    "",
+    "const a = 1;",
+    "let x = 2;",
+    "var v = 3;",
+    "// c\n",
+    "/* c */",
+    "\n ",
+    "if (true) { }",
+    "for (const n of [1]) { }",
+    "try { } catch { }",
+    "let.foo;",
+    "letters;",
+    "return 1;",
+    "throw new Error('e');",
+    "do { } while (false);",
+    "switch (1) { }",
+    "while (false) { }",
+  ];
+  const tails = [
+    "",
+    " 1 + 1",
+    " {a:1}",
+    " ({a:1})",
+    " class A {}",
+    " function f() {}",
+    " await Promise.resolve(1)",
+    " `t\nu`",
+    " o.a",
+    " let.foo",
+    " }bad",
+    " const b =",
+  ];
+  let seed = 0x2545_f491;
+  const next = (bound) => {
+    seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+    return seed % bound;
+  };
+  for (let round = 0; round < 600; round += 1) {
+    const code =
+      heads[next(heads.length)] + tails[next(tails.length)] + tails[next(tails.length)];
+    assert.equal(
+      await outcome(compileCode, code),
+      await outcome(expressionFirstCompile, code),
+      `compileCode diverged on ${JSON.stringify(code)}`,
+    );
+  }
+});

--- a/types/challenges.d.ts
+++ b/types/challenges.d.ts
@@ -16,5 +16,30 @@ export interface BotChallenge {
   advice: string;
 }
 
+export const CHALLENGE_BLOCK_WINDOW_MS: number;
+export const CHALLENGE_UNREAD_FRAME_BUDGET: number;
+
+export interface ChallengeScanState {
+  /** Providers left unresolved by the previous completed scan. */
+  openProviders?: { size: number } | readonly unknown[];
+  /** Epoch ms of the last 403/429/503 main-document response, 0 if none. */
+  blockedAt?: number;
+  /** Epoch ms to compare `blockedAt` against; defaults to `Date.now()`. */
+  now?: number;
+  main?: { url?: string; title?: string; text?: string };
+  /** Every frame the full scan would read, with whatever is already known. */
+  frames?: readonly {
+    url?: string;
+    title?: string;
+    text?: string;
+    visible?: boolean | null;
+    /** `true` only when `text` is the frame's real text; absent means unread. */
+    readable?: boolean;
+  }[];
+  solvedProviders?: readonly string[];
+}
+
+export function challengeScanNeeded(state?: ChallengeScanState): boolean;
 export function detectBotChallenge(metadata?: unknown): BotChallenge | null;
+export function frameUrlLooksLikeChallenge(url: string): boolean;
 export function isPublicSearchNavigation(url: string): boolean;


### PR DESCRIPTION
## Summary

Phase B of the round-trip perf program. **Stacked on #87 and #88** (merge those first; this diff includes their commits until then).

Challenge detection ran unconditionally on every execute — `page.title()` + 50K `innerText` + a token evaluate, plus ~5 sequential CDP round-trips per frame across up to 24 frames. On the benchmark fixture that taxed **every agent action +30ms (10 cross-site iframes) / +54ms (24)**.

Now staged:

- **Stage 1 (always)**: concurrent, independently-degrading reads — title, body text (750ms budget), solved tokens (untimed, old semantics), and one in-page iframe-descriptor walk under its own 250ms in-page deadline. A slow page degrades a field, not the whole scan.
- **Gate** (`challengeScanNeeded` in `src/challenges.ts`, next to the detector so they can't drift): stage 2 runs only on provider frame URLs (`frameUrlLooksLikeChallenge`), challenge-shaped URLs (`frameUrlSuggestsChallenge`: datadome/arkose/awswaf/perimeterx/geetest + token heuristics), main-frame text tripping the detector, an unresolved prior challenge, a recent 403/429/503 document response, or **1–3 unreadable cross-origin frames** — the unread-frame budget that keeps self-hosted cross-origin challenges detectable without re-paying the scan on ad-heavy pages. The >3-opaque-frames residual gap is documented (`docs/captcha.md`) and pinned by an explicit test, not hidden.
- **Stage 2 (gated)**: ~5 round-trips/frame → 2, reading text and checked state through **utility-world locators** so hostile page script can't shape what the detector sees (an improvement over the old mixed exposure). Ambiguous descriptor matches (duplicate ad-frame names/srcs) fall back to exact `frameElement()` resolution instead of guessing geometry.
- **Sandbox hoists**: the constant realm-factory `vm.Script` was recompiled per execute — now module-level. `compileCode` moved to `src/compile-code.ts` with a statement-first heuristic for snippets that can't parse as expressions, guarding sloppy-mode `let`-as-identifier cases (`let.foo`, `let instanceof X`) that must keep expression-first order.

## Benchmarks (`benchmarks/perf`)

| p50 | baseline | this PR |
|---|---|---|
| Per-action, 10 cross-site iframes | 33.3–36.7 ms | **8.6–9.0 ms** |
| Per-action, 24 cross-site iframes | 60.3–66.1 ms | **9.4–11.6 ms** |
| Iframe tax vs adjacent control, 10f | +26.8–30.2 ms | **+1.5–1.7 ms** (−94%) |
| Iframe tax, 24f | +53.8–59.9 ms | **+2.4–4.1 ms** (−93%) |
| Quiet-page per-action | 7.35–7.60 ms | 7.50–7.56 ms (flat) |

Gate verified directly, not inferred: instrumented runs show 90/90 gate decisions `false` on the benign fixture with **0** stage-2 invocations, while the 13 challenge/captcha browser tests fire it 8/13 times with stage 2 running — the gate discriminates, it isn't stuck.

## Review hardening

Three adversarial review passes produced 13 findings (4 blockers), all resolved: the cross-origin non-provider false-negative class (fixed via challenge-shaped URLs + the unread-frame budget + subframe 403 tracking), `let instanceof X` semantics swap in the compile heuristic, spare-descriptor geometry mis-attribution (deleted; exact fallback instead), shadow-DOM `checked` detection (reverted to the piercing locator), and stage-1 all-or-nothing degradation.

## Tests

- `tests/node/challenge-scan-gate.test.ts` (new): provider/lookalike URL families, gate conditions incl. 403-window boundaries, open-state lifecycle, and a 4,000-round seeded differential proving a skipped scan never changes reported `challenges` (divergences must be frame-text-only, gate-invisible, and over-budget — pinned by an explicit constructed case).
- `tests/node/compile-code.test.ts` (new): ~90-snippet corpus + 600 seeded random snippets, both algorithms actually evaluated in fresh `vm` contexts and compared by result-or-error.
- New browser test: cross-origin OOPIF challenge with no provider URL anywhere — detected.
- `npm run test:unit` 728 pass / 0 fail; typecheck, lint, test:types clean; 13/13 challenge/captcha browser tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)