### PR TITLE
Release BetterWright 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,46 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-08-03
+
+A performance release, continuing 1.6.2. No API changes: 1.6.3 is a drop-in
+replacement for 1.6.2. The theme is round trips — between the worker and the
+client, and between the worker and the browser.
+
+### Added
+
+- `benchmarks/perf`, a regression harness for this work: per-action latency
+  with an adjacent late-session control so per-session drift is not charged to
+  the thing being measured, guard RPCs counted at the client boundary and
+  bucketed by origin, and the challenge-scan tax at 10 and 24 genuinely
+  cross-site frames. Fixture servers count their own requests and the run fails
+  if a load is not exactly the expected size, so a browser-cache artifact cannot
+  be mistaken for a win.
+
 ### Changed
+
+- Guard decisions are cached in the worker. Every browser connection previously
+  cost a full RPC to the client process per policy check — one per HTTP request,
+  plus one per hostname and one *serial* RPC per resolved IP in the SOCKS guard.
+  For a stock `NetworkPolicy` the verdict is a pure function of scheme, host and
+  port, so those answers are now cached (5 s, 2048 entries). On a 50-subresource
+  page load: **95 guard RPCs to 1**.
+
+  The client, which is the only process the policy lives in, decides per
+  response whether it may be cached at all — a `custom` hook, a subclass, an
+  instance-patched `check` or any other object is never eligible, checked per
+  RPC rather than once at construction. Full-URL checks (navigations, documents,
+  downloads, websockets) are never cached in either direction, and a failed
+  check is never cached, so the transport still fails closed on retry.
+  Mutating `allowHosts`/`blockHosts` mid-session takes up to 5 s to apply to a
+  host already contacted; installing a `custom` hook empties the cache instead,
+  so it governs hosts already seen. See "Decision caching" in
+  `docs/network-policy.md`.
+
+- Resolved addresses are validated in one parallel wave rather than serially.
+  Every address is still decided before any connect, and failures are reported
+  in address order rather than settle order, so which error a caller sees does
+  not depend on guard timing.
 
 - Challenge detection is now staged. Every `run()` still reads the main frame's
   title, text and provider response tokens, but the per-frame walk — one round
@@ -22,6 +61,25 @@ Releases before 1.1.3 predate this file; their notes live on the
   "When detection runs" in `docs/captcha.md`, including the one accepted
   limitation: a page with more than three opaque cross-origin frames where the
   challenge is identifiable only by the text inside one of them.
+
+  On the benchmark fixture the per-action iframe tax falls from **+27–30 ms to
+  +1.5–1.7 ms at 10 cross-site frames**, and from **+54–60 ms to +2.4–4.1 ms at
+  24**. Stage 2 also dropped from about five round trips per frame to two, and
+  now reads frame text and checked state through utility-world locators, so page
+  script cannot shape what the detector sees — detection is harder to fool than
+  it was before, not just cheaper.
+
+- The sandbox no longer recompiles its constant realm factory on every execute;
+  the `vm.Script` is built once at module load. Snippet compilation moved to
+  `src/compile-code.ts`, which tries the statement form first for snippets that
+  cannot begin an expression. Which form runs is unchanged — including the
+  sloppy-mode cases where `let` is an identifier (`let.x`, `let in o`,
+  `let instanceof X`), which must stay expression-first — and a seeded
+  differential corpus evaluates both orders to prove it.
+
+  This shows up on trivial snippets rather than real ones: on a quiet page,
+  per-action latency is unchanged within noise, because a snippet that touches
+  the page is dominated by its round trip rather than by compilation.
 
 ## [1.6.2] - 2026-08-02
 
@@ -480,7 +538,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.6.2...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.6.3...HEAD
+[1.6.3]: https://github.com/BetterWright/betterwright/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/BetterWright/betterwright/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/BetterWright/betterwright/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/BetterWright/betterwright/compare/v1.5.2...v1.6.0

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.6.2
+generated_by: betterwright@1.6.3
 ---
 
 # Browser tool: BetterWright

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Cuts 1.6.3 from the perf work merged in #87, #88 and #89. Version bump, `CHANGELOG.md`, regenerated `SKILL.md`. No source changes.

## What's in it

**Guard decision cache (#88).** Every browser connection cost an RPC to the client per policy check — one per HTTP request, plus one per hostname and one *serial* RPC per resolved IP in the SOCKS guard. For a stock `NetworkPolicy` the verdict is a pure function of scheme/host/port, so those are cached for 5 s. **95 guard RPCs to 1** on a 50-subresource load. Cacheability is asserted by the client per response, never inferred by the worker; custom hooks, subclasses and instance-patched `check` are never eligible, and installing a hook mid-session empties the cache instead of leaving stale entries to answer for it. Resolved addresses are validated in one parallel wave — still every address before any connect, still failing in address order rather than settle order.

**Challenge scan staging (#89).** The per-frame walk now runs only when something already points at a challenge. Iframe tax **+27–30 ms → +1.5–1.7 ms** at 10 cross-site frames, **+54–60 ms → +2.4–4.1 ms** at 24. Stage 2 reads through utility-world locators, so page script can no longer shape what the detector sees — harder to fool than what it replaces, not just cheaper.

**Sandbox compile hoist (#89).** The constant realm factory is compiled once at module load instead of per execute; snippet compilation moved to `src/compile-code.ts`. Which form runs is unchanged, `let`-as-identifier cases included.

**`benchmarks/perf` (#87)** is the harness behind all of it.

## The one thing that is not a pure win

1.6.3 accepts a documented reduction in automatic challenge detection: a page with **more than three** opaque cross-origin frames, where the challenge is identifiable only by text inside one of them, is no longer detected automatically. `captcha.detect()` and `captcha.solve()` never stage and still read every frame. Written up under "When detection runs" in `docs/captcha.md` and pinned by a test rather than left to be discovered.

## Verification

`npm run release:check` clean — 738 tests, 733 pass, 0 fail, package smoke test OK.

Both merged phases were re-measured independently after the #89 rebase, on fixtures separate from `benchmarks/perf`, and they compose: guard RPCs 63 → 1 steady state on a 51-request load with the fixture asserting all 51 still served, and iframe tax +9.67 → +0.21 ms (10 frames) / +22.79 → +0.51 ms (24 frames).

One correction worth recording: an earlier read of mine suggested quiet-page per-action latency had roughly halved. It has not — that was machine load drifting between two runs. A controlled back-to-back A/B shows it flat (`return 1` 1.85 → 1.86 ms; `page.title()` 2.06 → 1.88 ms), matching the harness's own finding, and the changelog says so rather than claiming a win that is not there.