### PR TITLE
Route BetterWright application through LOLCODE

### DIFF
--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -74,6 +74,7 @@ import {
   resolveCoreDir,
 } from "../src/doctor.js";
 import { defaultLiveViewListen, guessLanHost } from "../src/live-view.js";
+import { runLolcodeCli } from "../src/lolcode.js";
 import { profileLabel, resolveProfileName } from "../src/profile-name.js";
 // `agentSystemPrompt` comes from the light prompt module, not index.js, which
 // would drag the whole browser/worker/vault graph in just to print a skill.
@@ -1943,7 +1944,15 @@ async function main() {
   }
 }
 
-main().then(
+async function runApplication() {
+  if (process.env.BETTERWRIGHT_LOLCODE_NATIVE === "1") return main();
+  return runLolcodeCli(process.argv.slice(2), {
+    cliEntry: CLI_PATH,
+    cwd: process.cwd(),
+  });
+}
+
+runApplication().then(
   (code) => process.exit(code),
   (error) => {
     console.error(error?.stack || String(error));

--- a/lolcode/api.lol
+++ b/lolcode/api.lol
@@ -1,0 +1,34 @@
+HAI 1.2
+
+BTW BetterWright's public application surface, expressed in LOLCODE.
+BTW The host words are the deliberately small Node boundary for async APIs.
+
+HOW DUZ I bw_run YR code AN YR session
+  FOUND YR bw_host "run" AN code AN session MKAY
+IF U SAY SO
+
+HOW DUZ I bw_exec YR task AN YR model AN YR session
+  FOUND YR bw_host "exec" AN task AN model AN session MKAY
+IF U SAY SO
+
+HOW DUZ I bw_models
+  FOUND YR bw_host "models" MKAY
+IF U SAY SO
+
+HOW DUZ I bw_doctor
+  FOUND YR bw_host "doctor" MKAY
+IF U SAY SO
+
+HOW DUZ I bw_close YR session
+  FOUND YR bw_host "close" AN session MKAY
+IF U SAY SO
+
+HOW DUZ I bw_sessions
+  FOUND YR bw_host "sessions" MKAY
+IF U SAY SO
+
+HOW DUZ I bw_auth YR provider
+  FOUND YR bw_host "auth" AN provider MKAY
+IF U SAY SO
+
+KTHXBYE

--- a/lolcode/cli.lol
+++ b/lolcode/cli.lol
@@ -1,0 +1,10 @@
+HAI 1.2
+
+BTW Keep the command-line boundary in LOLCODE. The native host command is
+BTW intentionally one operation: all parsing, help, sessions, browser-agent,
+BTW vault, MCP, and live-view behavior remains the tested BetterWright host.
+
+I HAS A exit_code ITZ bw_native_cli ARGS MKAY
+FOUND YR exit_code
+
+KTHXBYE

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
+        "@swizec/loljs": "1.3.0",
         "cloakbrowser": "0.4.10",
         "playwright-core": "1.61.1",
         "tldts": "7.4.9"
@@ -268,6 +269,14 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@swizec/loljs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swizec/loljs/-/loljs-1.3.0.tgz",
+      "integrity": "sha512-VYgW5HiIGplw/1Wf0gy/+sSda8xE/Lz3s/hk+6RSu4fn9X+8kbDASEvxAQXH5NQVMk2D9xq3omx/33bbYELt+w==",
+      "dependencies": {
+        "async": "*"
       }
     },
     "node_modules/@types/node": {
@@ -647,6 +656,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
       "import": "./dist/src/skills.js",
       "default": "./dist/src/skills.js"
     },
+    "./lolcode": {
+      "types": "./types/lolcode.d.ts",
+      "import": "./dist/src/lolcode.js",
+      "default": "./dist/src/lolcode.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {
@@ -73,6 +78,7 @@
     "skills",
     "docs/*.md",
     "examples/typescript",
+    "lolcode",
     "SETUP.md",
     "SKILL.md",
     "SECURITY.md",
@@ -109,6 +115,7 @@
     ]
   },
   "dependencies": {
+    "@swizec/loljs": "1.3.0",
     "cloakbrowser": "0.4.10",
     "playwright-core": "1.61.1",
     "tldts": "7.4.9"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -11,6 +11,10 @@ const tsc = path.join(root, "node_modules", "typescript", "bin", "tsc");
 
 fs.rmSync(dist, { recursive: true, force: true });
 
+const lolcodeSource = path.join(root, "lolcode");
+const lolcodeOutput = path.join(dist, "lolcode");
+fs.cpSync(lolcodeSource, lolcodeOutput, { recursive: true });
+
 const result = spawnSync(process.execPath, [tsc, "--project", "tsconfig.json"], {
   cwd: root,
   stdio: "inherit",

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -67,6 +67,8 @@ try {
     "dist/src/index.js",
     "dist/src/vault.js",
     "dist/src/worker.js",
+    "dist/lolcode/cli.lol",
+    "dist/lolcode/api.lol",
     "types/index.d.ts",
     "types/vault.d.ts",
     "types/captcha-solver.d.ts",
@@ -163,6 +165,7 @@ try {
         "const pi = await import('betterwright/pi');",
         "const piExtension = await import('betterwright/pi-extension');",
         "const mcp = await import('betterwright/mcp-server');",
+        "const lolcode = await import('betterwright/lolcode');",
         "const vault = await import('betterwright/vault');",
         "if (typeof root.BetterWright !== 'function') throw new Error('missing BetterWright');",
         "if (typeof root.LocalCredentialVault !== 'function') throw new Error('missing LocalCredentialVault');",
@@ -172,6 +175,7 @@ try {
         "if (typeof pi.piImageContent !== 'function') throw new Error('missing Pi export');",
         "if (typeof piExtension.default !== 'function') throw new Error('missing Pi extension');",
         "if (typeof vault.createLocalCredentialVault !== 'function') throw new Error('missing vault export');",
+        "if (typeof lolcode.runLolcode !== 'function') throw new Error('missing LOLCODE export');",
         // The owner-only reads are a supported surface now; a missing method
         // means `betterwright vault` would be broken in the published package.
         "const v = vault.createLocalCredentialVault({ home: '/tmp/betterwright-package-vault' });",
@@ -193,6 +197,7 @@ try {
       "import type { Guardrails } from 'betterwright/prompt';",
       "import { METADATA_RESOLVER_RULES } from 'betterwright/worker';",
       "import { runMcpServer } from 'betterwright/mcp-server';",
+      "import { runLolcode, type LolcodeOptions } from 'betterwright/lolcode';",
       "import { createLocalCredentialVault, type VaultRevealedRecord } from 'betterwright/vault';",
       "const policy = new NetworkPolicy();",
       "const browser = new BetterWright({ policy, browser: 'cloak' });",
@@ -204,7 +209,8 @@ try {
       "const decision: NetworkDecision = policy.check('https://example.com');",
       "const blocks: PiImageContentBlock[] = [];",
       "const guardrails: Guardrails = { passwordManager: '1Password' };",
-      "void [result, decision, blocks, guardrails, createPiExtension, METADATA_RESOLVER_RULES, runMcpServer, vault, noVault];",
+      "const lolcodeOptions: LolcodeOptions = { argv: [], host: {} };",
+      "void [result, decision, blocks, guardrails, createPiExtension, METADATA_RESOLVER_RULES, runMcpServer, vault, noVault, runLolcode, lolcodeOptions];",
     ].join("\n"),
   );
   const tsc = path.join(root, "node_modules", "typescript", "bin", "tsc");

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,11 @@ export {
 export { detectBotChallenge } from "./challenges.js";
 export { BetterWright, BrowserError } from "./client.js";
 export {
+  runLolcode,
+  runLolcodeCli,
+  runLolcodeModule,
+} from "./lolcode.js";
+export {
   piImageArtifacts,
   piImageContent,
   piPrimaryImageArtifact,

--- a/src/lolcode-host.ts
+++ b/src/lolcode-host.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+import { nativeModelCatalog, runAgentTask } from "./agent.js";
+import { loadCodexAuth, loadGrokAuth } from "./auth.js";
+import { BetterWright } from "./client.js";
+import { doctorReport } from "./doctor.js";
+import { NetworkPolicy } from "./policy.js";
+
+interface HostRequest {
+  operation: string;
+  args: unknown[];
+}
+
+function policyOptions(value: unknown) {
+  if (!value || typeof value !== "object") return {};
+  const options = value as Record<string, unknown>;
+  return {
+    allowPrivateNetwork: options.allowPrivateNetwork !== false,
+    allowLoopback: options.allowLoopback !== false,
+    allowHosts: Array.isArray(options.allowHosts) ? options.allowHosts.map(String) : [],
+    blockHosts: Array.isArray(options.blockHosts) ? options.blockHosts.map(String) : [],
+  };
+}
+
+async function run(request: HostRequest): Promise<unknown> {
+  const args = request.args || [];
+  switch (request.operation) {
+    case "run": {
+      const code = String(args[0] || "");
+      const session = String(args[1] || "default");
+      const browser = new BetterWright({ policy: new NetworkPolicy(policyOptions(args[2])) });
+      try {
+        return await browser.run(code, { session });
+      } finally {
+        await browser.close();
+      }
+    }
+    case "exec":
+      return runAgentTask({
+        task: String(args[0] || ""),
+        ...(args[1] ? { model: String(args[1]) } : {}),
+        session: String(args[2] || "default"),
+      });
+    case "doctor":
+      return doctorReport();
+    case "models":
+      return nativeModelCatalog();
+    case "close": {
+      const browser = new BetterWright();
+      return browser.closeSession(String(args[0] || "default"));
+    }
+    case "sessions":
+      return runNativeCli(["sessions"]);
+    case "auth": {
+      const provider = String(args[0] || "").toLowerCase();
+      if (provider === "codex") return loadCodexAuth();
+      if (provider === "grok") return loadGrokAuth();
+      throw new Error(`Unsupported auth provider: ${provider}`);
+    }
+    default:
+      throw new Error(`Unknown LOLCODE host operation: ${request.operation}`);
+  }
+}
+
+function runNativeCli(args: string[]): { exitCode: number; output: string } {
+  const entry = process.env.BETTERWRIGHT_CLI_ENTRY;
+  if (!entry) return { exitCode: 1, output: "BETTERWRIGHT_CLI_ENTRY is not configured" };
+  const result = spawnSync(process.execPath, [entry, ...args], { encoding: "utf8" });
+  return { exitCode: result.status ?? 1, output: `${result.stdout || ""}${result.stderr || ""}` };
+}
+
+async function main() {
+  const request = JSON.parse(fs.readFileSync(0, "utf8")) as HostRequest;
+  const result = await run(request);
+  process.stdout.write(JSON.stringify({ ok: true, result }));
+}
+
+main().catch((error) => {
+  process.stdout.write(JSON.stringify({ ok: false, error: error?.stack || String(error) }));
+  process.exitCode = 1;
+});

--- a/src/lolcode.ts
+++ b/src/lolcode.ts
@@ -1,0 +1,156 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { lol, parse } from "@swizec/loljs";
+
+export interface LolcodeIo {
+  visible?: (text: string) => void;
+  prompt?: (message: string) => Promise<string>;
+}
+
+export interface LolcodeOptions {
+  argv?: string[];
+  cliEntry?: string;
+  cwd?: string;
+  io?: LolcodeIo;
+  host?: Record<string, (...args: unknown[]) => unknown>;
+}
+
+const LOLCODE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../lolcode");
+
+function hostError(result: ReturnType<typeof spawnSync>, operation: string): Error {
+  const stderr = String(result.stderr || "").trim();
+  const stdout = String(result.stdout || "").trim();
+  return new Error(
+    `LOLCODE host operation ${operation} failed${stderr ? `: ${stderr}` : stdout ? `: ${stdout}` : "."}`,
+  );
+}
+
+function callHost(operation: string, args: unknown[], cwd?: string, cliEntry?: string): unknown {
+  const hostPath = fileURLToPath(new URL("./lolcode-host.js", import.meta.url));
+  const result = spawnSync(process.execPath, [hostPath], {
+    cwd,
+    encoding: "utf8",
+    input: JSON.stringify({ operation, args }),
+    env: {
+      ...process.env,
+      BETTERWRIGHT_LOLCODE_HOST: "1",
+      ...(cliEntry ? { BETTERWRIGHT_CLI_ENTRY: cliEntry } : {}),
+    },
+  });
+  if (result.error || result.status !== 0) throw result.error || hostError(result, operation);
+
+  let response: { ok?: boolean; result?: unknown; error?: string };
+  try {
+    response = JSON.parse(String(result.stdout || ""));
+  } catch {
+    throw hostError(result, operation);
+  }
+  if (!response.ok) throw new Error(response.error || `LOLCODE host operation ${operation} failed.`);
+  return response.result;
+}
+
+function runNativeCli(argv: unknown[], cliEntry?: string, cwd?: string): number {
+  const entry = cliEntry || process.argv[1];
+  if (!entry) throw new Error("LOLCODE CLI needs the BetterWright CLI entrypoint.");
+  const result = spawnSync(process.execPath, [entry, ...((Array.isArray(argv) ? argv : []) as string[])], {
+    cwd,
+    env: { ...process.env, BETTERWRIGHT_LOLCODE_NATIVE: "1" },
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+function sourcePath(name: string): string {
+  const safeName = name.replace(/[^a-z0-9_-]/gi, "");
+  if (!safeName) throw new TypeError("LOLCODE module name must be non-empty.");
+  return path.join(LOLCODE_DIR, `${safeName}.lol`);
+}
+
+/** Execute a LOLCODE BetterWright application module. */
+export function runLolcode(source: string, options: LolcodeOptions = {}): Promise<unknown> {
+  const argv = options.argv || [];
+  const originalBuiltIns = new Map<string, unknown>();
+  const builtIns = lol.builtIns as Record<string, unknown>;
+  lol.utils.nextTick ||= (callback) => setImmediate(callback);
+  const custom: Record<string, unknown> = {
+    ARGS: argv,
+    bw_native_cli: (receivedArgs: unknown) => runNativeCli(receivedArgs as unknown[], options.cliEntry, options.cwd),
+    bw_host: (operation: unknown, ...args: unknown[]) =>
+      callHost(String(operation), args, options.cwd, options.cliEntry),
+    ...options.host,
+  };
+
+  for (const [name, value] of Object.entries(custom)) {
+    originalBuiltIns.set(name, builtIns[name]);
+    builtIns[name] = value;
+  }
+
+  let ast: unknown;
+  try {
+    ast = parse(source);
+  } catch (error) {
+    for (const name of Object.keys(custom)) restoreBuiltIn(name, originalBuiltIns, builtIns);
+    throw error;
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const restore = () => {
+      for (const name of Object.keys(custom)) restoreBuiltIn(name, originalBuiltIns, builtIns);
+    };
+    const finish = (value: unknown) => {
+      if (settled) return;
+      settled = true;
+      restore();
+      resolve(value);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      restore();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+    const vm = new lol(finish, () => {
+      const errors = vm.errors();
+      if (errors.length) {
+        const position = vm.pos();
+        fail(new Error(`${String(errors[errors.length - 1])} (line ${position.line + 1})`));
+      }
+    });
+    vm.setIo({
+      visible: (text: unknown) => options.io?.visible?.(String(text)) ?? console.log(String(text)),
+      prompt: (message: string, done: (value: string) => void) => {
+        if (!options.io?.prompt) {
+          fail(new Error("GIMMEH needs an interactive LOLCODE prompt."));
+          return;
+        }
+        options.io.prompt(message).then(done, fail);
+      },
+    });
+    try {
+      vm.evaluate(ast);
+    } catch (error) {
+      fail(error);
+    }
+  });
+}
+
+function restoreBuiltIn(name: string, original: Map<string, unknown>, builtIns: Record<string, unknown>) {
+  const value = original.get(name);
+  if (value === undefined) delete builtIns[name];
+  else builtIns[name] = value;
+}
+
+export function runLolcodeModule(name: string, options: LolcodeOptions = {}): Promise<unknown> {
+  return runLolcode(fs.readFileSync(sourcePath(name), "utf8"), options);
+}
+
+export async function runLolcodeCli(argv: string[] = process.argv.slice(2), options: LolcodeOptions = {}): Promise<number> {
+  const result = await runLolcodeModule("cli", { ...options, argv });
+  const code = Number(result);
+  return Number.isInteger(code) ? code : 1;
+}

--- a/src/loljs.d.ts
+++ b/src/loljs.d.ts
@@ -1,0 +1,13 @@
+declare module "@swizec/loljs" {
+  export function parse(source: string): any;
+  export const lol: {
+    builtIns: Record<string, (...args: any[]) => any>;
+    utils: { nextTick?: (callback: () => void) => void };
+    new (done?: (value: unknown) => void, paused?: () => void): {
+      errors(): unknown[];
+      pos(): { line: number; col: number };
+      setIo(io: { visible?: (...values: unknown[]) => void; prompt?: (message: string, done: (value: string) => void) => void }): void;
+      evaluate(ast: any): void;
+    };
+  };
+}

--- a/tests/node/lolcode.test.ts
+++ b/tests/node/lolcode.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import { runLolcode, runLolcodeModule } from "../../dist/src/lolcode.js";
+
+test("LOLCODE host calls can implement a BetterWright application operation", async () => {
+  const calls: unknown[][] = [];
+  const result = await runLolcode(
+    [
+      "HAI 1.2",
+      "I HAS A answer ITZ host_call \"run\" AN \"return 42\" AN \"default\" MKAY",
+      "FOUND YR answer",
+      "KTHXBYE",
+    ].join("\n"),
+    {
+      host: {
+        host_call: (...args) => {
+          calls.push(args);
+          return "ok";
+        },
+      },
+    },
+  );
+
+  assert.equal(result, "ok");
+  assert.deepEqual(calls, [["run", "return 42", "default"]]);
+});
+
+test("the checked-in BetterWright API is valid LOLCODE", async () => {
+  await assert.doesNotReject(() => runLolcodeModule("api", { host: { bw_host: () => "ok" } }));
+});
+
+test("the public CLI enters through LOLCODE before native command handling", () => {
+  const version = execFileSync(process.execPath, ["dist/bin/betterwright.js", "--version"], {
+    encoding: "utf8",
+  }).trim();
+  assert.match(version, /^\d+\.\d+\.\d+$/);
+});

--- a/types/lolcode.d.ts
+++ b/types/lolcode.d.ts
@@ -1,0 +1,16 @@
+export interface LolcodeIo {
+  visible?: (text: string) => void;
+  prompt?: (message: string) => Promise<string>;
+}
+
+export interface LolcodeOptions {
+  argv?: string[];
+  cliEntry?: string;
+  cwd?: string;
+  io?: LolcodeIo;
+  host?: Record<string, (...args: unknown[]) => unknown>;
+}
+
+export function runLolcode(source: string, options?: LolcodeOptions): Promise<unknown>;
+export function runLolcodeModule(name: string, options?: LolcodeOptions): Promise<unknown>;
+export function runLolcodeCli(argv?: string[], options?: LolcodeOptions): Promise<number>;


### PR DESCRIPTION
## Summary

- add checked-in LOLCODE modules for the BetterWright CLI and public API surface
- route the public CLI through a LOLCODE entrypoint with a narrowly scoped Node host bridge for existing async browser primitives
- build and package the .lol modules, with focused smoke tests and public declarations

## Scope

This PR changes only BetterWright application, build, packaging, and test code. It does not touch Chromium, Chromium patches, or engine sources.

## Validation

- npm run lint
- npm run typecheck
- npm run build
- npm run build:harness
- npm run check:build
- NPM_CONFIG_CACHE=/tmp/betterwright-npm-cache npm run check:package
- npm run test:types
- node --test tests/node/lolcode.test.js
- node dist/bin/betterwright.js --version
- node dist/bin/betterwright.js --help

The full npm run test:unit suite reached the existing tests but the sandbox reported uv_interface_addresses returned Unknown system error 1 in network-interface/live-view tests; the new LOLCODE tests passed.