### PR TITLE
ci: isolate final release unit tests

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -123,6 +123,12 @@ jobs:
       - name: Run final release verification
         if: steps.existing.outputs.published != 'true'
         run: npm run release:check
+        # setup installed both managed browsers for the integration gates
+        # above. Keep the unit suite hermetic so it cannot discover and launch
+        # those real binaries; browser behavior has already been tested here.
+        env:
+          BETTERWRIGHT_OBSCURA_ROOT: "off"
+          BETTERWRIGHT_CHROMIUM_ROOT: "off"
       - name: Select npm distribution tag
         if: steps.existing.outputs.published != 'true'
         id: npm_tag


### PR DESCRIPTION
## Summary

- keep the final release unit suite from rediscovering managed browsers installed by earlier integration gates
- disable only the Obscura and Chromium-fork resolvers for `release:check`
- retain full browser coverage in the immediately preceding integration and headed Cloak steps

This fixes the publish run that stopped emitting after unit test 260 and held an open browser/process handle until the 45-minute job timeout.

## Verification

- reproduced the stuck release run: test output stopped after test 260, then timed out before npm
- `BETTERWRIGHT_OBSCURA_ROOT=off BETTERWRIGHT_CHROMIUM_ROOT=off npm run release:check`
  - 759 passed, 5 intentional skips, 0 failed
  - package smoke test passed: 113 files, 472480 bytes
- isolated unit suite completed in 30.7s with the same 759/5/0 result
- `git diff --check`

This is a regular, merge-ready PR (not a draft).