### PR TITLE
release: BetterWright 1.7.1 efficiency improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-09
+
+A token, CPU, and memory efficiency patch. There are no client API removals;
+model-facing optional result fields are now omitted when empty and retain the
+same names and values whenever present.
+
+### Added
+
+- Added `benchmarks/efficiency`, a deterministic, browser-free comparison
+  harness for the model observation, long-transcript, and snapshot-diff paths.
+  The recorded figures compare five fresh-process samples of 1.7.0 (`273e51d`)
+  and 1.7.1 on an Apple M4 Pro with Node v24.16.0.
+
+### Changed
+
+- Built-in-agent and MCP observations no longer repeat null placeholders and
+  empty arrays on every browser call. A minimal successful observation is 53
+  serialized characters instead of 174 in the built-in agent and 168 over MCP;
+  with `js-tiktoken@1.0.21` `cl100k_base`, that is **44 → 15 tokens (65.9%
+  fewer)** and **43 → 15 (65.1% fewer)** respectively. Non-empty errors,
+  console lines, pages, challenges, skill hints, warnings, files, screenshots,
+  and pending-credential metadata are still returned. Across the 2,000-turn
+  harness workload, the accumulated transcript is **750,009 → 476,009
+  characters (36.5% smaller)**.
+
+- The built-in agent now accounts for each appended transcript message once
+  instead of serializing the complete, growing history before every turn. The
+  no-I/O 2,000-turn harness falls from **906.3 ms to 17.2 ms (52.8× faster)**,
+  with process peak RSS down **81.1 → 77.3 MiB (4.8%)**. Real model and browser
+  latency reduces the end-to-end percentage, but the removed CPU work and
+  temporary strings do not return.
+
+- Snapshot diffs detect wholly replaced line sets in linear time and reconstruct
+  other LCS diffs from sparse checkpoints plus one reusable 64-row block. At
+  the public 3,000-line cap, retained DP storage falls from **18,012,002 bytes
+  to under 700 KiB** while randomized differential tests keep output
+  byte-for-byte identical to 1.7.0. A wholesale replacement improves from
+  **18.8 → 1.3 ms (14.6×)** and **66.0 → 45.9 MiB peak RSS (30.4% lower)**.
+  An adversarial input sharing only one displaced line uses **51.1 MiB instead
+  of 66.3 MiB (22.9% lower)** but takes 33.9 ms instead of 15.7 ms because it
+  recomputes bounded row blocks; ordinary snapshot diffs first trim their large
+  common prefix and suffix and operate on a much smaller changed region.
+
 ## [1.7.0] - 2026-08-07
 
 A browser-backend and agent-efficiency release. The public BetterWright client
@@ -616,7 +659,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/BetterWright/betterwright/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/BetterWright/betterwright/compare/v1.6.3...v1.7.0
 [1.6.3]: https://github.com/BetterWright/betterwright/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/BetterWright/betterwright/compare/v1.6.1...v1.6.2

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.7.0
+generated_by: betterwright@1.7.1
 ---
 
 # BetterWright browser

--- a/benchmarks/efficiency/REPORT.md
+++ b/benchmarks/efficiency/REPORT.md
@@ -1,0 +1,51 @@
+# BetterWright 1.7.1 efficiency measurements
+
+These local, deterministic probes cover the 1.7.1 paths without a network,
+browser, or model provider. Results below compare commit `273e51d` (1.7.0) to
+the 1.7.1 working tree on an Apple M4 Pro with Node v24.16.0. Each figure is the
+median of five fresh-process samples.
+
+## Results
+
+| Workload | 1.7.0 | 1.7.1 | Change |
+| --- | ---: | ---: | ---: |
+| 2,000-turn built-in agent loop | 906.3 ms / 81.1 MiB RSS | 17.2 ms / 77.3 MiB RSS | **52.8× faster / 4.8% lower RSS** |
+| Resulting transcript | 750,009 chars | 476,009 chars | **36.5% smaller** |
+| One successful built-in observation (cl100k) | 44 tokens / 174 chars | 15 tokens / 53 chars | **65.9% fewer tokens** |
+| One successful MCP observation (cl100k) | 43 tokens / 168 chars | 15 tokens / 53 chars | **65.1% fewer tokens** |
+| 3,000-line wholesale-replacement diff | 18.8 ms / 66.0 MiB RSS | 1.3 ms / 45.9 MiB RSS | **14.6× faster / 30.4% lower RSS** |
+| 3,000-line diff sharing one displaced line | 15.7 ms / 66.3 MiB RSS | 33.9 ms / 51.1 MiB RSS | **22.9% lower RSS** |
+
+The agent workload uses a no-I/O model and browser stub so it isolates harness
+overhead: each turn appends one ordinary browser call and its successful
+observation. The old loop serialized the complete, growing transcript before
+every turn; 1.7.1 accounts for each appended message once. Real model and
+browser latency will reduce the wall-clock percentage, but not the eliminated
+CPU work or allocations.
+
+Observation token counts use `js-tiktoken@1.0.21`, `cl100k_base`, on the exact
+JSON strings shown by the harness. Provider tokenizers differ, so the release
+notes quote both tokens and exact serialized characters.
+
+The diff probes exercise the public 3,000-line cap. A wholesale replacement
+now takes a linear no-common-line path. When an LCS must be reconstructed,
+1.7.1 retains sparse checkpoints plus one reusable 64-row block (under 700 KiB
+of DP storage at the cap) instead of an 18,012,002-byte table. That adversarial
+one-common-line case is 2.2× slower in exchange for bounded memory, as the final row reports;
+typical snapshot diffs are much smaller after common-prefix/suffix trimming.
+
+## Reproduce
+
+Build a clean 1.7.0 checkout and the candidate, then point the harness at both:
+
+```bash
+baseline_dir=$(mktemp -d)
+git worktree add --detach "$baseline_dir" 273e51d
+(cd "$baseline_dir" && npm ci && npm run build)
+npm run build:harness
+node benchmarks/efficiency/run.js --baseline "$baseline_dir"
+git worktree remove "$baseline_dir"
+```
+
+The harness prints every raw sample plus its medians. `--repeats` and `--turns`
+can change the defaults; `--candidate` can compare a second external checkout.

--- a/benchmarks/efficiency/run.ts
+++ b/benchmarks/efficiency/run.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Compare a built BetterWright checkout against this one on the three 1.7.1
+// efficiency paths. Both targets run in fresh child processes so module caches
+// and peak RSS do not bleed across samples.
+//
+//   npm run build:harness
+//   node benchmarks/efficiency/run.js --baseline /path/to/built/1.7.0
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const argv = process.argv.slice(2);
+function flag(name, fallback = "") {
+  const index = argv.indexOf(name);
+  return index >= 0 && argv[index + 1] ? argv[index + 1] : fallback;
+}
+
+const root = path.resolve(import.meta.dirname, "../..");
+const baseline = path.resolve(flag("--baseline"));
+const candidate = path.resolve(flag("--candidate", root));
+const repeats = Math.max(1, Number(flag("--repeats", "3")) || 3);
+const turns = Math.max(1, Number(flag("--turns", "2000")) || 2_000);
+if (!flag("--baseline"))
+  throw new Error("Pass --baseline /path/to/a built BetterWright 1.7.0 checkout.");
+
+const AGENT_PROBE = `
+import { pathToFileURL } from "node:url";
+const target = process.env.BW_BENCH_TARGET;
+const { runAgentTask } = await import(pathToFileURL(target + "/dist/src/agent.js"));
+const turns = Number(process.env.BW_BENCH_TURNS);
+let step = 0;
+const model = {
+  async complete() {
+    step += 1;
+    return step <= turns
+      ? { text: "", toolCalls: [{ id: "b" + step, name: "browser", input: { code: "return 1" } }] }
+      : { text: "", toolCalls: [{ id: "done", name: "done", input: { answer: "ok" } }] };
+  },
+};
+const browser = {
+  vault: null,
+  async run() {
+    return { ok: true, result: "Example Domain", artifacts: [], durationMs: 7 };
+  },
+  async close() {},
+};
+const start = process.hrtime.bigint();
+const result = await runAgentTask({
+  task: "benchmark",
+  model,
+  browser,
+  liveView: false,
+  maxTranscriptChars: 5_000_000,
+});
+console.log(JSON.stringify({
+  ms: Number(process.hrtime.bigint() - start) / 1e6,
+  steps: result.steps,
+  transcript_chars: JSON.stringify(result.transcript).length,
+  max_rss_kib: process.resourceUsage().maxRSS,
+}));
+`;
+
+const DIFF_PROBE = String.raw`
+import { pathToFileURL } from "node:url";
+const target = process.env.BW_BENCH_TARGET;
+const { diffSnapshots } = await import(pathToFileURL(target + "/dist/src/snapshot.js"));
+const count = 3_000;
+const before = Array.from({ length: count }, (_, i) => "- a" + i).join("\n");
+const afterLines = process.env.BW_BENCH_DIFF === "disjoint"
+  ? Array.from({ length: count }, (_, i) => "- b" + i)
+  : ["- a2999", ...Array.from({ length: count - 1 }, (_, i) => "- b" + i)];
+const start = process.hrtime.bigint();
+const result = diffSnapshots(before, afterLines.join("\n"));
+console.log(JSON.stringify({
+  ms: Number(process.hrtime.bigint() - start) / 1e6,
+  additions: result.additions,
+  removals: result.removals,
+  max_rss_kib: process.resourceUsage().maxRSS,
+}));
+`;
+
+function probe(target, source, extra = {}) {
+  const output = execFileSync(process.execPath, ["--input-type=module", "-e", source], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      BW_BENCH_TARGET: target,
+      BW_BENCH_TURNS: String(turns),
+      ...extra,
+    },
+  });
+  return JSON.parse(output.trim());
+}
+
+function samples(target) {
+  const agent = [];
+  const diffDisjoint = [];
+  const diffCheckpoint = [];
+  for (let i = 0; i < repeats; i += 1) {
+    agent.push(probe(target, AGENT_PROBE));
+    diffDisjoint.push(probe(target, DIFF_PROBE, { BW_BENCH_DIFF: "disjoint" }));
+    diffCheckpoint.push(probe(target, DIFF_PROBE, { BW_BENCH_DIFF: "checkpoint" }));
+  }
+  return { agent, diff_disjoint: diffDisjoint, diff_checkpoint: diffCheckpoint };
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function summarize(samplesByName) {
+  return Object.fromEntries(
+    Object.entries(samplesByName).map(([name, rows]: any) => [
+      name,
+      {
+        median_ms: median(rows.map((row) => row.ms)),
+        median_max_rss_kib: median(rows.map((row) => row.max_rss_kib)),
+        ...Object.fromEntries(
+          Object.entries(rows[0]).filter(([key]) => !["ms", "max_rss_kib"].includes(key)),
+        ),
+        samples: rows,
+      },
+    ]),
+  );
+}
+
+const result = {
+  node: process.version,
+  platform: `${process.platform}-${process.arch}`,
+  repeats,
+  turns,
+  baseline: { path: baseline, ...summarize(samples(baseline)) },
+  candidate: { path: candidate, ...summarize(samples(candidate)) },
+};
+console.log(JSON.stringify(result, null, 2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -314,19 +314,21 @@ function observationFromResult(result) {
   const screenshots = (result.artifacts || [])
     .filter((a) => a.path && /\.(png|jpe?g)$/i.test(a.path))
     .map((a) => ({ kind: a.kind, path: a.path }));
-  const summary = {
-    ok: result.ok,
-    result: result.result ?? null,
-    error: result.error ?? null,
-    pendingCredential: result.pendingCredential ?? null,
-    console: result.console || [],
-    pages: result.pages || [],
-    challenges: result.challenges || [],
-    skills: result.skills || [],
-    warnings: result.warnings || [],
-    screenshots,
-    duration_ms: result.durationMs,
-  };
+  // Empty arrays and null placeholders repeat on almost every successful call
+  // and convey nothing. Omit them from the model-facing observation: consumers
+  // already treat missing optional fields as empty, and long transcripts keep
+  // the saving once per browser step.
+  const summary: any = { ok: result.ok };
+  if (result.result !== undefined) summary.result = result.result;
+  if (result.error != null) summary.error = result.error;
+  if (result.pendingCredential != null)
+    summary.pendingCredential = result.pendingCredential;
+  for (const field of ["console", "pages", "challenges", "skills", "warnings"]) {
+    if (Array.isArray(result[field]) && result[field].length)
+      summary[field] = result[field];
+  }
+  if (screenshots.length) summary.screenshots = screenshots;
+  if (result.durationMs != null) summary.duration_ms = result.durationMs;
   let text = JSON.stringify(summary);
   if (text.length > OBSERVATION_LIMIT) {
     summary.result = "[truncated — inspect via a scoped snapshot]";
@@ -727,7 +729,7 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
     const lines = batches.flatMap(({ source, lines: items }) =>
       items.map((line) => `- [${source}] ${line}`),
     );
-    messages.push({
+    appendTranscriptMessage({
       role: "user",
       text:
         "The human sent steering while you were working. " +
@@ -763,6 +765,15 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
   // back to earlier work; otherwise start fresh.
   const history = Array.isArray(options.history) ? options.history : [];
   const messages = [...history, { role: "user", text: task }];
+  // The transcript only grows by appending complete JSON-safe messages. Track
+  // its exact serialized size as those messages arrive instead of rebuilding
+  // the entire string at every turn (quadratic total work on long runs).
+  let transcriptChars = JSON.stringify(messages).length;
+  function appendTranscriptMessage(message) {
+    const separator = messages.length ? 1 : 0;
+    messages.push(message);
+    transcriptChars += separator + JSON.stringify(message).length;
+  }
 
   let answer = "";
   let proof = null;
@@ -810,7 +821,7 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
         reason = "interrupted";
         break;
       }
-      if (JSON.stringify(messages).length > maxTranscriptChars) {
+      if (transcriptChars > maxTranscriptChars) {
         reason = "context_limit";
         break;
       }
@@ -840,7 +851,7 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
         contextTokens = response.usage.inputTokens || 0;
       }
       toolCallCount += toolCalls.length;
-      messages.push({ role: "assistant", text: response.text || "", toolCalls });
+      appendTranscriptMessage({ role: "assistant", text: response.text || "", toolCalls });
 
       // No tool call: the model answered in prose. Treat that text as the
       // result unless steering arrived while the model was answering.
@@ -1116,7 +1127,9 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
         }
         results.push({ id: call.id, name: call.name, content: `Unknown tool: ${call.name}` });
       }
-      messages.push({ role: "tool", results });
+      const toolMessage = { role: "tool", results };
+      const toolMessageChars = JSON.stringify(toolMessage).length;
+      appendTranscriptMessage(toolMessage);
       // A terminal or live-view message can arrive during model inference or a
       // long browser call. Apply it before accepting a completion from that
       // turn, so steering never becomes a stray follow-up task.
@@ -1134,6 +1147,10 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
         repeated = { signature: "", count: 0 };
         noProgress = false;
       }
+      // Steering can rewrite a batched `done` result after the message was
+      // appended. Account for that tiny mutation so the next cap check remains
+      // byte-for-byte equivalent to JSON.stringify(messages).length.
+      transcriptChars += JSON.stringify(toolMessage).length - toolMessageChars;
       if (finished) break;
       if (noProgress) {
         reason = "no_progress";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -156,8 +156,9 @@ function isLoopbackHost(host) {
   );
 }
 
-// The summary keys deliberately match a single documented shape (snake_case
-// duration_ms included) so MCP clients see one contract.
+// The summary uses one documented vocabulary (snake_case duration_ms included)
+// but omits optional fields when empty. These results become model context, so
+// repeating nulls and empty arrays on every successful call is real token cost.
 export async function contentForResult(result) {
   const imagePaths = new Set(piImageArtifacts(result).map((image) => image.path));
   const files = (result.artifacts || [])
@@ -171,25 +172,26 @@ export async function contentForResult(result) {
             .map((key) => [key, result.pendingCredential[key]]),
         )
       : (result.pendingCredential ?? null);
-  const summary = {
-    ok: result.ok,
-    // Coerce to null (not undefined) so the JSON keeps these keys, matching the
-    // documented summary shape on both success and failure.
-    result: result.result ?? null,
-    error: result.error ?? null,
-    pendingCredential,
-    console: result.console || [],
-    // Screenshots are returned as image content below, not as paths. Other
-    // files (downloads, spilled output) are listed here as paths only.
-    files,
-    pages: result.pages || [],
-    challenges: result.challenges || [],
-    // Deeper site/provider packs matching the open pages; read the `path` with
-    // your file tool before improvising site-specific behavior.
-    skills: result.skills || [],
-    warnings: result.warnings || [],
-    duration_ms: result.durationMs,
-  };
+  const summary: any = { ok: result.ok };
+  if (result.result !== undefined) summary.result = result.result;
+  if (result.error != null) summary.error = result.error;
+  if (pendingCredential != null) summary.pendingCredential = pendingCredential;
+  if (Array.isArray(result.console) && result.console.length)
+    summary.console = result.console;
+  // Screenshots are returned as image content below, not as paths. Other
+  // files (downloads, spilled output) are listed here as paths only.
+  if (files.length) summary.files = files;
+  if (Array.isArray(result.pages) && result.pages.length)
+    summary.pages = result.pages;
+  if (Array.isArray(result.challenges) && result.challenges.length)
+    summary.challenges = result.challenges;
+  // Deeper site/provider packs matching the open pages; read the `path` with
+  // your file tool before improvising site-specific behavior.
+  if (Array.isArray(result.skills) && result.skills.length)
+    summary.skills = result.skills;
+  if (Array.isArray(result.warnings) && result.warnings.length)
+    summary.warnings = result.warnings;
+  if (result.durationMs != null) summary.duration_ms = result.durationMs;
   return [
     { type: "text", text: JSON.stringify(summary) },
     ...(await piImageContent(result)),

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -486,40 +486,100 @@ export function diffSnapshots(previous, current) {
   for (let k = 0; k < before.length; k += 1) beforeIds[k] = idOf(before[k]);
   for (let k = 0; k < after.length; k += 1) afterIds[k] = idOf(after[k]);
 
-  // Longest-common-subsequence table over the changed region. Every entry is a
-  // subsequence length, so it cannot exceed MAX_DIFF_LINES — Uint16Array holds
-  // it exactly and halves a table that reaches 18 MB at the size cap.
-  const rows = before.length + 1;
-  const cols = after.length + 1;
-  const table = new Uint16Array(rows * cols);
-  for (let i = before.length - 1; i >= 0; i -= 1) {
-    const rowBase = i * cols;
-    const nextBase = rowBase + cols;
-    const beforeId = beforeIds[i];
-    for (let j = after.length - 1; j >= 0; j -= 1) {
-      table[rowBase + j] =
-        beforeId === afterIds[j]
-          ? table[nextBase + j + 1] + 1
-          : Math.max(table[nextBase + j], table[rowBase + j + 1]);
+  // A wholesale replacement has no LCS to calculate. The old removal-on-tie
+  // table always emitted every old line followed by every new line; detect
+  // that exact result in linear time and allocate no DP rows at all.
+  const presentBefore = new Uint8Array(ids.size);
+  for (const id of beforeIds) presentBefore[id] = 1;
+  let sharesLine = false;
+  for (const id of afterIds) {
+    if (presentBefore[id]) {
+      sharesLine = true;
+      break;
     }
   }
+  if (!sharesLine) {
+    return {
+      changed: true,
+      diff: before
+        .map((line) => `- ${line}`)
+        .concat(after.map((line) => `+ ${line}`))
+        .join("\n"),
+      additions: after.length,
+      removals: before.length,
+    };
+  }
+
   const out = [];
   let additions = 0;
   let removals = 0;
+  const rowsPerCheckpoint = 64;
+  const cols = after.length + 1;
+
+  // Store only every 64th suffix row. The former implementation retained all
+  // 3001 rows until reconstruction finished: 18,012,002 table bytes at the
+  // public limit. Checkpoints plus one reconstructed block stay below 700 KiB
+  // at that same limit while preserving the exact old tie behavior.
+  const checkpoints = new Map();
+  let next = new Uint16Array(cols);
+  checkpoints.set(before.length, next.slice());
+  let currentRow = new Uint16Array(cols);
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    const beforeId = beforeIds[i];
+    for (let j = after.length - 1; j >= 0; j -= 1) {
+      currentRow[j] =
+        beforeId === afterIds[j]
+          ? next[j + 1] + 1
+          : Math.max(next[j], currentRow[j + 1]);
+    }
+    [next, currentRow] = [currentRow, next];
+    if (i > 0 && i % rowsPerCheckpoint === 0)
+      checkpoints.set(i, next.slice());
+  }
+
+  // Rebuild one small row block at a time and walk its decisions immediately.
+  // This is the same recurrence and removal-on-tie rule as the full table, so
+  // diff text remains byte-for-byte stable; only the lifetime of the rows
+  // changes.
   let i = 0;
   let j = 0;
+  const table = new Uint16Array(
+    (Math.min(rowsPerCheckpoint, before.length) + 1) * cols,
+  );
   while (i < before.length && j < after.length) {
-    if (beforeIds[i] === afterIds[j]) {
-      i += 1;
-      j += 1;
-    } else if (table[(i + 1) * cols + j] >= table[i * cols + j + 1]) {
-      out.push(`- ${before[i]}`);
-      removals += 1;
-      i += 1;
-    } else {
-      out.push(`+ ${after[j]}`);
-      additions += 1;
-      j += 1;
+    const blockStart = i;
+    const blockEnd = Math.min(
+      before.length,
+      (Math.floor(blockStart / rowsPerCheckpoint) + 1) * rowsPerCheckpoint,
+    );
+    const blockRows = blockEnd - blockStart + 1;
+    table.set(checkpoints.get(blockEnd), (blockRows - 1) * cols);
+    for (let local = blockRows - 2; local >= 0; local -= 1) {
+      const rowBase = local * cols;
+      const nextBase = rowBase + cols;
+      const beforeId = beforeIds[blockStart + local];
+      table[rowBase + after.length] = 0;
+      for (let column = after.length - 1; column >= 0; column -= 1) {
+        table[rowBase + column] =
+          beforeId === afterIds[column]
+            ? table[nextBase + column + 1] + 1
+            : Math.max(table[nextBase + column], table[rowBase + column + 1]);
+      }
+    }
+    while (i < blockEnd && j < after.length) {
+      const rowBase = (i - blockStart) * cols;
+      if (beforeIds[i] === afterIds[j]) {
+        i += 1;
+        j += 1;
+      } else if (table[rowBase + cols + j] >= table[rowBase + j + 1]) {
+        out.push(`- ${before[i]}`);
+        removals += 1;
+        i += 1;
+      } else {
+        out.push(`+ ${after[j]}`);
+        additions += 1;
+        j += 1;
+      }
     }
   }
   for (; i < before.length; i += 1) {

--- a/tests/node/agent.test.ts
+++ b/tests/node/agent.test.ts
@@ -102,6 +102,29 @@ test("runAgentTask drives browser then finishes on done", async () => {
   assert.match(toolTurn.results[0].content, /"result":"HN"/);
 });
 
+test("successful browser observations omit empty optional fields", async () => {
+  const browser = fakeBrowser({
+    runs: [{ ok: true, result: "Example Domain", artifacts: [], durationMs: 7 }],
+  });
+  const model = scriptedModel([
+    { text: "", toolCalls: [{ id: "c1", name: "browser", input: { code: "title" } }] },
+    { text: "", toolCalls: [{ id: "d1", name: "done", input: { answer: "ok" } }] },
+  ]);
+
+  const result = await runAgentTask({ task: "read title", model, browser });
+  const observation = result.transcript.find((message) => message.role === "tool")
+    .results[0].content;
+  assert.equal(
+    observation,
+    '{"ok":true,"result":"Example Domain","duration_ms":7}',
+  );
+  assert.deepEqual(JSON.parse(observation), {
+    ok: true,
+    result: "Example Domain",
+    duration_ms: 7,
+  });
+});
+
 test("runAgentTask finishes in one turn when the code returns { finalAnswer }", async () => {
   const browser = fakeBrowser({
     runs: [

--- a/tests/node/mcp-server.test.ts
+++ b/tests/node/mcp-server.test.ts
@@ -261,24 +261,32 @@ test("contentForResult separates screenshots from file paths", async () => {
   assert.deepEqual(Object.keys(summary), [
     "ok",
     "result",
-    "error",
     "pendingCredential",
     "console",
     "files",
     "pages",
-    "challenges",
-    "skills",
-    "warnings",
     "duration_ms",
   ]);
   assert.equal(summary.ok, true);
   assert.equal(summary.duration_ms, 12.3);
   assert.equal(summary.pendingCredential.pendingId, "pending-1");
   assert.equal(Object.hasOwn(summary.pendingCredential, "secret"), false);
-  assert.deepEqual(summary.skills, []);
   assert.deepEqual(summary.files, [{ kind: "download", path: "/tmp/report.pdf" }]);
   assert.equal(content[1].type, "image");
   assert.equal(content[1].mimeType, "image/png");
+});
+
+test("contentForResult omits empty model-context fields", async () => {
+  const [content] = await contentForResult({
+    ok: true,
+    result: "Example Domain",
+    artifacts: [],
+    durationMs: 7,
+  });
+  assert.equal(
+    content.text,
+    '{"ok":true,"result":"Example Domain","duration_ms":7}',
+  );
 });
 
 test("liveViewFromEnv defaults to LAN bind and disabled remote exposure", () => {

--- a/tests/node/snapshot.test.ts
+++ b/tests/node/snapshot.test.ts
@@ -303,11 +303,10 @@ test("diffSnapshots flags oversized inputs instead of stalling", () => {
   assert.equal(result.tooLarge, true);
 });
 
-// The diff table is the only allocation in this file that scales with the
-// square of the input, so it grew a fast path (one-sided changes skip the
-// table entirely) and line interning (integer compares in the inner loop).
-// These pin the output against a straightforward reference so the
-// optimizations cannot quietly change which lines are reported.
+// Diff reconstruction uses sparse row checkpoints instead of retaining the
+// quadratic table, while the fast path skips all DP work for one-sided
+// changes. These pin the output against a straightforward reference so the
+// memory optimization cannot quietly change which lines are reported.
 
 /**
  * The 1.6.0 implementation, verbatim: shared prefix/suffix trimming, a full
@@ -390,8 +389,10 @@ test("diffSnapshots still agrees line-for-line with the 1.6.0 algorithm", () => 
   // A small alphabet makes repeated lines — and therefore interning
   // collisions and LCS ties — common rather than rare.
   const line = () => `- item ${Math.floor(random() * 6)}`;
+  // Lengths cross the 64-row checkpoint boundary so this covers both the
+  // single-block and multi-block reconstruction paths.
   for (let round = 0; round < 200; round += 1) {
-    const before = Array.from({ length: Math.floor(random() * 12) }, line);
+    const before = Array.from({ length: Math.floor(random() * 90) }, line);
     const after = before
       .filter(() => random() > 0.3)
       .flatMap((entry) => (random() > 0.75 ? [line(), entry] : [entry]));
@@ -420,12 +421,17 @@ test("a purely one-sided change reports every line without building a table", ()
   });
 });
 
-test("a diff at the size cap stays within the halved table budget", () => {
+test("a diff at the size cap reconstructs from bounded row checkpoints", () => {
   const before = Array.from({ length: 3_000 }, (_, i) => `- a${i}`).join("\n");
-  const after = Array.from({ length: 3_000 }, (_, i) => `- b${i}`).join("\n");
+  // One displaced shared line forces the LCS path; wholly disjoint inputs take
+  // the faster no-common-line branch instead.
+  const after = [
+    "- a2999",
+    ...Array.from({ length: 2_999 }, (_, i) => `- b${i}`),
+  ].join("\n");
   const result = diffSnapshots(before, after);
   assert.equal(result.changed, true);
   assert.equal(result.tooLarge, undefined);
-  assert.equal(result.additions, 3_000);
-  assert.equal(result.removals, 3_000);
+  assert.equal(result.additions, 2_999);
+  assert.equal(result.removals, 2_999);
 });


### PR DESCRIPTION
## What changed

- omit empty optional fields from built-in-agent and MCP model observations
- track transcript size incrementally instead of serializing the full growing history every turn
- add a linear fast path for wholly replaced snapshots and bounded-memory checkpoint reconstruction for other LCS diffs
- add deterministic efficiency benchmarks and publish BetterWright 1.7.1 release notes/version stamps

## Why

Long agent sessions paid quadratic transcript-accounting CPU and repeated token overhead for empty result fields. Snapshot diffs could retain an 18,012,002-byte DP table at the public 3,000-line limit.

## Measured impact

Five fresh-process samples against 1.7.0 commit `273e51d` on an Apple M4 Pro / Node v24.16.0:

- 2,000-turn harness: 906.3 ms → 17.2 ms (52.8× faster)
- accumulated transcript: 750,009 → 476,009 chars (36.5% smaller)
- minimal built-in observation: 44 → 15 cl100k tokens (65.9% fewer)
- minimal MCP observation: 43 → 15 cl100k tokens (65.1% fewer)
- 3,000-line wholesale diff: 18.8 → 1.3 ms and 66.0 → 45.9 MiB RSS
- bounded LCS case: 66.3 → 51.1 MiB RSS; the documented adversarial one-common-line case trades CPU (15.7 → 33.9 ms) for bounded memory

## Validation

- `npm run release:check`
- 761 unit tests passed; 5 optional live tests skipped
- lint, runtime/tool/example types, declaration tests, build layout, version pins, and package smoke test passed
- package smoke: `betterwright-1.7.1.tgz`, 113 files
