### PR TITLE
Fix object argument coercion for 1.7.2 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.7.2-beta.0] - 2026-08-11
+
+A beta of the boundary-validation fix for
+[#103](https://github.com/BetterWright/betterwright/issues/103). There are no
+public API removals or behavior changes for valid arguments.
+
+In the issue reproduction on a warm managed browser, the invalid role-name
+call now fails in 5 ms instead of exhausting the 30,000 ms run timeout. The
+invalid page-handle call fails in 4 ms.
+
+### Fixed
+
+- `getByRole(role, {name})` now rejects object-valued names before Playwright
+  builds an internal selector. The error identifies the argument and received
+  type (`name must be a string or RegExp, received object`) instead of emitting
+  an `InvalidSelectorError` containing `[object Object]` or consuming the
+  action/run timeout. Cross-realm `RegExp` matchers are preserved rather than
+  being flattened to `{}`, so valid calls such as `{name: /email/i}` continue
+  to work.
+- `usePage(handle)` and `closePage(handle)` now reject non-string/non-number
+  handles at the helper boundary with the received type. Objects no longer
+  become misleading `Unknown page [object Object]` messages or silent
+  `{closed: false}` results; page ID strings, numeric indexes, and the omitted
+  current-page argument retain their existing behavior.
+
 ## [1.7.1] - 2026-08-09
 
 A token, CPU, and memory efficiency patch. There are no client API removals;

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.7.1
+generated_by: betterwright@1.7.2-beta.0
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.7.1",
+  "version": "1.7.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.7.1",
+      "version": "1.7.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.7.1",
+  "version": "1.7.2-beta.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13,6 +13,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
+import { types as utilTypes } from "node:util";
 import vm from "node:vm";
 
 import {
@@ -2910,6 +2911,11 @@ function prepareArgument(value, property, realm) {
   }
   if (Array.isArray(value))
     return value.map((item) => prepareArgument(item, property, realm));
+  // RegExp values originate in the model's vm realm. Treating them as plain
+  // objects erases their non-enumerable source/flags and turns valid
+  // Playwright text/name matchers into {}, which later stringify as
+  // "[object Object]" inside internal selectors.
+  if (utilTypes.isRegExp(value)) return new RegExp(value.source, value.flags);
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value).map(([key, item]) => [
@@ -2919,6 +2925,28 @@ function prepareArgument(value, property, realm) {
     );
   }
   return value;
+}
+
+function argumentType(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function validateMethodArguments(property, args) {
+  if (property !== "getByRole" || args[1]?.name === undefined) return;
+  const name = args[1].name;
+  if (typeof name === "string" || utilTypes.isRegExp(name)) return;
+  throw new TypeError(
+    `getByRole name must be a string or RegExp, received ${argumentType(name)}.`,
+  );
+}
+
+function assertPageHandle(value, helper) {
+  if (typeof value === "string" || typeof value === "number") return;
+  throw new TypeError(
+    `${helper} page handle must be a page ID string or numeric index, received ${argumentType(value)}.`,
+  );
 }
 
 function validateMethodPaths(kind, property, args) {
@@ -3894,6 +3922,7 @@ function wrap(value, realm) {
           prepareArgument(arg, property, realm),
         );
         const kind = objectKind(value);
+        validateMethodArguments(property, prepared);
         if (
           browserBackend === "obscura" &&
           ["Page", "Frame"].includes(kind) &&
@@ -5710,6 +5739,7 @@ function buildSandbox(session, consoleMessages, execution) {
     return wrap(page, realm);
   });
   sandbox.usePage = realm.safeFunction(async (selector) => {
+    assertPageHandle(selector, "usePage");
     const entries = [...session.pages.entries()].filter(
       ([, page]) => !page.isClosed(),
     );
@@ -5727,6 +5757,7 @@ function buildSandbox(session, consoleMessages, execution) {
   });
   sandbox.closePage = realm.safeFunction(async (selector) => {
     const target = selector === undefined ? session.currentId : selector;
+    assertPageHandle(target, "closePage");
     const entries = [...session.pages.entries()];
     const entry =
       typeof target === "number"

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -166,6 +166,45 @@ test("page summaries identify the active tab", opts, async () => {
   }
 });
 
+test("role names and page handles reject objects at the call boundary", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const regexName = await bw.run(`
+      await page.setContent('<input aria-label="Email">');
+      return page.getByRole('textbox', {name: /email/i}).count();
+    `);
+    assert.equal(regexName.ok, true, regexName.error);
+    assert.equal(regexName.result, 1);
+
+    const roleName = await bw.run(`
+      await page.getByRole('textbox', {name: {text: 'Email'}}).click();
+    `);
+    assert.equal(roleName.ok, false);
+    assert.equal(
+      roleName.error,
+      "getByRole name must be a string or RegExp, received object.",
+    );
+    assert.doesNotMatch(roleName.error, /\[object Object\]|InvalidSelector|timed out/i);
+
+    const pageHandle = await bw.run("await usePage(pages[0]);");
+    assert.equal(pageHandle.ok, false);
+    assert.equal(
+      pageHandle.error,
+      "usePage page handle must be a page ID string or numeric index, received object.",
+    );
+    assert.doesNotMatch(pageHandle.error, /\[object Object\]|Unknown page/i);
+
+    const closeHandle = await bw.run("await closePage({pageId: 'page-1'});");
+    assert.equal(closeHandle.ok, false);
+    assert.equal(
+      closeHandle.error,
+      "closePage page handle must be a page ID string or numeric index, received object.",
+    );
+  } finally {
+    await bw.close();
+  }
+});
+
 test("public search UIs route agents to the host search tool", opts, async () => {
   // Public search is allowed by default now, so opt into the block routing.
   const bw = new BetterWright({


### PR DESCRIPTION
## Summary

- reject object-valued `getByRole(..., { name })` arguments before Playwright selector construction
- preserve cross-realm `RegExp` matchers from the model sandbox
- reject object page handles in `usePage` and `closePage` before string coercion
- publish the fix as `1.7.2-beta.0`, with measured release notes

## Measured result

On a warm managed browser, the issue reproduction now returns the typed role-name error in **5 ms** instead of exhausting the **30,000 ms** run timeout. The invalid page-handle reproduction returns in **4 ms**.

## Validation

- `npm run release:check` — 761 passed, 5 skipped, 0 failed
- `BETTERWRIGHT_REQUIRE_BROWSER=1 npm test` — 810 passed, 5 skipped, 0 failed
- package smoke test: `betterwright-1.7.2-beta.0.tgz`

This is a prerelease candidate. After protected CI passes, it will be tagged `v1.7.2-beta.0`, released as a GitHub prerelease, and published to npm under the `beta` dist-tag. The npm `latest` tag will remain on `1.7.1`.

Closes #103
