### PR TITLE
Release BetterWright 1.7.2 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
-## [1.7.2-beta.0] - 2026-08-11
+## [1.7.2] - 2026-08-11
 
-A beta of the boundary-validation fix for
-[#103](https://github.com/BetterWright/betterwright/issues/103). There are no
-public API removals or behavior changes for valid arguments.
+The stable boundary-validation fix for
+[#103](https://github.com/BetterWright/betterwright/issues/103), promoted from
+`1.7.2-beta.0` after beta testing. There are no public API removals or behavior
+changes for valid arguments.
 
 In the issue reproduction on a warm managed browser, the invalid role-name
 call now fails in 5 ms instead of exhausting the 30,000 ms run timeout. The

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.7.2-beta.0
+generated_by: betterwright@1.7.2
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.7.2-beta.0",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.7.2-beta.0",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.7.2-beta.0",
+  "version": "1.7.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- promote the tested `1.7.2-beta.0` runtime to stable `1.7.2`
- update package, lockfile, and generated skill version stamps
- promote the measured #103 changelog entry to the stable release notes

No runtime code changed after the beta. The invalid role-name reproduction still improves from the 30,000 ms timeout to a 5 ms typed boundary error, and invalid page handles fail in 4 ms.

## Validation

- `npm ci` — 0 vulnerabilities
- `npm run release:check` — 761 passed, 5 skipped, 0 failed
- package smoke test: `betterwright-1.7.2.tgz`
- `1.7.2-beta.0` previously passed the complete managed-browser suite and trusted npm beta publish

After protected CI passes, this will be tagged `v1.7.2`, released as a stable GitHub release, and published to npm `latest`.
