### PR TITLE
fix: restore cross-platform browser compatibility for 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,26 +26,33 @@ environment override.
   install, update, verify, and report CloakBrowser without requiring
   `BETTERWRIGHT_CHROMIUM_ROOT=off`.
 - Fixed [#109](https://github.com/BetterWright/betterwright/issues/109):
-  GPU-less Linux hosts now keep standard WebGL available through the packaged
-  SwiftShader renderer instead of presenting a macOS browser identity with the
-  graphics surface blocked. Explicit GPU-capable hosts retain hardware
-  acceleration. The browser-level regression test requires a real context,
-  extensions, pixel readback, and the captured Apple vendor/renderer identity.
+  GPU-less Linux hosts now automatically use the managed CloakBrowser backend,
+  whose packaged software renderer keeps standard WebGL available instead of
+  presenting a macOS browser identity with the graphics surface blocked.
+  GPU-capable hosts retain native BetterChromium. The browser-level regression
+  test runs against whichever backend `doctor` selects and requires a real
+  context, extensions, pixel readback, and a coherent UA/platform/GPU identity.
 - Supported hosts with a missing BetterChromium install still fail closed with
   setup guidance. Invalid explicit paths and roots remain errors rather than
   silently switching browsers.
+- If BetterChromium 151 already upgraded a persistent profile, the older Cloak
+  backend uses a stable nested compatibility profile instead of crashing on a
+  forbidden profile downgrade. The original profile and logins stay untouched;
+  the compatibility profile maintains its own persistent sign-ins.
 
 ### Security and performance
 
 - The fallback reuses the existing managed CloakBrowser launcher and keeps all
   browser traffic on BetterWright's SOCKS guard; no direct or unguarded launch
   path was added.
-- Supported BetterChromium launches do not take a new compatibility path. The
-  selection change is one constant-time platform lookup at startup and adds no
-  per-page work, retained processes, or page-world scripts.
-- The SwANGLE path starts only when Linux has no accessible hardware render
-  device. It restores standards-compatible WebGL but uses CPU rendering, so
-  1.8.1 makes no new memory or speed claim for that fallback.
+- GPU-capable BetterChromium launches do not take a new compatibility path.
+  GPU detection is one bounded `/dev/dri` directory check at startup and adds
+  no per-page work or page-world scripts.
+- On the same GPU-less Linux container that reproduces BetterChromium's blocked
+  WebGL, the automatic Cloak fallback created WebGL, exposed 33 extensions, and
+  completed pixel readback correctly. Its first diagnostic launch took 8.76 s;
+  that single cold run validates compatibility and is not a speed benchmark.
+  1.8.1 makes no new memory or speed claim for this fallback.
 - A fresh-profile CreepJS verification completed its fingerprint in 2.27 s with
   WebGL available, the captured Apple M4 Pro renderer, 0% `headless`, and 0%
   `stealth`. Its `like headless` heuristic was 31%; because that check ran on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-12
+
+A cross-platform compatibility and graphics fix for 1.8.0. BetterChromium
+remains the default wherever a pinned native artifact exists; unsupported hosts
+once again launch managed CloakBrowser without requiring an undocumented
+environment override.
+
+### Fixed
+
+- Linux arm64 systems, including Raspberry Pi, now automatically select
+  CloakBrowser because no BetterChromium artifact is published for that target.
+  The same routing applies to every unsupported OS/architecture pair.
+- `betterwright setup`, `betterwright update`, `betterwright init`, and
+  `betterwright doctor` now agree on the selected backend: unsupported hosts
+  install, update, verify, and report CloakBrowser without requiring
+  `BETTERWRIGHT_CHROMIUM_ROOT=off`.
+- Fixed [#109](https://github.com/BetterWright/betterwright/issues/109):
+  GPU-less Linux hosts now keep standard WebGL available through the packaged
+  SwiftShader renderer instead of presenting a macOS browser identity with the
+  graphics surface blocked. Explicit GPU-capable hosts retain hardware
+  acceleration. The browser-level regression test requires a real context,
+  extensions, pixel readback, and the captured Apple vendor/renderer identity.
+- Supported hosts with a missing BetterChromium install still fail closed with
+  setup guidance. Invalid explicit paths and roots remain errors rather than
+  silently switching browsers.
+
+### Security and performance
+
+- The fallback reuses the existing managed CloakBrowser launcher and keeps all
+  browser traffic on BetterWright's SOCKS guard; no direct or unguarded launch
+  path was added.
+- Supported BetterChromium launches do not take a new compatibility path. The
+  selection change is one constant-time platform lookup at startup and adds no
+  per-page work, retained processes, or page-world scripts.
+- The SwANGLE path starts only when Linux has no accessible hardware render
+  device. It restores standards-compatible WebGL but uses CPU rendering, so
+  1.8.1 makes no new memory or speed claim for that fallback.
+- A fresh-profile CreepJS verification completed its fingerprint in 2.27 s with
+  WebGL available, the captured Apple M4 Pro renderer, 0% `headless`, and 0%
+  `stealth`. Its `like headless` heuristic was 31%; because that check ran on a
+  different host from the issue's 44% report, this is recorded as validation,
+  not claimed as a comparable score reduction.
+
 ## [1.8.0] - 2026-08-12
 
 A native-browser overhaul centered on BetterChromium 151. Public archives for

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ step from what it sees, in a browser that must still be there next turn:
 | [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
 | [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel — no extra dependency |
 | [**Cloaking V2**](docs/cloaking-v2.md) | Coherent native fingerprint: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; the two public reCAPTCHA v3 score-detector demos in the stealth report return a server-verified 0.9 headed and headless |
-| [**BetterChromium**](docs/chromium-fork.md) | Default browser on supported macOS arm64, Linux x64, and Windows x64 hosts: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. Other platforms automatically use managed CloakBrowser compatibility mode |
+| [**BetterChromium**](docs/chromium-fork.md) | Default browser on supported macOS arm64, GPU-capable Linux x64, and Windows x64 hosts: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. Other platforms and GPU-less Linux automatically use managed CloakBrowser compatibility mode |
 | [**Skill packs**](docs/skills.md) | Per-site and per-password-manager guidance the driving agent reads on demand — your own or the built-in loop — surfaced automatically when an open page matches |
 | [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time |
 | [**Operator guidance**](docs/agent-prompt.md) | `betterwright skill` / `agentSystemPrompt()` — decisive action on authorized tasks, with optional confirmation/spending guardrails |
@@ -239,7 +239,8 @@ step from what it sees, in a browser that must still be there next turn:
 ## Install
 
 Requires **Node.js 22+**. Setup downloads the pinned native BetterChromium
-browser on supported hosts and managed CloakBrowser on other platforms.
+browser on supported hosts and managed CloakBrowser on other platforms or
+GPU-less Linux.
 Nothing is downloaded as an npm lifecycle side effect, so installs stay
 predictable with `--ignore-scripts`.
 

--- a/README.md
+++ b/README.md
@@ -231,17 +231,17 @@ step from what it sees, in a browser that must still be there next turn:
 | [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
 | [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel — no extra dependency |
 | [**Cloaking V2**](docs/cloaking-v2.md) | Coherent native fingerprint: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; the two public reCAPTCHA v3 score-detector demos in the stealth report return a server-verified 0.9 headed and headless |
-| [**BetterChromium**](docs/chromium-fork.md) | Required/default browser on supported Linux x64 and macOS arm64: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. CloakBrowser is explicit compatibility opt-out only |
+| [**BetterChromium**](docs/chromium-fork.md) | Default browser on supported macOS arm64, Linux x64, and Windows x64 hosts: per-profile-stable canvas/audio farbling, platform masking, macOS-metric fonts. Other platforms automatically use managed CloakBrowser compatibility mode |
 | [**Skill packs**](docs/skills.md) | Per-site and per-password-manager guidance the driving agent reads on demand — your own or the built-in loop — surfaced automatically when an open page matches |
 | [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time |
 | [**Operator guidance**](docs/agent-prompt.md) | `betterwright skill` / `agentSystemPrompt()` — decisive action on authorized tasks, with optional confirmation/spending guardrails |
 
 ## Install
 
-Requires **Node.js 22+**. Setup downloads the pinned native BetterWright
-Chromium browser. CloakBrowser is available only as an explicit compatibility opt-out. Nothing is
-downloaded as an npm lifecycle side effect, so installs stay predictable with
-`--ignore-scripts`.
+Requires **Node.js 22+**. Setup downloads the pinned native BetterChromium
+browser on supported hosts and managed CloakBrowser on other platforms.
+Nothing is downloaded as an npm lifecycle side effect, so installs stay
+predictable with `--ignore-scripts`.
 
 ```bash
 npm install -g betterwright
@@ -252,8 +252,8 @@ betterwright init      # guided: browser + agent wiring + a real page load
 are all available on their own:
 
 ```bash
-betterwright setup     # install native BetterChromium
-betterwright update    # refresh pinned BetterChromium
+betterwright setup     # install the managed browser for this host
+betterwright update    # refresh the managed browser for this host
 betterwright doctor    # what is installed, what is missing, how to fix it
 ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -66,8 +66,9 @@ client it does not know), or when you want to do it deliberately.
    ```
 
    On macOS arm64, Linux x64, and Windows x64, setup fetches checksum-pinned
-   BetterChromium into `~/.betterwright/chromium/`. Other platforms
-   automatically install managed CloakBrowser compatibility mode. npm
+   BetterChromium into `~/.betterwright/chromium/`. Other platforms, plus Linux
+   without an accessible `/dev/dri` render device, automatically install
+   managed CloakBrowser compatibility mode. npm
    installation itself has no hidden browser-download lifecycle script.
 4. **Verify** with `betterwright doctor` — it must end with
    `BetterWright is ready.` Every line it flags with `✗` names its own fix; if
@@ -250,8 +251,9 @@ The server keeps one browser alive for its lifetime, so pages and logins persist
 across tool calls.
 
 BetterChromium (`~/.betterwright/chromium/`) is the default backend on
-supported macOS arm64, Linux x64, and Windows x64 hosts. Platforms without a
-published artifact automatically use managed CloakBrowser; `--cloak-only` and
+supported macOS arm64, GPU-capable Linux x64, and Windows x64 hosts. Platforms
+without a published artifact and Linux hosts without an accessible `/dev/dri`
+render device automatically use managed CloakBrowser; `--cloak-only` and
 `BETTERWRIGHT_CHROMIUM_ROOT=off` force the same compatibility backend on a
 supported host. See [docs/chromium-fork.md](docs/chromium-fork.md). This is not
 a guarantee of undetectability.

--- a/SETUP.md
+++ b/SETUP.md
@@ -61,14 +61,14 @@ client it does not know), or when you want to do it deliberately.
 3. **Download the managed browser** (one-time):
 
    ```bash
-   betterwright setup     # install native BetterChromium
-   # or: betterwright update   # refresh BetterChromium
+   betterwright setup     # install the managed browser for this host
+   # or: betterwright update   # refresh the managed browser
    ```
 
-   Setup fetches checksum-pinned BetterChromium into
-   `~/.betterwright/chromium/`. CloakBrowser is available only through the
-   explicit `--cloak-only` compatibility opt-out. npm installation itself has
-   no hidden browser-download lifecycle script.
+   On macOS arm64, Linux x64, and Windows x64, setup fetches checksum-pinned
+   BetterChromium into `~/.betterwright/chromium/`. Other platforms
+   automatically install managed CloakBrowser compatibility mode. npm
+   installation itself has no hidden browser-download lifecycle script.
 4. **Verify** with `betterwright doctor` — it must end with
    `BetterWright is ready.` Every line it flags with `✗` names its own fix; if
    any remain, stop and report exactly what `doctor` printed. `!` lines are
@@ -249,11 +249,12 @@ usually swallow the error), and a missing browser.
 The server keeps one browser alive for its lifetime, so pages and logins persist
 across tool calls.
 
-BetterChromium (`~/.betterwright/chromium/`) is the required/default
-backend on supported Linux x64 and macOS arm64 hosts. CloakBrowser is used only
-when explicitly selected with `betterwright setup --cloak-only` and
-`BETTERWRIGHT_CHROMIUM_ROOT=off`; it is never a silent fallback. See
-[docs/chromium-fork.md](docs/chromium-fork.md). This is not a guarantee of undetectability.
+BetterChromium (`~/.betterwright/chromium/`) is the default backend on
+supported macOS arm64, Linux x64, and Windows x64 hosts. Platforms without a
+published artifact automatically use managed CloakBrowser; `--cloak-only` and
+`BETTERWRIGHT_CHROMIUM_ROOT=off` force the same compatibility backend on a
+supported host. See [docs/chromium-fork.md](docs/chromium-fork.md). This is not
+a guarantee of undetectability.
 
 Broad discovery should use the host's web-search tool, then open selected
 first-party pages in BetterWright; the operator guidance says so. Set

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.8.0
+generated_by: betterwright@1.8.1
 ---
 
 # BetterWright browser

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -51,6 +51,7 @@ import {
   makeLineReader,
   readExecTaskFromStdin,
 } from "../src/cli-io.js";
+import { chromiumForkNeedsSoftwareGpu } from "../src/cloak.js";
 import {
   daemonLogPath,
   daemonProfilesInHome,
@@ -420,8 +421,16 @@ async function cmdUpdate(flags) {
     refreshAgentSkillsQuietly();
     return 0;
   }
-  console.log("\nUpdate complete. BetterWright will use BetterChromium.");
-  console.log("Run `betterwright doctor` to confirm (browser: chromium-fork).");
+  if (chromiumForkNeedsSoftwareGpu()) {
+    console.log("Installing the automatic WebGL-compatible backend for this GPU-less Linux host.");
+    const cloakCode = await installCloakBrowser();
+    if (cloakCode !== 0) return cloakCode;
+    console.log("\nUpdate complete. BetterWright will use CloakBrowser automatically on this host.");
+    console.log("Run `betterwright doctor` to confirm (browser: cloak).");
+  } else {
+    console.log("\nUpdate complete. BetterWright will use BetterChromium.");
+    console.log("Run `betterwright doctor` to confirm (browser: chromium-fork).");
+  }
   refreshAgentSkillsQuietly();
   return 0;
 }
@@ -444,6 +453,11 @@ async function cmdSetup(flags, { quiet = false }: any = {}) {
     if (chromium.skipped) {
       console.log(chromium.skipped);
       console.log("Installing the automatic compatibility backend for this platform.");
+      const cloakCode = await installCloakBrowser();
+      if (cloakCode !== 0) return cloakCode;
+      selectedBrowser = "cloak";
+    } else if (chromiumForkNeedsSoftwareGpu()) {
+      console.log("Installing the automatic WebGL-compatible backend for this GPU-less Linux host.");
       const cloakCode = await installCloakBrowser();
       if (cloakCode !== 0) return cloakCode;
       selectedBrowser = "cloak";

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -3,8 +3,8 @@
 //
 //   betterwright                  interactive agent console (type tasks, watch
 //                                 progress, answer the agent's questions)
-//   betterwright setup            install native BetterChromium
-//   betterwright update           refresh native BetterChromium
+//   betterwright setup            install the managed browser for this host
+//   betterwright update           refresh the managed browser for this host
 //   betterwright doctor           report runtime readiness
 //   betterwright run <file|-|-c>  execute a Playwright snippet in the
 //                                 persistent session (tabs/state survive calls)
@@ -412,9 +412,13 @@ async function cmdUpdate(flags) {
   }
   const result = await installChromiumFork({ force: flags.has("--force") });
   if (result.skipped) {
-    console.error(result.skipped);
-    console.error("BetterChromium is unavailable on this host. Use `betterwright setup --cloak-only` for compatibility mode.");
-    return 1;
+    console.log(result.skipped);
+    const cloakCode = await installCloakBrowser();
+    if (cloakCode !== 0) return cloakCode;
+    console.log("\nUpdate complete. BetterWright will use CloakBrowser automatically on this host.");
+    console.log("Run `betterwright doctor` to confirm (browser: cloak).");
+    refreshAgentSkillsQuietly();
+    return 0;
   }
   console.log("\nUpdate complete. BetterWright will use BetterChromium.");
   console.log("Run `betterwright doctor` to confirm (browser: chromium-fork).");
@@ -429,6 +433,7 @@ async function cmdSetup(flags, { quiet = false }: any = {}) {
   }
 
   const cloakOnly = flags.has("--cloak-only");
+  let selectedBrowser = "chromium-fork";
   if (cloakOnly) {
     console.log("Selecting explicit CloakBrowser compatibility mode (--cloak-only).");
     const cloakCode = await installCloakBrowser();
@@ -437,11 +442,12 @@ async function cmdSetup(flags, { quiet = false }: any = {}) {
   } else {
     const chromium = await installChromiumFork({ force: flags.has("--force") });
     if (chromium.skipped) {
-      console.error(chromium.skipped);
-      console.error("Re-run with --cloak-only to explicitly install the compatibility backend.");
-      return 1;
-    }
-    if (!chromium.alreadyInstalled) {
+      console.log(chromium.skipped);
+      console.log("Installing the automatic compatibility backend for this platform.");
+      const cloakCode = await installCloakBrowser();
+      if (cloakCode !== 0) return cloakCode;
+      selectedBrowser = "cloak";
+    } else if (!chromium.alreadyInstalled) {
       console.log("BetterChromium installed as the required browser backend.");
     }
   }
@@ -451,7 +457,7 @@ async function cmdSetup(flags, { quiet = false }: any = {}) {
     console.log(
       cloakOnly
         ? "Doctor should report browser: cloak when BETTERWRIGHT_CHROMIUM_ROOT=off is set."
-        : "Doctor should report browser: chromium-fork.",
+        : `Doctor should report browser: ${selectedBrowser}.`,
     );
   }
   refreshAgentSkillsQuietly();

--- a/docs/attach-mode.md
+++ b/docs/attach-mode.md
@@ -90,14 +90,12 @@ directory under `doctor --json`).
    gives the same facts as the raw `ready` / `browser` fields.
 2. Run `betterwright setup` if the managed binary is missing.
 3. On Linux, confirm a display is present or use `xvfb-run`.
-4. If BetterWright reports that the profile was upgraded by a newer browser,
-   move or remove `$BETTERWRIGHT_HOME/browser/profile` and sign in again. The
-   guard deliberately stops before an older browser build can crash while
-   opening an incompatible profile. The usual cause is switching backends: the
-   Chromium fork and CloakBrowser ship different Chromium versions, so they
-   cannot share one profile. Vault credentials live outside the profile and
-   survive the reset; browser-saved logins do not. To keep both backends,
-   give each its own `BETTERWRIGHT_HOME`.
+4. If BetterWright reports that a compatibility profile was upgraded by a
+   newer browser, move only the path named in that error and sign in again.
+   BetterWright automatically isolates the normal BetterChromium-151-to-Cloak
+   fallback in 1.8.1; the guard remains for an already-upgraded compatibility
+   profile. Vault credentials live outside browser profiles and survive a
+   reset; browser-saved logins do not.
 
 The managed browser reduces common automation false positives; it cannot
 guarantee that a site will accept a session or never present a challenge.

--- a/docs/chromium-fork-patches.md
+++ b/docs/chromium-fork-patches.md
@@ -58,11 +58,12 @@ what real Chrome returns for the non-debug parameters. The WebGL2 context
 inherits the same base implementation, so one interception covers both.
 
 Chromium 151 no longer guarantees an automatic software WebGL fallback. The
-BetterWright launcher checks for an accessible Linux `/dev/dri` render device:
-hardware-capable hosts keep Chromium's native selection, while GPU-less hosts
-select the SwANGLE implementation already shipped in the verified archive.
-This keeps the standard WebGL context, extensions, and pixel readback available
-for the masked identity without opting into `--enable-unsafe-swiftshader`.
+r1 Linux BetterChromium binary cannot initialize its bundled SwANGLE renderer
+when no accessible `/dev/dri` render device exists, leaving WebGL blocked. The
+BetterWright launcher therefore keeps native BetterChromium on GPU-capable
+hosts and automatically selects managed CloakBrowser on GPU-less Linux. That
+backend supplies a working software-rendered WebGL context without opting into
+Chromium's lower-security `--enable-unsafe-swiftshader` switch.
 
 ## 3. Canvas noise
 

--- a/docs/chromium-fork-patches.md
+++ b/docs/chromium-fork-patches.md
@@ -57,6 +57,13 @@ inherit them, which the CDP emulation layer cannot reach.
 what real Chrome returns for the non-debug parameters. The WebGL2 context
 inherits the same base implementation, so one interception covers both.
 
+Chromium 151 no longer guarantees an automatic software WebGL fallback. The
+BetterWright launcher checks for an accessible Linux `/dev/dri` render device:
+hardware-capable hosts keep Chromium's native selection, while GPU-less hosts
+select the SwANGLE implementation already shipped in the verified archive.
+This keeps the standard WebGL context, extensions, and pixel readback available
+for the masked identity without opting into `--enable-unsafe-swiftshader`.
+
 ## 3. Canvas noise
 
 The goal is a canvas hash that is unique to a profile and seed and **stable

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -93,16 +93,19 @@ export BETTERWRIGHT_CHROMIUM_ROOT=/opt/betterwright/chromium
 ```
 
 The profile, runtime, and artifacts under `BETTERWRIGHT_HOME` need their normal
-writable mount. On Linux, binding `/dev/dri` is optional: when no accessible
-render device exists, BetterWright uses the packaged SwANGLE software renderer
-so WebGL remains available. Every network connection still passes through the
-worker's local SOCKS guard.
+writable mount. On Linux, binding an accessible `/dev/dri` render device keeps
+native BetterChromium selected. Without one, BetterWright automatically uses
+CloakBrowser so WebGL remains available; install and bind its cache too (or run
+`betterwright setup` inside the sandbox). Every network connection still passes
+through the worker's local SOCKS guard.
 
 **Profiles are not interchangeable.** Fork and Cloak share
 `$BETTERWRIGHT_HOME/browser/profile` by default. Prefer a dedicated home for
-fork deployments (e.g. `BETTERWRIGHT_HOME=~/.betterwright-fork`). Switching
-`off` after the fork has upgraded that profile requires deleting
-`browser/profile` first.
+fork deployments (e.g. `BETTERWRIGHT_HOME=~/.betterwright-fork`). If Chromium
+151 already upgraded the profile, 1.8.1 preserves it and opens the older Cloak
+backend in a stable nested compatibility profile. Sign-ins in the original
+profile are not copied, but new compatibility-backend sign-ins persist across
+restarts.
 
 **Match timezone/locale to egress** (or enable `geoip` with `upstreamProxy`).
 Nothing in the fork hard-codes Singapore or any other region — pin whatever

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -4,15 +4,16 @@ BetterWright can run the pinned BetterChromium 151 fork while keeping
 its public `run()`, `human.*`, `captcha.*`, snapshot, policy, proxy, and vault
 APIs unchanged. On platforms with a checksum-pinned release asset,
 `betterwright setup` / `betterwright update` download the fork into the
-zero-config discovery root. It is the required/default runtime backend.
-CloakBrowser is selected only through an explicit compatibility opt-out.
+zero-config discovery root. It is the default runtime backend on supported
+hosts. Platforms without a published artifact automatically use the managed
+CloakBrowser compatibility backend.
 
 ## Install / update
 
 ```bash
 betterwright update          # download fork → ~/.betterwright/chromium/
 betterwright update --force  # re-fetch + re-verify even if already present
-betterwright setup           # install BetterChromium
+betterwright setup           # install the managed browser for this host
 betterwright setup --cloak-only  # explicit CloakBrowser compatibility mode
 ```
 
@@ -60,8 +61,9 @@ BetterWright fails closed instead of silently falling back to another browser.
 
 With neither variable set, BetterWright checks the default root
 `~/.betterwright/chromium/` for the current platform's artifact. Found → the
-fork runs with no configuration at all. If it is absent or unsupported, launch
-fails with setup guidance; BetterWright never silently switches browsers.
+fork runs with no configuration at all. If this platform has no published
+artifact, BetterWright automatically uses managed CloakBrowser. If the platform
+is supported but its artifact is missing, launch fails with setup guidance.
 
 ```text
 ~/.betterwright/chromium/
@@ -70,9 +72,31 @@ fails with setup guidance; BetterWright never silently switches browsers.
   win-x64/betterchromium.exe
 ```
 
-This makes mixed fleets trivial: run `betterwright update` (or `setup`) on a host only after its platform archive appears in the pinned manifest; every published platform then picks the native backend with the same configuration. Set
-`BETTERWRIGHT_CHROMIUM_ROOT=off` (or `BETTERWRIGHT_CHROMIUM_PATH=off`) only to
-explicitly select the managed CloakBrowser compatibility backend.
+This makes mixed fleets consistent: `betterwright update` (or `setup`) installs
+BetterChromium wherever the manifest has a matching archive and CloakBrowser
+everywhere else. Set `BETTERWRIGHT_CHROMIUM_ROOT=off` (or
+`BETTERWRIGHT_CHROMIUM_PATH=off`) to explicitly select CloakBrowser on a
+supported host.
+
+## Containers and OS sandboxes
+
+On supported platforms BetterChromium remains fail-closed: a missing native
+artifact does not silently change browser engines. A container or
+`bwrap --clearenv` lane must bind the installed artifact into the sandbox and
+set an absolute path inside that namespace, for example:
+
+```bash
+betterwright setup
+# Bind ~/.betterwright/chromium at /opt/betterwright/chromium in the sandbox,
+# then set this inside the cleared environment:
+export BETTERWRIGHT_CHROMIUM_ROOT=/opt/betterwright/chromium
+```
+
+The profile, runtime, and artifacts under `BETTERWRIGHT_HOME` need their normal
+writable mount. On Linux, binding `/dev/dri` is optional: when no accessible
+render device exists, BetterWright uses the packaged SwANGLE software renderer
+so WebGL remains available. Every network connection still passes through the
+worker's local SOCKS guard.
 
 **Profiles are not interchangeable.** Fork and Cloak share
 `$BETTERWRIGHT_HOME/browser/profile` by default. Prefer a dedicated home for

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,11 +133,11 @@ Whitespace-separated; quote a value that contains spaces
 together.
 
 On Linux without an accessible `/dev/dri` render device, BetterWright selects
-the packaged SwANGLE software GPU automatically so standard WebGL remains
-available. `--disable-software-rasterizer` is reserved because it recreates the
-blocked graphics surface fixed in 1.8.1. `--disable-gpu` remains available as
-a caller-controlled compatibility switch, but it is not recommended for the
-macOS identity profile.
+managed CloakBrowser automatically so standard WebGL remains available.
+`--disable-software-rasterizer` is reserved because it recreates the blocked
+graphics surface fixed in 1.8.1. `--disable-gpu` remains available as a
+caller-controlled compatibility switch, but it is not recommended for either
+managed backend.
 
 Two rules keep this from undermining the managed browser:
 
@@ -160,15 +160,16 @@ country. Pin `timezone` and `locale` to the geography of the IP sites see
 geo-sensitive gates (e.g. Google `/sorry`); the same binary with
 `Asia/Singapore` + `en-US` does not.
 
-**Do not share one profile across backends.** Cloak (~146) and the fork
-(150) both write `$BETTERWRIGHT_HOME/browser/profile`. Once the fork has
-opened that directory, falling back to Cloak fails closed
-(`assertProfileNotNewer`). Use a separate `BETTERWRIGHT_HOME` for fork
-hosts, or delete `browser/profile` when switching backends (saved site
-logins in that profile are lost).
+**Profiles are versioned by backend.** Cloak (~146) cannot open a profile that
+BetterChromium 151 already upgraded. BetterWright 1.8.1 detects that boundary,
+preserves the newer profile, and gives Cloak a stable nested compatibility
+profile. Its sign-ins persist independently; existing BetterChromium cookies
+are intentionally not copied into the older format. A separate
+`BETTERWRIGHT_HOME` remains useful when operators want visibly separate homes.
 
-macOS arm64, Linux x64, and Windows x64 hosts all get the fork artifact with
-one config and no platform branching in deployment code.
+macOS arm64, Linux x64, and Windows x64 hosts all get the fork artifact. Linux
+without an accessible render device also gets Cloak for automatic WebGL-safe
+selection.
 
 ### Idle CPU and page parking
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,24 +60,29 @@ pinned BetterChromium release matches that package. Package updates are intentio
 rather than automatic, so application lockfiles continue to control when a
 new BetterWright version is adopted.
 
-### BetterChromium
+### BetterChromium and cross-platform fallback
 
-On supported Linux x64 and macOS arm64 hosts, native BetterChromium is
-the required/default backend for every session, including screenshots,
+On supported macOS arm64, Linux x64, and Windows x64 hosts, native
+BetterChromium is the default backend for every session, including screenshots,
 credentials, CAPTCHA handling, and live view. `betterwright setup` installs it
 under `~/.betterwright/chromium/`; `betterwright update` refreshes the pinned
 release. There is no silent fallback when it is missing or fails to launch.
 
+When BetterWright does not publish a BetterChromium artifact for the current
+OS/architecture (for example Linux arm64 on Raspberry Pi), `setup` and `update`
+install managed CloakBrowser and the runtime selects it automatically. This is
+platform routing, not error recovery: a missing artifact on a supported host
+still fails closed.
+
 ### Explicit CloakBrowser compatibility mode
 
-CloakBrowser is retained for operators who deliberately opt out of the native
-backend. Run `betterwright setup --cloak-only`, then set
+CloakBrowser is also retained for operators who deliberately opt out of the
+native backend on a supported host. Run `betterwright setup --cloak-only`, then set
 `BETTERWRIGHT_CHROMIUM_ROOT=off` (or `BETTERWRIGHT_CHROMIUM_PATH=off`) when
-launching. BetterWright never selects CloakBrowser merely because native
-Chromium is absent. The wrapper verifies its signed browser release before
-extraction; `CLOAKBROWSER_BINARY_PATH` may point at an official existing binary.
+launching. The wrapper verifies its signed browser release before extraction;
+`CLOAKBROWSER_BINARY_PATH` may point at an official existing binary.
 
-### BetterChromium backend (macOS arm64 / Linux x64)
+### BetterChromium backend (macOS arm64 / Linux x64 / Windows x64)
 
 `betterwright setup` downloads BetterWright's own
 Chromium build into `~/.betterwright/chromium/` (SHA-256 verified from the
@@ -101,7 +106,10 @@ Resolution order:
 2. Zero-config discovery at `~/.betterwright/chromium/<platform>/`: if the
    artifact for this platform exists there, it is used automatically
    (this is what default `setup` populates).
-3. Otherwise launch fails with setup guidance. CloakBrowser is selected only when either variable is explicitly `off`.
+3. If this platform has no published artifact, use managed CloakBrowser
+   automatically. If the platform is supported but its artifact is missing,
+   launch fails with setup guidance. Either variable set to `off` explicitly
+   selects CloakBrowser on any platform.
 
 Force the managed path even with an artifact installed:
 
@@ -112,24 +120,32 @@ export BETTERWRIGHT_CHROMIUM_ROOT=off
 ### Extra Chromium switches
 
 BetterWright builds its own launch arguments, but a host can append switches the
-managed list has no opinion on. The common case is a server with no GPU, where
-Chromium otherwise runs a SwiftShader `gpu-process` that burns a fraction of a
-core for the life of the browser, compositing frames nothing will display:
+managed list has no opinion on. For example, a host can cap Chromium's on-disk
+HTTP cache without changing browser identity or network routing:
 
 ```bash
-export BETTERWRIGHT_CHROMIUM_ARGS="--disable-gpu --disable-software-rasterizer"
+export BETTERWRIGHT_CHROMIUM_ARGS="--disk-cache-size=104857600"
 ```
 
 Whitespace-separated; quote a value that contains spaces
 (`--host-rules="MAP * 127.0.0.1"`). The same list is settable in code as
-`chromiumArgs: ["--disable-gpu"]`, and both sources apply together.
+`chromiumArgs: ["--disk-cache-size=104857600"]`, and both sources apply
+together.
+
+On Linux without an accessible `/dev/dri` render device, BetterWright selects
+the packaged SwANGLE software GPU automatically so standard WebGL remains
+available. `--disable-software-rasterizer` is reserved because it recreates the
+blocked graphics surface fixed in 1.8.1. `--disable-gpu` remains available as
+a caller-controlled compatibility switch, but it is not recommended for the
+macOS identity profile.
 
 Two rules keep this from undermining the managed browser:
 
 - **Reserved switches are rejected** with a `TypeError` naming the supported
   alternative — proxy selection (`--proxy-server`, `--no-proxy-server`, …),
   remote debugging, `--user-data-dir` / `--profile-directory`, and the identity
-  family (`--fingerprint*`, `--lang`, `--bw-timezone`, `--headless`). These are
+  family (`--fingerprint*`, `--lang`, `--bw-timezone`, `--headless`), plus
+  `--disable-software-rasterizer`. These are
   the switches that decide where traffic goes, who can drive the browser, which
   profile is opened, and what identity is presented.
 - **Duplicates are dropped, not appended.** Chromium resolves a repeated switch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/chromium-args.ts
+++ b/src/chromium-args.ts
@@ -4,10 +4,9 @@
 // proxy boundary, locale/timezone/platform masking) and that list is
 // load-bearing: it is what keeps the managed browser's identity coherent and
 // every connection on the guard proxy. But it left no room for the
-// host-specific switches that have nothing to do with identity. The motivating
-// case is `--disable-gpu` on a GPU-less server, where Chromium otherwise parks
-// a SwiftShader gpu-process on a fraction of a core for the whole life of a
-// lease, compositing frames nothing will ever display.
+// host-specific switches that have nothing to do with identity. GPU-less Linux
+// hosts are handled by BetterWright's managed SwANGLE selection so WebGL stays
+// available; callers do not need to disable the software renderer themselves.
 //
 // PRECEDENCE. Chromium's base::CommandLine parses argv left to right into a
 // map, so a repeated switch is won by the LAST occurrence. Appending caller
@@ -54,6 +53,10 @@ const RESERVED = Object.freeze({
   // Headless is resolved from the `headless` option and must not desync from
   // the viewport and window-geometry decisions made alongside it.
   "--headless": "use the `headless` option",
+  // GPU-less Linux uses the packaged software renderer to retain the standard
+  // WebGL surface. Disabling it recreates issue #109's blocked-GPU identity.
+  "--disable-software-rasterizer":
+    "BetterWright manages the software renderer on GPU-less hosts",
 });
 
 const RESERVED_PREFIXES = Object.freeze([

--- a/src/chromium-args.ts
+++ b/src/chromium-args.ts
@@ -5,8 +5,8 @@
 // load-bearing: it is what keeps the managed browser's identity coherent and
 // every connection on the guard proxy. But it left no room for the
 // host-specific switches that have nothing to do with identity. GPU-less Linux
-// hosts are handled by BetterWright's managed SwANGLE selection so WebGL stays
-// available; callers do not need to disable the software renderer themselves.
+// hosts use the managed CloakBrowser compatibility backend so WebGL stays
+// available.
 //
 // PRECEDENCE. Chromium's base::CommandLine parses argv left to right into a
 // map, so a repeated switch is won by the LAST occurrence. Appending caller
@@ -53,10 +53,10 @@ const RESERVED = Object.freeze({
   // Headless is resolved from the `headless` option and must not desync from
   // the viewport and window-geometry decisions made alongside it.
   "--headless": "use the `headless` option",
-  // GPU-less Linux uses the packaged software renderer to retain the standard
-  // WebGL surface. Disabling it recreates issue #109's blocked-GPU identity.
+  // Every automatically selected backend must retain a working WebGL surface.
+  // Disabling its software fallback recreates issue #109's blocked-GPU state.
   "--disable-software-rasterizer":
-    "BetterWright manages the software renderer on GPU-less hosts",
+    "the managed browser must retain its WebGL software fallback",
 });
 
 const RESERVED_PREFIXES = Object.freeze([

--- a/src/chromium-fork.ts
+++ b/src/chromium-fork.ts
@@ -102,20 +102,19 @@ export function chromiumForkPlatformSupported({
  *
  * A host for which no artifact is published uses CloakBrowser automatically,
  * matching the compatibility behavior BetterWright had before 1.8.0. A
- * supported host with a missing artifact stays unavailable so a broken native
- * install or sandbox mount cannot silently downgrade. Explicit paths and roots
- * remain strict in resolveChromiumForkBinary().
+ * supported Linux host without an accessible render device also uses Cloak so
+ * it retains a working WebGL surface. A supported host with a missing artifact
+ * stays unavailable so a broken native install or sandbox mount cannot silently
+ * downgrade. Explicit paths and roots remain strict during resolution; Linux
+ * GPU capability still decides whether that resolved binary is safe to launch.
  */
 export function selectManagedBrowserBackend({
   chromiumFork = null,
   env = process.env,
   platform = process.platform,
   arch = process.arch,
+  softwareGpu = false,
 } = {}) {
-  if (chromiumFork) {
-    return { browser: "chromium-fork", cloakFallback: null };
-  }
-
   const explicitPath = configuredValue(env.BETTERWRIGHT_CHROMIUM_PATH);
   const explicitRoot = configuredValue(env.BETTERWRIGHT_CHROMIUM_ROOT);
   if (
@@ -123,6 +122,13 @@ export function selectManagedBrowserBackend({
     explicitRoot.toLowerCase() === "off"
   ) {
     return { browser: "cloak", cloakFallback: "explicit" };
+  }
+
+  if (chromiumFork) {
+    if (softwareGpu) {
+      return { browser: "cloak", cloakFallback: "gpu-unavailable" };
+    }
+    return { browser: "chromium-fork", cloakFallback: null };
   }
 
   // A custom path/root is resolved strictly before this selector runs. Never

--- a/src/chromium-fork.ts
+++ b/src/chromium-fork.ts
@@ -89,6 +89,54 @@ function configuredValue(value) {
   return String(value || "").trim();
 }
 
+/** Whether BetterWright publishes a native BetterChromium artifact here. */
+export function chromiumForkPlatformSupported({
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  return Object.hasOwn(PLATFORM_LAYOUT, `${platform}-${arch}`);
+}
+
+/**
+ * Select the managed browser after native-binary resolution.
+ *
+ * A host for which no artifact is published uses CloakBrowser automatically,
+ * matching the compatibility behavior BetterWright had before 1.8.0. A
+ * supported host with a missing artifact stays unavailable so a broken native
+ * install or sandbox mount cannot silently downgrade. Explicit paths and roots
+ * remain strict in resolveChromiumForkBinary().
+ */
+export function selectManagedBrowserBackend({
+  chromiumFork = null,
+  env = process.env,
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  if (chromiumFork) {
+    return { browser: "chromium-fork", cloakFallback: null };
+  }
+
+  const explicitPath = configuredValue(env.BETTERWRIGHT_CHROMIUM_PATH);
+  const explicitRoot = configuredValue(env.BETTERWRIGHT_CHROMIUM_ROOT);
+  if (
+    explicitPath.toLowerCase() === "off" ||
+    explicitRoot.toLowerCase() === "off"
+  ) {
+    return { browser: "cloak", cloakFallback: "explicit" };
+  }
+
+  // A custom path/root is resolved strictly before this selector runs. Never
+  // interpret an invalid explicit configuration as permission to fall back.
+  if (explicitPath || explicitRoot) {
+    return { browser: "unavailable", cloakFallback: null };
+  }
+
+  if (!chromiumForkPlatformSupported({ platform, arch })) {
+    return { browser: "cloak", cloakFallback: "unsupported-platform" };
+  }
+  return { browser: "unavailable", cloakFallback: null };
+}
+
 /** Where deployments drop the fork artifact for zero-config discovery. */
 export function defaultChromiumForkRoot({ home = os.homedir() } = {}) {
   return path.join(home, ".betterwright", "chromium");
@@ -101,7 +149,8 @@ export function defaultChromiumForkRoot({ home = os.homedir() } = {}) {
  *  1. BETTERWRIGHT_CHROMIUM_PATH / BETTERWRIGHT_CHROMIUM_ROOT (strict: a
  *     configured-but-missing binary is an error).
  *  2. The default root (~/.betterwright/chromium) — if the artifact for this
- *     platform exists there, use it silently. Platforms without a shipped artifact report the native backend as missing.
+ *     platform exists there, use it silently. Backend selection routes hosts
+ *     without a published artifact to managed CloakBrowser.
  *  3. Either variable set to "off" forces the managed CloakBrowser path.
  */
 export function resolveChromiumForkBinary({

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -9,8 +9,8 @@
 
 export const COMMAND_SUMMARIES = [
   ["init", "guided first-time setup — browser, agent wiring, verification"],
-  ["setup", "download native BetterChromium"],
-  ["update", "download or refresh native BetterChromium"],
+  ["setup", "download the managed browser for this host"],
+  ["update", "download or refresh the managed browser for this host"],
   ["doctor", "check that everything needed is installed and reachable"],
   ["run", "run one Playwright snippet in the persistent session"],
   ["repl", "run blank-line-separated snippets from stdin"],
@@ -54,27 +54,26 @@ Options:
   --yes            accept every default; never prompt (for scripts and CI)
   --skip-browser   do not download or verify the browser
   --skip-agents    do not touch any agent configuration
-  --cloak-only     explicitly use CloakBrowser compatibility mode
+  --cloak-only     force CloakBrowser compatibility mode
 
 Safe to re-run: it reports what is already done and changes only what is not.`,
 
   setup: `Usage: betterwright setup [options]
 
-Download native BetterChromium, the required/default backend on supported
-Linux x64 and macOS arm64 hosts. CloakBrowser is available only as an explicit
-compatibility opt-out and is never selected as a silent fallback.
+Download native BetterChromium, the default backend on supported macOS arm64,
+Linux x64, and Windows x64 hosts. On other platforms, setup automatically
+installs the managed CloakBrowser compatibility backend.
 
 Options:
-  --cloak-only   install CloakBrowser compatibility mode instead of BetterChromium
+  --cloak-only   force CloakBrowser compatibility mode instead of BetterChromium
   --force        re-download the managed browser even when already present
 
 Also refreshes installed agent skill files. Run \`betterwright doctor\` afterwards.`,
 
   update: `Usage: betterwright update [options]
 
-Download or refresh native BetterChromium. This command fails on hosts
-without a native artifact; use \`betterwright setup --cloak-only\` only when you
-intend to opt out to the compatibility backend.
+Download or refresh the managed browser: native BetterChromium when a pinned
+artifact is published for this host, otherwise CloakBrowser compatibility mode.
 
 Options:
   --force   re-download even if the pinned version is already installed`,

--- a/src/client.ts
+++ b/src/client.ts
@@ -302,8 +302,8 @@ export class BetterWright {
    *   Silicon); the managed CloakBrowser path defaults to the host platform.
    * @param {string[]} [options.chromiumArgs] extra Chromium switches appended
    *   to the managed launch arguments, for host-level tuning the managed list
-   *   has no opinion on — `["--disable-gpu", "--disable-software-rasterizer"]`
-   *   on a GPU-less server being the motivating case. Also settable per host
+   *   has no opinion on. GPU-less Linux hosts automatically use the packaged
+   *   software renderer so WebGL stays available. Also settable per host
    *   via `BETTERWRIGHT_CHROMIUM_ARGS` (whitespace-separated); both apply.
    *   Switches BetterWright owns — proxy, remote debugging, profile directory,
    *   and the `--fingerprint*`/locale/timezone identity family — are rejected

--- a/src/cloak.ts
+++ b/src/cloak.ts
@@ -4,6 +4,18 @@ import { pathToFileURL } from "node:url";
 
 let cloakModulePromise = null;
 
+function versionMajor(value) {
+  return Number.parseInt(String(value || "").split(".")[0], 10);
+}
+
+function storedProfileVersion(profileDir, readFileSync = fs.readFileSync) {
+  try {
+    return readFileSync(path.join(profileDir, "Last Version"), "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Guard against opening a profile that a newer Chromium already upgraded.
  * Chromium records its version in a "Last Version" file and does not downgrade
@@ -15,16 +27,11 @@ let cloakModulePromise = null;
  * unparseable version, or a fresh profile, is a no-op.
  */
 export function assertProfileNotNewer(profileDir, runningVersion) {
-  const major = (value) => Number.parseInt(String(value || "").split(".")[0], 10);
-  const runningMajor = major(runningVersion);
+  const runningMajor = versionMajor(runningVersion);
   if (!Number.isFinite(runningMajor)) return;
-  let stored;
-  try {
-    stored = fs.readFileSync(path.join(profileDir, "Last Version"), "utf8").trim();
-  } catch {
-    return; /* fresh profile, or Chromium has not written the marker yet */
-  }
-  const profileMajor = major(stored);
+  const stored = storedProfileVersion(profileDir);
+  if (!stored) return; /* fresh profile, or Chromium has not written the marker yet */
+  const profileMajor = versionMajor(stored);
   if (Number.isFinite(profileMajor) && profileMajor > runningMajor) {
     throw new Error(
       `Browser profile at ${profileDir} was upgraded by a newer Chromium ` +
@@ -37,6 +44,37 @@ export function assertProfileNotNewer(profileDir, runningVersion) {
         "or point BETTERWRIGHT_HOME at a separate directory per backend.",
     );
   }
+}
+
+/**
+ * Keep a lower-version compatibility backend away from a profile upgraded by
+ * newer Chromium. The original profile is preserved in place; the stable
+ * nested path gives the compatibility backend persistence across restarts.
+ */
+export function compatibleBrowserProfile(profileDir, runningVersion, {
+  readFileSync = fs.readFileSync,
+} = {}) {
+  const runningMajor = versionMajor(runningVersion);
+  const stored = storedProfileVersion(profileDir, readFileSync);
+  const profileMajor = versionMajor(stored);
+  if (
+    !Number.isFinite(runningMajor) ||
+    !Number.isFinite(profileMajor) ||
+    profileMajor <= runningMajor
+  ) {
+    return { profileDir, warning: null };
+  }
+  const isolated = path.join(
+    profileDir,
+    `.betterwright-compat-chromium-${runningMajor}`,
+  );
+  return {
+    profileDir: isolated,
+    warning:
+      `The existing browser profile was upgraded by Chromium ${stored}; ` +
+      `the Chromium ${runningVersion} compatibility backend is using ${isolated} ` +
+      "instead. The original profile and its logins were preserved.",
+  };
 }
 
 function isFreeBinary(binaryInfo, platformPrefix, versionPrefix) {
@@ -104,21 +142,10 @@ export function chromiumForkNeedsSoftwareGpu({
   return true;
 }
 
-/** Native fork arguments: guarded WebRTC, graphics, and fingerprint seed. */
-export function managedChromiumForkArgs(
-  fingerprintSeed,
-  { softwareGpu = chromiumForkNeedsSoftwareGpu() }: any = {},
-) {
+/** Native fork arguments: guarded WebRTC and a stable fingerprint seed. */
+export function managedChromiumForkArgs(fingerprintSeed) {
   return [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
-    // Chromium 151 no longer guarantees automatic software WebGL fallback.
-    // On Linux hosts without an accessible DRI device, explicitly use the
-    // packaged SwANGLE renderer so ordinary WebGL remains available. This is
-    // the normal ANGLE GL driver, not the lower-security
-    // --enable-unsafe-swiftshader WebGL fallback.
-    ...(softwareGpu
-      ? ["--use-gl=angle", "--use-angle=swiftshader"]
-      : []),
     // Chromium 151 otherwise keeps a spare renderer resident beside the page
     // and Top Chrome WebUI renderers. Two is a soft ceiling: Chromium still
     // creates site-isolated renderers when security requires them, but it does

--- a/src/cloak.ts
+++ b/src/cloak.ts
@@ -78,10 +78,47 @@ export function managedCloakArgs(fingerprintSeed) {
   ];
 }
 
-/** Native fork arguments: WebRTC proxy boundary plus optional fingerprint seed. */
-export function managedChromiumForkArgs(fingerprintSeed) {
+/** Whether Linux lacks an accessible hardware-rendering device. */
+export function chromiumForkNeedsSoftwareGpu({
+  platform = process.platform,
+  readdirSync = fs.readdirSync,
+  accessSync = fs.accessSync,
+} = {}) {
+  if (platform !== "linux") return false;
+  let devices = [];
+  try {
+    devices = readdirSync("/dev/dri")
+      .filter((name) => /^(?:renderD|card)\d+$/.test(name))
+      .map((name) => path.join("/dev/dri", name));
+  } catch {
+    return true;
+  }
+  for (const device of devices) {
+    try {
+      accessSync(device, fs.constants.R_OK | fs.constants.W_OK);
+      return false;
+    } catch {
+      /* try the next DRI device */
+    }
+  }
+  return true;
+}
+
+/** Native fork arguments: guarded WebRTC, graphics, and fingerprint seed. */
+export function managedChromiumForkArgs(
+  fingerprintSeed,
+  { softwareGpu = chromiumForkNeedsSoftwareGpu() }: any = {},
+) {
   return [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+    // Chromium 151 no longer guarantees automatic software WebGL fallback.
+    // On Linux hosts without an accessible DRI device, explicitly use the
+    // packaged SwANGLE renderer so ordinary WebGL remains available. This is
+    // the normal ANGLE GL driver, not the lower-security
+    // --enable-unsafe-swiftshader WebGL fallback.
+    ...(softwareGpu
+      ? ["--use-gl=angle", "--use-angle=swiftshader"]
+      : []),
     // Chromium 151 otherwise keeps a spare renderer resident beside the page
     // and Top Chrome WebUI renderers. Two is a soft ceiling: Chromium still
     // creates site-isolated renderers when security requires them, but it does

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -14,6 +14,7 @@ import { loadCodexAuth, loadGrokAuth } from "./auth.js";
 import {
   BETTERWRIGHT_CHROMIUM_VERSION,
   resolveChromiumForkBinary,
+  selectManagedBrowserBackend,
 } from "./chromium-fork.js";
 import { forkFontsDir } from "./fork-identity.js";
 import { defaultHome } from "./home.js";
@@ -116,11 +117,8 @@ export async function doctorReport() {
   } catch (error) {
     chromiumForkError = error instanceof Error ? error.message : String(error);
   }
-  const chromiumOptOut = [
-    process.env.BETTERWRIGHT_CHROMIUM_PATH,
-    process.env.BETTERWRIGHT_CHROMIUM_ROOT,
-  ].some((value) => String(value || "").trim().toLowerCase() === "off");
-  const browser = chromiumFork ? "chromium-fork" : chromiumOptOut ? "cloak" : "unavailable";
+  const browserSelection = selectManagedBrowserBackend({ chromiumFork });
+  const browser = chromiumForkError ? "unavailable" : browserSelection.browser;
   const chromiumForkFonts = chromiumFork ? forkFontsDir(chromiumFork) : null;
   const chromiumForkFontsWarning = missingForkFontsWarning({
     chromiumFork,
@@ -129,7 +127,7 @@ export async function doctorReport() {
   const ready =
     workerOk &&
     version === PINNED_PLAYWRIGHT_VERSION &&
-    Boolean(chromiumFork || (chromiumOptOut && cloakOk)) &&
+    Boolean(chromiumFork || (browser === "cloak" && cloakOk)) &&
     !chromiumForkError;
   return {
     node: process.execPath,
@@ -148,6 +146,7 @@ export async function doctorReport() {
     chromium_fork: chromiumFork,
     chromium_fork_version: chromiumFork ? BETTERWRIGHT_CHROMIUM_VERSION : null,
     chromium_fork_error: chromiumForkError,
+    cloak_fallback: browserSelection.cloakFallback,
     chromium_fork_fonts: chromiumForkFonts,
     chromium_fork_fonts_warning: chromiumForkFontsWarning,
     stealth_driver: stealth,
@@ -330,12 +329,17 @@ export function doctorChecks(
       "Run `betterwright setup`, or unset BETTERWRIGHT_CHROMIUM_PATH/ROOT.",
     );
   } else if (report.browser === "cloak") {
+    const automatic = report.cloak_fallback === "unsupported-platform";
     add(
       "Browser",
       "BetterChromium",
       "warn",
-      "explicitly disabled — using CloakBrowser compatibility mode",
-      "Run `betterwright setup` and unset BETTERWRIGHT_CHROMIUM_PATH/ROOT to restore the default backend.",
+      automatic
+        ? "no artifact is published for this platform — using CloakBrowser compatibility mode"
+        : "explicitly disabled — using CloakBrowser compatibility mode",
+      automatic
+        ? null
+        : "Run `betterwright setup` and unset BETTERWRIGHT_CHROMIUM_PATH/ROOT to restore the default backend.",
     );
   } else {
     add(
@@ -353,9 +357,19 @@ export function doctorChecks(
     report.cloakbrowser_ok
       ? `${report.cloakbrowser_binary_version} (${report.cloakbrowser_binary_tier})` +
         (report.cloakbrowser_binary ? ` — ${report.cloakbrowser_binary}` : "") +
-        (report.browser === "cloak" ? " — explicit compatibility backend" : " — compatibility backend available")
-      : "binary not installed (optional compatibility backend)",
-    report.cloakbrowser_ok ? null : "Optional: run `betterwright setup --cloak-only` to download it.",
+        (report.browser === "cloak"
+          ? report.cloak_fallback === "unsupported-platform"
+            ? " — automatic compatibility backend"
+            : " — explicit compatibility backend"
+          : " — compatibility backend available")
+      : report.browser === "cloak"
+        ? "binary not installed (required compatibility backend on this platform)"
+        : "binary not installed (optional compatibility backend)",
+    report.cloakbrowser_ok
+      ? null
+      : report.browser === "cloak"
+        ? "Run `betterwright setup` to download the compatibility backend."
+        : "Optional: run `betterwright setup --cloak-only` to download it.",
   );
   add("Browser", "In use", report.ready ? "ok" : "fail", report.browser, report.ready ? null : "Run `betterwright setup`.");
   // Optional isolated-world stealth driver. Reported here (not only in --json)

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -16,6 +16,7 @@ import {
   resolveChromiumForkBinary,
   selectManagedBrowserBackend,
 } from "./chromium-fork.js";
+import { chromiumForkNeedsSoftwareGpu } from "./cloak.js";
 import { forkFontsDir } from "./fork-identity.js";
 import { defaultHome } from "./home.js";
 import { optionalPeerAvailable } from "./optional-peer.js";
@@ -117,7 +118,10 @@ export async function doctorReport() {
   } catch (error) {
     chromiumForkError = error instanceof Error ? error.message : String(error);
   }
-  const browserSelection = selectManagedBrowserBackend({ chromiumFork });
+  const browserSelection = selectManagedBrowserBackend({
+    chromiumFork,
+    softwareGpu: chromiumForkNeedsSoftwareGpu(),
+  });
   const browser = chromiumForkError ? "unavailable" : browserSelection.browser;
   const chromiumForkFonts = chromiumFork ? forkFontsDir(chromiumFork) : null;
   const chromiumForkFontsWarning = missingForkFontsWarning({
@@ -127,7 +131,11 @@ export async function doctorReport() {
   const ready =
     workerOk &&
     version === PINNED_PLAYWRIGHT_VERSION &&
-    Boolean(chromiumFork || (browser === "cloak" && cloakOk)) &&
+    Boolean(
+      browser === "chromium-fork"
+        ? chromiumFork
+        : browser === "cloak" && cloakOk,
+    ) &&
     !chromiumForkError;
   return {
     node: process.execPath,
@@ -310,7 +318,15 @@ export function doctorChecks(
   );
   add("Runtime", "Worker", report.worker_ok ? "ok" : "fail", report.worker, report.worker_ok ? null : "The package looks incomplete — reinstall betterwright.");
 
-  if (report.chromium_fork) {
+  if (report.browser === "cloak" && report.cloak_fallback === "gpu-unavailable") {
+    add(
+      "Browser",
+      "BetterChromium",
+      "warn",
+      "installed, but no accessible Linux render device was found — using CloakBrowser compatibility mode so WebGL remains available",
+      "Optional: expose a read/write /dev/dri render device to use native BetterChromium.",
+    );
+  } else if (report.chromium_fork) {
     add(
       "Browser",
       "BetterChromium",
@@ -353,12 +369,18 @@ export function doctorChecks(
   add(
     "Browser",
     "CloakBrowser",
-    report.cloakbrowser_ok ? "ok" : report.chromium_fork ? "warn" : "fail",
+    report.cloakbrowser_ok
+      ? "ok"
+      : report.browser === "cloak"
+        ? "fail"
+        : report.chromium_fork
+          ? "warn"
+          : "fail",
     report.cloakbrowser_ok
       ? `${report.cloakbrowser_binary_version} (${report.cloakbrowser_binary_tier})` +
         (report.cloakbrowser_binary ? ` — ${report.cloakbrowser_binary}` : "") +
         (report.browser === "cloak"
-          ? report.cloak_fallback === "unsupported-platform"
+          ? ["unsupported-platform", "gpu-unavailable"].includes(report.cloak_fallback)
             ? " — automatic compatibility backend"
             : " — explicit compatibility backend"
           : " — compatibility backend available")

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,6 +44,7 @@ import {
   BETTERWRIGHT_CHROMIUM_VERSION,
   chromiumForkContextOptions,
   resolveChromiumForkBinary,
+  selectManagedBrowserBackend,
 } from "./chromium-fork.js";
 import {
   assertProfileNotNewer,
@@ -1566,22 +1567,22 @@ async function ensureBrowser(config) {
     guardProxy.setUpstream(upstream);
 
     const forkBinary = resolveChromiumForkBinary();
-    const chromiumOptOut = [
-      process.env.BETTERWRIGHT_CHROMIUM_PATH,
-      process.env.BETTERWRIGHT_CHROMIUM_ROOT,
-    ].some((value) => String(value || "").trim().toLowerCase() === "off");
-    if (!forkBinary && !chromiumOptOut) {
+    const browserSelection = selectManagedBrowserBackend({
+      chromiumFork: forkBinary,
+    });
+    if (browserSelection.browser === "unavailable") {
       throw new Error(
         "BetterChromium is required but not installed. Run `betterwright setup`, " +
           "or explicitly select CloakBrowser with `betterwright setup --cloak-only` " +
-          "and BETTERWRIGHT_CHROMIUM_ROOT=off.",
+          "and BETTERWRIGHT_CHROMIUM_ROOT=off. Hosts without a published " +
+          "BetterChromium artifact use CloakBrowser automatically.",
       );
     }
-      const args = forkBinary
-        ? managedChromiumForkArgs(
-            fingerprintSeedForProfile(profileLock.profileDir),
-          )
-        : managedCloakArgs(fingerprintSeedForProfile(profileLock.profileDir));
+    const args = forkBinary
+      ? managedChromiumForkArgs(
+          fingerprintSeedForProfile(profileLock.profileDir),
+        )
+      : managedCloakArgs(fingerprintSeedForProfile(profileLock.profileDir));
 
     // Cloaking V2: one coherent identity across the Chromium and network
     // layers. geoip resolves the locale/timezone to match the egress
@@ -1643,8 +1644,7 @@ async function ensureBrowser(config) {
       if (fonts) forkEnv = { ...process.env, FONTCONFIG_FILE: fonts.confPath };
     }
     // Caller-supplied switches go last, after every argument BetterWright
-    // derives, so a host can tune things the managed list has no opinion on
-    // (`--disable-gpu` on a GPU-less server being the motivating case).
+    // derives, so a host can tune things the managed list has no opinion on.
     // Switches that collide with a managed one are dropped rather than
     // appended: Chromium resolves duplicates last-wins, so appending would
     // override BetterWright's value instead of losing to it. See

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -48,7 +48,9 @@ import {
 } from "./chromium-fork.js";
 import {
   assertProfileNotNewer,
+  chromiumForkNeedsSoftwareGpu,
   cloakBinaryInfo,
+  compatibleBrowserProfile,
   launchCloakPersistentContext,
   managedChromiumForkArgs,
   managedCloakArgs,
@@ -1540,6 +1542,26 @@ async function ensureBrowser(config) {
   launchPromise = (async () => {
     mkdirPrivate(launchConfig.artifactsDir);
 
+    const forkBinary = resolveChromiumForkBinary();
+    const browserSelection = selectManagedBrowserBackend({
+      chromiumFork: forkBinary,
+      softwareGpu: chromiumForkNeedsSoftwareGpu(),
+    });
+    if (browserSelection.browser === "unavailable") {
+      throw new Error(
+        "BetterChromium is required but not installed. Run `betterwright setup`, " +
+          "or explicitly select CloakBrowser with `betterwright setup --cloak-only` " +
+          "and BETTERWRIGHT_CHROMIUM_ROOT=off. Hosts without a published " +
+          "BetterChromium artifact, and GPU-less Linux hosts, use CloakBrowser automatically.",
+      );
+    }
+    const activeForkBinary =
+      browserSelection.browser === "chromium-fork" ? forkBinary : null;
+    let binaryInfo = null;
+    if (!activeForkBinary) {
+      binaryInfo = await cloakBinaryInfo();
+    }
+
     mkdirPrivate(launchConfig.runtimeDir);
     profileLock = acquireProfileLock(
       launchConfig.profileDir,
@@ -1547,7 +1569,14 @@ async function ensureBrowser(config) {
     );
     startProfileLockHeartbeat();
     profileMode = profileLock.ephemeral ? "ephemeral" : "persistent";
-    profileWarning = profileLock.warning;
+    const compatible = activeForkBinary
+      ? { profileDir: profileLock.profileDir, warning: null }
+      : compatibleBrowserProfile(profileLock.profileDir, binaryInfo?.version);
+    const browserProfileDir = compatible.profileDir;
+    mkdirPrivate(browserProfileDir);
+    profileWarning = [compatible.warning, profileLock.warning]
+      .filter(Boolean)
+      .join(" ");
     transportProxyPort = await guardProxy.ensure();
 
     const headless = launchConfig.headless !== false;
@@ -1566,23 +1595,11 @@ async function ensureBrowser(config) {
     }
     guardProxy.setUpstream(upstream);
 
-    const forkBinary = resolveChromiumForkBinary();
-    const browserSelection = selectManagedBrowserBackend({
-      chromiumFork: forkBinary,
-    });
-    if (browserSelection.browser === "unavailable") {
-      throw new Error(
-        "BetterChromium is required but not installed. Run `betterwright setup`, " +
-          "or explicitly select CloakBrowser with `betterwright setup --cloak-only` " +
-          "and BETTERWRIGHT_CHROMIUM_ROOT=off. Hosts without a published " +
-          "BetterChromium artifact use CloakBrowser automatically.",
-      );
-    }
-    const args = forkBinary
+    const args = activeForkBinary
       ? managedChromiumForkArgs(
-          fingerprintSeedForProfile(profileLock.profileDir),
+          fingerprintSeedForProfile(browserProfileDir),
         )
-      : managedCloakArgs(fingerprintSeedForProfile(profileLock.profileDir));
+      : managedCloakArgs(fingerprintSeedForProfile(browserProfileDir));
 
     // Cloaking V2: one coherent identity across the Chromium and network
     // layers. geoip resolves the locale/timezone to match the egress
@@ -1609,7 +1626,7 @@ async function ensureBrowser(config) {
         timezone: identity.timezone || undefined,
         platform: launchConfig.platform || undefined,
         headedInvisible: launchConfig.headedInvisible === true,
-        nativeFork: Boolean(forkBinary),
+        nativeFork: Boolean(activeForkBinary),
       });
       args.push(...v2Plan.args);
     }
@@ -1620,7 +1637,7 @@ async function ensureBrowser(config) {
     // geometry + DPR flags make screen.* coherent in headless; UA, UA-CH and navigator.platform are owned by the native startup profile in every process.
     let forkIdentity = null;
     if (
-      forkBinary &&
+      activeForkBinary &&
       v2Plan &&
       v2Plan.identity.platform === "macos" &&
       launchConfig.platform !== "linux" &&
@@ -1638,7 +1655,7 @@ async function ensureBrowser(config) {
     let forkEnv = null;
     if (forkIdentity) {
       const fonts = prepareForkFontsConfig({
-        forkBinary,
+        forkBinary: activeForkBinary,
         runtimeDir: launchConfig.runtimeDir,
       });
       if (fonts) forkEnv = { ...process.env, FONTCONFIG_FILE: fonts.confPath };
@@ -1667,19 +1684,19 @@ async function ensureBrowser(config) {
       bypass: "<-loopback>",
     };
 
-    if (forkBinary) {
+    if (activeForkBinary) {
       if (!profileLock.ephemeral) {
         assertProfileNotNewer(
-          profileLock.profileDir,
+          browserProfileDir,
           BETTERWRIGHT_CHROMIUM_VERSION,
         );
       }
       useSetContentCompatibility = true;
       const { chromium } = await import("playwright-core");
       browserContext = await chromium.launchPersistentContext(
-        profileLock.profileDir,
+        browserProfileDir,
         {
-          executablePath: forkBinary,
+          executablePath: activeForkBinary,
           headless,
           ...chromiumForkContextOptions(),
           proxy,
@@ -1700,9 +1717,8 @@ async function ensureBrowser(config) {
       // not appear to change hardware on every restart. Its blanket humanizer is
       // intentionally disabled; BetterWright's frame-safe human helpers remain
       // the only model-facing interaction layer.
-      const binaryInfo = await cloakBinaryInfo();
       if (!profileLock.ephemeral) {
-        assertProfileNotNewer(profileLock.profileDir, binaryInfo?.version);
+        assertProfileNotNewer(browserProfileDir, binaryInfo?.version);
       }
       // Patched Cloak builds can report stale lifecycle events to Playwright's
       // protocol-level setContent implementation. The document-write fallback
@@ -1710,7 +1726,7 @@ async function ensureBrowser(config) {
       useSetContentCompatibility = true;
       const viewport = managedCloakViewport(binaryInfo, headless);
       browserContext = await launchCloakPersistentContext({
-        userDataDir: profileLock.profileDir,
+        userDataDir: browserProfileDir,
         headless,
         humanize: false,
         ...(viewport ? { viewport } : {}),

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -26,6 +26,12 @@ if (!ready && process.env.BETTERWRIGHT_REQUIRE_BROWSER) {
 const opts = {
   skip: ready ? false : `browser runtime not ready (doctor browser: ${browserStatus.browser})`,
 };
+const nativeForkOpts = {
+  skip:
+    browserStatus.browser === "chromium-fork"
+      ? false
+      : `requires BetterChromium (doctor browser: ${browserStatus.browser})`,
+};
 
 function tempHome() {
   return makeTempDir("betterwright-test-");
@@ -98,6 +104,39 @@ test("navigate and read the title", opts, async () => {
     const result = await bw.run("await page.goto('https://example.com'); return page.title()");
     assert.equal(result.ok, true, result.error);
     assert.equal(result.result, "Example Domain");
+  } finally {
+    await bw.close();
+  }
+});
+
+test("BetterChromium keeps WebGL available with its native identity", nativeForkOpts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`return await page.evaluate(() => {
+      const canvas = document.createElement("canvas");
+      canvas.width = 2;
+      canvas.height = 2;
+      const gl = canvas.getContext("webgl");
+      if (!gl) return { available: false };
+      gl.clearColor(0.25, 0.5, 0.75, 1);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      const pixels = new Uint8Array(4);
+      gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+      const debug = gl.getExtension("WEBGL_debug_renderer_info");
+      return {
+        available: true,
+        vendor: debug ? gl.getParameter(debug.UNMASKED_VENDOR_WEBGL) : null,
+        renderer: debug ? gl.getParameter(debug.UNMASKED_RENDERER_WEBGL) : null,
+        extensions: gl.getSupportedExtensions()?.length || 0,
+        pixels: [...pixels],
+      };
+    });`);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.available, true);
+    assert.equal(result.result.vendor, "Google Inc. (Apple)");
+    assert.match(result.result.renderer, /ANGLE Metal Renderer: Apple M4 Pro/);
+    assert.ok(result.result.extensions > 0);
+    assert.equal(result.result.pixels.length, 4);
   } finally {
     await bw.close();
   }

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -26,13 +26,6 @@ if (!ready && process.env.BETTERWRIGHT_REQUIRE_BROWSER) {
 const opts = {
   skip: ready ? false : `browser runtime not ready (doctor browser: ${browserStatus.browser})`,
 };
-const nativeForkOpts = {
-  skip:
-    browserStatus.browser === "chromium-fork"
-      ? false
-      : `requires BetterChromium (doctor browser: ${browserStatus.browser})`,
-};
-
 function tempHome() {
   return makeTempDir("betterwright-test-");
 }
@@ -109,7 +102,7 @@ test("navigate and read the title", opts, async () => {
   }
 });
 
-test("BetterChromium keeps WebGL available with its native identity", nativeForkOpts, async () => {
+test("the selected managed browser keeps WebGL available with a coherent identity", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {
     const result = await bw.run(`return await page.evaluate(() => {
@@ -129,14 +122,33 @@ test("BetterChromium keeps WebGL available with its native identity", nativeFork
         renderer: debug ? gl.getParameter(debug.UNMASKED_RENDERER_WEBGL) : null,
         extensions: gl.getSupportedExtensions()?.length || 0,
         pixels: [...pixels],
+        userAgent: navigator.userAgent,
+        platform: navigator.platform,
       };
     });`);
     assert.equal(result.ok, true, result.error);
     assert.equal(result.result.available, true);
-    assert.equal(result.result.vendor, "Google Inc. (Apple)");
-    assert.match(result.result.renderer, /ANGLE Metal Renderer: Apple M4 Pro/);
+    assert.equal(typeof result.result.vendor, "string");
+    assert.ok(result.result.vendor.length > 0);
+    assert.equal(typeof result.result.renderer, "string");
+    assert.ok(result.result.renderer.length > 0);
     assert.ok(result.result.extensions > 0);
-    assert.equal(result.result.pixels.length, 4);
+    for (const [index, actual] of result.result.pixels.entries()) {
+      assert.ok(Math.abs(actual - [64, 128, 191, 255][index]) <= 1);
+    }
+    if (browserStatus.browser === "chromium-fork") {
+      assert.equal(result.result.vendor, "Google Inc. (Apple)");
+      assert.match(result.result.renderer, /ANGLE Metal Renderer: Apple M4 Pro/);
+      assert.equal(result.result.platform, "MacIntel");
+      assert.match(result.result.userAgent, /Macintosh/);
+    } else if (/Macintosh/.test(result.result.userAgent)) {
+      assert.equal(result.result.platform, "MacIntel");
+    } else if (/Windows/.test(result.result.userAgent)) {
+      assert.equal(result.result.platform, "Win32");
+    } else {
+      assert.match(result.result.userAgent, /Linux/);
+      assert.match(result.result.platform, /Linux/);
+    }
   } finally {
     await bw.close();
   }

--- a/tests/node/chromium-args.test.ts
+++ b/tests/node/chromium-args.test.ts
@@ -128,7 +128,7 @@ test("profile, identity, and headless switches are rejected with their alternati
     ["--fingerprint=1234", /`locale`, `timezone`, and `platform`/],
     ["--fingerprint-platform=windows", /`locale`, `timezone`, and `platform`/],
     ["--fingerprint-locale=de-DE", /`locale`, `timezone`, and `platform`/],
-    ["--disable-software-rasterizer", /manages the software renderer/],
+    ["--disable-software-rasterizer", /retain its WebGL software fallback/],
   ];
   for (const [arg, message] of cases) {
     // Node regex-matches RegExp values in the expectation object; its types
@@ -208,7 +208,7 @@ test("the WebRTC proxy boundary cannot be displaced on either browser backend", 
   }
 });
 
-test("GPU-less Linux uses packaged SwANGLE while hardware hosts stay native", () => {
+test("GPU capability detection distinguishes accessible DRI devices", () => {
   assert.equal(
     chromiumForkNeedsSoftwareGpu({
       platform: "linux",
@@ -240,14 +240,10 @@ test("GPU-less Linux uses packaged SwANGLE while hardware hosts stay native", ()
     false,
   );
 
-  const software = managedChromiumForkArgs("seed", { softwareGpu: true });
-  assert.ok(software.includes("--use-gl=angle"));
-  assert.ok(software.includes("--use-angle=swiftshader"));
-  assert.ok(!software.includes("--enable-unsafe-swiftshader"));
-
-  const hardware = managedChromiumForkArgs("seed", { softwareGpu: false });
-  assert.ok(!hardware.some((arg) => arg.startsWith("--use-gl=")));
-  assert.ok(!hardware.some((arg) => arg.startsWith("--use-angle=")));
+  const native = managedChromiumForkArgs("seed");
+  assert.ok(!native.some((arg) => arg.startsWith("--use-gl=")));
+  assert.ok(!native.some((arg) => arg.startsWith("--use-angle=")));
+  assert.ok(!native.includes("--enable-unsafe-swiftshader"));
 });
 
 test("a switch repeated by the caller is applied once", () => {

--- a/tests/node/chromium-args.test.ts
+++ b/tests/node/chromium-args.test.ts
@@ -8,7 +8,11 @@ import {
   parseChromiumArgs,
   resolveChromiumArgs,
 } from "../../dist/src/chromium-args.js";
-import { managedChromiumForkArgs, managedCloakArgs } from "../../dist/src/cloak.js";
+import {
+  chromiumForkNeedsSoftwareGpu,
+  managedChromiumForkArgs,
+  managedCloakArgs,
+} from "../../dist/src/cloak.js";
 
 test("empty and whitespace-only argument strings parse to nothing", () => {
   for (const raw of ["", "   ", "\t\n", null, undefined]) {
@@ -124,6 +128,7 @@ test("profile, identity, and headless switches are rejected with their alternati
     ["--fingerprint=1234", /`locale`, `timezone`, and `platform`/],
     ["--fingerprint-platform=windows", /`locale`, `timezone`, and `platform`/],
     ["--fingerprint-locale=de-DE", /`locale`, `timezone`, and `platform`/],
+    ["--disable-software-rasterizer", /manages the software renderer/],
   ];
   for (const [arg, message] of cases) {
     // Node regex-matches RegExp values in the expectation object; its types
@@ -150,11 +155,11 @@ test("a switch merely prefixed like a reserved one is still allowed", () => {
 
 test("the option and the environment variable both contribute, option first", () => {
   const resolved = resolveChromiumArgs(["--disable-gpu"], {
-    BETTERWRIGHT_CHROMIUM_ARGS: "--disable-software-rasterizer --mute-audio",
+    BETTERWRIGHT_CHROMIUM_ARGS: "--disk-cache-size=1 --mute-audio",
   });
   assert.deepEqual(resolved, [
     "--disable-gpu",
-    "--disable-software-rasterizer",
+    "--disk-cache-size=1",
     "--mute-audio",
   ]);
 });
@@ -201,6 +206,48 @@ test("the WebRTC proxy boundary cannot be displaced on either browser backend", 
     assert.ok(args.includes(`${boundary}=disable_non_proxied_udp`));
     assert.equal(args.filter((arg) => arg.startsWith(boundary)).length, 1);
   }
+});
+
+test("GPU-less Linux uses packaged SwANGLE while hardware hosts stay native", () => {
+  assert.equal(
+    chromiumForkNeedsSoftwareGpu({
+      platform: "linux",
+      readdirSync: () => ["renderD128", "card0"],
+      accessSync: (device) => {
+        if (device.endsWith("renderD128")) return;
+        throw new Error("inaccessible");
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    chromiumForkNeedsSoftwareGpu({
+      platform: "linux",
+      readdirSync: () => ["renderD128"],
+      accessSync: () => {
+        throw new Error("not bound into sandbox");
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    chromiumForkNeedsSoftwareGpu({
+      platform: "darwin",
+      readdirSync: () => {
+        throw new Error("must not inspect DRI on macOS");
+      },
+    }),
+    false,
+  );
+
+  const software = managedChromiumForkArgs("seed", { softwareGpu: true });
+  assert.ok(software.includes("--use-gl=angle"));
+  assert.ok(software.includes("--use-angle=swiftshader"));
+  assert.ok(!software.includes("--enable-unsafe-swiftshader"));
+
+  const hardware = managedChromiumForkArgs("seed", { softwareGpu: false });
+  assert.ok(!hardware.some((arg) => arg.startsWith("--use-gl=")));
+  assert.ok(!hardware.some((arg) => arg.startsWith("--use-angle=")));
 });
 
 test("a switch repeated by the caller is applied once", () => {

--- a/tests/node/chromium-fork.test.ts
+++ b/tests/node/chromium-fork.test.ts
@@ -109,6 +109,29 @@ test("all published platform layouts select native BetterChromium", () => {
   }
 });
 
+test("GPU-less Linux selects Cloak even when the native artifact is explicit", () => {
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: "/managed/betterchromium",
+      env: {},
+      platform: "linux",
+      arch: "x64",
+      softwareGpu: true,
+    }),
+    { browser: "cloak", cloakFallback: "gpu-unavailable" },
+  );
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: "/managed/betterchromium",
+      env: { BETTERWRIGHT_CHROMIUM_PATH: "/managed/betterchromium" },
+      platform: "linux",
+      arch: "x64",
+      softwareGpu: true,
+    }),
+    { browser: "cloak", cloakFallback: "gpu-unavailable" },
+  );
+});
+
 test("explicit off forces managed CloakBrowser even with an artifact", () => {
   assert.equal(
     resolveChromiumForkBinary({

--- a/tests/node/chromium-fork.test.ts
+++ b/tests/node/chromium-fork.test.ts
@@ -7,7 +7,9 @@ import { fileURLToPath } from "node:url";
 import {
   BETTERWRIGHT_CHROMIUM_VERSION,
   chromiumForkContextOptions,
+  chromiumForkPlatformSupported,
   resolveChromiumForkBinary,
+  selectManagedBrowserBackend,
 } from "../../dist/src/chromium-fork.js";
 
 const present = () => true;
@@ -40,7 +42,7 @@ test("default root discovers a deployed artifact (zero-config fork)", () => {
   );
 });
 
-test("platforms without a deployed artifact fall back to managed CloakBrowser", () => {
+test("supported platforms with a missing deployment remain unavailable", () => {
   assert.equal(
     resolveChromiumForkBinary({
       env: {},
@@ -51,6 +53,60 @@ test("platforms without a deployed artifact fall back to managed CloakBrowser", 
     }),
     null,
   );
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: null,
+      env: {},
+      platform: "win32",
+      arch: "x64",
+    }),
+    { browser: "unavailable", cloakFallback: null },
+  );
+});
+
+test("unsupported platforms automatically select managed CloakBrowser", () => {
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: {},
+      platform: "linux",
+      arch: "arm64",
+      home: "/home/pi",
+      existsSync: () => false,
+    }),
+    null,
+  );
+  assert.equal(
+    chromiumForkPlatformSupported({ platform: "linux", arch: "arm64" }),
+    false,
+  );
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: null,
+      env: {},
+      platform: "linux",
+      arch: "arm64",
+    }),
+    { browser: "cloak", cloakFallback: "unsupported-platform" },
+  );
+});
+
+test("all published platform layouts select native BetterChromium", () => {
+  for (const [platform, arch] of [
+    ["darwin", "arm64"],
+    ["linux", "x64"],
+    ["win32", "x64"],
+  ]) {
+    assert.equal(chromiumForkPlatformSupported({ platform, arch }), true);
+    assert.deepEqual(
+      selectManagedBrowserBackend({
+        chromiumFork: "/managed/betterchromium",
+        env: {},
+        platform,
+        arch,
+      }),
+      { browser: "chromium-fork", cloakFallback: null },
+    );
+  }
 });
 
 test("explicit off forces managed CloakBrowser even with an artifact", () => {
@@ -60,6 +116,14 @@ test("explicit off forces managed CloakBrowser even with an artifact", () => {
       existsSync: present,
     }),
     null,
+  );
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      env: { BETTERWRIGHT_CHROMIUM_ROOT: "off" },
+      platform: "linux",
+      arch: "x64",
+    }),
+    { browser: "cloak", cloakFallback: "explicit" },
   );
   assert.equal(
     resolveChromiumForkBinary({
@@ -188,5 +252,13 @@ test("configured fork paths fail closed when missing or unsupported", () => {
         existsSync: present,
       }),
     /No BetterChromium artifact layout/,
+  );
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      env: { BETTERWRIGHT_CHROMIUM_ROOT: "/opt/betterwright" },
+      platform: "linux",
+      arch: "arm64",
+    }),
+    { browser: "unavailable", cloakFallback: null },
   );
 });

--- a/tests/node/client.test.ts
+++ b/tests/node/client.test.ts
@@ -140,7 +140,7 @@ test("chromiumArgs reach the worker config and reserved switches fail at constru
     );
     assert.throws(
       () => new BetterWright({ chromiumArgs: ["--disable-software-rasterizer"] }),
-      { name: "TypeError", message: /manages the software renderer/ },
+      { name: "TypeError", message: /retain its WebGL software fallback/ },
     );
   } finally {
     await defaults.close();

--- a/tests/node/client.test.ts
+++ b/tests/node/client.test.ts
@@ -123,20 +123,24 @@ test("Cloaking V2 options reach the worker and headedInvisible forces headed mod
 test("chromiumArgs reach the worker config and reserved switches fail at construction", async () => {
   const defaults = new BetterWright();
   const tuned = new BetterWright({
-    chromiumArgs: ["--disable-gpu", "--disable-software-rasterizer"],
+    chromiumArgs: ["--disable-gpu", "--disk-cache-size=1"],
   });
   try {
     assert.deepEqual(defaults.chromiumArgs, []);
     assert.deepEqual(defaults._workerConfig().chromiumArgs, []);
     assert.deepEqual(tuned._workerConfig().chromiumArgs, [
       "--disable-gpu",
-      "--disable-software-rasterizer",
+      "--disk-cache-size=1",
     ]);
     // Rejected in the constructor, so a switch that would bypass the guard
     // proxy surfaces as a clear TypeError instead of an opaque launch failure.
     assert.throws(
       () => new BetterWright({ chromiumArgs: ["--proxy-server=http://10.0.0.1:8080"] }),
       { name: "TypeError", message: /reserved by BetterWright/ },
+    );
+    assert.throws(
+      () => new BetterWright({ chromiumArgs: ["--disable-software-rasterizer"] }),
+      { name: "TypeError", message: /manages the software renderer/ },
     );
   } finally {
     await defaults.close();

--- a/tests/node/cloak.test.ts
+++ b/tests/node/cloak.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { test } from "node:test";
 import {
   assertProfileNotNewer,
+  compatibleBrowserProfile,
   managedChromiumForkArgs,
   managedCloakArgs,
   managedCloakViewport,
@@ -31,15 +32,38 @@ test("managed Cloak arguments omit resolver rules and suppress bad-flag bars", (
 });
 
 test("native fork keeps one warm page renderer without disabling site isolation", () => {
-  assert.deepEqual(managedChromiumForkArgs("12345", { softwareGpu: false }), [
+  assert.deepEqual(managedChromiumForkArgs("12345"), [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--renderer-process-limit=2",
     "--fingerprint=12345",
   ]);
-  assert.deepEqual(managedChromiumForkArgs("", { softwareGpu: false }), [
+  assert.deepEqual(managedChromiumForkArgs(""), [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--renderer-process-limit=2",
   ]);
+});
+
+test("a lower-version compatibility backend preserves the upgraded profile", () => {
+  const profileDir = "/home/user/.betterwright/browser/profile";
+  assert.deepEqual(
+    compatibleBrowserProfile(profileDir, "146.0.7680.177", {
+      readFileSync: () => "151.0.7922.108\n",
+    }),
+    {
+      profileDir: path.join(profileDir, ".betterwright-compat-chromium-146"),
+      warning:
+        "The existing browser profile was upgraded by Chromium 151.0.7922.108; " +
+        "the Chromium 146.0.7680.177 compatibility backend is using " +
+        path.join(profileDir, ".betterwright-compat-chromium-146") +
+        " instead. The original profile and its logins were preserved.",
+    },
+  );
+  assert.deepEqual(
+    compatibleBrowserProfile(profileDir, "151.0.7922.108", {
+      readFileSync: () => "151.0.7922.108\n",
+    }),
+    { profileDir, warning: null },
+  );
 });
 
 test("managed Cloak viewports stay coherent on affected builds", () => {

--- a/tests/node/cloak.test.ts
+++ b/tests/node/cloak.test.ts
@@ -36,7 +36,7 @@ test("native fork keeps one warm page renderer without disabling site isolation"
     "--renderer-process-limit=2",
     "--fingerprint=12345",
   ]);
-  assert.deepEqual(managedChromiumForkArgs(""), [
+  assert.deepEqual(managedChromiumForkArgs("", { softwareGpu: false }), [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--renderer-process-limit=2",
   ]);

--- a/tests/node/cloak.test.ts
+++ b/tests/node/cloak.test.ts
@@ -31,7 +31,7 @@ test("managed Cloak arguments omit resolver rules and suppress bad-flag bars", (
 });
 
 test("native fork keeps one warm page renderer without disabling site isolation", () => {
-  assert.deepEqual(managedChromiumForkArgs("12345"), [
+  assert.deepEqual(managedChromiumForkArgs("12345", { softwareGpu: false }), [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--renderer-process-limit=2",
     "--fingerprint=12345",

--- a/tests/node/credential-fill.test.ts
+++ b/tests/node/credential-fill.test.ts
@@ -15,6 +15,19 @@ import { makeTempDir } from "./helpers/temp-dir.js";
 
 const ready = (await cloakRuntime()).installed;
 const opts = { skip: ready ? false : "browser runtime not installed" };
+// This integration suite gates on the CloakBrowser binary specifically, so
+// select the same backend for the workers it launches. Otherwise a supported
+// host with no BetterChromium artifact would run instead of skipping, then
+// fail before reaching the credential behavior under test.
+const previousChromiumRoot = process.env.BETTERWRIGHT_CHROMIUM_ROOT;
+if (ready) process.env.BETTERWRIGHT_CHROMIUM_ROOT = "off";
+test.after(() => {
+  if (previousChromiumRoot === undefined) {
+    delete process.env.BETTERWRIGHT_CHROMIUM_ROOT;
+  } else {
+    process.env.BETTERWRIGHT_CHROMIUM_ROOT = previousChromiumRoot;
+  }
+});
 
 function tempHome() {
   return makeTempDir("betterwright-credential-test-");

--- a/tests/node/onboard.test.ts
+++ b/tests/node/onboard.test.ts
@@ -44,6 +44,7 @@ const READY_REPORT = {
   chromium_fork: "/x/fork/chrome",
   chromium_fork_version: "150.0.0.0",
   chromium_fork_error: null,
+  cloak_fallback: null,
   chromium_fork_fonts: "/x/fork/fonts",
   chromium_fork_fonts_warning: null,
   stealth_driver: "1.61.1",
@@ -325,6 +326,21 @@ test("doctor only warns about missing fork font bundles on Linux", () => {
     }),
     null,
   );
+});
+
+test("doctor explains the automatic compatibility backend on unsupported hosts", () => {
+  const checks = doctorChecks({
+    ...READY_REPORT,
+    chromium_fork: null,
+    chromium_fork_version: null,
+    cloak_fallback: "unsupported-platform",
+    browser: "cloak",
+  });
+  const native = checks.find((check) => check.label === "BetterChromium");
+  const cloak = checks.find((check) => check.label === "CloakBrowser");
+  assert.equal(native.status, "warn");
+  assert.match(native.detail, /no artifact is published/);
+  assert.match(cloak.detail, /automatic compatibility backend/);
 });
 
 test("doctor output groups checks and marks each status", () => {

--- a/tests/node/onboard.test.ts
+++ b/tests/node/onboard.test.ts
@@ -343,6 +343,20 @@ test("doctor explains the automatic compatibility backend on unsupported hosts",
   assert.match(cloak.detail, /automatic compatibility backend/);
 });
 
+test("doctor explains the WebGL-compatible fallback on GPU-less Linux", () => {
+  const checks = doctorChecks({
+    ...READY_REPORT,
+    cloak_fallback: "gpu-unavailable",
+    browser: "cloak",
+  });
+  const native = checks.find((check) => check.label === "BetterChromium");
+  const cloak = checks.find((check) => check.label === "CloakBrowser");
+  assert.equal(native.status, "warn");
+  assert.match(native.detail, /no accessible Linux render device/);
+  assert.match(native.detail, /WebGL remains available/);
+  assert.match(cloak.detail, /automatic compatibility backend/);
+});
+
 test("doctor output groups checks and marks each status", () => {
   const text = formatDoctorChecks(doctorChecks(READY_REPORT));
   assert.match(text, /^Runtime$/m);

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -84,15 +84,15 @@ export interface BetterWrightOptions {
   /**
    * Extra Chromium switches appended to the managed launch arguments, for
    * host-level tuning the managed list has no opinion on —
-   * `["--disable-gpu", "--disable-software-rasterizer"]` on a GPU-less server
-   * being the motivating case. Also settable per host with
+   * `["--disk-cache-size=104857600"]` being one example. Also settable per host with
    * `BETTERWRIGHT_CHROMIUM_ARGS` (whitespace-separated, quotes allowed); both
    * sources apply.
    *
    * Switches BetterWright owns are rejected with a `TypeError`: proxy
    * selection, remote debugging, the profile directory, and the
    * `--fingerprint*` / `--lang` / `--bw-timezone` / `--headless` identity
-   * family. A switch that merely duplicates one already in the managed list is
+   * family, plus `--disable-software-rasterizer` because the selected backend
+   * must retain WebGL. A switch that merely duplicates one already in the managed list is
    * dropped — Chromium resolves duplicates last-wins, so appending it would
    * override BetterWright's value rather than lose to it — and the drop is
    * reported in the next result's `warnings`.


### PR DESCRIPTION
## Summary

- restore automatic managed CloakBrowser selection on Linux ARM64 and every host without a published BetterChromium artifact
- fix #109 by selecting CloakBrowser on GPU-less Linux, where BetterChromium r1 cannot initialize its bundled SwANGLE renderer; GPU-capable Linux keeps native BetterChromium
- preserve an existing Chromium 151 profile and use a stable compatibility profile for the older Cloak backend
- keep supported missing native artifacts and invalid explicit paths fail-closed, with container and `bwrap --clearenv` guidance
- add real-browser WebGL regression coverage, cross-platform backend tests, and honest 1.8.1 release notes

Fixes #109

## Validation

- `BETTERWRIGHT_CHROMIUM_ROOT=off npm run release:check` — 774 tests, 769 passed, 5 intentional skips, 0 failures; build, types, package, pins, and smoke install passed
- `BETTERWRIGHT_REQUIRE_BROWSER=1 npm test` — 825 tests, 820 passed, 5 intentional live/headed skips, 0 failures
- GPU-less Linux reproducer: doctor automatically selected Cloak; browser test created WebGL, exposed 33 extensions, and passed pixel readback with a coherent Linux UA/platform/GPU identity
- upgraded-profile reproducer: Chromium 151 profile remained unchanged, stable Chromium 146 compatibility profile was created, and WebGL launched successfully
- fresh-profile macOS BetterChromium CreepJS validation: fingerprint in 2.27 s, WebGL available, 0% headless, 0% stealth, 31% like-headless (cross-host validation only, not a score-reduction claim)

## Security and performance

- both backends retain the existing SOCKS guard; no direct launch path or unsafe SwiftShader flag was added
- GPU-capable BetterChromium behavior is unchanged apart from one bounded startup `/dev/dri` capability check
- no new memory or speed gain is claimed for the compatibility fallback