### PR TITLE
fix: make browser backend selection explicit for 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-08-12
+
+A compatibility patch for the two regressions reported in
+[#111](https://github.com/BetterWright/betterwright/issues/111). Existing
+Chromium argument lists launch again, and container operators can make backend
+selection deterministic instead of relying on a device-mount heuristic.
+
+### Fixed
+
+- `--disable-software-rasterizer` is now ignored with a result warning instead
+  of throwing before browser launch. BetterWright still retains the software
+  WebGL fallback required by the selected backend, but common headless-Chromium
+  boilerplate no longer breaks an upgrade. Security boundaries such as proxy,
+  remote-debugging, profile, and fingerprint switches remain hard errors.
+- Added `BETTERWRIGHT_BACKEND=auto|chromium-fork|cloak`. The default `auto`
+  policy is unchanged; `chromium-fork` overrides the Linux `/dev/dri` probe for
+  bubblewrap, containers, and other mount namespaces where the host's device
+  tree is hidden. A forced native backend still fails closed if the artifact is
+  missing. `cloak` selects the compatibility backend directly.
+- Runtime result warnings now expose every non-default routing decision, and
+  `betterwright doctor --json` always exposes the selected backend and exact
+  reason. Human-readable doctor output calls out automatic render-device
+  fallback, forced native selection, and forced Cloak selection with the
+  corresponding fix or tradeoff.
+- `setup` and `update` honor the same explicit backend selector as runtime and
+  doctor, including conflicts and unsupported-platform failures.
+
+### Measured impact
+
+- The deterministic regression in #111 changes from 0/5 pre-launch failures to
+  5/5 successful forced-BetterChromium launches in the local macOS arm64
+  regression repetition, with the caller's incompatible flag removed and both
+  decisions reported. Linux x64 remains covered by the release workflow; this
+  5/5 result is compatibility evidence, not a cross-platform speed benchmark.
+- Backend selection performs one environment-value parse in addition to the
+  existing startup-only `/dev/dri` probe. It adds no per-page script, network
+  hop, or persistent process, so 1.8.2 makes no new speed or RSS claim.
+- The speed and memory table in #111 was collected after 1.8.1 had silently
+  selected CloakBrowser. Those numbers are not presented as BetterChromium
+  gains in this release.
+
 ## [1.8.1] - 2026-08-12
 
 A cross-platform compatibility and graphics fix for 1.8.0. BetterChromium

--- a/SETUP.md
+++ b/SETUP.md
@@ -254,9 +254,12 @@ BetterChromium (`~/.betterwright/chromium/`) is the default backend on
 supported macOS arm64, GPU-capable Linux x64, and Windows x64 hosts. Platforms
 without a published artifact and Linux hosts without an accessible `/dev/dri`
 render device automatically use managed CloakBrowser; `--cloak-only` and
-`BETTERWRIGHT_CHROMIUM_ROOT=off` force the same compatibility backend on a
-supported host. See [docs/chromium-fork.md](docs/chromium-fork.md). This is not
-a guarantee of undetectability.
+`BETTERWRIGHT_BACKEND=cloak` force the same compatibility backend on a
+supported host. In a sandbox that hides `/dev/dri`, explicitly require the
+native backend with `BETTERWRIGHT_BACKEND=chromium-fork`; doctor reports the
+routing reason and warns that WebGL must be verified inside that namespace.
+See [docs/chromium-fork.md](docs/chromium-fork.md). This is not a guarantee of
+undetectability.
 
 Broad discovery should use the host's web-search tool, then open selected
 first-party pages in BetterWright; the operator guidance says so. Set

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.8.1
+generated_by: betterwright@1.8.2
 ---
 
 # BetterWright browser

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -42,6 +42,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { formatAgentUsage } from "../src/agent-usage.js";
+import { configuredBrowserBackend } from "../src/chromium-fork.js";
 import { installChromiumFork } from "../src/chromium-fork-install.js";
 import { collectValues, firstPositional, flagValue } from "../src/cli-flags.js";
 import { helpFor, MAIN_USAGE, wantsHelp } from "../src/cli-help.js";
@@ -411,9 +412,25 @@ async function cmdUpdate(flags) {
     );
     return 1;
   }
+  const backend = configuredBrowserBackend();
+  if (backend === "cloak") {
+    console.log("BETTERWRIGHT_BACKEND=cloak selects the compatibility backend.");
+    const cloakCode = await installCloakBrowser();
+    if (cloakCode !== 0) return cloakCode;
+    console.log("\nUpdate complete. BetterWright will use CloakBrowser.");
+    console.log("Run `betterwright doctor` to confirm (browser: cloak).");
+    refreshAgentSkillsQuietly();
+    return 0;
+  }
   const result = await installChromiumFork({ force: flags.has("--force") });
   if (result.skipped) {
     console.log(result.skipped);
+    if (backend === "chromium-fork") {
+      console.error(
+        "BETTERWRIGHT_BACKEND=chromium-fork was requested, but no native artifact is published for this host.",
+      );
+      return 1;
+    }
     const cloakCode = await installCloakBrowser();
     if (cloakCode !== 0) return cloakCode;
     console.log("\nUpdate complete. BetterWright will use CloakBrowser automatically on this host.");
@@ -421,14 +438,19 @@ async function cmdUpdate(flags) {
     refreshAgentSkillsQuietly();
     return 0;
   }
-  if (chromiumForkNeedsSoftwareGpu()) {
-    console.log("Installing the automatic WebGL-compatible backend for this GPU-less Linux host.");
+  if (chromiumForkNeedsSoftwareGpu() && backend !== "chromium-fork") {
+    console.log("Installing the automatic WebGL-compatible backend because no accessible Linux render device was found.");
     const cloakCode = await installCloakBrowser();
     if (cloakCode !== 0) return cloakCode;
     console.log("\nUpdate complete. BetterWright will use CloakBrowser automatically on this host.");
     console.log("Run `betterwright doctor` to confirm (browser: cloak).");
   } else {
     console.log("\nUpdate complete. BetterWright will use BetterChromium.");
+    if (backend === "chromium-fork" && chromiumForkNeedsSoftwareGpu()) {
+      console.log(
+        "Backend forced despite no accessible Linux render device; verify WebGL inside the sandbox.",
+      );
+    }
     console.log("Run `betterwright doctor` to confirm (browser: chromium-fork).");
   }
   refreshAgentSkillsQuietly();
@@ -442,35 +464,59 @@ async function cmdSetup(flags, { quiet = false }: any = {}) {
   }
 
   const cloakOnly = flags.has("--cloak-only");
+  const backend = configuredBrowserBackend();
+  if (cloakOnly && backend === "chromium-fork") {
+    console.error(
+      "`--cloak-only` conflicts with BETTERWRIGHT_BACKEND=chromium-fork.",
+    );
+    return 1;
+  }
   let selectedBrowser = "chromium-fork";
-  if (cloakOnly) {
-    console.log("Selecting explicit CloakBrowser compatibility mode (--cloak-only).");
+  if (cloakOnly || backend === "cloak") {
+    console.log(
+      cloakOnly
+        ? "Selecting explicit CloakBrowser compatibility mode (--cloak-only)."
+        : "Selecting CloakBrowser from BETTERWRIGHT_BACKEND=cloak.",
+    );
     const cloakCode = await installCloakBrowser();
     if (cloakCode !== 0) return cloakCode;
-    console.log("Set BETTERWRIGHT_CHROMIUM_ROOT=off when launching BetterWright.");
+    if (cloakOnly && backend === "auto") {
+      console.log("Set BETTERWRIGHT_BACKEND=cloak when launching BetterWright.");
+    }
   } else {
     const chromium = await installChromiumFork({ force: flags.has("--force") });
     if (chromium.skipped) {
       console.log(chromium.skipped);
+      if (backend === "chromium-fork") {
+        console.error(
+          "BETTERWRIGHT_BACKEND=chromium-fork was requested, but no native artifact is published for this host.",
+        );
+        return 1;
+      }
       console.log("Installing the automatic compatibility backend for this platform.");
       const cloakCode = await installCloakBrowser();
       if (cloakCode !== 0) return cloakCode;
       selectedBrowser = "cloak";
-    } else if (chromiumForkNeedsSoftwareGpu()) {
-      console.log("Installing the automatic WebGL-compatible backend for this GPU-less Linux host.");
+    } else if (chromiumForkNeedsSoftwareGpu() && backend !== "chromium-fork") {
+      console.log("Installing the automatic WebGL-compatible backend because no accessible Linux render device was found.");
       const cloakCode = await installCloakBrowser();
       if (cloakCode !== 0) return cloakCode;
       selectedBrowser = "cloak";
     } else if (!chromium.alreadyInstalled) {
       console.log("BetterChromium installed as the required browser backend.");
     }
+    if (backend === "chromium-fork" && chromiumForkNeedsSoftwareGpu()) {
+      console.log(
+        "Backend forced despite no accessible Linux render device; verify WebGL inside the sandbox.",
+      );
+    }
   }
 
   if (!quiet) {
     console.log("\nSetup complete. Run `betterwright doctor` to confirm.");
     console.log(
-      cloakOnly
-        ? "Doctor should report browser: cloak when BETTERWRIGHT_CHROMIUM_ROOT=off is set."
+      cloakOnly || backend === "cloak"
+        ? "Doctor should report browser: cloak when BETTERWRIGHT_BACKEND=cloak is set."
         : `Doctor should report browser: ${selectedBrowser}.`,
     );
   }

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -57,6 +57,18 @@ SHA-256 value pinned in `src/chromium-fork.ts`.
 `BETTERWRIGHT_CHROMIUM_ROOT`. Configured paths must be absolute and must exist;
 BetterWright fails closed instead of silently falling back to another browser.
 
+Set the backend policy independently of artifact location:
+
+```bash
+export BETTERWRIGHT_BACKEND=auto            # default: use capability policy
+export BETTERWRIGHT_BACKEND=chromium-fork   # require the native fork
+export BETTERWRIGHT_BACKEND=cloak           # require compatibility mode
+```
+
+An invalid value is an error. Forced BetterChromium remains fail-closed when
+its artifact is absent; forced Cloak ignores native path settings because they
+are irrelevant to the selected backend.
+
 ## Zero-Config Discovery and Platform Routing
 
 With neither variable set, BetterWright checks the default root
@@ -96,8 +108,12 @@ The profile, runtime, and artifacts under `BETTERWRIGHT_HOME` need their normal
 writable mount. On Linux, binding an accessible `/dev/dri` render device keeps
 native BetterChromium selected. Without one, BetterWright automatically uses
 CloakBrowser so WebGL remains available; install and bind its cache too (or run
-`betterwright setup` inside the sandbox). Every network connection still passes
-through the worker's local SOCKS guard.
+`betterwright setup` inside the sandbox). When a minimal `bwrap --dev` or
+container mount hides `/dev/dri` and the operator has independently verified
+the native path, set `BETTERWRIGHT_BACKEND=chromium-fork` inside the cleared
+environment. The forced choice and missing-device warning appear in run results
+and `betterwright doctor`; verify WebGL in that exact sandbox. Every network
+connection still passes through the worker's local SOCKS guard.
 
 **Profiles are not interchangeable.** Fork and Cloak share
 `$BETTERWRIGHT_HOME/browser/profile` by default. Prefer a dedicated home for

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,6 +111,20 @@ Resolution order:
    launch fails with setup guidance. Either variable set to `off` explicitly
    selects CloakBrowser on any platform.
 
+Backend policy can also be stated directly:
+
+```bash
+export BETTERWRIGHT_BACKEND=auto            # default policy
+export BETTERWRIGHT_BACKEND=chromium-fork   # require BetterChromium
+export BETTERWRIGHT_BACKEND=cloak           # require CloakBrowser
+```
+
+`chromium-fork` is the escape hatch for containers and OS sandboxes where
+`/dev/dri` is hidden by the mount namespace even though the operator has
+verified the native backend. It fails closed when the native artifact cannot be
+resolved. `betterwright doctor --json` reports `browser_selection_reason` so a
+routing decision is never silent.
+
 Force the managed path even with an artifact installed:
 
 ```bash
@@ -134,18 +148,17 @@ together.
 
 On Linux without an accessible `/dev/dri` render device, BetterWright selects
 managed CloakBrowser automatically so standard WebGL remains available.
-`--disable-software-rasterizer` is reserved because it recreates the blocked
-graphics surface fixed in 1.8.1. `--disable-gpu` remains available as a
-caller-controlled compatibility switch, but it is not recommended for either
-managed backend.
+`--disable-software-rasterizer` is ignored with a result warning because it
+would recreate the blocked graphics surface fixed in 1.8.1; it does not fail
+launch. `--disable-gpu` remains available as a caller-controlled compatibility
+switch, but it is not recommended for either managed backend.
 
 Two rules keep this from undermining the managed browser:
 
 - **Reserved switches are rejected** with a `TypeError` naming the supported
   alternative — proxy selection (`--proxy-server`, `--no-proxy-server`, …),
   remote debugging, `--user-data-dir` / `--profile-directory`, and the identity
-  family (`--fingerprint*`, `--lang`, `--bw-timezone`, `--headless`), plus
-  `--disable-software-rasterizer`. These are
+  family (`--fingerprint*`, `--lang`, `--bw-timezone`, `--headless`). These are
   the switches that decide where traffic goes, who can drive the browser, which
   profile is opened, and what identity is presented.
 - **Duplicates are dropped, not appended.** Chromium resolves a repeated switch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "dependencies": {
         "cloakbrowser": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/chromium-args.ts
+++ b/src/chromium-args.ts
@@ -17,9 +17,11 @@
 //      error naming the supported alternative. These are the ones that decide
 //      where traffic goes (proxy), who can drive the browser (remote
 //      debugging), which profile is opened, and what identity is presented.
-//   2. A switch that merely collides with one already in the managed list is
-//      dropped, and reported back so the caller learns it was ignored rather
-//      than silently getting different behavior than they asked for.
+//   2. A switch that merely collides with one already in the managed list, or
+//      is common compatibility boilerplate that would break the selected
+//      backend, is dropped and reported back. The caller learns it was ignored
+//      rather than getting an upgrade-time launch failure or different
+//      behavior than they asked for.
 //
 // Everything else is appended last and takes effect.
 
@@ -53,8 +55,13 @@ const RESERVED = Object.freeze({
   // Headless is resolved from the `headless` option and must not desync from
   // the viewport and window-geometry decisions made alongside it.
   "--headless": "use the `headless` option",
-  // Every automatically selected backend must retain a working WebGL surface.
-  // Disabling its software fallback recreates issue #109's blocked-GPU state.
+});
+
+// Common Chromium boilerplate that cannot take effect safely but also should
+// not turn an otherwise compatible pre-existing configuration into a hard
+// launch failure. Unlike RESERVED, these switches survive normalization and
+// are dropped by mergeChromiumArgs so the result can carry a clear warning.
+const DROP_WITH_WARNING = Object.freeze({
   "--disable-software-rasterizer":
     "the managed browser must retain its WebGL software fallback",
 });
@@ -195,7 +202,7 @@ export function mergeChromiumArgs(managedArgs, extraArgs) {
   const taken = new Set(managedArgs.map(switchName));
   for (const arg of extraArgs) {
     const name = switchName(arg);
-    if (taken.has(name)) {
+    if (Object.hasOwn(DROP_WITH_WARNING, name) || taken.has(name)) {
       if (!ignored.includes(name)) ignored.push(name);
       continue;
     }
@@ -205,11 +212,27 @@ export function mergeChromiumArgs(managedArgs, extraArgs) {
   return { args, ignored };
 }
 
-/** Human-readable note for switches that were dropped as duplicates. */
+/** Human-readable note for switches that were dropped. */
 export function chromiumArgsWarning(ignored) {
   if (!ignored?.length) return "";
-  return (
-    `Ignored Chromium ${ignored.length === 1 ? "switch" : "switches"} ${ignored.join(", ")}: ` +
-    "already set by BetterWright, whose value takes precedence."
+  const compatibility = ignored.filter((name) =>
+    Object.hasOwn(DROP_WITH_WARNING, name)
   );
+  const duplicates = ignored.filter((name) =>
+    !Object.hasOwn(DROP_WITH_WARNING, name)
+  );
+  const notes = [];
+  if (compatibility.length) {
+    notes.push(
+      `Ignored Chromium ${compatibility.length === 1 ? "switch" : "switches"} ${compatibility.join(", ")}: ` +
+        compatibility.map((name) => DROP_WITH_WARNING[name]).join("; ") + ".",
+    );
+  }
+  if (duplicates.length) {
+    notes.push(
+      `Ignored Chromium ${duplicates.length === 1 ? "switch" : "switches"} ${duplicates.join(", ")}: ` +
+        "already set by BetterWright, whose value takes precedence.",
+    );
+  }
+  return notes.join(" ");
 }

--- a/src/chromium-fork.ts
+++ b/src/chromium-fork.ts
@@ -89,6 +89,17 @@ function configuredValue(value) {
   return String(value || "").trim();
 }
 
+/** Explicit backend preference, or automatic policy when unset. */
+export function configuredBrowserBackend(env = process.env) {
+  const value = configuredValue(env.BETTERWRIGHT_BACKEND).toLowerCase();
+  if (!value || value === "auto") return "auto";
+  if (value === "chromium-fork" || value === "cloak") return value;
+  throw new Error(
+    "BETTERWRIGHT_BACKEND must be auto, chromium-fork, or cloak; " +
+      `received ${JSON.stringify(value)}.`,
+  );
+}
+
 /** Whether BetterWright publishes a native BetterChromium artifact here. */
 export function chromiumForkPlatformSupported({
   platform = process.platform,
@@ -105,8 +116,9 @@ export function chromiumForkPlatformSupported({
  * supported Linux host without an accessible render device also uses Cloak so
  * it retains a working WebGL surface. A supported host with a missing artifact
  * stays unavailable so a broken native install or sandbox mount cannot silently
- * downgrade. Explicit paths and roots remain strict during resolution; Linux
- * GPU capability still decides whether that resolved binary is safe to launch.
+ * downgrade. Explicit paths and roots remain strict during resolution. In auto
+ * mode, Linux render-device accessibility decides whether the resolved binary
+ * is safe to launch; an explicit backend preference wins that heuristic.
  */
 export function selectManagedBrowserBackend({
   chromiumFork = null,
@@ -115,32 +127,103 @@ export function selectManagedBrowserBackend({
   arch = process.arch,
   softwareGpu = false,
 } = {}) {
+  const preference = configuredBrowserBackend(env);
   const explicitPath = configuredValue(env.BETTERWRIGHT_CHROMIUM_PATH);
   const explicitRoot = configuredValue(env.BETTERWRIGHT_CHROMIUM_ROOT);
+  if (preference === "cloak") {
+    return {
+      browser: "cloak",
+      cloakFallback: "explicit",
+      selectionReason: "forced-cloak",
+    };
+  }
+  if (preference === "chromium-fork") {
+    return chromiumFork
+      ? {
+          browser: "chromium-fork",
+          cloakFallback: null,
+          selectionReason: "forced-chromium-fork",
+        }
+      : {
+          browser: "unavailable",
+          cloakFallback: null,
+          selectionReason: "forced-chromium-fork-missing",
+        };
+  }
   if (
     explicitPath.toLowerCase() === "off" ||
     explicitRoot.toLowerCase() === "off"
   ) {
-    return { browser: "cloak", cloakFallback: "explicit" };
+    return {
+      browser: "cloak",
+      cloakFallback: "explicit",
+      selectionReason: "legacy-off",
+    };
   }
 
   if (chromiumFork) {
     if (softwareGpu) {
-      return { browser: "cloak", cloakFallback: "gpu-unavailable" };
+      return {
+        browser: "cloak",
+        cloakFallback: "gpu-unavailable",
+        selectionReason: "render-device-unavailable",
+      };
     }
-    return { browser: "chromium-fork", cloakFallback: null };
+    return {
+      browser: "chromium-fork",
+      cloakFallback: null,
+      selectionReason: "native-available",
+    };
   }
 
   // A custom path/root is resolved strictly before this selector runs. Never
   // interpret an invalid explicit configuration as permission to fall back.
   if (explicitPath || explicitRoot) {
-    return { browser: "unavailable", cloakFallback: null };
+    return {
+      browser: "unavailable",
+      cloakFallback: null,
+      selectionReason: "explicit-native-unavailable",
+    };
   }
 
   if (!chromiumForkPlatformSupported({ platform, arch })) {
-    return { browser: "cloak", cloakFallback: "unsupported-platform" };
+    return {
+      browser: "cloak",
+      cloakFallback: "unsupported-platform",
+      selectionReason: "unsupported-platform",
+    };
   }
-  return { browser: "unavailable", cloakFallback: null };
+  return {
+    browser: "unavailable",
+    cloakFallback: null,
+    selectionReason: "native-missing",
+  };
+}
+
+/** Result warning that makes every non-default backend decision observable. */
+export function browserSelectionWarning(selection, { softwareGpu = false } = {}) {
+  if (selection.selectionReason === "forced-chromium-fork") {
+    return softwareGpu
+      ? "Browser backend: BetterChromium, forced by BETTERWRIGHT_BACKEND=chromium-fork even though no accessible Linux render device was found; verify WebGL in this sandbox."
+      : "Browser backend: BetterChromium, forced by BETTERWRIGHT_BACKEND=chromium-fork.";
+  }
+  if (selection.selectionReason === "forced-cloak") {
+    return "Browser backend: CloakBrowser, forced by BETTERWRIGHT_BACKEND=cloak.";
+  }
+  if (selection.selectionReason === "render-device-unavailable") {
+    return (
+      "Browser backend: CloakBrowser compatibility mode because no accessible Linux " +
+      "render device was found. In a container or OS sandbox, set " +
+      "BETTERWRIGHT_BACKEND=chromium-fork to override this mount-based probe."
+    );
+  }
+  if (selection.selectionReason === "unsupported-platform") {
+    return "Browser backend: CloakBrowser compatibility mode because this platform has no published BetterChromium artifact.";
+  }
+  if (selection.selectionReason === "legacy-off") {
+    return "Browser backend: CloakBrowser because BETTERWRIGHT_CHROMIUM_PATH or BETTERWRIGHT_CHROMIUM_ROOT is set to off.";
+  }
+  return "";
 }
 
 /** Where deployments drop the fork artifact for zero-config discovery. */
@@ -152,12 +235,15 @@ export function defaultChromiumForkRoot({ home = os.homedir() } = {}) {
  * Resolve the pinned fork binary without changing BetterWright's public API.
  *
  * Resolution order:
- *  1. BETTERWRIGHT_CHROMIUM_PATH / BETTERWRIGHT_CHROMIUM_ROOT (strict: a
+ *  1. BETTERWRIGHT_BACKEND (forced Cloak needs no native path; forced native
+ *     conflicts with a legacy "off" path/root).
+ *  2. BETTERWRIGHT_CHROMIUM_PATH / BETTERWRIGHT_CHROMIUM_ROOT (strict: a
  *     configured-but-missing binary is an error).
- *  2. The default root (~/.betterwright/chromium) — if the artifact for this
+ *  3. The default root (~/.betterwright/chromium) — if the artifact for this
  *     platform exists there, use it silently. Backend selection routes hosts
  *     without a published artifact to managed CloakBrowser.
- *  3. Either variable set to "off" forces the managed CloakBrowser path.
+ *  4. Either path variable set to "off" forces managed CloakBrowser in auto
+ *     mode.
  */
 export function resolveChromiumForkBinary({
   env = process.env,
@@ -166,12 +252,20 @@ export function resolveChromiumForkBinary({
   home = os.homedir(),
   existsSync = fs.existsSync,
 } = {}) {
+  const preference = configuredBrowserBackend(env);
   const explicit = configuredValue(env.BETTERWRIGHT_CHROMIUM_PATH);
   let root = configuredValue(env.BETTERWRIGHT_CHROMIUM_ROOT);
+  if (preference === "cloak") return null;
   if (
     explicit.toLowerCase() === "off" ||
     root.toLowerCase() === "off"
   ) {
+    if (preference === "chromium-fork") {
+      throw new Error(
+        "BETTERWRIGHT_BACKEND=chromium-fork conflicts with " +
+          "BETTERWRIGHT_CHROMIUM_PATH/ROOT=off.",
+      );
+    }
     return null;
   }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -155,6 +155,7 @@ export async function doctorReport() {
     chromium_fork_version: chromiumFork ? BETTERWRIGHT_CHROMIUM_VERSION : null,
     chromium_fork_error: chromiumForkError,
     cloak_fallback: browserSelection.cloakFallback,
+    browser_selection_reason: browserSelection.selectionReason,
     chromium_fork_fonts: chromiumForkFonts,
     chromium_fork_fonts_warning: chromiumForkFontsWarning,
     stealth_driver: stealth,
@@ -318,13 +319,21 @@ export function doctorChecks(
   );
   add("Runtime", "Worker", report.worker_ok ? "ok" : "fail", report.worker, report.worker_ok ? null : "The package looks incomplete — reinstall betterwright.");
 
-  if (report.browser === "cloak" && report.cloak_fallback === "gpu-unavailable") {
+  if (report.browser_selection_reason === "forced-chromium-fork") {
+    add(
+      "Browser",
+      "BetterChromium",
+      "warn",
+      `BetterChromium ${report.chromium_fork_version} — ${report.chromium_fork} — forced by BETTERWRIGHT_BACKEND=chromium-fork`,
+      "Verify WebGL inside this container or OS sandbox when /dev/dri is not visible.",
+    );
+  } else if (report.browser === "cloak" && report.cloak_fallback === "gpu-unavailable") {
     add(
       "Browser",
       "BetterChromium",
       "warn",
       "installed, but no accessible Linux render device was found — using CloakBrowser compatibility mode so WebGL remains available",
-      "Optional: expose a read/write /dev/dri render device to use native BetterChromium.",
+      "Expose a read/write /dev/dri render device, or set BETTERWRIGHT_BACKEND=chromium-fork to override this mount-based probe.",
     );
   } else if (report.chromium_fork) {
     add(
@@ -346,16 +355,21 @@ export function doctorChecks(
     );
   } else if (report.browser === "cloak") {
     const automatic = report.cloak_fallback === "unsupported-platform";
+    const forced = report.browser_selection_reason === "forced-cloak";
     add(
       "Browser",
       "BetterChromium",
       "warn",
       automatic
         ? "no artifact is published for this platform — using CloakBrowser compatibility mode"
-        : "explicitly disabled — using CloakBrowser compatibility mode",
+        : forced
+          ? "forced by BETTERWRIGHT_BACKEND=cloak — using CloakBrowser compatibility mode"
+          : "explicitly disabled — using CloakBrowser compatibility mode",
       automatic
         ? null
-        : "Run `betterwright setup` and unset BETTERWRIGHT_CHROMIUM_PATH/ROOT to restore the default backend.",
+        : forced
+          ? "Unset BETTERWRIGHT_BACKEND (or set it to auto) to restore automatic selection."
+          : "Run `betterwright setup` and unset BETTERWRIGHT_CHROMIUM_PATH/ROOT to restore the default backend.",
     );
   } else {
     add(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,6 +42,7 @@ import {
 } from "./chromium-args.js";
 import {
   BETTERWRIGHT_CHROMIUM_VERSION,
+  browserSelectionWarning,
   chromiumForkContextOptions,
   resolveChromiumForkBinary,
   selectManagedBrowserBackend,
@@ -175,6 +176,7 @@ let profileWarning = "";
 // of BetterWright's own, so the caller is told rather than left wondering why
 // a switch had no effect.
 let chromiumArgsNote = "";
+let backendSelectionNote = "";
 // Set by the client via `--import` when stealthRuntimeFix is on: the driver is
 // patchright-core and every page.evaluate runs in an isolated world.
 const stealthActive = process.env.BETTERWRIGHT_STEALTH_ACTIVE === "1";
@@ -1543,15 +1545,19 @@ async function ensureBrowser(config) {
     mkdirPrivate(launchConfig.artifactsDir);
 
     const forkBinary = resolveChromiumForkBinary();
+    const softwareGpu = chromiumForkNeedsSoftwareGpu();
     const browserSelection = selectManagedBrowserBackend({
       chromiumFork: forkBinary,
-      softwareGpu: chromiumForkNeedsSoftwareGpu(),
+      softwareGpu,
+    });
+    backendSelectionNote = browserSelectionWarning(browserSelection, {
+      softwareGpu,
     });
     if (browserSelection.browser === "unavailable") {
       throw new Error(
         "BetterChromium is required but not installed. Run `betterwright setup`, " +
           "or explicitly select CloakBrowser with `betterwright setup --cloak-only` " +
-          "and BETTERWRIGHT_CHROMIUM_ROOT=off. Hosts without a published " +
+          "and BETTERWRIGHT_BACKEND=cloak. Hosts without a published " +
           "BetterChromium artifact, and GPU-less Linux hosts, use CloakBrowser automatically.",
       );
     }
@@ -3395,6 +3401,7 @@ async function buildEnvelope(
     artifacts: redactDeep(artifacts),
     warnings: [
       ...(profileWarning ? [profileWarning] : []),
+      ...(backendSelectionNote ? [backendSelectionNote] : []),
       ...(chromiumArgsNote ? [chromiumArgsNote] : []),
       ...(stealthActive ? [STEALTH_WARNING] : []),
       ...(challenges.length ? [challenges[0].advice] : []),

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -102,6 +102,27 @@ test("navigate and read the title", opts, async () => {
   }
 });
 
+test("stock software-rasterizer boilerplate warns without blocking launch", opts, async () => {
+  const bw = new BetterWright({
+    home: tempHome(),
+    headless: true,
+    chromiumArgs: ["--disable-software-rasterizer"],
+  });
+  try {
+    const result = await bw.run("return 42");
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result, 42);
+    assert.ok(
+      result.warnings.some((warning) =>
+        /Ignored Chromium switch --disable-software-rasterizer/.test(warning),
+      ),
+      JSON.stringify(result.warnings),
+    );
+  } finally {
+    await bw.close();
+  }
+});
+
 test("the selected managed browser keeps WebGL available with a coherent identity", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/chromium-args.test.ts
+++ b/tests/node/chromium-args.test.ts
@@ -128,7 +128,6 @@ test("profile, identity, and headless switches are rejected with their alternati
     ["--fingerprint=1234", /`locale`, `timezone`, and `platform`/],
     ["--fingerprint-platform=windows", /`locale`, `timezone`, and `platform`/],
     ["--fingerprint-locale=de-DE", /`locale`, `timezone`, and `platform`/],
-    ["--disable-software-rasterizer", /retain its WebGL software fallback/],
   ];
   for (const [arg, message] of cases) {
     // Node regex-matches RegExp values in the expectation object; its types
@@ -196,6 +195,18 @@ test("a collision keeps BetterWright's value and reports the dropped switch", ()
   assert.ok(args.includes("--test-type"));
   assert.ok(!args.some((arg) => arg.startsWith("--test-type=")));
   assert.ok(args.includes("--disable-gpu"));
+});
+
+test("software rasterizer boilerplate is dropped with a warning instead of failing launch", () => {
+  const extra = normalizeChromiumArgs(["--disable-software-rasterizer"]);
+  assert.deepEqual(extra, ["--disable-software-rasterizer"]);
+  const { args, ignored } = mergeChromiumArgs([], extra);
+  assert.deepEqual(args, []);
+  assert.deepEqual(ignored, ["--disable-software-rasterizer"]);
+  assert.match(
+    chromiumArgsWarning(ignored),
+    /managed browser must retain its WebGL software fallback/,
+  );
 });
 
 test("the WebRTC proxy boundary cannot be displaced on either browser backend", () => {

--- a/tests/node/chromium-fork.test.ts
+++ b/tests/node/chromium-fork.test.ts
@@ -6,8 +6,10 @@ import { fileURLToPath } from "node:url";
 
 import {
   BETTERWRIGHT_CHROMIUM_VERSION,
+  browserSelectionWarning,
   chromiumForkContextOptions,
   chromiumForkPlatformSupported,
+  configuredBrowserBackend,
   resolveChromiumForkBinary,
   selectManagedBrowserBackend,
 } from "../../dist/src/chromium-fork.js";
@@ -60,7 +62,7 @@ test("supported platforms with a missing deployment remain unavailable", () => {
       platform: "win32",
       arch: "x64",
     }),
-    { browser: "unavailable", cloakFallback: null },
+    { browser: "unavailable", cloakFallback: null, selectionReason: "native-missing" },
   );
 });
 
@@ -86,7 +88,11 @@ test("unsupported platforms automatically select managed CloakBrowser", () => {
       platform: "linux",
       arch: "arm64",
     }),
-    { browser: "cloak", cloakFallback: "unsupported-platform" },
+    {
+      browser: "cloak",
+      cloakFallback: "unsupported-platform",
+      selectionReason: "unsupported-platform",
+    },
   );
 });
 
@@ -104,7 +110,11 @@ test("all published platform layouts select native BetterChromium", () => {
         platform,
         arch,
       }),
-      { browser: "chromium-fork", cloakFallback: null },
+      {
+        browser: "chromium-fork",
+        cloakFallback: null,
+        selectionReason: "native-available",
+      },
     );
   }
 });
@@ -118,7 +128,11 @@ test("GPU-less Linux selects Cloak even when the native artifact is explicit", (
       arch: "x64",
       softwareGpu: true,
     }),
-    { browser: "cloak", cloakFallback: "gpu-unavailable" },
+    {
+      browser: "cloak",
+      cloakFallback: "gpu-unavailable",
+      selectionReason: "render-device-unavailable",
+    },
   );
   assert.deepEqual(
     selectManagedBrowserBackend({
@@ -128,7 +142,11 @@ test("GPU-less Linux selects Cloak even when the native artifact is explicit", (
       arch: "x64",
       softwareGpu: true,
     }),
-    { browser: "cloak", cloakFallback: "gpu-unavailable" },
+    {
+      browser: "cloak",
+      cloakFallback: "gpu-unavailable",
+      selectionReason: "render-device-unavailable",
+    },
   );
 });
 
@@ -146,12 +164,100 @@ test("explicit off forces managed CloakBrowser even with an artifact", () => {
       platform: "linux",
       arch: "x64",
     }),
-    { browser: "cloak", cloakFallback: "explicit" },
+    {
+      browser: "cloak",
+      cloakFallback: "explicit",
+      selectionReason: "legacy-off",
+    },
   );
   assert.equal(
     resolveChromiumForkBinary({
       env: { BETTERWRIGHT_CHROMIUM_PATH: "OFF" },
       existsSync: present,
+    }),
+    null,
+  );
+});
+
+test("BETTERWRIGHT_BACKEND explicitly selects either managed backend", () => {
+  assert.equal(configuredBrowserBackend({}), "auto");
+  assert.equal(configuredBrowserBackend({ BETTERWRIGHT_BACKEND: "AUTO" }), "auto");
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: "/managed/betterchromium",
+      env: { BETTERWRIGHT_BACKEND: "chromium-fork" },
+      platform: "linux",
+      arch: "x64",
+      softwareGpu: true,
+    }),
+    {
+      browser: "chromium-fork",
+      cloakFallback: null,
+      selectionReason: "forced-chromium-fork",
+    },
+  );
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: "/managed/betterchromium",
+      env: { BETTERWRIGHT_BACKEND: "cloak" },
+    }),
+    {
+      browser: "cloak",
+      cloakFallback: "explicit",
+      selectionReason: "forced-cloak",
+    },
+  );
+  assert.match(
+    browserSelectionWarning(
+      {
+        browser: "chromium-fork",
+        cloakFallback: null,
+        selectionReason: "forced-chromium-fork",
+      },
+      { softwareGpu: true },
+    ),
+    /verify WebGL in this sandbox/,
+  );
+});
+
+test("a forced native backend fails closed when it is missing or disabled", () => {
+  assert.deepEqual(
+    selectManagedBrowserBackend({
+      chromiumFork: null,
+      env: { BETTERWRIGHT_BACKEND: "chromium-fork" },
+      platform: "linux",
+      arch: "x64",
+    }),
+    {
+      browser: "unavailable",
+      cloakFallback: null,
+      selectionReason: "forced-chromium-fork-missing",
+    },
+  );
+  assert.throws(
+    () => resolveChromiumForkBinary({
+      env: {
+        BETTERWRIGHT_BACKEND: "chromium-fork",
+        BETTERWRIGHT_CHROMIUM_ROOT: "off",
+      },
+      existsSync: present,
+    }),
+    /conflicts/,
+  );
+  assert.throws(
+    () => configuredBrowserBackend({ BETTERWRIGHT_BACKEND: "chromium" }),
+    /must be auto, chromium-fork, or cloak/,
+  );
+});
+
+test("a forced Cloak backend ignores irrelevant native path configuration", () => {
+  assert.equal(
+    resolveChromiumForkBinary({
+      env: {
+        BETTERWRIGHT_BACKEND: "cloak",
+        BETTERWRIGHT_CHROMIUM_PATH: "relative/missing",
+      },
+      existsSync: () => false,
     }),
     null,
   );
@@ -282,6 +388,10 @@ test("configured fork paths fail closed when missing or unsupported", () => {
       platform: "linux",
       arch: "arm64",
     }),
-    { browser: "unavailable", cloakFallback: null },
+    {
+      browser: "unavailable",
+      cloakFallback: null,
+      selectionReason: "explicit-native-unavailable",
+    },
   );
 });

--- a/tests/node/client.test.ts
+++ b/tests/node/client.test.ts
@@ -120,7 +120,7 @@ test("Cloaking V2 options reach the worker and headedInvisible forces headed mod
   }
 });
 
-test("chromiumArgs reach the worker config and reserved switches fail at construction", async () => {
+test("chromiumArgs reach the worker config and only security-sensitive switches fail", async () => {
   const defaults = new BetterWright();
   const tuned = new BetterWright({
     chromiumArgs: ["--disable-gpu", "--disk-cache-size=1"],
@@ -138,10 +138,13 @@ test("chromiumArgs reach the worker config and reserved switches fail at constru
       () => new BetterWright({ chromiumArgs: ["--proxy-server=http://10.0.0.1:8080"] }),
       { name: "TypeError", message: /reserved by BetterWright/ },
     );
-    assert.throws(
-      () => new BetterWright({ chromiumArgs: ["--disable-software-rasterizer"] }),
-      { name: "TypeError", message: /retain its WebGL software fallback/ },
-    );
+    const compatible = new BetterWright({
+      chromiumArgs: ["--disable-software-rasterizer"],
+    });
+    assert.deepEqual(compatible._workerConfig().chromiumArgs, [
+      "--disable-software-rasterizer",
+    ]);
+    await compatible.close();
   } finally {
     await defaults.close();
     await tuned.close();

--- a/tests/node/onboard.test.ts
+++ b/tests/node/onboard.test.ts
@@ -45,6 +45,7 @@ const READY_REPORT = {
   chromium_fork_version: "150.0.0.0",
   chromium_fork_error: null,
   cloak_fallback: null,
+  browser_selection_reason: "native-available",
   chromium_fork_fonts: "/x/fork/fonts",
   chromium_fork_fonts_warning: null,
   stealth_driver: "1.61.1",
@@ -334,6 +335,7 @@ test("doctor explains the automatic compatibility backend on unsupported hosts",
     chromium_fork: null,
     chromium_fork_version: null,
     cloak_fallback: "unsupported-platform",
+    browser_selection_reason: "unsupported-platform",
     browser: "cloak",
   });
   const native = checks.find((check) => check.label === "BetterChromium");
@@ -347,6 +349,7 @@ test("doctor explains the WebGL-compatible fallback on GPU-less Linux", () => {
   const checks = doctorChecks({
     ...READY_REPORT,
     cloak_fallback: "gpu-unavailable",
+    browser_selection_reason: "render-device-unavailable",
     browser: "cloak",
   });
   const native = checks.find((check) => check.label === "BetterChromium");
@@ -355,6 +358,30 @@ test("doctor explains the WebGL-compatible fallback on GPU-less Linux", () => {
   assert.match(native.detail, /no accessible Linux render device/);
   assert.match(native.detail, /WebGL remains available/);
   assert.match(cloak.detail, /automatic compatibility backend/);
+});
+
+test("doctor makes forced backend selection and its tradeoff explicit", () => {
+  const nativeChecks = doctorChecks({
+    ...READY_REPORT,
+    browser_selection_reason: "forced-chromium-fork",
+  });
+  const native = nativeChecks.find((check) => check.label === "BetterChromium");
+  assert.equal(native.status, "warn");
+  assert.match(native.detail, /BETTERWRIGHT_BACKEND=chromium-fork/);
+  assert.match(native.fix, /Verify WebGL/);
+
+  const cloakChecks = doctorChecks({
+    ...READY_REPORT,
+    chromium_fork: null,
+    chromium_fork_version: null,
+    browser: "cloak",
+    cloak_fallback: "explicit",
+    browser_selection_reason: "forced-cloak",
+  });
+  const cloak = cloakChecks.find((check) => check.label === "BetterChromium");
+  assert.equal(cloak.status, "warn");
+  assert.match(cloak.detail, /BETTERWRIGHT_BACKEND=cloak/);
+  assert.match(cloak.fix, /Unset BETTERWRIGHT_BACKEND/);
 });
 
 test("doctor output groups checks and marks each status", () => {

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -91,11 +91,13 @@ export interface BetterWrightOptions {
    * Switches BetterWright owns are rejected with a `TypeError`: proxy
    * selection, remote debugging, the profile directory, and the
    * `--fingerprint*` / `--lang` / `--bw-timezone` / `--headless` identity
-   * family, plus `--disable-software-rasterizer` because the selected backend
-   * must retain WebGL. A switch that merely duplicates one already in the managed list is
+   * family. A switch that merely duplicates one already in the managed list is
    * dropped — Chromium resolves duplicates last-wins, so appending it would
    * override BetterWright's value rather than lose to it — and the drop is
-   * reported in the next result's `warnings`.
+   * reported in the next result's `warnings`. The common
+   * `--disable-software-rasterizer` compatibility flag is also dropped with a
+   * warning, rather than failing launch, because the selected backend must
+   * retain WebGL.
    */
   chromiumArgs?: string[];
   /**


### PR DESCRIPTION
## What and why

Fixes #111 by dropping `--disable-software-rasterizer` with an observable warning instead of hard-failing, and adding `BETTERWRIGHT_BACKEND=auto|chromium-fork|cloak` so sandboxed hosts can override mount-based `/dev/dri` detection. Backend decisions are exposed in run warnings and doctor output; this also prepares the immutable npm patch release as 1.8.2.

## Checklist

- [x] `npm run release:check` passes locally (versions, lint, typecheck, build, unit tests, published declarations, tarball).
- [x] **Every browser connection still goes through the guard proxy.** No new launch path, transport, or fetch bypasses the worker SOCKS guard.
- [x] **No secret value reaches the model sandbox.** The new messages contain backend and switch names only.
- [x] **Dependency pins are still mirrored everywhere.** `npm run check:versions` is green.
- [x] **Public API changes update `types/*.d.ts` in this same commit.** The Chromium-argument behavior is documented in the published declarations.
- [x] The branch-protected CI job names are unchanged; no action was added.
- [x] No unit test imports the worker entrypoint directly.
- [x] User-visible behavior is reflected in `CHANGELOG.md`, `SETUP.md`, and `docs/`.
- [x] `npm run check:package` passes; no private runtime data is committed.

## How it was verified

- `npm ci --ignore-scripts`
- `npm run release:check` (779 tests: 774 pass, five intentional skips; package smoke test passes)
- `BETTERWRIGHT_REQUIRE_BROWSER=1 node --test --test-name-pattern="stock software-rasterizer boilerplate" tests/node/browser.test.js`
- Five consecutive real BetterChromium launches on macOS arm64 with `BETTERWRIGHT_BACKEND=chromium-fork` and `--disable-software-rasterizer`: 5/5 passed, with both decisions present in result warnings.
- `betterwright doctor --json` reports `browser_selection_reason: native-available` on the default local path.