### PR TITLE
Release 1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.8.6] - 2026-08-16
+
+Releases the 1.8.5 content below. The 1.8.5 tag was cut before its squash merge
+and pointed at a commit that is not an ancestor of `main`, so it could not pass
+the publish workflow's provenance check; the release ships as 1.8.6. There are
+no code changes from 1.8.5.
+
 ## [1.8.5] - 2026-08-16
 
 A browser-platform release. The managed BetterChromium fork no longer

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.8.5
+generated_by: betterwright@1.8.6
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- Ship the 1.8.5 content as **1.8.6** (version-only bump, no code changes).
- The 1.8.5 tag was cut before its squash merge and points at a commit that is not an ancestor of `main`, so it cannot pass the publish workflow's provenance check (`git merge-base --is-ancestor`). Shipping the identical content under a fresh tag on `main` resolves this.

## Changes
- `package.json` / `package-lock.json` / `SKILL.md`: 1.8.5 → 1.8.6
- `CHANGELOG.md`: new 1.8.6 entry noting it supersedes the unreleasable 1.8.5

## Test plan
- [x] `npm run release:check` passes locally (lint, typecheck, unit + browser suite, package smoke)
- [ ] CI green
- [ ] After merge: tag `v1.8.6` on the merge commit, create GitHub Release → publish-npm.yml publishes to npm

Made with [Cursor](https://cursor.com)