### PR TITLE
Fix credential-fill gate to skip cleanly under CHROMIUM_ROOT=off

### DIFF
--- a/tests/node/credential-fill.test.ts
+++ b/tests/node/credential-fill.test.ts
@@ -14,8 +14,16 @@ import { BetterWright, NetworkPolicy } from "../../dist/src/index.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
 // Integration suite: gates on the managed BetterChromium fork being
-// installed on this host (`betterwright setup`).
-const ready = Boolean(resolveChromiumForkBinary());
+// installed on this host (`betterwright setup`). `resolveChromiumForkBinary`
+// is fail-closed: it throws when BETTERWRIGHT_CHROMIUM_PATH/ROOT=off (a
+// leftover bundled-fallback toggle) rather than returning null, so guard the
+// gate and treat that misconfiguration as "not installed" to skip cleanly.
+let ready = false;
+try {
+  ready = Boolean(resolveChromiumForkBinary());
+} catch {
+  ready = false;
+}
 const opts = { skip: ready ? false : "browser runtime not installed" };
 
 function tempHome() {


### PR DESCRIPTION
## Summary
`resolveChromiumForkBinary` is fail-closed: it **throws** when `BETTERWRIGHT_CHROMIUM_PATH/ROOT=off` rather than returning null. The credential-fill integration suite called it bare at module load to decide whether to skip, so under the publish workflow's final release verification (`npm run release:check` with `BETTERWRIGHT_CHROMIUM_ROOT=off`) the throw escaped before the skip and failed the suite — blocking the v1.8.6 npm publish at "Run final release verification".

This guards the gate so a misconfigured/absent browser skips cleanly, matching how the other integration suites gate via `doctorReport`'s try/catch.

## Test plan
- [x] `BETTERWRIGHT_CHROMIUM_ROOT=off npm run test:unit` → 0 fail (was 1 fail)
- [x] `node --test tests/node/credential-fill.test.js` with browser installed → 46 pass, 0 skip (still runs)
- [ ] CI green; then retag v1.8.6 onto the merge commit and re-publish

Made with [Cursor](https://cursor.com)