### PR TITLE
Release 1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.8.7] - 2026-08-16
+
+Ships the release. 1.8.6 was tagged before the `credential-fill` gate fix
+landed, and release tags are immutable after creation, so the publish workflow
+re-ran the pre-fix suite and could not pass; the release ships as 1.8.7. This
+adds the gate fix and the version bump on top of the (otherwise unchanged)
+1.8.5/1.8.6 content.
+
+### Fixed
+
+- The `credential-fill` integration suite now skips cleanly when
+  `BETTERWRIGHT_CHROMIUM_PATH/ROOT=off` (no managed browser) instead of
+  failing at module load, so the publish workflow's final release verification
+  passes.
+
 ## [1.8.6] - 2026-08-16
 
 Releases the 1.8.5 content below. The 1.8.5 tag was cut before its squash merge

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.8.6
+generated_by: betterwright@1.8.7
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
Ship the release as **1.8.7**. 1.8.6 was tagged before the credential-fill gate fix (PR #120) landed, and release tags are immutable after creation — so the publish workflow re-ran the pre-fix suite from the 1.8.6 tag and failed at "Run final release verification". This ships the gate fix + version bump on top of the unchanged 1.8.5/1.8.6 content.

## Changes
- `package.json` / `package-lock.json` / `SKILL.md`: 1.8.6 → 1.8.7
- `CHANGELOG.md`: new 1.8.7 entry (includes the credential-fill gate fix)

## Test plan
- [x] `npm run release:check` passes locally
- [ ] CI green; then tag `v1.8.7` on the merge commit, create GitHub Release → publish-npm.yml publishes to npm

Made with [Cursor](https://cursor.com)