### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-08-16
+
+### Fixed
+
+- **Headless launches on a GPU host now use the real GPU for WebGL.**
+  Playwright's headless default silently appends `--use-angle=swiftshader-webgl`,
+  which forced software GL even when hardware was present and tripped the fork's
+  integrated-GPU spoof — so a headless run on a GPU machine reported an "Intel
+  UHD 620" string that contradicted the desktop User-Agent, an inconsistency
+  PixelScan-style checkers flag as "Masking detected." On a host with an
+  accessible render device the managed args now bind `--use-gl=angle
+  --use-angle=gl`, so the hardware backend wins and the genuine GPU is reported.
+  GPU-less hosts keep the explicit SwiftShader binding unchanged.
+
+### Added
+
+- **`fingerprintNoise` option** (default `true`). The managed fork's
+  per-profile canvas/audio/WebGL-readPixels farbling is keyed to the profile's
+  `--fingerprint` seed. Keep it on for multi-account isolation (each profile
+  gets a distinct, stable rendering fingerprint); set
+  `new BetterWright({ fingerprintNoise: false })` when a single identity should
+  present the host's genuine GPU rendering. Only affects the managed
+  BetterChromium fork, not provider/remote browsers.
+
 ## [1.8.7] - 2026-08-16
 
 Ships the release. 1.8.6 was tagged before the `credential-fill` gate fix

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.8.7
+generated_by: betterwright@1.9.0
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.8.7",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/research/pixelscan-probe.ts
+++ b/research/pixelscan-probe.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// PixelScan evaluation of the managed BetterChromium fork.
+//
+// Launches the fork through the normal BetterWright stack and opens
+// pixelscan.net, waits for the scan to compute, then dumps the full report
+// text plus the raw consistency signals PixelScan cross-references, so the
+// exact "inconsistent fingerprint" drivers are visible.
+//
+// Usage:
+//   DISPLAY=:99 node research/pixelscan-probe.js            # headed on Xorg
+//   node research/pixelscan-probe.js --headless             # headless
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BetterWright } from "../dist/src/index.js";
+
+const args = process.argv.slice(2);
+const HEADLESS = args.includes("--headless");
+const NO_GPU = args.includes("--no-gpu");
+
+if (!NO_GPU) {
+  process.env.__EGL_VENDOR_LIBRARY_FILENAMES =
+    "/usr/share/glvnd/egl_vendor.d/10_nvidia.json";
+  process.env.__GLX_VENDOR_LIBRARY_NAME = "nvidia";
+}
+
+const home = fs.mkdtempSync(path.join(os.tmpdir(), "bw-pixelscan-"));
+const browser = new BetterWright({
+  home,
+  headless: HEADLESS,
+  launchIdentity: true,
+  defaultTimeout: 90,
+  chromiumArgs: NO_GPU
+    ? []
+    : [
+        "--enable-gpu",
+        "--use-gl=angle",
+        "--use-angle=gl-egl",
+        "--enable-webgl",
+        "--ignore-gpu-blocklist",
+        "--enable-gpu-rasterization",
+      ],
+});
+
+try {
+  const result = await browser.run(
+    `await page.goto("https://pixelscan.net/", {
+       waitUntil: "domcontentloaded",
+       timeout: 60000,
+     });
+     // PixelScan runs its checks automatically on load; give it time to finish.
+     await page.waitForTimeout(20000);
+     // Try to expand any "details"/"show more" controls so the full report text
+     // is in the DOM, then let any revealed content settle.
+     try {
+       const buttons = await page.$$("button, a, [role=button]");
+       for (const b of buttons) {
+         const t = ((await b.innerText().catch(() => "")) || "").toLowerCase();
+         if (/detail|more|expand|show|why|inconsist/.test(t)) {
+           await b.click().catch(() => {});
+         }
+       }
+     } catch {}
+     await page.waitForTimeout(4000);
+     await page.evaluate(() => window.scrollTo(0, 0));
+     const shot = await screenshot({ kind: "debug", fullPage: true });
+     return await page.evaluate((shotPath) => {
+       const text = (el) => (el ? (el.innerText || "").trim() : "");
+       const body = document.body ? document.body.innerText : "";
+       // Collect likely verdict/flag elements by scanning for status keywords.
+       const flagged = [];
+       const kw = /inconsist|suspicious|fail|mask|mismatch|leak|bot|automat|headless|anomal|risk|warn/i;
+       for (const el of document.querySelectorAll("*")) {
+         if (el.children.length === 0) {
+           const t = text(el);
+           if (t && t.length < 200 && kw.test(t)) flagged.push(t);
+         }
+       }
+       const lower = body.toLowerCase();
+       const verdict = /\\b(inconsistent|consistent|suspicious|trustworthy|bot|human|masked|natural)\\b/.test(lower)
+         ? (body.match(/[^\\n]*(inconsistent|consistent|suspicious|trustworthy|masked|natural)[^\\n]*/i) || [""])[0]
+         : "";
+       return {
+         title: document.title,
+         url: location.href,
+         screenshotPath: shotPath,
+         verdictLine: verdict.trim().slice(0, 300),
+         // Raw signals PixelScan cross-references for consistency.
+         signals: {
+           userAgent: navigator.userAgent,
+           platform: navigator.platform,
+           uaDataPlatform: (navigator.userAgentData && navigator.userAgentData.platform) || null,
+           uaDataMobile: (navigator.userAgentData && navigator.userAgentData.mobile) || null,
+           uaDataBrands: (navigator.userAgentData && navigator.userAgentData.brands) || null,
+           webdriver: navigator.webdriver,
+           languages: navigator.languages,
+           language: navigator.language,
+           timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+           timezoneOffset: new Date().getTimezoneOffset(),
+           hardwareConcurrency: navigator.hardwareConcurrency,
+           deviceMemory: navigator.deviceMemory,
+           screen: [screen.width, screen.height],
+           avail: [screen.availWidth, screen.availHeight],
+           outer: [window.outerWidth, window.outerHeight],
+           inner: [window.innerWidth, window.innerHeight],
+           devicePixelRatio: window.devicePixelRatio,
+           colorScheme: matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
+           touchPoints: navigator.maxTouchPoints,
+           webglVendor: (() => {
+             try {
+               const gl = document.createElement("canvas").getContext("webgl");
+               if (!gl) return "no-context";
+               const ext = gl.getExtension("WEBGL_debug_renderer_info");
+               return ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR);
+             } catch (e) { return "error:" + e.message; }
+           })(),
+           webglRenderer: (() => {
+             try {
+               const gl = document.createElement("canvas").getContext("webgl");
+               if (!gl) return "no-context";
+               const ext = gl.getExtension("WEBGL_debug_renderer_info");
+               return ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+             } catch (e) { return "error:" + e.message; }
+           })(),
+         },
+         flagged: [...new Set(flagged)].slice(0, 60),
+         fullBody: body,
+       };
+     }, shot.path);`,
+    { timeout: 120 },
+  );
+  if (!result?.ok) {
+    console.error("run failed:", JSON.stringify(result)?.slice(0, 800));
+    process.exitCode = 1;
+  } else {
+    const { fullBody, ...rest } = result.result || {};
+    console.log(JSON.stringify(rest, null, 2));
+    console.log("=== full body ===");
+    console.log(fullBody);
+    if (result.result?.screenshotPath) {
+      const target = "/tmp/bw-pixelscan/pixelscan.png";
+      fs.mkdirSync("/tmp/bw-pixelscan", { recursive: true });
+      fs.copyFileSync(result.result.screenshotPath, target);
+      console.log("screenshot copied to:", target);
+    }
+  }
+} finally {
+  await browser.close().catch(() => {});
+  fs.rmSync(home, { recursive: true, force: true });
+}

--- a/src/browser-runtime.ts
+++ b/src/browser-runtime.ts
@@ -139,8 +139,10 @@ export function managedForkArgs(fingerprintSeed, { softwareGpu = false } = {}) {
         // UA's desktop hardware — exactly the cross-signal inconsistency
         // PixelScan flags as "Masking detected". Bind the real GL backend so
         // the software default never wins and the genuine GPU is reported.
-        // The host may still override by passing its own --use-angle via
-        // chromiumArgs (caller switches are merged last and win).
+        // mergeChromiumArgs drops a same-name caller switch rather than
+        // letting it override, so a host that passes its own --use-angle gets
+        // this managed value and a chromiumArgs warning naming the dropped
+        // switch.
         ["--use-gl=angle", "--use-angle=gl"]),
     ...(fingerprintSeed ? [`--fingerprint=${fingerprintSeed}`] : []),
   ];

--- a/src/browser-runtime.ts
+++ b/src/browser-runtime.ts
@@ -131,7 +131,17 @@ export function managedForkArgs(fingerprintSeed, { softwareGpu = false } = {}) {
           "--use-angle=swiftshader",
           "--enable-unsafe-swiftshader",
         ]
-      : []),
+      : // On a host WITH a GPU, the opposite risk applies: a headless launch
+        // (Playwright's default for the browser worker) appends
+        // --use-angle=swiftshader-webgl on its own, which forces software GL
+        // even when hardware is present. That trips the fork's integrated-GPU
+        // spoof, and the resulting "Intel UHD 620" string contradicts the
+        // UA's desktop hardware — exactly the cross-signal inconsistency
+        // PixelScan flags as "Masking detected". Bind the real GL backend so
+        // the software default never wins and the genuine GPU is reported.
+        // The host may still override by passing its own --use-angle via
+        // chromiumArgs (caller switches are merged last and win).
+        ["--use-gl=angle", "--use-angle=gl"]),
     ...(fingerprintSeed ? [`--fingerprint=${fingerprintSeed}`] : []),
   ];
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -211,6 +211,7 @@ export class BetterWright {
   declare downloadPolicy: "ask" | "allow" | "deny";
   declare stealthRuntimeFix: boolean;
   declare launchIdentity: boolean;
+  declare fingerprintNoise: boolean;
   declare upstreamProxy: string | null;
   declare geoip: boolean;
   declare locale: string | null;
@@ -284,6 +285,13 @@ export class BetterWright {
    *   locale/timezone flags for the managed browser, resolved to match the
    *   egress IP when `geoip` is on. No page-world API shims are installed and
    *   no operating system is masked as another — the fork presents the host.
+   * @param {boolean} [options.fingerprintNoise=true] per-profile canvas/audio/
+   *   WebGL-readPixels farbling keyed to the profile seed. Keep it on for
+   *   multi-account isolation (each profile gets a distinct, stable rendering
+   *   fingerprint). Turn it off when a single identity must present the host's
+   *   genuine GPU rendering — consistency checkers (PixelScan's "Masking
+   *   detected") flag farbled output because it no longer matches a stock
+   *   hardware signature. Only affects the managed fork.
    * @param {object|null} [options.provider] non-managed browser, opt-in:
    *   `{ executablePath }` launches a caller-supplied local Chromium binary
    *   (guard proxy still applies); `{ cdpUrl, headers? }` attaches to any CDP
@@ -360,6 +368,7 @@ export class BetterWright {
     this.provider = resolveProviderOption(options);
     this.browserFlavor = "chromium-fork";
     this.headless = resolveHeadless(options.headless);
+    this.fingerprintNoise = options.fingerprintNoise !== false;
     this.searchMinIntervalMs = Math.max(Number(options.searchMinIntervalMs) || 0, 0);
     this.publicSearchPolicy = resolvePublicSearchPolicy(options.publicSearchPolicy);
     this.downloadPolicy = normalizeDownloadPolicy(options.downloadPolicy);
@@ -461,6 +470,7 @@ export class BetterWright {
       provider: this.provider,
       stealthRuntimeFix: this.stealthRuntimeFix,
       launchIdentity: this.launchIdentity,
+      fingerprintNoise: this.fingerprintNoise,
       upstreamProxy: this.upstreamProxy,
       geoip: this.geoip,
       locale: this.locale,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1778,12 +1778,21 @@ async function ensureBrowser(config) {
 
     // The fingerprint seed belongs to the managed fork; a caller-supplied
     // binary does not carry the fork's --fingerprint patches, and a remote
-    // browser never receives launch args at all.
+    // browser never receives launch args at all. When fingerprintNoise is off
+    // the seed is withheld entirely so the fork renders the host's genuine
+    // canvas/audio/WebGL output (the noise is a pure function of the seed, so
+    // no seed means SeedKey()===0 and FingerprintFarblingEnabled() is false) —
+    // that is what clears the "masking detected" verdict on consistency
+    // checkers that compare rendering against stock hardware.
+    const fingerprintNoise = launchConfig.fingerprintNoise !== false;
     const args =
       !remoteCdp && forkBinary
-        ? managedForkArgs(fingerprintSeedForProfile(browserProfileDir), {
-            softwareGpu,
-          })
+        ? managedForkArgs(
+            fingerprintNoise ? fingerprintSeedForProfile(browserProfileDir) : null,
+            {
+              softwareGpu,
+            },
+          )
         : [];
 
     // Coherent launch identity: one story across the Chromium and network

--- a/tests/node/browser-runtime.test.ts
+++ b/tests/node/browser-runtime.test.ts
@@ -117,9 +117,13 @@ test("managed fork args pin WebRTC to the proxy and the profile seed", () => {
   assert.ok(args.includes("--webrtc-ip-handling-policy=disable_non_proxied_udp"));
   assert.ok(args.includes("--fingerprint=12345"));
   assert.ok(args.includes("--renderer-process-limit=2"));
+  // A null/empty seed withholds the --fingerprint switch entirely, which is how
+  // the fingerprintNoise:false path turns the fork's farbling off.
   assert.deepEqual(managedForkArgs(""), [
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--renderer-process-limit=2",
+    "--use-gl=angle",
+    "--use-angle=gl",
   ]);
 });
 
@@ -132,6 +136,9 @@ test("GPU-less Linux binds the SwiftShader software rasterizer", () => {
     "--enable-unsafe-swiftshader",
     "--fingerprint=seed",
   ]);
-  // A GPU host (or non-Linux) gets no software-rasterizer switches.
-  assert.ok(!managedForkArgs("seed").includes("--use-angle=swiftshader"));
+  // A GPU host binds the hardware GL backend instead, so a headless launch's
+  // implicit --use-angle=swiftshader-webgl never wins and forces software GL.
+  const gpuArgs = managedForkArgs("seed");
+  assert.ok(!gpuArgs.includes("--use-angle=swiftshader"));
+  assert.ok(gpuArgs.includes("--use-angle=gl"));
 });

--- a/tests/node/chromium-args.test.ts
+++ b/tests/node/chromium-args.test.ts
@@ -273,9 +273,14 @@ test("GPU capability detection distinguishes accessible DRI devices", () => {
     false,
   );
 
+  // On a GPU host (the default), the managed args bind the hardware GL backend
+  // so a headless launch's implicit --use-angle=swiftshader-webgl never wins and
+  // silently forces software rendering (which would trip the fork's integrated-
+  // GPU spoof and the resulting PixelScan "masking detected" inconsistency).
   const native = managedForkArgs("seed");
-  assert.ok(!native.some((arg) => arg.startsWith("--use-gl=")));
-  assert.ok(!native.some((arg) => arg.startsWith("--use-angle=")));
+  assert.ok(native.includes("--use-gl=angle"));
+  assert.ok(native.includes("--use-angle=gl"));
+  assert.ok(!native.includes("--use-angle=swiftshader"));
   assert.ok(!native.includes("--enable-unsafe-swiftshader"));
 });
 

--- a/tsconfig.harness.json
+++ b/tsconfig.harness.json
@@ -38,6 +38,7 @@
     "research/cdpfree-probe.ts",
     "research/creepjs-probe.ts",
     "research/headless-tells.ts",
+    "research/pixelscan-probe.ts",
     "research/stealth-report.ts",
     "research/warm-profile.ts",
     "tests/node/**/*.ts",

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -42,6 +42,7 @@ export class BetterWright {
   downloadPolicy: "ask" | "allow" | "deny";
   stealthRuntimeFix: boolean;
   launchIdentity: boolean;
+  fingerprintNoise: boolean;
   upstreamProxy: string | null;
   geoip: boolean;
   locale: string | null;

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -125,6 +125,15 @@ export interface BetterWrightOptions {
    * another — the fork presents the host it runs on.
    */
   launchIdentity?: boolean;
+  /**
+   * Per-profile canvas/audio/WebGL-readPixels farbling keyed to the profile
+   * seed. Defaults to true (each profile gets a distinct, stable rendering
+   * fingerprint for multi-account isolation). Set false when a single identity
+   * must present the host's genuine GPU rendering — consistency checkers
+   * (PixelScan's "Masking detected") flag farbled output because it no longer
+   * matches a stock hardware signature. Only affects the managed fork.
+   */
+  fingerprintNoise?: boolean;
   upstreamProxy?: string;
   geoip?: boolean;
   locale?: string;


### PR DESCRIPTION
## Summary
- **Fix:** headless launches on a GPU host now bind hardware GL (`--use-angle=gl`) instead of inheriting Playwright's implicit `--use-angle=swiftshader-webgl`, which forced software rendering and tripped the fork's integrated-GPU spoof — the "Intel UHD 620" + desktop-UA mismatch that PixelScan-style checkers flag as "Masking detected."
- **Add:** `fingerprintNoise` option (default `true`). Setting it `false` withholds the profile `--fingerprint` seed so the managed fork presents genuine host GPU rendering instead of per-profile farbled output, for single-identity workloads that must match stock hardware signatures.
- Ships the `research/pixelscan-probe` harness used to diagnose the above.

## Test plan
- [x] `npm run release:check` (lint, typecheck, unit, types, version, package) passes
- [x] 802 unit tests pass, 0 fail
- [x] Verified headless launch reports the real RTX 4090 (no spoof)
- [x] Verified `fingerprintNoise:false` drops `--fingerprint` seed while keeping `--fingerprint-platform`

Made with [Cursor](https://cursor.com)