### PR TITLE
Release BetterWright 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-08-17
+
 ### Fixed
 
 - **Image-grid recapture after a selected reCAPTCHA tile.** Clicking a cell
@@ -977,7 +979,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.1...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.2...HEAD
+[1.9.2]: https://github.com/BetterWright/betterwright/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/BetterWright/betterwright/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/BetterWright/betterwright/compare/v1.8.7...v1.9.0
 [1.8.7]: https://github.com/BetterWright/betterwright/compare/v1.8.6...v1.8.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ Releases before 1.1.3 predate this file; their notes live on the
 - **Image-grid recapture after a selected reCAPTCHA tile.** Clicking a cell
   exposes a ~4px-inset selected-state wrapper. The tile cluster treated those
   inner boxes as extra cells, so a 3×3 recapture numbered 12 tiles and the
-  overlay skipped indexes. Nested boxes are now collapsed and a regular 3×3
-  or 4×4 wins over a larger messy cluster. A crop with no tiles no longer
-  asks the host to pick numbered indexes.
+  overlay skipped indexes. Nested boxes are now collapsed and a regular
+  photo-sized 3×3, 3×4, or 4×4 wins over a larger messy cluster. 2×2 and
+  2×3 stay unboosted so widget chrome cannot outrank a real puzzle. A crop
+  with no tiles no longer asks the host to pick numbered indexes.
 
 ## [1.9.1] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Fixed
+
+- **Image-grid recapture after a selected reCAPTCHA tile.** Clicking a cell
+  exposes a ~4px-inset selected-state wrapper. The tile cluster treated those
+  inner boxes as extra cells, so a 3×3 recapture numbered 12 tiles and the
+  overlay skipped indexes. Nested boxes are now collapsed and a regular 3×3
+  or 4×4 wins over a larger messy cluster. A crop with no tiles no longer
+  asks the host to pick numbered indexes.
+
 ## [1.9.1] - 2026-08-16
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.9.1
+generated_by: betterwright@1.9.2
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/captcha-solver.ts
+++ b/src/captcha-solver.ts
@@ -586,11 +586,24 @@ export function pickBestTileSet(sets) {
         0,
       ) / collapsed.length;
     const grid = gridFromTiles(collapsed);
-    const regular =
+    const minSide = Math.min(
+      ...collapsed.map((box) =>
+        Math.min(
+          Number(untrustedField(box, "width")) || 0,
+          Number(untrustedField(box, "height")) || 0,
+        ),
+      ),
+    );
+    // Only photo-sized 3×3 / 3×4 / 4×4 get the regularity bonus. 2×2 and
+    // 2×3 also match widget chrome from collectClickableCluster (buttons,
+    // decorative images), and a million-point boost let those outrank a
+    // genuine noisy or 12-tile puzzle.
+    const regularPhotoGrid =
       grid.rows * grid.cols === collapsed.length &&
-      [4, 6, 9, 16].includes(collapsed.length);
-    // A regular 3×3/4×4 beats a larger messy cluster of inset wrappers.
-    const score = (regular ? 1_000_000 : 0) + collapsed.length * 10_000 + area;
+      [9, 12, 16].includes(collapsed.length) &&
+      minSide >= 80;
+    const score =
+      (regularPhotoGrid ? 1_000_000 : 0) + collapsed.length * 10_000 + area;
     if (score <= bestScore) continue;
     bestScore = score;
     best = collapsed.map((box, index) => {

--- a/src/captcha-solver.ts
+++ b/src/captcha-solver.ts
@@ -450,8 +450,52 @@ export function sortTilesReadingOrder(boxes, yTolerance = 12) {
 }
 
 /**
+ * Intersection area of two axis-aligned boxes, or 0 when they do not overlap.
+ */
+function intersectionArea(a, b) {
+  const width = Math.max(
+    0,
+    Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x),
+  );
+  const height = Math.max(
+    0,
+    Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y),
+  );
+  return width * height;
+}
+
+/**
+ * Drop inset / selected-state inner boxes that sit inside a larger tile.
+ * After a reCAPTCHA Verify click the selected cells expose a ~4px-inset
+ * wrapper; keeping both numbers a 3×3 as 12 tiles and the overlay skips.
+ *
+ * Only near-same-size wrappers are removed. A photo tile inside a much
+ * larger widget frame is left alone so a real 3×3 is not swallowed.
+ */
+export function collapseNestedBoxes(
+  boxes,
+  { overlap = 0.8, minAreaRatio = 0.7 }: any = {},
+) {
+  const list = sortTilesReadingOrder(dedupeBoxes(boxes)).sort(
+    (a, b) => b.width * b.height - a.width * a.height,
+  );
+  const kept = [];
+  for (const box of list) {
+    const area = Math.max(1, box.width * box.height);
+    const nested = kept.some((outer) => {
+      const outerArea = Math.max(1, outer.width * outer.height);
+      if (area / outerArea < minAreaRatio) return false;
+      return intersectionArea(box, outer) / area >= overlap;
+    });
+    if (!nested) kept.push(box);
+  }
+  return sortTilesReadingOrder(kept);
+}
+
+/**
  * Keep the largest cluster of similarly sized rectangles. Image-grid tiles
- * share a size; headers, prompts, and the widget chrome do not.
+ * share a size; headers, prompts, and the widget chrome do not. Nested
+ * selected-state wrappers are collapsed so a 3×3 stays nine cells.
  */
 export function clusterSimilarBoxes(boxes, { minCount = 3, sizeSlack = 14 }: any = {}) {
   const usable = dedupeBoxes(boxes).filter(
@@ -471,7 +515,9 @@ export function clusterSimilarBoxes(boxes, { minCount = 3, sizeSlack = 14 }: any
     if (group.length > best.length) best = group;
   }
   if (best.length < minCount) return [];
-  return sortTilesReadingOrder(best);
+  const collapsed = collapseNestedBoxes(best);
+  if (collapsed.length < minCount) return [];
+  return sortTilesReadingOrder(collapsed);
 }
 
 /**
@@ -529,25 +575,33 @@ export function pickBestTileSet(sets) {
   let bestScore = 0;
   for (const set of Array.isArray(sets) ? sets : []) {
     if (!Array.isArray(set) || !set.length) continue;
-    const boxes = set.map(tileBounds);
-    if (!isPlausibleImageGrid(boxes)) continue;
+    const collapsed = collapseNestedBoxes(set.map(tileBounds));
+    if (!isPlausibleImageGrid(collapsed)) continue;
     const area =
-      boxes.reduce<number>(
+      collapsed.reduce<number>(
         (sum, box) =>
           sum +
           (Number(untrustedField(box, "width")) || 0) *
             (Number(untrustedField(box, "height")) || 0),
         0,
-      ) / boxes.length;
-    const score = set.length * 10_000 + area;
+      ) / collapsed.length;
+    const grid = gridFromTiles(collapsed);
+    const regular =
+      grid.rows * grid.cols === collapsed.length &&
+      [4, 6, 9, 16].includes(collapsed.length);
+    // A regular 3×3/4×4 beats a larger messy cluster of inset wrappers.
+    const score = (regular ? 1_000_000 : 0) + collapsed.length * 10_000 + area;
     if (score <= bestScore) continue;
     bestScore = score;
-    best = set.map((tile, index) => {
-      const bounds = roundedBox(tileBounds(tile));
+    best = collapsed.map((box, index) => {
+      const match = set.find((tile) => {
+        const bounds = roundedBox(tileBounds(tile));
+        return Math.abs(bounds.x - box.x) < 3 && Math.abs(bounds.y - box.y) < 3;
+      });
       return {
-        index: Number.isInteger(tile?.index) ? tile.index : index,
-        bounds,
-        label: tile?.label || null,
+        index,
+        bounds: roundedBox(box),
+        label: match?.label || null,
       };
     });
   }
@@ -650,8 +704,18 @@ export function unionClip(boxes, { pad = 12, promptPad = 72, viewport = null }: 
 export function visionGridInstruction({ prompt, grid, tileCount }: any = {}) {
   const rows = Number(grid?.rows) || 0;
   const cols = Number(grid?.cols) || 0;
-  const layout = rows && cols ? `${rows}×${cols}` : `${Number(tileCount) || 0}-tile`;
+  const count = Number(tileCount) || 0;
   const task = String(prompt || "").replace(/\s+/g, " ").trim();
+  if (!count && !rows && !cols) {
+    const match = task
+      ? `Open the attached crop and click the region that matches: ${task}`
+      : "Open the attached crop and click the matching region";
+    return (
+      `${match}. There is no numbered tile grid; use captcha.click(bounds) ` +
+      "on that region rather than captcha.solve({ tiles })."
+    );
+  }
+  const layout = rows && cols ? `${rows}×${cols}` : `${count}-tile`;
   const match = task
     ? `Pick every numbered tile that matches: ${task}`
     : "Pick every numbered tile that matches the on-screen prompt";

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   CAPTCHA_STAGES,
   classifyChallengeStage,
   clusterSimilarBoxes,
+  collapseNestedBoxes,
   extractDarkBlobs,
   findGrowingRegion,
   gridFromTiles,

--- a/tests/node/captcha-solver.test.ts
+++ b/tests/node/captcha-solver.test.ts
@@ -352,6 +352,30 @@ test("pickBestTileSet prefers a 3x3 puzzle over widget chrome", () => {
   assert.equal(picked[0].bounds.width, 100);
 });
 
+test("pickBestTileSet does not let a regular chrome cluster beat a photo grid", () => {
+  // collectClickableCluster can yield a 2×3 of similarly sized buttons or
+  // images. Those used to take the regular-grid bonus (4/6/9/16) and outrank
+  // a 3×4 puzzle or a slightly irregular 3×3.
+  const chrome = [
+    { x: 20, y: 520, width: 88, height: 88 },
+    { x: 116, y: 520, width: 88, height: 88 },
+    { x: 212, y: 520, width: 88, height: 88 },
+    { x: 20, y: 616, width: 88, height: 88 },
+    { x: 116, y: 616, width: 88, height: 88 },
+    { x: 212, y: 616, width: 88, height: 88 },
+  ].map((bounds, index) => ({ index, bounds, label: "task" }));
+  const photos12 = inferGridTiles({ x: 90, y: 200, width: 520, height: 390 }, 4, 3);
+  const picked12 = pickBestTileSet([chrome, photos12]);
+  assert.equal(picked12.length, 12);
+  assert.equal(picked12[0].bounds.width >= 120, true);
+
+  const noisyNine = inferGridTiles({ x: 90, y: 200, width: 390, height: 390 }, 3, 3);
+  noisyNine[8].bounds.y += 20;
+  const pickedNoisy = pickBestTileSet([chrome, noisyNine]);
+  assert.equal(pickedNoisy.length, 9);
+  assert.equal(pickedNoisy[0].bounds.width, 130);
+});
+
 test("collapseNestedBoxes drops inset selected-state wrappers", () => {
   const outer = { x: 220, y: 209, width: 130, height: 130 };
   const inset = { x: 222, y: 211, width: 126, height: 126 };

--- a/tests/node/captcha-solver.test.ts
+++ b/tests/node/captcha-solver.test.ts
@@ -8,6 +8,7 @@ import {
   CAPTCHA_STAGES,
   classifyChallengeStage,
   clusterSimilarBoxes,
+  collapseNestedBoxes,
   extractDarkBlobs,
   findGrowingRegion,
   gridFromTiles,
@@ -349,6 +350,72 @@ test("pickBestTileSet prefers a 3x3 puzzle over widget chrome", () => {
   const picked = pickBestTileSet([chrome, grid]);
   assert.equal(picked.length, 9);
   assert.equal(picked[0].bounds.width, 100);
+});
+
+test("collapseNestedBoxes drops inset selected-state wrappers", () => {
+  const outer = { x: 220, y: 209, width: 130, height: 130 };
+  const inset = { x: 222, y: 211, width: 126, height: 126 };
+  const neighbor = { x: 350, y: 209, width: 130, height: 130 };
+  const collapsed = collapseNestedBoxes([outer, inset, neighbor]);
+  assert.equal(collapsed.length, 2);
+  assert.deepEqual(collapsed[0], outer);
+  assert.deepEqual(collapsed[1], neighbor);
+});
+
+test("collapseNestedBoxes does not swallow a 3x3 inside a larger widget frame", () => {
+  const frame = { x: 40, y: 160, width: 460, height: 460 };
+  const grid = inferGridTiles({ x: 90, y: 209, width: 390, height: 390 }, 3, 3).map(
+    (tile) => tile.bounds,
+  );
+  const collapsed = collapseNestedBoxes([frame, ...grid]);
+  assert.equal(collapsed.length, 10);
+  assert.equal(collapsed.some((box) => box.width === 460), true);
+  assert.equal(collapsed.filter((box) => box.width < 200).length, 9);
+});
+
+test("clusterSimilarBoxes keeps a 3x3 when selected tiles add inset wrappers", () => {
+  // Live recapture after clicking buses on Google's reCAPTCHA demo: nine
+  // 130px cells plus three ~4px-inset selected wrappers. Size slack 14
+  // used to keep all twelve and number the overlay 0–11.
+  const cells = [
+    { x: 90, y: 209, width: 130, height: 130 },
+    { x: 220, y: 209, width: 130, height: 130 },
+    { x: 222, y: 211, width: 126, height: 126 },
+    { x: 350, y: 209, width: 130, height: 130 },
+    { x: 90, y: 339, width: 130, height: 130 },
+    { x: 220, y: 339, width: 130, height: 130 },
+    { x: 350, y: 339, width: 130, height: 130 },
+    { x: 90, y: 469, width: 130, height: 130 },
+    { x: 92, y: 471, width: 126, height: 126 },
+    { x: 220, y: 469, width: 130, height: 130 },
+    { x: 350, y: 469, width: 130, height: 130 },
+    { x: 352, y: 471, width: 126, height: 126 },
+  ];
+  const clustered = clusterSimilarBoxes(cells);
+  assert.equal(clustered.length, 9);
+  assert.equal(gridFromTiles(clustered).rows, 3);
+  assert.equal(gridFromTiles(clustered).cols, 3);
+  assert.equal(
+    clustered.every((box) => box.width === 130 && box.height === 130),
+    true,
+  );
+  const picked = pickBestTileSet([cells.map((bounds, index) => ({ index, bounds }))]);
+  assert.equal(picked.length, 9);
+  assert.deepEqual(
+    picked.map((tile) => tile.index),
+    [0, 1, 2, 3, 4, 5, 6, 7, 8],
+  );
+});
+
+test("visionGridInstruction does not invent numbered tiles for a click-target crop", () => {
+  const text = visionGridInstruction({
+    prompt: "Please click on the animal who jumps the highest",
+    grid: { rows: 0, cols: 0 },
+    tileCount: 0,
+  });
+  assert.match(text, /animal who jumps the highest/);
+  assert.match(text, /captcha\.click\(bounds\)/);
+  assert.equal(/captcha\.solve\(\{ tiles:/.test(text), false);
 });
 
 test("publicCaptchaTiles flattens bounds for host vision", () => {

--- a/types/captcha-solver.d.ts
+++ b/types/captcha-solver.d.ts
@@ -94,6 +94,10 @@ export function clusterSimilarBoxes(
   boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
   options?: { minCount?: number; sizeSlack?: number },
 ): Array<{ x: number; y: number; width: number; height: number }>;
+export function collapseNestedBoxes(
+  boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
+  options?: { overlap?: number; minAreaRatio?: number },
+): Array<{ x: number; y: number; width: number; height: number }>;
 export function isCaptchaChromeLabel(label?: UntrustedValue): boolean;
 export function isPlausibleImageGrid(
   boxes?: UntrustedValue,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,6 +33,7 @@ export {
   CAPTCHA_STAGES,
   classifyChallengeStage,
   clusterSimilarBoxes,
+  collapseNestedBoxes,
   gridFromTiles,
   inferGridTiles,
   isCaptchaChromeLabel,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

1.9.2: fix reCAPTCHA image-grid recapture after a selected tile, and stop treating 2×2 / 2×3 widget chrome as a regular photo grid.

After a reCAPTCHA image-grid click, the selected cell exposes a ~4px-inset wrapper. The tile cluster treated those inner boxes as extra cells, so a 3×3 recapture numbered 12 tiles and the overlay skipped indexes. Nested near-same-size boxes are now collapsed, a regular photo-sized 3×3 / 3×4 / 4×4 wins over a larger messy cluster, and a crop with no tiles no longer asks the host for numbered picks.

Greptile flagged that the regularity bonus also applied to 2×2 and 2×3 clusters. Those sizes match widget chrome from `collectClickableCluster`. The bonus is now limited to photo-sized 9 / 12 / 16-cell grids. Greptile re-reviewed at 5/5.

## Checklist

- [x] `npm run release:check` passes locally (versions, lint, typecheck, build, unit tests, published declarations, tarball).
- [x] **Every browser connection still goes through the guard proxy.** No new launch path or transport.
- [x] **No secret value reaches the model sandbox.** No new output channel.
- [x] **Dependency pins are still mirrored everywhere.** Untouched.
- [x] **Public API changes update `types/*.d.ts` in this same commit.** `collapseNestedBoxes` is exported from `types/captcha-solver.d.ts` and `types/index.d.ts`.
- [x] Branch-protected CI job names unchanged; no new Actions.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js`.
- [x] User-visible behaviour is in `CHANGELOG.md` under 1.9.2.
- [x] Nothing private is being committed.

## How it was verified

- `npm run release:check` on this branch (package smoke test `betterwright-1.9.2.tgz`).
- `tests/node/captcha-solver.test.ts` — live 12-box recapture coords, large-frame not swallowed, empty-grid instruction, 2×3 chrome must not beat a 3×4 or noisy 3×3.
- Headed official demos: Google reCAPTCHA v2 produced clean 3×3 recaptures after selected tiles (indexes 0–8). Cloudflare Turnstile dummy demo cleared with a 21-char test token.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a98fc878-865b-4c0d-b908-6470475eba1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a98fc878-865b-4c0d-b908-6470475eba1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

