### PR TITLE
docs: protect BetterWright project identity

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: If you reference BetterWright in research or documentation, please cite the project.
+title: BetterWright
+type: software
+authors:
+  - name: The BetterWright Project and contributors
+repository-code: https://github.com/BetterWright/betterwright
+url: https://betterwright.com
+license: MIT
+abstract: A persistent, policy-guarded browser runtime for AI agents.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,18 @@ turn it into a tool primarily for evading anti-bot systems at scale, bulk
 account creation, or credential stuffing are out of scope. Features that make
 authorized automation safer, clearer, or more reliable are welcome.
 
+## Licensing and attribution
+
+Unless explicitly agreed otherwise in writing, every contribution submitted
+for inclusion in BetterWright is licensed under the repository's
+[MIT License](LICENSE). By submitting a contribution, you confirm that you have
+the right to license it on those terms.
+
+Contributors retain copyright in their contributions. Preserve applicable
+copyright, license, and third-party notices, and do not submit code under terms
+that conflict with the MIT License. Project identity and fork guidance are in
+[NOTICE.md](NOTICE.md) and [TRADEMARKS.md](TRADEMARKS.md).
+
 ## Pinned Playwright
 
 The Playwright version is pinned in `package.json`. A bump is tested against

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 BetterWright contributors
+Copyright (c) 2026 The BetterWright Project and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,23 @@
+# BetterWright project notice
+
+BetterWright is an open-source browser runtime developed by The BetterWright
+Project and contributors.
+
+The official source repository is:
+
+<https://github.com/BetterWright/betterwright>
+
+BetterWright is licensed under the MIT License. Copies or substantial portions
+of the software must retain the copyright and permission notice in
+[LICENSE](LICENSE).
+
+When publishing a fork or derivative as source code, the project asks that you
+identify it as "based on BetterWright" and link to the official repository.
+This attribution request does not add a condition to the MIT License.
+
+The BetterWright name, logo, and visual identity identify the official project.
+See [TRADEMARKS.md](TRADEMARKS.md) for guidance on using them without implying
+that a fork or third-party product is official or endorsed.
+
+Third-party code and patches retain their own copyright and license notices in
+the relevant source files and upstream projects.

--- a/README.md
+++ b/README.md
@@ -341,6 +341,20 @@ browser configuration can guarantee undetectability or challenge acceptance.
 See [the security model](docs/architecture.md#security-model) for the
 boundaries the code does and does not enforce.
 
+## Project identity and attribution
+
+The official BetterWright project lives at
+[github.com/BetterWright/betterwright](https://github.com/BetterWright/betterwright).
+Forking, modification, integration, and commercial use are welcome under the
+MIT License. Distributed copies or substantial portions must retain the
+copyright and permission notice in [LICENSE](LICENSE).
+
+Public source forks are asked to identify themselves as based on BetterWright
+and use a distinct name and visual identity so users do not mistake them for
+the official project. This does not restrict using BetterWright as a component
+inside a larger product. See [NOTICE.md](NOTICE.md) and
+[TRADEMARKS.md](TRADEMARKS.md).
+
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,38 @@
+# BetterWright name and logo policy
+
+The MIT License grants broad permission to use BetterWright's code. It does not
+grant permission to use the BetterWright name, logo, icons, or visual identity
+in a way that suggests a fork, service, or product is the official BetterWright
+project or is endorsed by it.
+
+This policy exists to prevent confusion, not to restrict truthful discussion,
+compatibility, integration, or commercial use of the software.
+
+## Uses that are welcome
+
+You may use the BetterWright name without separate permission to:
+
+- truthfully state that software is based on, integrates with, or is compatible
+  with BetterWright;
+- link to or discuss the official project in documentation, articles, talks,
+  comparisons, and reviews;
+- reproduce the name and logo when referring to an unmodified official release;
+- describe a fork as "based on BetterWright," provided its presentation does
+  not imply that it is official or endorsed.
+
+## Uses that require a distinct identity
+
+A public fork, redistributed derivative, or competing product should:
+
+- use a name and logo that are clearly distinct from BetterWright;
+- identify the official BetterWright project as the upstream source when
+  describing its origin;
+- avoid names, domains, package names, artwork, or presentation likely to make
+  users believe it is the official project; and
+- preserve all copyright and license notices required by the MIT License.
+
+Do not use the BetterWright name or visual identity to make false claims about
+origin, authorship, affiliation, sponsorship, or endorsement.
+
+For a use that falls outside this guidance, ask the project maintainers through
+<https://github.com/BetterWright/betterwright/discussions>.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,10 @@
     "SECURITY.md",
     "README.md",
     "CHANGELOG.md",
-    "LICENSE"
+    "CITATION.cff",
+    "LICENSE",
+    "NOTICE.md",
+    "TRADEMARKS.md"
   ],
   "scripts": {
     "build:tools": "tsc -p tsconfig.tools.json",
@@ -137,7 +140,7 @@
     "pi-package"
   ],
   "license": "MIT",
-  "author": "BetterWright contributors",
+  "author": "The BetterWright Project and contributors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/BetterWright/betterwright.git"


### PR DESCRIPTION
## What and why

Keep BetterWright commercially permissive under MIT while making the official project origin and fork identity expectations clear.

This adds:

- project-only attribution with no personal or company names;
- a project notice and non-confusing name/logo guidance;
- citation metadata and contributor licensing terms; and
- the new policy files to the published npm package.

The requested source-fork credit is explicitly advisory and does not add a condition to MIT. Using BetterWright inside larger commercial products remains welcome.

## Checklist

- [ ] `npm run release:check` was not available in this shell because Node/npm are not installed; GitHub CI will run the repository checks.
- [x] Runtime, browser, security, dependency, public API, and protected-workflow invariants are unaffected. This changes documentation and package metadata only.
- [x] No personal or company names are included.
- [x] No private data, credentials, infrastructure details, or generated artifacts are included.
- [x] `CITATION.cff`, `NOTICE.md`, and `TRADEMARKS.md` are included in the npm package file list.

## How it was verified

- `git diff --check`
- parsed `package.json` and verified the new files exist and are packed
- searched all changed files for excluded personal and company identities
- independent wording review confirmed MIT commercial use remains permissive and the extra attribution request is not presented as a license condition
