### PR TITLE
Release BetterWright 1.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@ Releases before 1.1.3 predate this file; their notes live on the
   Rich-text editors such as Draft.js swallow synthetic key events, so
   typing resolved with `{ typed: N }` while the composer was still blank.
   After typing, `human.type` reads the field back and treats the action as
-  landed only when the requested text is present as a new change — a
-  prefix, or an unchanged field that already contained the string, is a
-  miss. It then retries with `insertText` (then `document.execCommand` /
-  `beforeinput`) and throws if the field still did not accept the text.
-  (#129)
+  landed only when the requested text occurs more times than before — a
+  prefix, an unchanged field, or a partial append onto a value that
+  already contained the string, is a miss. It then retries with
+  `insertText` (then `document.execCommand` / `beforeinput`) and throws if
+  the field still did not accept the text. (#129)
 
 ## [1.9.5] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ Releases before 1.1.3 predate this file; their notes live on the
   After typing, `human.type` reads the field back and treats the action as
   landed only when the requested text occurs more times than before — a
   prefix, an unchanged field, or a partial append onto a value that
-  already contained the string, is a miss. It then retries with
-  `insertText` (then `document.execCommand` / `beforeinput`) and throws if
-  the field still did not accept the text. (#129)
+  already contained the string, is a miss. A failed append restores the
+  original value before retrying, so a leaked prefix is not left behind.
+  It then retries with `insertText` (then `document.execCommand` /
+  `beforeinput`) and throws if the field still did not accept the text.
+  (#129)
 
 ## [1.9.5] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@ Releases before 1.1.3 predate this file; their notes live on the
 - **`human.type` no longer reports success when the field stayed empty.**
   Rich-text editors such as Draft.js swallow synthetic key events, so
   typing resolved with `{ typed: N }` while the composer was still blank.
-  After typing, `human.type` reads the field back; if nothing landed it
-  retries with `insertText` (then `document.execCommand` / `beforeinput`)
-  and throws if the field is still unchanged. (#129)
+  After typing, `human.type` reads the field back and treats the action as
+  landed only when the requested text is present as a new change — a
+  prefix, or an unchanged field that already contained the string, is a
+  miss. It then retries with `insertText` (then `document.execCommand` /
+  `beforeinput`) and throws if the field still did not accept the text.
+  (#129)
 
 ## [1.9.5] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,12 @@ Releases before 1.1.3 predate this file; their notes live on the
   Rich-text editors such as Draft.js swallow synthetic key events, so
   typing resolved with `{ typed: N }` while the composer was still blank.
   After typing, `human.type` reads the field back and treats the action as
-  landed only when the requested text occurs more times than before — a
-  prefix, an unchanged field, or a partial append onto a value that
-  already contained the string, is a miss. A failed append restores the
-  original value before retrying, so a leaked prefix is not left behind.
-  It then retries with `insertText` (then `document.execCommand` /
-  `beforeinput`) and throws if the field still did not accept the text.
-  (#129)
+  landed only when the requested text was inserted in full — a prefix, an
+  unchanged field, or an overlapping partial append is a miss. A failed
+  append restores the original value before retrying, so a leaked prefix
+  is not left behind. It then retries with `insertText` (then
+  `document.execCommand` / `beforeinput`) and throws if the field still
+  did not accept the text. (#129)
 
 ## [1.9.5] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.9.6] - 2026-08-19
+
+### Fixed
+
+- **A failed upstream connect no longer poisons the guard proxy.** An
+  `ENETUNREACH` from one IPv4 target — a dead TEST-NET address, a down
+  service, a private range with no route — was cached as "IPv4 is
+  unreachable" for 30 seconds. After that, unrelated reachable hosts,
+  including a live loopback server, failed with `ERR_SOCKS_CONNECTION_FAILED`
+  until the worker was restarted. Family-unreachability caching is now
+  IPv6-only, where `ENETUNREACH` / `EAFNOSUPPORT` still mean the host has no
+  IPv6. Connect timeouts are reported to Chromium as host-unreachable
+  (SOCKS reply 4) rather than a general SOCKS server failure (reply 1), so
+  the browser does not treat the proxy itself as dead. (#128)
+- **`human.type` no longer reports success when the field stayed empty.**
+  Rich-text editors such as Draft.js swallow synthetic key events, so
+  typing resolved with `{ typed: N }` while the composer was still blank.
+  After typing, `human.type` reads the field back; if nothing landed it
+  retries with `insertText` (then `document.execCommand` / `beforeinput`)
+  and throws if the field is still unchanged. (#129)
+
 ## [1.9.5] - 2026-08-17
 
 ### Added
@@ -1008,7 +1029,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.5...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.6...HEAD
+[1.9.6]: https://github.com/BetterWright/betterwright/compare/v1.9.5...v1.9.6
 [1.9.5]: https://github.com/BetterWright/betterwright/compare/v1.9.3...v1.9.5
 [1.9.3]: https://github.com/BetterWright/betterwright/compare/v1.9.2...v1.9.3
 [1.9.2]: https://github.com/BetterWright/betterwright/compare/v1.9.1...v1.9.2

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.9.5
+generated_by: betterwright@1.9.6
 ---
 
 # BetterWright browser

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -132,9 +132,12 @@ await human.scroll(650); // negative values scroll upward
 `human.click(target, options?)` and `human.type(target, text, options?)` accept a
 selector, Locator, ElementHandle, or `{x, y, width, height}` bounds. Typing clears
 the field by default; pass `{clear: false}` to append, or set `minDelay` and
-`maxDelay`. After typing, `human.type` reads the field back. If nothing landed —
+`maxDelay`. After typing, `human.type` reads the field back. Success requires the requested
+text to be present as a new change, so a prefix or an unchanged field that
+already contained the string is not treated as a hit. If that check fails —
 typical of Draft.js and other rich-text editors that swallow synthetic key
-events — it retries with `insertText` and throws if the field is still unchanged.
+events — it retries with `insertText` and throws if the field still did not
+accept the text.
 `human.scroll(deltaY, options?)` accepts `steps`, while the object
 form also accepts `deltaX`.
 

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -132,7 +132,10 @@ await human.scroll(650); // negative values scroll upward
 `human.click(target, options?)` and `human.type(target, text, options?)` accept a
 selector, Locator, ElementHandle, or `{x, y, width, height}` bounds. Typing clears
 the field by default; pass `{clear: false}` to append, or set `minDelay` and
-`maxDelay`. `human.scroll(deltaY, options?)` accepts `steps`, while the object
+`maxDelay`. After typing, `human.type` reads the field back. If nothing landed —
+typical of Draft.js and other rich-text editors that swallow synthetic key
+events — it retries with `insertText` and throws if the field is still unchanged.
+`human.scroll(deltaY, options?)` accepts `steps`, while the object
 form also accepts `deltaX`.
 
 These helpers and the managed engines reduce behavioral and

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -132,12 +132,12 @@ await human.scroll(650); // negative values scroll upward
 `human.click(target, options?)` and `human.type(target, text, options?)` accept a
 selector, Locator, ElementHandle, or `{x, y, width, height}` bounds. Typing clears
 the field by default; pass `{clear: false}` to append, or set `minDelay` and
-`maxDelay`. After typing, `human.type` reads the field back. Success requires the requested
-text to be present as a new change, so a prefix or an unchanged field that
-already contained the string is not treated as a hit. If that check fails —
-typical of Draft.js and other rich-text editors that swallow synthetic key
-events — it retries with `insertText` and throws if the field still did not
-accept the text.
+`maxDelay`. After typing, `human.type` reads the field back. Success requires a new
+occurrence of the requested text, so a prefix, an unchanged field, or a
+partial append onto a value that already contained the string is not a hit.
+If that check fails — typical of Draft.js and other rich-text editors that
+swallow synthetic key events — it retries with `insertText` and throws if
+the field still did not accept the text.
 `human.scroll(deltaY, options?)` accepts `steps`, while the object
 form also accepts `deltaX`.
 

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -132,9 +132,9 @@ await human.scroll(650); // negative values scroll upward
 `human.click(target, options?)` and `human.type(target, text, options?)` accept a
 selector, Locator, ElementHandle, or `{x, y, width, height}` bounds. Typing clears
 the field by default; pass `{clear: false}` to append, or set `minDelay` and
-`maxDelay`. After typing, `human.type` reads the field back. Success requires a new
-occurrence of the requested text, so a prefix, an unchanged field, or a
-partial append onto a value that already contained the string is not a hit.
+`maxDelay`. After typing, `human.type` reads the field back. Success requires the
+requested text to be inserted in full, so a prefix, an unchanged field, or
+an overlapping partial append is not a hit.
 If that check fails — typical of Draft.js and other rich-text editors that
 swallow synthetic key events — it restores the original value when appending,
 retries with `insertText`, and throws if the field still did not accept the

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -136,8 +136,9 @@ the field by default; pass `{clear: false}` to append, or set `minDelay` and
 occurrence of the requested text, so a prefix, an unchanged field, or a
 partial append onto a value that already contained the string is not a hit.
 If that check fails — typical of Draft.js and other rich-text editors that
-swallow synthetic key events — it retries with `insertText` and throws if
-the field still did not accept the text.
+swallow synthetic key events — it restores the original value when appending,
+retries with `insertText`, and throws if the field still did not accept the
+text.
 `human.scroll(deltaY, options?)` accepts `steps`, while the object
 form also accepts `deltaX`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.9.5",
+      "version": "1.9.6",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/guard-proxy.ts
+++ b/src/guard-proxy.ts
@@ -74,7 +74,17 @@ function socksReply(code) {
 function socksReplyCode(error) {
   if (error?.code === "BW_PROXY_BLOCKED") return 2;
   if (error?.code === "ENETUNREACH") return 3;
-  if (["BW_PROXY_DNS", "EHOSTUNREACH"].includes(error?.code)) return 4;
+  // Timeouts and generic connect failures are a dead *target*, not a dead
+  // SOCKS server. Reply 1 (general server failure) is what Chromium treats as
+  // "the proxy itself is broken", after which unrelated reachable hosts fail
+  // with ERR_SOCKS_CONNECTION_FAILED until the worker restarts.
+  if (
+    ["BW_PROXY_DNS", "EHOSTUNREACH", "BW_PROXY_CONNECT", "ETIMEDOUT"].includes(
+      error?.code,
+    )
+  ) {
+    return 4;
+  }
   if (error?.code === "ECONNREFUSED") return 5;
   if (error?.code === "EAFNOSUPPORT") return 8;
   return 1;
@@ -489,6 +499,12 @@ export function createGuardProxy(
   function rememberUnavailableFamily(family, error) {
     if (![4, 6].includes(family) || !FAMILY_UNREACHABLE_CODES.has(error?.code))
       return;
+    // IPv4 ENETUNREACH is per-destination (no route to that network). Caching
+    // it as "IPv4 is down" makes the next unrelated target — a live loopback
+    // server, example.com — fail until the worker restarts. IPv6 ENETUNREACH
+    // and EAFNOSUPPORT usually mean the host has no IPv6, which is the case
+    // this cache exists to skip.
+    if (family === 4 && error.code === "ENETUNREACH") return;
     unavailableFamilies.delete(family);
     unavailableFamilies.set(family, {
       code: error.code,

--- a/src/human.ts
+++ b/src/human.ts
@@ -112,31 +112,32 @@ export async function pressPointer(mouse, inputLike = false) {
   await mouse.up();
 }
 
-function countOccurrences(haystack, needle) {
-  if (!needle) return 0;
-  let count = 0;
-  let from = 0;
-  while (from <= haystack.length - needle.length) {
-    const index = haystack.indexOf(needle, from);
-    if (index === -1) return count;
-    count += 1;
-    from = index + needle.length;
+function isInsertOf(before, after, inserted) {
+  if (after.length !== before.length + inserted.length) return false;
+  for (let index = 0; index <= before.length; index += 1) {
+    if (
+      after.slice(0, index) === before.slice(0, index) &&
+      after.slice(index, index + inserted.length) === inserted &&
+      after.slice(index + inserted.length) === before.slice(index)
+    ) {
+      return true;
+    }
   }
-  return count;
+  return false;
 }
 
-// True only when `text` landed as a *new* occurrence. An unchanged field, a
-// prefix, or a partial append that leaves the old occurrence count the same
-// (the prior value already contained the string) is a miss. Unreadable
-// targets and empty requests cannot be verified and pass.
+// True only when `after` is `before` with the full requested string spliced
+// in once. A prefix, an unchanged field, a leftover occurrence, or an
+// overlapping partial append (`aa` + two of `aaa` → `aaaa`) is a miss.
+// Unreadable targets and empty requests cannot be verified and pass.
 export function typedTextLanded(expected, before, after) {
   if (!expected || after == null) return true;
   const request = String(expected);
   const beforeText = String(before ?? "");
   const afterText = String(after);
-  return (
-    countOccurrences(afterText, request) > countOccurrences(beforeText, request)
-  );
+  const baseline = beforeText.trim().length === 0 ? "" : beforeText;
+  if (baseline === "" && afterText.trim() === request) return true;
+  return isInsertOf(baseline, afterText, request);
 }
 
 export async function typeText(keyboard, text, options: any = {}) {

--- a/src/human.ts
+++ b/src/human.ts
@@ -112,6 +112,18 @@ export async function pressPointer(mouse, inputLike = false) {
   await mouse.up();
 }
 
+// True only when `text` is present as a *new* change. A field that already
+// contained the requested string and did not change is a miss (append into a
+// key-swallowing editor). A non-empty change that does not contain `text` is
+// also a miss (the editor accepted a prefix). Unreadable targets and empty
+// requests cannot be verified and pass.
+export function typedTextLanded(expected, before, after) {
+  if (!expected || after == null) return true;
+  const beforeText = String(before ?? "");
+  const afterText = String(after);
+  return afterText.includes(String(expected)) && afterText !== beforeText;
+}
+
 export async function typeText(keyboard, text, options: any = {}) {
   const minDelay = Math.max(10, Number(options.minDelay) || 35);
   const maxDelay = Math.max(minDelay, Number(options.maxDelay) || 95);

--- a/src/human.ts
+++ b/src/human.ts
@@ -112,16 +112,31 @@ export async function pressPointer(mouse, inputLike = false) {
   await mouse.up();
 }
 
-// True only when `text` is present as a *new* change. A field that already
-// contained the requested string and did not change is a miss (append into a
-// key-swallowing editor). A non-empty change that does not contain `text` is
-// also a miss (the editor accepted a prefix). Unreadable targets and empty
-// requests cannot be verified and pass.
+function countOccurrences(haystack, needle) {
+  if (!needle) return 0;
+  let count = 0;
+  let from = 0;
+  while (from <= haystack.length - needle.length) {
+    const index = haystack.indexOf(needle, from);
+    if (index === -1) return count;
+    count += 1;
+    from = index + needle.length;
+  }
+  return count;
+}
+
+// True only when `text` landed as a *new* occurrence. An unchanged field, a
+// prefix, or a partial append that leaves the old occurrence count the same
+// (the prior value already contained the string) is a miss. Unreadable
+// targets and empty requests cannot be verified and pass.
 export function typedTextLanded(expected, before, after) {
   if (!expected || after == null) return true;
+  const request = String(expected);
   const beforeText = String(before ?? "");
   const afterText = String(after);
-  return afterText.includes(String(expected)) && afterText !== beforeText;
+  return (
+    countOccurrences(afterText, request) > countOccurrences(beforeText, request)
+  );
 }
 
 export async function typeText(keyboard, text, options: any = {}) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1669,6 +1669,57 @@ async function selectAllForClear(page, target) {
   await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A");
 }
 
+async function readTypedFieldText(target) {
+  if (!target || !isCallable(untrustedField(target, "evaluate"))) return null;
+  return target.evaluate((element) => {
+    if (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement
+    ) {
+      return String(element.value ?? "");
+    }
+    return String(element.innerText ?? element.textContent ?? "");
+  });
+}
+
+function typedTextLanded(expected, before, after) {
+  if (!expected || after == null) return true;
+  if (String(after).includes(expected)) return true;
+  return String(after) !== String(before ?? "") && String(after).trim().length > 0;
+}
+
+async function insertTypedText(page, target, text) {
+  const value = String(text);
+  if (!value) return;
+  if (target && isCallable(untrustedField(target, "focus"))) {
+    await target.focus().catch(() => {});
+  }
+  await page.keyboard.insertText(value);
+  const afterInsert = await readTypedFieldText(target);
+  if (afterInsert != null && typedTextLanded(value, "", afterInsert)) return;
+  if (!target || !isCallable(untrustedField(target, "evaluate"))) return;
+  await target.evaluate((element, inserted) => {
+    const isCallableValue = (value: UntrustedValue): value is UntrustedFunction =>
+      typeof value === "function";
+    if (isCallableValue(element.focus)) element.focus();
+    const doc = element.ownerDocument;
+    if (
+      isCallableValue(doc.execCommand) &&
+      doc.execCommand("insertText", false, inserted)
+    ) {
+      return;
+    }
+    const eventInit = {
+      bubbles: true,
+      composed: true,
+      inputType: "insertText",
+      data: inserted,
+    };
+    element.dispatchEvent(new InputEvent("beforeinput", eventInit));
+    element.dispatchEvent(new InputEvent("input", eventInit));
+  }, value);
+}
+
 async function installContextGuard(context) {
   await context.route("**/*", async (route) => {
     const request = route.request();
@@ -4432,12 +4483,29 @@ function buildSandbox(session, consoleMessages, execution) {
   human.type = realm.safeFunction(async (target, text, options: any = {}) => {
     const page = await ensureSessionPage(session);
     const clickedTarget = await humanClickTarget(page, session, target, options);
-    if (options?.clear !== false) {
+    const clear = options?.clear !== false;
+    if (clear) {
       await selectAllForClear(page, clickedTarget);
       await page.keyboard.press("Backspace");
     }
-    await typeText(page.keyboard, text, options);
-    return { typed: String(text).length };
+    const expected = String(text);
+    const before = await readTypedFieldText(clickedTarget);
+    await typeText(page.keyboard, expected, options);
+    let after = await readTypedFieldText(clickedTarget);
+    if (!typedTextLanded(expected, before, after)) {
+      if (clear) {
+        await selectAllForClear(page, clickedTarget);
+        await page.keyboard.press("Backspace");
+      }
+      await insertTypedText(page, clickedTarget, expected);
+      after = await readTypedFieldText(clickedTarget);
+    }
+    if (!typedTextLanded(expected, before, after)) {
+      throw new Error(
+        "human.type did not change the field. The target may ignore synthetic key events (common in Draft.js and other rich-text editors).",
+      );
+    }
+    return { typed: expected.length };
   });
   human.scroll = realm.safeFunction(async (deltaOrOptions, options: any = {}) => {
     const page = await ensureSessionPage(session);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -105,6 +105,7 @@ import {
   pointInside,
   pressPointer,
   scrollWheel,
+  typedTextLanded,
   typeText,
 } from "./human.js";
 import { buildLaunchIdentityPlan, resolveGeoIdentity } from "./launch-identity.js";
@@ -1682,21 +1683,35 @@ async function readTypedFieldText(target) {
   });
 }
 
-function typedTextLanded(expected, before, after) {
-  if (!expected || after == null) return true;
-  if (String(after).includes(expected)) return true;
-  return String(after) !== String(before ?? "") && String(after).trim().length > 0;
-}
-
-async function insertTypedText(page, target, text) {
+async function insertTypedText(page, target, text, before) {
   const value = String(text);
   if (!value) return;
   if (target && isCallable(untrustedField(target, "focus"))) {
     await target.focus().catch(() => {});
   }
+  if (target && isCallable(untrustedField(target, "evaluate"))) {
+    await target.evaluate((element) => {
+      if (
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement
+      ) {
+        const end = element.value.length;
+        element.setSelectionRange(end, end);
+        return;
+      }
+      if (!element.isContentEditable) return;
+      const selection = element.ownerDocument.defaultView?.getSelection();
+      if (!selection) return;
+      const range = element.ownerDocument.createRange();
+      range.selectNodeContents(element);
+      range.collapse(false);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    });
+  }
   await page.keyboard.insertText(value);
   const afterInsert = await readTypedFieldText(target);
-  if (afterInsert != null && typedTextLanded(value, "", afterInsert)) return;
+  if (afterInsert != null && typedTextLanded(value, before, afterInsert)) return;
   if (!target || !isCallable(untrustedField(target, "evaluate"))) return;
   await target.evaluate((element, inserted) => {
     const isCallableValue = (value: UntrustedValue): value is UntrustedFunction =>
@@ -4497,7 +4512,8 @@ function buildSandbox(session, consoleMessages, execution) {
         await selectAllForClear(page, clickedTarget);
         await page.keyboard.press("Backspace");
       }
-      await insertTypedText(page, clickedTarget, expected);
+      const retryBefore = await readTypedFieldText(clickedTarget);
+      await insertTypedText(page, clickedTarget, expected, retryBefore);
       after = await readTypedFieldText(clickedTarget);
     }
     if (!typedTextLanded(expected, before, after)) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1683,6 +1683,27 @@ async function readTypedFieldText(target) {
   });
 }
 
+async function restoreTypedFieldText(page, target, text) {
+  if (text == null || !target) return;
+  if (isCallable(untrustedField(target, "evaluate"))) {
+    const restored = await target.evaluate((element, value) => {
+      if (
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement
+      ) {
+        element.value = value;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+        return true;
+      }
+      return false;
+    }, String(text));
+    if (restored) return;
+  }
+  await selectAllForClear(page, target);
+  if (String(text)) await page.keyboard.insertText(String(text));
+  else await page.keyboard.press("Backspace");
+}
+
 async function insertTypedText(page, target, text, before) {
   const value = String(text);
   if (!value) return;
@@ -4511,6 +4532,8 @@ function buildSandbox(session, consoleMessages, execution) {
       if (clear) {
         await selectAllForClear(page, clickedTarget);
         await page.keyboard.press("Backspace");
+      } else if (before != null) {
+        await restoreTypedFieldText(page, clickedTarget, before);
       }
       const retryBefore = await readTypedFieldText(clickedTarget);
       await insertTypedText(page, clickedTarget, expected, retryBefore);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1683,25 +1683,42 @@ async function readTypedFieldText(target) {
   });
 }
 
-async function restoreTypedFieldText(page, target, text) {
-  if (text == null || !target) return;
+async function restoreTypedFieldText(target, text) {
+  const value = String(text ?? "");
+  if (!target) return;
   if (isCallable(untrustedField(target, "evaluate"))) {
-    const restored = await target.evaluate((element, value) => {
+    await target.evaluate((element, next) => {
+      const isCallableValue = (value: UntrustedValue): value is UntrustedFunction =>
+        typeof value === "function";
       if (
         element instanceof HTMLInputElement ||
         element instanceof HTMLTextAreaElement
       ) {
-        element.value = value;
+        element.value = next;
         element.dispatchEvent(new Event("input", { bubbles: true }));
-        return true;
+        return;
       }
-      return false;
-    }, String(text));
-    if (restored) return;
+      if (!element.isContentEditable) return;
+      if (isCallableValue(element.focus)) element.focus();
+      const selection = element.ownerDocument.defaultView?.getSelection();
+      if (selection) {
+        const range = element.ownerDocument.createRange();
+        range.selectNodeContents(element);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+      const doc = element.ownerDocument;
+      if (!isCallableValue(doc.execCommand)) return;
+      if (next) doc.execCommand("insertText", false, next);
+      else doc.execCommand("delete");
+    }, value);
   }
-  await selectAllForClear(page, target);
-  if (String(text)) await page.keyboard.insertText(String(text));
-  else await page.keyboard.press("Backspace");
+  const after = await readTypedFieldText(target);
+  if (after != null && after !== value) {
+    throw new Error(
+      "human.type could not restore the field before retrying the insert.",
+    );
+  }
 }
 
 async function insertTypedText(page, target, text, before) {
@@ -4533,7 +4550,7 @@ function buildSandbox(session, consoleMessages, execution) {
         await selectAllForClear(page, clickedTarget);
         await page.keyboard.press("Backspace");
       } else if (before != null) {
-        await restoreTypedFieldText(page, clickedTarget, before);
+        await restoreTypedFieldText(clickedTarget, before);
       }
       const retryBefore = await readTypedFieldText(clickedTarget);
       await insertTypedText(page, clickedTarget, expected, retryBefore);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1714,10 +1714,22 @@ async function restoreTypedFieldText(target, text) {
     }, value);
   }
   const after = await readTypedFieldText(target);
-  if (after != null && after !== value) {
-    throw new Error(
-      "human.type could not restore the field before retrying the insert.",
-    );
+  if (after != null && !typedFieldMatches(after, value)) {
+    throw new Error("human.type could not replace the field contents.");
+  }
+}
+
+function typedFieldMatches(actual, expected) {
+  if (expected === "") return String(actual).trim().length === 0;
+  return String(actual) === String(expected);
+}
+
+async function clearTypedField(page, target) {
+  await selectAllForClear(page, target);
+  await page.keyboard.press("Backspace");
+  const afterClear = await readTypedFieldText(target);
+  if (afterClear != null && afterClear.trim().length > 0) {
+    await restoreTypedFieldText(target, "");
   }
 }
 
@@ -4537,19 +4549,14 @@ function buildSandbox(session, consoleMessages, execution) {
     const page = await ensureSessionPage(session);
     const clickedTarget = await humanClickTarget(page, session, target, options);
     const clear = options?.clear !== false;
-    if (clear) {
-      await selectAllForClear(page, clickedTarget);
-      await page.keyboard.press("Backspace");
-    }
+    if (clear) await clearTypedField(page, clickedTarget);
     const expected = String(text);
     const before = await readTypedFieldText(clickedTarget);
     await typeText(page.keyboard, expected, options);
     let after = await readTypedFieldText(clickedTarget);
     if (!typedTextLanded(expected, before, after)) {
-      if (clear) {
-        await selectAllForClear(page, clickedTarget);
-        await page.keyboard.press("Backspace");
-      } else if (before != null) {
+      if (clear) await clearTypedField(page, clickedTarget);
+      else if (before != null) {
         await restoreTypedFieldText(clickedTarget, before);
       }
       const retryBefore = await readTypedFieldText(clickedTarget);

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1636,6 +1636,32 @@ test("human helpers use shaped pointer, keyboard, and wheel events", opts, async
   }
 });
 
+test("human.type clears even when Backspace is swallowed", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <input id="name" value="old" style="width:240px;height:40px">
+        <script>
+          document.querySelector('#name').addEventListener('keydown', (event) => {
+            if (event.key === 'Backspace' || event.key === 'Delete') event.preventDefault();
+          });
+        </script>
+      \`);
+      const typed = await human.type('#name', 'hello');
+      return {
+        typed,
+        value: await page.evaluate(() => document.querySelector('#name').value),
+      };
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.typed.typed, 5);
+    assert.equal(result.result.value, "hello");
+  } finally {
+    await bw.close();
+  }
+});
+
 test("human.type inserts into a rich-text editor that swallows key events", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1691,6 +1691,39 @@ test("human.type retries when key events only land a prefix", opts, async () => 
   }
 });
 
+test("human.type restores a contenteditable before retrying a partial append", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <div id="editor" contenteditable="true" style="width:400px;height:80px">Ada</div>
+        <script>
+          const editor = document.querySelector('#editor');
+          let accepted = 0;
+          editor.addEventListener('keydown', (event) => {
+            if (event.key.length !== 1) return;
+            event.preventDefault();
+            if (accepted < 1) {
+              accepted += 1;
+              editor.textContent += event.key;
+            }
+          });
+        </script>
+      \`);
+      const typed = await human.type('#editor', 'Ada', {clear: false});
+      return {
+        typed,
+        text: await page.evaluate(() => document.querySelector('#editor').textContent),
+      };
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.typed.typed, 3);
+    assert.equal(result.result.text, "AdaAda");
+  } finally {
+    await bw.close();
+  }
+});
+
 test("human.type retries a partial append onto existing matching text", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1718,9 +1718,7 @@ test("human.type retries a partial append onto existing matching text", opts, as
     `);
     assert.equal(result.ok, true, result.error);
     assert.equal(result.result.typed.typed, 3);
-    assert.match(result.result.value, /Ada.*Ada/);
-    assert.notEqual(result.result.value, "Ada");
-    assert.notEqual(result.result.value, "AdaA");
+    assert.equal(result.result.value, "AdaAda");
   } finally {
     await bw.close();
   }

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1636,6 +1636,60 @@ test("human helpers use shaped pointer, keyboard, and wheel events", opts, async
   }
 });
 
+test("human.type inserts into a rich-text editor that swallows key events", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <div id="editor" contenteditable="true" style="width:400px;height:80px"></div>
+        <script>
+          document.querySelector('#editor').addEventListener('keydown', (event) => {
+            if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+              event.preventDefault();
+            }
+          });
+        </script>
+      \`);
+      const typed = await human.type('#editor', 'hello from human');
+      return {
+        typed,
+        text: await page.evaluate(() => document.querySelector('#editor').textContent),
+      };
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.typed.typed, 16);
+    assert.equal(result.result.text, "hello from human");
+  } finally {
+    await bw.close();
+  }
+});
+
+test("human.type throws when the field stays empty", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <div id="editor" contenteditable="true" style="width:400px;height:80px"></div>
+        <script>
+          const editor = document.querySelector('#editor');
+          new MutationObserver(() => { editor.textContent = ''; }).observe(editor, {
+            childList: true, subtree: true, characterData: true,
+          });
+          editor.addEventListener('keydown', (event) => {
+            if (event.key.length === 1) event.preventDefault();
+          });
+          editor.addEventListener('beforeinput', (event) => event.preventDefault());
+        </script>
+      \`);
+      await human.type('#editor', 'hello');
+    `);
+    assert.equal(result.ok, false);
+    assert.match(String(result.error), /did not change the field/i);
+  } finally {
+    await bw.close();
+  }
+});
+
 test("interactive snapshots expose refs that aria-ref locators can act on", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1691,6 +1691,41 @@ test("human.type retries when key events only land a prefix", opts, async () => 
   }
 });
 
+test("human.type retries a partial append onto existing matching text", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <input id="name" value="Ada" style="width:240px;height:40px">
+        <script>
+          const name = document.querySelector('#name');
+          let accepted = 0;
+          name.addEventListener('keydown', (event) => {
+            if (event.key.length !== 1) return;
+            event.preventDefault();
+            if (accepted < 1) {
+              accepted += 1;
+              name.value += event.key;
+            }
+          });
+        </script>
+      \`);
+      const typed = await human.type('#name', 'Ada', {clear: false});
+      return {
+        typed,
+        value: await page.evaluate(() => document.querySelector('#name').value),
+      };
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.typed.typed, 3);
+    assert.match(result.result.value, /Ada.*Ada/);
+    assert.notEqual(result.result.value, "Ada");
+    assert.notEqual(result.result.value, "AdaA");
+  } finally {
+    await bw.close();
+  }
+});
+
 test("human.type appends when the field already contains the requested text", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1664,6 +1664,59 @@ test("human.type inserts into a rich-text editor that swallows key events", opts
   }
 });
 
+test("human.type retries when key events only land a prefix", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <input id="name" style="width:240px;height:40px">
+        <script>
+          const name = document.querySelector('#name');
+          name.addEventListener('keydown', (event) => {
+            if (event.key.length === 1 && name.value.length >= 3) event.preventDefault();
+          });
+        </script>
+      \`);
+      const typed = await human.type('#name', 'hello');
+      return {
+        typed,
+        value: await page.evaluate(() => document.querySelector('#name').value),
+      };
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.typed.typed, 5);
+    assert.equal(result.result.value, "hello");
+  } finally {
+    await bw.close();
+  }
+});
+
+test("human.type appends when the field already contains the requested text", opts, async () => {
+  const bw = new BetterWright({ home: tempHome(), headless: true });
+  try {
+    const result = await bw.run(`
+      await page.setContent(\`
+        <input id="name" value="Ada" style="width:240px;height:40px">
+        <script>
+          document.querySelector('#name').addEventListener('keydown', (event) => {
+            if (event.key.length === 1) event.preventDefault();
+          });
+        </script>
+      \`);
+      const typed = await human.type('#name', 'Ada', {clear: false});
+      return {
+        typed,
+        value: await page.evaluate(() => document.querySelector('#name').value),
+      };
+    `);
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.result.typed.typed, 3);
+    assert.equal(result.result.value, "AdaAda");
+  } finally {
+    await bw.close();
+  }
+});
+
 test("human.type throws when the field stays empty", opts, async () => {
   const bw = new BetterWright({ home: tempHome(), headless: true });
   try {

--- a/tests/node/guard-proxy.test.ts
+++ b/tests/node/guard-proxy.test.ts
@@ -303,6 +303,28 @@ test("family unreachability suppresses new dials without skipping guard checks",
   }
 });
 
+test("IPv4 ENETUNREACH does not suppress an unrelated IPv4 target", async () => {
+  const dials = [];
+  const proxy = createGuardProxy(
+    proxyOptions({
+      delay: async () => {},
+      connect: async ({ host }) => {
+        dials.push(host);
+        if (host === "198.51.100.7") throw codedError("ENETUNREACH");
+        return new PassThrough();
+      },
+    }),
+  );
+  try {
+    const port = await proxy.ensure();
+    assert.equal(await socksConnect(port, "198.51.100.7", 81), 3);
+    assert.equal(await socksConnect(port, "127.0.0.1", 45999), 0);
+    assert.deepEqual(dials, ["198.51.100.7", "127.0.0.1"]);
+  } finally {
+    await proxy.close();
+  }
+});
+
 test("family suppression expires at its bounded TTL", async () => {
   let clock = 1_000;
   let dialCount = 0;
@@ -713,7 +735,8 @@ test("SOCKS5 replies preserve policy, reachability, and address errors", async (
     { name: "host unreachable", expected: 4, errorCode: "EHOSTUNREACH" },
     { name: "connection refused", expected: 5, errorCode: "ECONNREFUSED" },
     { name: "address family unsupported", expected: 8, errorCode: "EAFNOSUPPORT" },
-    { name: "general connect failure", expected: 1, errorCode: "BW_PROXY_CONNECT" },
+    { name: "connect timeout", expected: 4, errorCode: "BW_PROXY_CONNECT" },
+    { name: "OS timeout", expected: 4, errorCode: "ETIMEDOUT" },
     { name: "success", expected: 0, success: true },
   ];
 

--- a/tests/node/human.test.ts
+++ b/tests/node/human.test.ts
@@ -13,6 +13,7 @@ import {
   pointInside,
   pressPointer,
   scrollWheel,
+  typedTextLanded,
   typeText,
 } from "../../dist/src/human.js";
 
@@ -214,6 +215,19 @@ test("pressPointer dwells before pressing and between down and up", async (t) =>
   assert.deepEqual(mouse.calls, [["down"], ["up"]]);
   assert.equal(settled, true);
   await done;
+});
+
+test("typedTextLanded requires the requested text as a new change", () => {
+  assert.equal(typedTextLanded("", "", ""), true);
+  assert.equal(typedTextLanded("hello", "", null), true);
+  assert.equal(typedTextLanded("hello", "", "hello"), true);
+  assert.equal(typedTextLanded("hello", "pre", "prehello"), true);
+  assert.equal(typedTextLanded("hello", "hello", "hellohello"), true);
+  // Partial accept: the field changed but does not contain the request.
+  assert.equal(typedTextLanded("hello", "", "hel"), false);
+  // Unchanged append: the request is already in the field and nothing new landed.
+  assert.equal(typedTextLanded("hello", "hello", "hello"), false);
+  assert.equal(typedTextLanded("Ada", "Ada Lovelace", "Ada Lovelace"), false);
 });
 
 test("typeText routes ASCII through type and everything else through insertText, per character", async (t) => {

--- a/tests/node/human.test.ts
+++ b/tests/node/human.test.ts
@@ -217,20 +217,23 @@ test("pressPointer dwells before pressing and between down and up", async (t) =>
   await done;
 });
 
-test("typedTextLanded requires the requested text as a new occurrence", () => {
+test("typedTextLanded requires the requested text as a full insert", () => {
   assert.equal(typedTextLanded("", "", ""), true);
   assert.equal(typedTextLanded("hello", "", null), true);
   assert.equal(typedTextLanded("hello", "", "hello"), true);
   assert.equal(typedTextLanded("hello", "pre", "prehello"), true);
   assert.equal(typedTextLanded("hello", "hello", "hellohello"), true);
-  // Partial accept: the field changed but does not contain the request.
+  assert.equal(typedTextLanded("Lovelace", "\n", "Lovelace"), true);
+  // Partial accept: the field changed but is not a full insert of the request.
   assert.equal(typedTextLanded("hello", "", "hel"), false);
   // Unchanged append: the request is already in the field and nothing new landed.
   assert.equal(typedTextLanded("hello", "hello", "hello"), false);
   assert.equal(typedTextLanded("Ada", "Ada Lovelace", "Ada Lovelace"), false);
-  // Partial append: the old occurrence remains and only a suffix fragment landed.
+  // Partial append: leftover occurrence plus a fragment, or an overlapping prefix.
   assert.equal(typedTextLanded("hello", "hello", "helloX"), false);
   assert.equal(typedTextLanded("Ada", "Ada Lovelace", "Ada Lovelace!"), false);
+  assert.equal(typedTextLanded("aaa", "aa", "aaaa"), false);
+  assert.equal(typedTextLanded("aaa", "aa", "aaaaa"), true);
 });
 
 test("typeText routes ASCII through type and everything else through insertText, per character", async (t) => {

--- a/tests/node/human.test.ts
+++ b/tests/node/human.test.ts
@@ -217,7 +217,7 @@ test("pressPointer dwells before pressing and between down and up", async (t) =>
   await done;
 });
 
-test("typedTextLanded requires the requested text as a new change", () => {
+test("typedTextLanded requires the requested text as a new occurrence", () => {
   assert.equal(typedTextLanded("", "", ""), true);
   assert.equal(typedTextLanded("hello", "", null), true);
   assert.equal(typedTextLanded("hello", "", "hello"), true);
@@ -228,6 +228,9 @@ test("typedTextLanded requires the requested text as a new change", () => {
   // Unchanged append: the request is already in the field and nothing new landed.
   assert.equal(typedTextLanded("hello", "hello", "hello"), false);
   assert.equal(typedTextLanded("Ada", "Ada Lovelace", "Ada Lovelace"), false);
+  // Partial append: the old occurrence remains and only a suffix fragment landed.
+  assert.equal(typedTextLanded("hello", "hello", "helloX"), false);
+  assert.equal(typedTextLanded("Ada", "Ada Lovelace", "Ada Lovelace!"), false);
 });
 
 test("typeText routes ASCII through type and everything else through insertText, per character", async (t) => {


### PR DESCRIPTION
## Summary

Both [#128](https://github.com/BetterWright/betterwright/issues/128) and [#129](https://github.com/BetterWright/betterwright/issues/129) are real 1.9.5 bugs. This ships 1.9.6 with fixes and regression tests.

### #128 — failed upstream connect poisons the guard proxy

Reproduced at the SOCKS layer: an `ENETUNREACH` from one IPv4 target (`198.51.100.7:81`) was cached as "IPv4 is unreachable", so an unrelated live `127.0.0.1` target was never dialed and failed with SOCKS reply 3. The live Chromium table from the report did not trip on this Mac (TEST-NET addresses time out here rather than returning `ENETUNREACH`), but the code path the report pointed at is exactly that family cache.

- Do not treat IPv4 `ENETUNREACH` as family-wide unreachability (IPv6 cache unchanged).
- Map connect timeouts to SOCKS host-unreachable (reply 4) instead of general server failure (reply 1), so Chromium does not blame the proxy.

### #129 — `type()` succeeds when the field stayed empty

Reproduced against 1.9.5 with a Draft.js-shaped `contenteditable` that `preventDefault`s keydown: `human.type('#editor', 'hello from human')` returned `{ typed: 16 }` while the editor was still empty. Ordinary inputs and plain contenteditables were fine.

`human.type` now reads the field back. If nothing landed it retries with `insertText` (then `execCommand` / `beforeinput`) and throws if the field is still unchanged.

## Test plan

- [x] `npm run release:check` (820 unit tests, lint, types, package smoke)
- [x] Guard-proxy unit: IPv4 ENETUNREACH on A does not suppress B
- [x] Browser: `human.type` fills a key-swallowing rich-text editor
- [x] Browser: `human.type` throws when the field stays empty
- [x] Browser smoke: two dead TEST-NET navigations, then `example.com` and a live loopback server still succeed