### PR TITLE
Release BetterWright 1.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.9.7] - 2026-08-19
+
 ### Added
 
 - **Typed first-party WebMCP page tools.** Browser snippets can discover a
@@ -1045,7 +1047,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.6...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.7...HEAD
+[1.9.7]: https://github.com/BetterWright/betterwright/compare/v1.9.6...v1.9.7
 [1.9.6]: https://github.com/BetterWright/betterwright/compare/v1.9.5...v1.9.6
 [1.9.5]: https://github.com/BetterWright/betterwright/compare/v1.9.3...v1.9.5
 [1.9.3]: https://github.com/BetterWright/betterwright/compare/v1.9.2...v1.9.3

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.9.6
+generated_by: betterwright@1.9.7
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.9.6",
+      "version": "1.9.7",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- bump BetterWright from 1.9.6 to 1.9.7
- finalize the WebMCP feature notes in the changelog
- update the generated browser skill version stamp

## Release contents

1.9.7 ships the safe first-class WebMCP integration merged in #131: fresh frame-aware discovery, bounded untrusted inputs and outputs, autosubmit authorization, timeout cancellation, worker-private CDP, Chromium feature-flag composition, documentation, and browser integration coverage.

## Validation

- `npm run release:check`
  - 826 tests passed, 3 opt-in live tests skipped, 0 failed
  - version alignment, lint, typecheck, build layout, declarations, and package smoke test passed
- package smoke test built `betterwright-1.9.7.tgz`
