### PR TITLE
fix: make MCP browser_download work without elicitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ Releases before 1.1.3 predate this file; their notes live on the
 ### Changed
 
 - **MCP `browser_download` is autonomous.** Calling that tool grants the run
-  permission to save a remote file. Ordinary `browser` still cannot download
+  permission to save a remote file. The `browser` tool still cannot download
   under the default `ask` worker policy. `BETTERWRIGHT_DOWNLOAD_POLICY=deny`
-  disables downloads; `allow` also permits ordinary `browser` runs. MCP no
-  longer depends on elicitation, which most hosts cannot present. (#134)
+  disables downloads; `allow` also permits the `browser` tool to save files.
+  MCP no longer depends on elicitation, which most hosts cannot present. (#134)
 
 ## [1.9.8] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- **MCP `browser_download` now returns configuration guidance when the client
-  cannot present elicitation.** The default `ask` policy still fails closed:
-  conversation text is not a trusted approval channel, and `approvedDownloads`
-  remains host-only. Clients that declare form elicitation still get a prompt;
-  hosts without that UI are told to set `BETTERWRIGHT_DOWNLOAD_POLICY=allow`
-  in the MCP server environment. Empty `elicitation: {}` capabilities are
-  treated as form support per the spec. (#134)
+- **MCP `browser_download` is autonomous.** Calling that tool grants the run
+  permission to save a remote file. Ordinary `browser` still cannot download
+  under the default `ask` worker policy. `BETTERWRIGHT_DOWNLOAD_POLICY=deny`
+  disables downloads; `allow` also permits ordinary `browser` runs. MCP no
+  longer depends on elicitation, which most hosts cannot present. (#134)
 
 ## [1.9.8] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP `browser_download` now returns configuration guidance when the client
+  cannot present elicitation.** The default `ask` policy still fails closed:
+  conversation text is not a trusted approval channel, and `approvedDownloads`
+  remains host-only. Clients that declare form elicitation still get a prompt;
+  hosts without that UI are told to set `BETTERWRIGHT_DOWNLOAD_POLICY=allow`
+  in the MCP server environment. Empty `elicitation: {}` capabilities are
+  treated as form support per the spec. (#134)
+
 ## [1.9.8] - 2026-08-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases before 1.1.3 predate this file; their notes live on the
 [GitHub releases page](https://github.com/BetterWright/betterwright/releases).
 
-## [Unreleased]
+## [1.9.9] - Unreleased
 
 ### Changed
 
@@ -1089,7 +1089,7 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.8...HEAD
+[1.9.9]: https://github.com/BetterWright/betterwright/compare/v1.9.8...HEAD
 [1.9.8]: https://github.com/BetterWright/betterwright/compare/v1.9.7...v1.9.8
 [1.9.7]: https://github.com/BetterWright/betterwright/compare/v1.9.6...v1.9.7
 [1.9.6]: https://github.com/BetterWright/betterwright/compare/v1.9.5...v1.9.6

--- a/SETUP.md
+++ b/SETUP.md
@@ -267,9 +267,31 @@ Broad discovery should use the host's web-search tool, then open selected
 first-party pages in BetterWright; the operator guidance says so. Set
 `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block` to have the worker enforce it.
 
-The default `BETTERWRIGHT_DOWNLOAD_POLICY=ask` fails closed when an MCP client
-cannot present elicitation. Set it to `allow` to remove approval prompts or
-`deny` to disable downloads completely.
+The default `BETTERWRIGHT_DOWNLOAD_POLICY=ask` uses MCP elicitation so a
+capable host can show a real approval UI. A sentence in the conversation is
+not a trusted grant: the model could invent it, so `browser_download` never
+accepts an `approvedDownloads` (or similar) tool argument.
+
+When the client cannot present elicitation — Cloud Agents, headless hosts, or
+clients that never declared the capability — `ask` fails closed with
+configuration guidance rather than hanging or silently saving a file. Record
+the operator's standing approval in the MCP server environment:
+
+```json
+{
+  "mcpServers": {
+    "betterwright": {
+      "command": "npx",
+      "args": ["betterwright", "mcp"],
+      "env": {
+        "BETTERWRIGHT_DOWNLOAD_POLICY": "allow"
+      }
+    }
+  }
+}
+```
+
+Set the same variable to `deny` to disable downloads completely. See **§6**.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -209,10 +209,9 @@ If the host is an MCP client and you prefer a first-class tool over the CLI,
 BetterWright ships an MCP server that exposes `browser`, `browser_download`,
 `browser_handoff`, and `browser_doctor`, plus `browser_login` when the
 credential vault is enabled. `browser_download` is the autonomous download
-tool: calling it grants that one run permission to save a remote file. Ordinary
-`browser` cannot download. Set `BETTERWRIGHT_DOWNLOAD_POLICY=deny` to disable
-downloads, or `allow` if even ordinary `browser` runs should be able to save
-files.
+tool: calling it grants that one run permission to save a remote file. The
+`browser` tool cannot download. Set `BETTERWRIGHT_DOWNLOAD_POLICY=deny` to disable
+downloads, or `allow` if the `browser` tool should be able to save files too.
 
 The MCP server is the Node package plus the `@modelcontextprotocol/sdk` peer
 dependency (`npm install betterwright @modelcontextprotocol/sdk`).
@@ -272,12 +271,12 @@ first-party pages in BetterWright; the operator guidance says so. Set
 
 MCP `browser_download` is autonomous under the default `ask` worker policy:
 calling that tool is the grant, so hosts that cannot present a confirmation UI
-can still save files the user asked for. Ordinary `browser` still cannot
+can still save files the user asked for. The `browser` tool still cannot
 download. A sentence in the conversation is not a grant, and the tool never
 accepts an `approvedDownloads` (or similar) argument.
 
 Set `BETTERWRIGHT_DOWNLOAD_POLICY=deny` to disable downloads completely, or
-`allow` if every browser run should be able to save files. See **§6**.
+`allow` if the `browser` tool should be able to save files too. See **§6**.
 
 ---
 
@@ -385,7 +384,7 @@ or the MCP env vars):
 | Block loopback too | `--block-loopback` / `allowLoopback: false` | `BETTERWRIGHT_BLOCK_LOOPBACK=1` |
 | Restrict to specific sites | `--allow-host example.com` / `allowHosts: ["example.com"]` | `BETTERWRIGHT_ALLOW_HOSTS=example.com` |
 | Block specific sites | `--block-host ads.example.com` / `blockHosts: [...]` | `BETTERWRIGHT_BLOCK_HOSTS=ads.example.com` |
-| `browser_download` may save files; ordinary browser may not | `downloadPolicy: "ask"` (default) | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
+| `browser_download` may save files; the `browser` tool may not | `downloadPolicy: "ask"` (default) | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
 | Allow downloads from any run | `downloadPolicy: "allow"` | `BETTERWRIGHT_DOWNLOAD_POLICY=allow` |
 | Disable all downloads | `downloadPolicy: "deny"` | `BETTERWRIGHT_DOWNLOAD_POLICY=deny` |
 | Block public search-result UIs | `publicSearchPolicy: "block"` | `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block` |

--- a/SETUP.md
+++ b/SETUP.md
@@ -208,8 +208,11 @@ keep download approval and network policy under trusted host control. Then do
 If the host is an MCP client and you prefer a first-class tool over the CLI,
 BetterWright ships an MCP server that exposes `browser`, `browser_download`,
 `browser_handoff`, and `browser_doctor`, plus `browser_login` when the
-credential vault is enabled. `browser_download` uses MCP elicitation to ask the
-user before any download-capable code runs.
+credential vault is enabled. `browser_download` is the autonomous download
+tool: calling it grants that one run permission to save a remote file. Ordinary
+`browser` cannot download. Set `BETTERWRIGHT_DOWNLOAD_POLICY=deny` to disable
+downloads, or `allow` if even ordinary `browser` runs should be able to save
+files.
 
 The MCP server is the Node package plus the `@modelcontextprotocol/sdk` peer
 dependency (`npm install betterwright @modelcontextprotocol/sdk`).
@@ -267,31 +270,14 @@ Broad discovery should use the host's web-search tool, then open selected
 first-party pages in BetterWright; the operator guidance says so. Set
 `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block` to have the worker enforce it.
 
-The default `BETTERWRIGHT_DOWNLOAD_POLICY=ask` uses MCP elicitation so a
-capable host can show a real approval UI. A sentence in the conversation is
-not a trusted grant: the model could invent it, so `browser_download` never
-accepts an `approvedDownloads` (or similar) tool argument.
+MCP `browser_download` is autonomous under the default `ask` worker policy:
+calling that tool is the grant, so hosts that cannot present a confirmation UI
+can still save files the user asked for. Ordinary `browser` still cannot
+download. A sentence in the conversation is not a grant, and the tool never
+accepts an `approvedDownloads` (or similar) argument.
 
-When the client cannot present elicitation — Cloud Agents, headless hosts, or
-clients that never declared the capability — `ask` fails closed with
-configuration guidance rather than hanging or silently saving a file. Record
-the operator's standing approval in the MCP server environment:
-
-```json
-{
-  "mcpServers": {
-    "betterwright": {
-      "command": "npx",
-      "args": ["betterwright", "mcp"],
-      "env": {
-        "BETTERWRIGHT_DOWNLOAD_POLICY": "allow"
-      }
-    }
-  }
-}
-```
-
-Set the same variable to `deny` to disable downloads completely. See **§6**.
+Set `BETTERWRIGHT_DOWNLOAD_POLICY=deny` to disable downloads completely, or
+`allow` if every browser run should be able to save files. See **§6**.
 
 ---
 
@@ -399,8 +385,8 @@ or the MCP env vars):
 | Block loopback too | `--block-loopback` / `allowLoopback: false` | `BETTERWRIGHT_BLOCK_LOOPBACK=1` |
 | Restrict to specific sites | `--allow-host example.com` / `allowHosts: ["example.com"]` | `BETTERWRIGHT_ALLOW_HOSTS=example.com` |
 | Block specific sites | `--block-host ads.example.com` / `blockHosts: [...]` | `BETTERWRIGHT_BLOCK_HOSTS=ads.example.com` |
-| Ask before each download | `downloadPolicy: "ask"` (default) | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
-| Remove download approval | `downloadPolicy: "allow"` | `BETTERWRIGHT_DOWNLOAD_POLICY=allow` |
+| `browser_download` may save files; ordinary browser may not | `downloadPolicy: "ask"` (default) | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
+| Allow downloads from any run | `downloadPolicy: "allow"` | `BETTERWRIGHT_DOWNLOAD_POLICY=allow` |
 | Disable all downloads | `downloadPolicy: "deny"` | `BETTERWRIGHT_DOWNLOAD_POLICY=deny` |
 | Block public search-result UIs | `publicSearchPolicy: "block"` | `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block` |
 | Act as a second identity | `--profile social` / `profile: "social"` | `BETTERWRIGHT_PROFILE=social` (the CLI reads it too) |

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -588,7 +588,8 @@ async function cmdRun(arg, flags) {
   const acquired = await acquireRunBrowser(flags);
   try {
     // One bounded download-enabled run; the skill instructs agents to get
-    // explicit user approval before passing this (MCP/Pi elicit instead).
+    // explicit user approval before passing this (Pi elicits; MCP
+    // browser_download is the autonomous grant).
     const runOptions: CliRunOptions = {
       session: acquired.session,
     };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2,8 +2,8 @@
 //
 // This lets any MCP client — Claude Code, Cursor, Windsurf, and others — drive
 // a persistent, policy-guarded browser. It exposes `browser` for ordinary
-// runs, `browser_download` for approval-gated downloads, and `browser_doctor`
-// for runtime diagnostics.
+// runs, `browser_download` for autonomous file saves the ordinary `browser`
+// tool cannot perform, and `browser_doctor` for runtime diagnostics.
 //
 // Run it directly (stdio transport):
 //
@@ -23,7 +23,10 @@
 //     BETTERWRIGHT_BLOCK_PRIVATE_NETWORK=1 block RFC1918 / *.internal (open by default)
 //     BETTERWRIGHT_ALLOW_HOSTS=a.com,b.com always-allow list (comma-separated)
 //     BETTERWRIGHT_BLOCK_HOSTS=ads.com     always-block list (comma-separated)
-//     BETTERWRIGHT_DOWNLOAD_POLICY=ask     ask (default), allow, or deny downloads
+//     BETTERWRIGHT_DOWNLOAD_POLICY=ask     ask (default): browser_download may
+//                                          save files autonomously; ordinary
+//                                          browser cannot. allow: any run.
+//                                          deny: no downloads.
 //     BETTERWRIGHT_HEADLESS=0              run the managed browser headed
 //     BETTERWRIGHT_PROFILE=<name>          act as a named browser profile: a
 //                                          separate identity (own cookies, own
@@ -210,7 +213,7 @@ Plan then batch: for named controls/content use getByRole/getByLabel/getByText a
 snapshot({interactive: true}) reads unknown UIs; page.locator('aria-ref=eN') acts; snapshot({ref}) scopes; snapshot({diff: true}) verifies. Snapshots include iframes/off-screen content — never scroll to read or guess refs/URLs. Capture screenshot({kind: 'proof'}) inside the final verifying call.
 Challenge: keep page; captcha.solve() first; on 'processing', open crop then captcha.solve({tiles:[indexes]}). Replacement photo grids are the same stage. Max three distinct challenge types; rejection = stop/alternate/handoff. Verify cleared; replay only if idempotent/provably incomplete. Never duplicate a submission, purchase, or message.`;
 
-const BROWSER_DOWNLOAD_DESCRIPTION = `Variant of browser for code that clicks a download link or saves a remote file — user approval first: 'ask' (default) confirms via the MCP client. BETTERWRIGHT_DOWNLOAD_POLICY=allow skips the prompt, deny disables downloads.`;
+const BROWSER_DOWNLOAD_DESCRIPTION = `Variant of browser that may click a download link or save a remote file; ordinary browser cannot. Autonomous by default. BETTERWRIGHT_DOWNLOAD_POLICY=deny disables downloads, allow also permits the browser tool.`;
 
 const LOGIN_DESCRIPTION = `Fill a saved/generated credential; the secret never enters the conversation. The worker detects visible login/signup controls, fills internally, and submits only with submit=true or submitSelector; values are never returned and password snapshots show '[redacted]'. Use CSS/current aria-ref selectors only after ambiguity. Typing passwords in browser code is blocked.
 Signup/rotation: generate=true stages and fills a strong password. After visible success call credentials.commitGenerated({pendingId}); on failure credentials.discardGenerated({pendingId}). Pending is inactive; after restart credentials.listPending() returns secret-free metadata.`;
@@ -290,85 +293,6 @@ async function loadSdk() {
   return { Server, StdioServerTransport, ListToolsRequestSchema, CallToolRequestSchema };
 }
 
-const DOWNLOAD_APPROVAL_SCHEMA = {
-  type: "object",
-  properties: {
-    approved: { type: "boolean", description: "Approve this browser download?" },
-  },
-  required: ["approved"],
-};
-
-const DOWNLOAD_ELICITATION_UNAVAILABLE =
-  "This MCP client cannot present download approval; the download was blocked. " +
-  "Conversation text is not a trusted approval channel. Set " +
-  "BETTERWRIGHT_DOWNLOAD_POLICY=allow in the MCP server environment to permit " +
-  "downloads without a prompt on this host, or deny to disable them.";
-
-function elicitationCapability(server) {
-  return server?.getClientCapabilities?.()?.elicitation;
-}
-
-// Spec: elicitation:{} means form mode. URL-only clients declare {url:{}}
-// without form. SDK 1.29's elicitInput additionally requires .form, so empty
-// {} is treated as form-capable here and retried via elicitation/create below.
-function clientSupportsFormElicitation(server) {
-  if (typeof server?.getClientCapabilities !== "function") {
-    return typeof server?.elicitInput === "function" || typeof server?.request === "function";
-  }
-  const elicitation = elicitationCapability(server);
-  if (elicitation == null) return false;
-  if (elicitation.form) return true;
-  return elicitation.url == null;
-}
-
-const PASSTHROUGH_ELICIT_RESULT = {
-  safeParse(data) {
-    return { success: true, data };
-  },
-};
-
-async function elicitFormInput(server, params) {
-  if (typeof server.elicitInput === "function") {
-    try {
-      return await server.elicitInput(params);
-    } catch (error) {
-      const elicitation = elicitationCapability(server);
-      const emptyFormDeclared =
-        elicitation != null && elicitation.form == null && elicitation.url == null;
-      if (!emptyFormDeclared || typeof server.request !== "function") throw error;
-    }
-  } else if (typeof server.request !== "function") {
-    throw new Error("MCP elicitation is unavailable");
-  }
-  // SDK 1.29+ elicitInput rejects elicitation:{} even though the spec treats
-  // that as form mode. request() still sends elicitation/create; we validate
-  // the accept/approved decision ourselves rather than importing the SDK schema.
-  return await server.request(
-    { method: "elicitation/create", params: { mode: "form", ...params } },
-    PASSTHROUGH_ELICIT_RESULT,
-  );
-}
-
-async function approveDownload(server, note) {
-  if (!clientSupportsFormElicitation(server)) {
-    throw new Error(DOWNLOAD_ELICITATION_UNAVAILABLE);
-  }
-  let decision;
-  try {
-    decision = await elicitFormInput(server, {
-      message:
-        "Allow BetterWright to run browser code that may download a file?" +
-        (note ? ` Requested action: ${note}` : ""),
-      requestedSchema: DOWNLOAD_APPROVAL_SCHEMA,
-    });
-  } catch {
-    throw new Error(DOWNLOAD_ELICITATION_UNAVAILABLE);
-  }
-  if (decision?.action !== "accept" || decision?.content?.approved !== true) {
-    throw new Error("The user declined or cancelled the download.");
-  }
-}
-
 function mcpTools(withLogin) {
   const tools: any[] = [
     { name: "browser", description: BROWSER_DESCRIPTION, inputSchema: RUN_INPUT_SCHEMA },
@@ -398,7 +322,7 @@ function mcpTools(withLogin) {
   return tools;
 }
 
-function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveViewFromEnv() }) {
+function createMcpHandlers({ browser, downloadPolicy, liveView = liveViewFromEnv() }) {
   const withLogin = Boolean(browser.vault);
   // Chat plumbing between the live-view page and the MCP client's model. The
   // standalone agent harness drains viewer chat at its own turn boundaries;
@@ -501,8 +425,10 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
           throw new Error(`Unknown tool: ${name}`);
         }
         // approvedDownloads is never taken from tool arguments: the model
-        // must not grant itself a download. Ask-mode elicitation or the
-        // deployer download policy is the only trusted grant.
+        // must not grant itself a download via the ordinary browser tool.
+        // Calling browser_download is the MCP grant — autonomous unless the
+        // deployer set downloadPolicy=deny. Worker policy stays "ask" by
+        // default, so a plain browser run still cannot save files.
         const options: BrowserRunToolOptions = {
           session: String(args.session || "default"),
           note: String(args.note || "") || undefined,
@@ -513,7 +439,6 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
               "Downloads are disabled by BETTERWRIGHT_DOWNLOAD_POLICY=deny.",
             );
           }
-          if (downloadPolicy === "ask") await approveDownload(server, options.note);
           options.approvedDownloads = true;
         }
         if (liveViewActive && options.note) {
@@ -573,7 +498,7 @@ export async function runMcpServer(env = process.env, options: any = {}) {
     { capabilities: { tools: {} } },
   );
 
-  const handlers = createMcpHandlers({ browser, server, downloadPolicy });
+  const handlers = createMcpHandlers({ browser, downloadPolicy });
   server.setRequestHandler(ListToolsRequestSchema, handlers.listTools);
   server.setRequestHandler(CallToolRequestSchema, handlers.callTool);
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -290,26 +290,79 @@ async function loadSdk() {
   return { Server, StdioServerTransport, ListToolsRequestSchema, CallToolRequestSchema };
 }
 
+const DOWNLOAD_APPROVAL_SCHEMA = {
+  type: "object",
+  properties: {
+    approved: { type: "boolean", description: "Approve this browser download?" },
+  },
+  required: ["approved"],
+};
+
+const DOWNLOAD_ELICITATION_UNAVAILABLE =
+  "This MCP client cannot present download approval; the download was blocked. " +
+  "Conversation text is not a trusted approval channel. Set " +
+  "BETTERWRIGHT_DOWNLOAD_POLICY=allow in the MCP server environment to permit " +
+  "downloads without a prompt on this host, or deny to disable them.";
+
+function elicitationCapability(server) {
+  return server?.getClientCapabilities?.()?.elicitation;
+}
+
+// Spec: elicitation:{} means form mode. URL-only clients declare {url:{}}
+// without form. SDK 1.29's elicitInput additionally requires .form, so empty
+// {} is treated as form-capable here and retried via elicitation/create below.
+function clientSupportsFormElicitation(server) {
+  if (typeof server?.getClientCapabilities !== "function") {
+    return typeof server?.elicitInput === "function" || typeof server?.request === "function";
+  }
+  const elicitation = elicitationCapability(server);
+  if (elicitation == null) return false;
+  if (elicitation.form) return true;
+  return elicitation.url == null;
+}
+
+const PASSTHROUGH_ELICIT_RESULT = {
+  safeParse(data) {
+    return { success: true, data };
+  },
+};
+
+async function elicitFormInput(server, params) {
+  if (typeof server.elicitInput === "function") {
+    try {
+      return await server.elicitInput(params);
+    } catch (error) {
+      const elicitation = elicitationCapability(server);
+      const emptyFormDeclared =
+        elicitation != null && elicitation.form == null && elicitation.url == null;
+      if (!emptyFormDeclared || typeof server.request !== "function") throw error;
+    }
+  } else if (typeof server.request !== "function") {
+    throw new Error("MCP elicitation is unavailable");
+  }
+  // SDK 1.29+ elicitInput rejects elicitation:{} even though the spec treats
+  // that as form mode. request() still sends elicitation/create; we validate
+  // the accept/approved decision ourselves rather than importing the SDK schema.
+  return await server.request(
+    { method: "elicitation/create", params: { mode: "form", ...params } },
+    PASSTHROUGH_ELICIT_RESULT,
+  );
+}
+
 async function approveDownload(server, note) {
+  if (!clientSupportsFormElicitation(server)) {
+    throw new Error(DOWNLOAD_ELICITATION_UNAVAILABLE);
+  }
   let decision;
   try {
-    decision = await server.elicitInput({
+    decision = await elicitFormInput(server, {
       message:
         "Allow BetterWright to run browser code that may download a file?" +
         (note ? ` Requested action: ${note}` : ""),
-      requestedSchema: {
-        type: "object",
-        properties: {
-          approved: { type: "boolean", description: "Approve this browser download?" },
-        },
-        required: ["approved"],
-      },
+      requestedSchema: DOWNLOAD_APPROVAL_SCHEMA,
     });
   } catch {
-    // Clients without elicitation support fail closed.
-    throw new Error(
-      "This MCP client cannot present download approval; the download was blocked.",
-    );
+    throw new Error(DOWNLOAD_ELICITATION_UNAVAILABLE);
   }
   if (decision?.action !== "accept" || decision?.content?.approved !== true) {
     throw new Error("The user declined or cancelled the download.");
@@ -447,6 +500,9 @@ function createMcpHandlers({ browser, server, downloadPolicy, liveView = liveVie
         if (name !== "browser" && name !== "browser_download") {
           throw new Error(`Unknown tool: ${name}`);
         }
+        // approvedDownloads is never taken from tool arguments: the model
+        // must not grant itself a download. Ask-mode elicitation or the
+        // deployer download policy is the only trusted grant.
         const options: BrowserRunToolOptions = {
           session: String(args.session || "default"),
           note: String(args.note || "") || undefined,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2,8 +2,8 @@
 //
 // This lets any MCP client — Claude Code, Cursor, Windsurf, and others — drive
 // a persistent, policy-guarded browser. It exposes `browser` for ordinary
-// runs, `browser_download` for autonomous file saves the ordinary `browser`
-// tool cannot perform, and `browser_doctor` for runtime diagnostics.
+// runs, `browser_download` for autonomous file saves the `browser` tool
+// cannot perform, and `browser_doctor` for runtime diagnostics.
 //
 // Run it directly (stdio transport):
 //
@@ -24,8 +24,8 @@
 //     BETTERWRIGHT_ALLOW_HOSTS=a.com,b.com always-allow list (comma-separated)
 //     BETTERWRIGHT_BLOCK_HOSTS=ads.com     always-block list (comma-separated)
 //     BETTERWRIGHT_DOWNLOAD_POLICY=ask     ask (default): browser_download may
-//                                          save files autonomously; ordinary
-//                                          browser cannot. allow: any run.
+//                                          save files autonomously; the browser
+//                                          tool cannot. allow: either tool.
 //                                          deny: no downloads.
 //     BETTERWRIGHT_HEADLESS=0              run the managed browser headed
 //     BETTERWRIGHT_PROFILE=<name>          act as a named browser profile: a
@@ -213,7 +213,7 @@ Plan then batch: for named controls/content use getByRole/getByLabel/getByText a
 snapshot({interactive: true}) reads unknown UIs; page.locator('aria-ref=eN') acts; snapshot({ref}) scopes; snapshot({diff: true}) verifies. Snapshots include iframes/off-screen content — never scroll to read or guess refs/URLs. Capture screenshot({kind: 'proof'}) inside the final verifying call.
 Challenge: keep page; captcha.solve() first; on 'processing', open crop then captcha.solve({tiles:[indexes]}). Replacement photo grids are the same stage. Max three distinct challenge types; rejection = stop/alternate/handoff. Verify cleared; replay only if idempotent/provably incomplete. Never duplicate a submission, purchase, or message.`;
 
-const BROWSER_DOWNLOAD_DESCRIPTION = `Variant of browser that may click a download link or save a remote file; ordinary browser cannot. Autonomous by default. BETTERWRIGHT_DOWNLOAD_POLICY=deny disables downloads, allow also permits the browser tool.`;
+const BROWSER_DOWNLOAD_DESCRIPTION = `Variant of the browser tool that may click a download link or save a remote file; the browser tool cannot. Autonomous by default. BETTERWRIGHT_DOWNLOAD_POLICY=deny disables downloads, allow also permits the browser tool.`;
 
 const LOGIN_DESCRIPTION = `Fill a saved/generated credential; the secret never enters the conversation. The worker detects visible login/signup controls, fills internally, and submits only with submit=true or submitSelector; values are never returned and password snapshots show '[redacted]'. Use CSS/current aria-ref selectors only after ambiguity. Typing passwords in browser code is blocked.
 Signup/rotation: generate=true stages and fills a strong password. After visible success call credentials.commitGenerated({pendingId}); on failure credentials.discardGenerated({pendingId}). Pending is inactive; after restart credentials.listPending() returns secret-free metadata.`;
@@ -425,10 +425,10 @@ function createMcpHandlers({ browser, downloadPolicy, liveView = liveViewFromEnv
           throw new Error(`Unknown tool: ${name}`);
         }
         // approvedDownloads is never taken from tool arguments: the model
-        // must not grant itself a download via the ordinary browser tool.
+        // must not grant itself a download via the browser tool.
         // Calling browser_download is the MCP grant — autonomous unless the
         // deployer set downloadPolicy=deny. Worker policy stays "ask" by
-        // default, so a plain browser run still cannot save files.
+        // default, so a browser-tool run still cannot save files.
         const options: BrowserRunToolOptions = {
           session: String(args.session || "default"),
           note: String(args.note || "") || undefined,

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -10,6 +10,7 @@ import { test } from "node:test";
 
 import { doctorReport } from "../../dist/src/doctor.js";
 import { BetterWright, NetworkPolicy, runAgentTask } from "../../dist/src/index.js";
+import { _createMcpHandlersForTest } from "../../dist/src/mcp-server.js";
 import { isBoolean, isCallable, isString } from "../../dist/src/untrusted-value.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
@@ -1097,6 +1098,63 @@ test("downloads require a trusted per-run approval by default", opts, async () =
     );
     assert.equal(downloads.length, 1, JSON.stringify(approved.events));
     assert.deepEqual(fs.readFileSync(downloads[0].path), body);
+  } finally {
+    await bw.close();
+    await server.close();
+  }
+});
+
+test("MCP browser_download saves one real file without elicitation", opts, async () => {
+  const body = Buffer.from("MCP autonomous download contents");
+  const server = await listen((request, response) => {
+    if (request.url === "/") {
+      response.setHeader("content-type", "text/html");
+      response.end('<a id="download" href="/report.txt" download>Download</a>');
+      return;
+    }
+    response.setHeader("content-type", "text/plain");
+    response.setHeader(
+      "content-disposition",
+      'attachment; filename="report.txt"',
+    );
+    response.end(body);
+  });
+  const home = tempHome();
+  const bw = new BetterWright({
+    home,
+    headless: true,
+    policy: new NetworkPolicy({ allowLoopback: true }),
+  });
+  const handlers = _createMcpHandlersForTest({
+    browser: bw,
+    downloadPolicy: "ask",
+    liveView: { enabled: false, host: "127.0.0.1", port: 0 },
+  });
+  const code = `
+    await page.goto(${JSON.stringify(server.origin)});
+    await page.locator('#download').click();
+    await page.waitForTimeout(100);
+    return 'done';
+  `;
+  try {
+    const ordinary = await handlers.callTool({
+      params: { name: "browser", arguments: { code } },
+    });
+    assert.equal(ordinary.isError, undefined, ordinary.content[0].text);
+    const ordinarySummary = JSON.parse(ordinary.content[0].text);
+    assert.equal(ordinarySummary.ok, true, ordinarySummary.error);
+    assert.equal(ordinarySummary.files, undefined);
+    assert.equal(directorySize(path.join(home, "artifacts", "downloads")), 0);
+
+    const download = await handlers.callTool({
+      params: { name: "browser_download", arguments: { code } },
+    });
+    assert.equal(download.isError, undefined, download.content[0].text);
+    const downloadSummary = JSON.parse(download.content[0].text);
+    assert.equal(downloadSummary.ok, true, downloadSummary.error);
+    const file = downloadSummary.files?.find((item) => item.kind === "download");
+    assert.ok(file?.path, JSON.stringify(downloadSummary));
+    assert.deepEqual(fs.readFileSync(file.path), body);
   } finally {
     await bw.close();
     await server.close();

--- a/tests/node/mcp-server.test.ts
+++ b/tests/node/mcp-server.test.ts
@@ -177,10 +177,10 @@ test("the advertised MCP tool list stays inside its context budget", async () =>
   assert.match(text("browser"), /webmcp\.tools\(\)\/webmcp\.invoke\(\)/);
   assert.match(text("browser"), /autosubmit requires explicit opt-in/);
 
-  // Downloads are gated; both escape hatches must stay discoverable.
-  assert.match(text("browser_download"), /approval first/);
-  assert.match(text("browser_download"), /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
-  assert.match(text("browser_download"), /deny/);
+  // Downloads are gated to this tool; deny must stay discoverable.
+  assert.match(text("browser_download"), /ordinary browser cannot/);
+  assert.match(text("browser_download"), /Autonomous by default/);
+  assert.match(text("browser_download"), /BETTERWRIGHT_DOWNLOAD_POLICY=deny/);
 
   // The whole point of browser_login is that the secret stays out of the
   // transcript, and that a generated password is not saved until verified.
@@ -595,18 +595,15 @@ async function callDownload(handlers, args = {}) {
   });
 }
 
-test("browser_download ask-mode elicits then runs with trusted approval", async () => {
+test("browser_download ask-mode grants the run without elicitation", async () => {
   const browser = downloadBrowser();
-  const elicitations = [];
+  let elicited = 0;
   const handlers = _createMcpHandlersForTest({
     browser,
     server: {
-      getClientCapabilities() {
-        return { elicitation: { form: {} } };
-      },
-      async elicitInput(params) {
-        elicitations.push(params);
-        return { action: "accept", content: { approved: true } };
+      async elicitInput() {
+        elicited += 1;
+        throw new Error("MCP downloads must not wait on elicitation");
       },
     },
     downloadPolicy: "ask",
@@ -615,15 +612,13 @@ test("browser_download ask-mode elicits then runs with trusted approval", async 
   const response = await callDownload(handlers, { note: "Save the report" });
   assert.equal(response.isError, undefined);
   assert.equal(JSON.parse(response.content[0].text).result, "saved");
-  assert.equal(elicitations.length, 1);
-  assert.match(elicitations[0].message, /Save the report/);
-  assert.deepEqual(elicitations[0].requestedSchema.required, ["approved"]);
+  assert.equal(elicited, 0);
   assert.deepEqual(browser.runs, [
     { code: "return 1", options: { session: "default", note: "Save the report", approvedDownloads: true } },
   ]);
 });
 
-test("browser_download ask-mode does not treat model-supplied flags as approval", async () => {
+test("browser_download ignores model-supplied approval flags and still grants", async () => {
   const browser = downloadBrowser();
   const handlers = _createMcpHandlersForTest({
     browser,
@@ -632,157 +627,38 @@ test("browser_download ask-mode does not treat model-supplied flags as approval"
   });
 
   const response = await callDownload(handlers, { approvedDownloads: true, approved: true });
-  assert.equal(response.isError, true);
-  assert.match(response.content[0].text, /cannot present download approval/);
-  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
-  assert.match(response.content[0].text, /Conversation text is not a trusted approval channel/);
-  assert.equal(browser.runs.length, 0);
-});
-
-test("browser_download ask-mode blocks when elicitInput throws, with config guidance", async () => {
-  const browser = downloadBrowser();
-  const handlers = _createMcpHandlersForTest({
-    browser,
-    server: {
-      getClientCapabilities() {
-        return { elicitation: { form: {} } };
-      },
-      async elicitInput() {
-        throw new Error("Client does not support form elicitation.");
-      },
-    },
-    downloadPolicy: "ask",
-  });
-
-  const response = await callDownload(handlers);
-  assert.equal(response.isError, true);
-  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
-  assert.equal(browser.runs.length, 0);
-});
-
-test("browser_download ask-mode treats empty elicitation:{} as form support", async () => {
-  const browser = downloadBrowser();
-  const requests = [];
-  const handlers = _createMcpHandlersForTest({
-    browser,
-    server: {
-      getClientCapabilities() {
-        return { elicitation: {} };
-      },
-      async elicitInput() {
-        throw new Error("Client does not support form elicitation.");
-      },
-      async request(payload) {
-        requests.push(payload);
-        return { action: "accept", content: { approved: true } };
-      },
-    },
-    downloadPolicy: "ask",
-  });
-
-  const response = await callDownload(handlers);
   assert.equal(response.isError, undefined);
-  assert.equal(requests.length, 1);
-  assert.equal(requests[0].method, "elicitation/create");
-  assert.equal(requests[0].params.mode, "form");
-  assert.equal(browser.runs[0].options.approvedDownloads, true);
-});
-
-test("browser_download ask-mode URL-only clients fail closed", async () => {
-  const browser = downloadBrowser();
-  let elicited = 0;
-  const handlers = _createMcpHandlersForTest({
-    browser,
-    server: {
-      getClientCapabilities() {
-        return { elicitation: { url: {} } };
-      },
-      async elicitInput() {
-        elicited += 1;
-        return { action: "accept", content: { approved: true } };
-      },
-    },
-    downloadPolicy: "ask",
+  assert.deepEqual(browser.runs[0].options, {
+    session: "default",
+    note: undefined,
+    approvedDownloads: true,
   });
-
-  const response = await callDownload(handlers);
-  assert.equal(response.isError, true);
-  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
-  assert.equal(elicited, 0);
-  assert.equal(browser.runs.length, 0);
 });
 
-test("browser_download declined elicitation does not run", async () => {
+test("browser_download allow-mode grants the run", async () => {
   const browser = downloadBrowser();
   const handlers = _createMcpHandlersForTest({
     browser,
-    server: {
-      async elicitInput() {
-        return { action: "accept", content: { approved: false } };
-      },
-    },
-    downloadPolicy: "ask",
-  });
-
-  const declined = await callDownload(handlers);
-  assert.equal(declined.isError, true);
-  assert.match(declined.content[0].text, /declined or cancelled/);
-  assert.equal(browser.runs.length, 0);
-
-  const cancelled = await _createMcpHandlersForTest({
-    browser,
-    server: {
-      async elicitInput() {
-        return { action: "cancel" };
-      },
-    },
-    downloadPolicy: "ask",
-  }).callTool({
-    params: { name: "browser_download", arguments: { code: "return 1" } },
-  });
-  assert.equal(cancelled.isError, true);
-  assert.match(cancelled.content[0].text, /declined or cancelled/);
-  assert.equal(browser.runs.length, 0);
-});
-
-test("browser_download allow-mode skips elicitation and grants the run", async () => {
-  const browser = downloadBrowser();
-  let elicited = 0;
-  const handlers = _createMcpHandlersForTest({
-    browser,
-    server: {
-      async elicitInput() {
-        elicited += 1;
-        throw new Error("should not elicit when policy is allow");
-      },
-    },
+    server: {},
     downloadPolicy: "allow",
   });
 
   const response = await callDownload(handlers);
   assert.equal(response.isError, undefined);
-  assert.equal(elicited, 0);
   assert.equal(browser.runs[0].options.approvedDownloads, true);
 });
 
-test("browser_download deny-mode refuses before elicitation", async () => {
+test("browser_download deny-mode refuses before the run", async () => {
   const browser = downloadBrowser();
-  let elicited = 0;
   const handlers = _createMcpHandlersForTest({
     browser,
-    server: {
-      async elicitInput() {
-        elicited += 1;
-        return { action: "accept", content: { approved: true } };
-      },
-    },
+    server: {},
     downloadPolicy: "deny",
   });
 
   const response = await callDownload(handlers);
   assert.equal(response.isError, true);
   assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=deny/);
-  assert.equal(elicited, 0);
   assert.equal(browser.runs.length, 0);
 });
 
@@ -814,7 +690,7 @@ async function loadMcpSdk() {
   return { Client, Server, InMemoryTransport, types };
 }
 
-async function connectDownloadServer({ downloadPolicy, clientCapabilities, onElicit = null }) {
+async function connectDownloadServer({ downloadPolicy, clientCapabilities = {} }) {
   const sdk = await loadMcpSdk();
   const browser = downloadBrowser();
   const server = new sdk.Server(
@@ -829,9 +705,6 @@ async function connectDownloadServer({ downloadPolicy, clientCapabilities, onEli
     { name: "test-host", version: "0.0.0" },
     { capabilities: clientCapabilities },
   );
-  if (onElicit) {
-    client.setRequestHandler(sdk.types.ElicitRequestSchema, onElicit);
-  }
   const [clientTransport, serverTransport] = sdk.InMemoryTransport.createLinkedPair();
   await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
   return {
@@ -844,62 +717,36 @@ async function connectDownloadServer({ downloadPolicy, clientCapabilities, onEli
   };
 }
 
-test("MCP protocol roundtrip: a form-capable host approves browser_download", async () => {
-  const session = await connectDownloadServer({
-    downloadPolicy: "ask",
-    clientCapabilities: { elicitation: { form: {} } },
-    onElicit: async (request) => {
-      assert.match(request.params.message, /Save the image/);
-      return { action: "accept", content: { approved: true } };
-    },
-  });
+test("MCP protocol roundtrip: browser_download is autonomous without elicitation", async () => {
+  const session = await connectDownloadServer({ downloadPolicy: "ask" });
   try {
     const result = await session.client.callTool({
       name: "browser_download",
       arguments: { code: "return 1", note: "Save the image" },
     });
-    assert.equal(result.isError, undefined);
+    assert.equal(result.isError, undefined, result.content?.[0]?.text);
     assert.equal(JSON.parse(result.content[0].text).result, "saved");
     assert.equal(session.browser.runs[0].options.approvedDownloads, true);
+    assert.equal(session.browser.runs[0].options.note, "Save the image");
   } finally {
     await session.close();
   }
 });
 
-test("MCP protocol roundtrip: a host without elicitation gets config guidance", async () => {
-  const session = await connectDownloadServer({
-    downloadPolicy: "ask",
-    clientCapabilities: {},
-  });
+test("MCP protocol roundtrip: deny still blocks browser_download", async () => {
+  const session = await connectDownloadServer({ downloadPolicy: "deny" });
   try {
     const result = await session.client.callTool({
       name: "browser_download",
       arguments: { code: "return 1" },
     });
     assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
+    assert.match(result.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=deny/);
     assert.equal(session.browser.runs.length, 0);
   } finally {
     await session.close();
   }
 });
 
-test("MCP protocol roundtrip: empty elicitation:{} still presents form approval", async () => {
-  const session = await connectDownloadServer({
-    downloadPolicy: "ask",
-    clientCapabilities: { elicitation: {} },
-    onElicit: async () => ({ action: "accept", content: { approved: true } }),
-  });
-  try {
-    const result = await session.client.callTool({
-      name: "browser_download",
-      arguments: { code: "return 1" },
-    });
-    assert.equal(result.isError, undefined, result.content?.[0]?.text);
-    assert.equal(session.browser.runs[0].options.approvedDownloads, true);
-  } finally {
-    await session.close();
-  }
-});
 
 

--- a/tests/node/mcp-server.test.ts
+++ b/tests/node/mcp-server.test.ts
@@ -178,7 +178,7 @@ test("the advertised MCP tool list stays inside its context budget", async () =>
   assert.match(text("browser"), /autosubmit requires explicit opt-in/);
 
   // Downloads are gated to this tool; deny must stay discoverable.
-  assert.match(text("browser_download"), /ordinary browser cannot/);
+  assert.match(text("browser_download"), /the browser tool cannot/);
   assert.match(text("browser_download"), /Autonomous by default/);
   assert.match(text("browser_download"), /BETTERWRIGHT_DOWNLOAD_POLICY=deny/);
 
@@ -662,7 +662,7 @@ test("browser_download deny-mode refuses before the run", async () => {
   assert.equal(browser.runs.length, 0);
 });
 
-test("ordinary browser tool never sets approvedDownloads", async () => {
+test("the browser tool never sets approvedDownloads", async () => {
   const browser = downloadBrowser();
   const handlers = _createMcpHandlersForTest({
     browser,

--- a/tests/node/mcp-server.test.ts
+++ b/tests/node/mcp-server.test.ts
@@ -576,3 +576,330 @@ test("browser_handoff status carries drained viewer chat and stop ends mirroring
   assert.ok(!after.content.some((block) => /gone/.test(block.text || "")));
   assert.equal(browser.posted.length, 0);
 });
+
+function downloadBrowser() {
+  const runs = [];
+  return {
+    vault: null,
+    runs,
+    async run(code, options) {
+      runs.push({ code, options });
+      return { ok: true, result: "saved" };
+    },
+  };
+}
+
+async function callDownload(handlers, args = {}) {
+  return handlers.callTool({
+    params: { name: "browser_download", arguments: { code: "return 1", ...args } },
+  });
+}
+
+test("browser_download ask-mode elicits then runs with trusted approval", async () => {
+  const browser = downloadBrowser();
+  const elicitations = [];
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      getClientCapabilities() {
+        return { elicitation: { form: {} } };
+      },
+      async elicitInput(params) {
+        elicitations.push(params);
+        return { action: "accept", content: { approved: true } };
+      },
+    },
+    downloadPolicy: "ask",
+  });
+
+  const response = await callDownload(handlers, { note: "Save the report" });
+  assert.equal(response.isError, undefined);
+  assert.equal(JSON.parse(response.content[0].text).result, "saved");
+  assert.equal(elicitations.length, 1);
+  assert.match(elicitations[0].message, /Save the report/);
+  assert.deepEqual(elicitations[0].requestedSchema.required, ["approved"]);
+  assert.deepEqual(browser.runs, [
+    { code: "return 1", options: { session: "default", note: "Save the report", approvedDownloads: true } },
+  ]);
+});
+
+test("browser_download ask-mode does not treat model-supplied flags as approval", async () => {
+  const browser = downloadBrowser();
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {},
+    downloadPolicy: "ask",
+  });
+
+  const response = await callDownload(handlers, { approvedDownloads: true, approved: true });
+  assert.equal(response.isError, true);
+  assert.match(response.content[0].text, /cannot present download approval/);
+  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
+  assert.match(response.content[0].text, /Conversation text is not a trusted approval channel/);
+  assert.equal(browser.runs.length, 0);
+});
+
+test("browser_download ask-mode blocks when elicitInput throws, with config guidance", async () => {
+  const browser = downloadBrowser();
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      getClientCapabilities() {
+        return { elicitation: { form: {} } };
+      },
+      async elicitInput() {
+        throw new Error("Client does not support form elicitation.");
+      },
+    },
+    downloadPolicy: "ask",
+  });
+
+  const response = await callDownload(handlers);
+  assert.equal(response.isError, true);
+  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
+  assert.equal(browser.runs.length, 0);
+});
+
+test("browser_download ask-mode treats empty elicitation:{} as form support", async () => {
+  const browser = downloadBrowser();
+  const requests = [];
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      getClientCapabilities() {
+        return { elicitation: {} };
+      },
+      async elicitInput() {
+        throw new Error("Client does not support form elicitation.");
+      },
+      async request(payload) {
+        requests.push(payload);
+        return { action: "accept", content: { approved: true } };
+      },
+    },
+    downloadPolicy: "ask",
+  });
+
+  const response = await callDownload(handlers);
+  assert.equal(response.isError, undefined);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].method, "elicitation/create");
+  assert.equal(requests[0].params.mode, "form");
+  assert.equal(browser.runs[0].options.approvedDownloads, true);
+});
+
+test("browser_download ask-mode URL-only clients fail closed", async () => {
+  const browser = downloadBrowser();
+  let elicited = 0;
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      getClientCapabilities() {
+        return { elicitation: { url: {} } };
+      },
+      async elicitInput() {
+        elicited += 1;
+        return { action: "accept", content: { approved: true } };
+      },
+    },
+    downloadPolicy: "ask",
+  });
+
+  const response = await callDownload(handlers);
+  assert.equal(response.isError, true);
+  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
+  assert.equal(elicited, 0);
+  assert.equal(browser.runs.length, 0);
+});
+
+test("browser_download declined elicitation does not run", async () => {
+  const browser = downloadBrowser();
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      async elicitInput() {
+        return { action: "accept", content: { approved: false } };
+      },
+    },
+    downloadPolicy: "ask",
+  });
+
+  const declined = await callDownload(handlers);
+  assert.equal(declined.isError, true);
+  assert.match(declined.content[0].text, /declined or cancelled/);
+  assert.equal(browser.runs.length, 0);
+
+  const cancelled = await _createMcpHandlersForTest({
+    browser,
+    server: {
+      async elicitInput() {
+        return { action: "cancel" };
+      },
+    },
+    downloadPolicy: "ask",
+  }).callTool({
+    params: { name: "browser_download", arguments: { code: "return 1" } },
+  });
+  assert.equal(cancelled.isError, true);
+  assert.match(cancelled.content[0].text, /declined or cancelled/);
+  assert.equal(browser.runs.length, 0);
+});
+
+test("browser_download allow-mode skips elicitation and grants the run", async () => {
+  const browser = downloadBrowser();
+  let elicited = 0;
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      async elicitInput() {
+        elicited += 1;
+        throw new Error("should not elicit when policy is allow");
+      },
+    },
+    downloadPolicy: "allow",
+  });
+
+  const response = await callDownload(handlers);
+  assert.equal(response.isError, undefined);
+  assert.equal(elicited, 0);
+  assert.equal(browser.runs[0].options.approvedDownloads, true);
+});
+
+test("browser_download deny-mode refuses before elicitation", async () => {
+  const browser = downloadBrowser();
+  let elicited = 0;
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {
+      async elicitInput() {
+        elicited += 1;
+        return { action: "accept", content: { approved: true } };
+      },
+    },
+    downloadPolicy: "deny",
+  });
+
+  const response = await callDownload(handlers);
+  assert.equal(response.isError, true);
+  assert.match(response.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=deny/);
+  assert.equal(elicited, 0);
+  assert.equal(browser.runs.length, 0);
+});
+
+test("ordinary browser tool never sets approvedDownloads", async () => {
+  const browser = downloadBrowser();
+  const handlers = _createMcpHandlersForTest({
+    browser,
+    server: {},
+    downloadPolicy: "ask",
+  });
+
+  const response = await handlers.callTool({
+    params: {
+      name: "browser",
+      arguments: { code: "return 1", approvedDownloads: true },
+    },
+  });
+  assert.equal(response.isError, undefined);
+  assert.deepEqual(browser.runs[0].options, { session: "default", note: undefined });
+});
+
+async function loadMcpSdk() {
+  const [{ Client }, { Server }, { InMemoryTransport }, types] = await Promise.all([
+    import("@modelcontextprotocol/sdk/client/index.js"),
+    import("@modelcontextprotocol/sdk/server/index.js"),
+    import("@modelcontextprotocol/sdk/inMemory.js"),
+    import("@modelcontextprotocol/sdk/types.js"),
+  ]);
+  return { Client, Server, InMemoryTransport, types };
+}
+
+async function connectDownloadServer({ downloadPolicy, clientCapabilities, onElicit }) {
+  const sdk = await loadMcpSdk();
+  const browser = downloadBrowser();
+  const server = new sdk.Server(
+    { name: "betterwright-test", version: "0.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  const handlers = _createMcpHandlersForTest({ browser, server, downloadPolicy });
+  server.setRequestHandler(sdk.types.ListToolsRequestSchema, handlers.listTools);
+  server.setRequestHandler(sdk.types.CallToolRequestSchema, handlers.callTool);
+
+  const client = new sdk.Client(
+    { name: "test-host", version: "0.0.0" },
+    { capabilities: clientCapabilities },
+  );
+  if (onElicit) {
+    client.setRequestHandler(sdk.types.ElicitRequestSchema, onElicit);
+  }
+  const [clientTransport, serverTransport] = sdk.InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return {
+    browser,
+    client,
+    async close() {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+test("MCP protocol roundtrip: a form-capable host approves browser_download", async () => {
+  const session = await connectDownloadServer({
+    downloadPolicy: "ask",
+    clientCapabilities: { elicitation: { form: {} } },
+    onElicit: async (request) => {
+      assert.match(request.params.message, /Save the image/);
+      return { action: "accept", content: { approved: true } };
+    },
+  });
+  try {
+    const result = await session.client.callTool({
+      name: "browser_download",
+      arguments: { code: "return 1", note: "Save the image" },
+    });
+    assert.equal(result.isError, undefined);
+    assert.equal(JSON.parse(result.content[0].text).result, "saved");
+    assert.equal(session.browser.runs[0].options.approvedDownloads, true);
+  } finally {
+    await session.close();
+  }
+});
+
+test("MCP protocol roundtrip: a host without elicitation gets config guidance", async () => {
+  const session = await connectDownloadServer({
+    downloadPolicy: "ask",
+    clientCapabilities: {},
+  });
+  try {
+    const result = await session.client.callTool({
+      name: "browser_download",
+      arguments: { code: "return 1" },
+    });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /BETTERWRIGHT_DOWNLOAD_POLICY=allow/);
+    assert.equal(session.browser.runs.length, 0);
+  } finally {
+    await session.close();
+  }
+});
+
+test("MCP protocol roundtrip: empty elicitation:{} still presents form approval", async () => {
+  const session = await connectDownloadServer({
+    downloadPolicy: "ask",
+    clientCapabilities: { elicitation: {} },
+    onElicit: async () => ({ action: "accept", content: { approved: true } }),
+  });
+  try {
+    const result = await session.client.callTool({
+      name: "browser_download",
+      arguments: { code: "return 1" },
+    });
+    assert.equal(result.isError, undefined, result.content?.[0]?.text);
+    assert.equal(session.browser.runs[0].options.approvedDownloads, true);
+  } finally {
+    await session.close();
+  }
+});
+
+

--- a/tests/node/mcp-server.test.ts
+++ b/tests/node/mcp-server.test.ts
@@ -814,7 +814,7 @@ async function loadMcpSdk() {
   return { Client, Server, InMemoryTransport, types };
 }
 
-async function connectDownloadServer({ downloadPolicy, clientCapabilities, onElicit }) {
+async function connectDownloadServer({ downloadPolicy, clientCapabilities, onElicit = null }) {
   const sdk = await loadMcpSdk();
   const browser = downloadBrowser();
   const server = new sdk.Server(


### PR DESCRIPTION
Fixes #134.

## Root cause

MCP `browser_download` depended on MCP elicitation for every download-enabled
run. Most MCP hosts cannot present that elicitation flow, so even a
user-requested download failed before browser code ran.

## What changed

- The dedicated MCP `browser_download` tool now grants download permission to
  that one run without requiring elicitation.
- The ordinary MCP `browser` tool remains unable to download under the default
  `ask` worker policy.
- `BETTERWRIGHT_DOWNLOAD_POLICY=deny` still blocks every download; `allow` also
  permits downloads from ordinary `browser` runs.
- Model-supplied `approvedDownloads` or similar arguments are ignored.
- Documentation and the changelog explain the MCP-specific behavior.

This changes no public API, package export, tool input schema, or TypeScript
declaration, so it remains a drop-in replacement for 1.9.8. Standalone and
embedded BetterWright approval behavior is unchanged.

## Safety properties

- Every managed-browser connection still uses the guard proxy.
- Permission remains bounded to the current `browser_download` run and session.
- Concurrent or different sessions cannot borrow the permission.
- Download byte limits and artifact handling are unchanged.
- No secret or new output channel is introduced.

## Verification

- `npm run release:check` — passed; 836 unit tests, 0 failures
- `BETTERWRIGHT_REQUIRE_BROWSER=1 npm test` — 898 tests: 895 passed, 3
  intentionally skipped live CAPTCHA demos, 0 failures
- A real managed-browser MCP regression test proves:
  - ordinary `browser` writes no file under the default policy
  - `browser_download` saves the exact response without elicitation
- Existing tests cover deny mode, byte limits, per-run gating, cross-session
  isolation, concurrent-session isolation, MCP protocol roundtrips, and
  unchanged tool schemas.
