### PR TITLE
Release BetterWright 1.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Releases before 1.1.3 predate this file; their notes live on the
 [GitHub releases page](https://github.com/BetterWright/betterwright/releases).
 
-## [1.9.9] - Unreleased
+## [Unreleased]
+
+## [1.9.9] - 2026-08-19
 
 ### Changed
 
@@ -1089,7 +1091,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[1.9.9]: https://github.com/BetterWright/betterwright/compare/v1.9.8...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.9.9...HEAD
+[1.9.9]: https://github.com/BetterWright/betterwright/compare/v1.9.8...v1.9.9
 [1.9.8]: https://github.com/BetterWright/betterwright/compare/v1.9.7...v1.9.8
 [1.9.7]: https://github.com/BetterWright/betterwright/compare/v1.9.6...v1.9.7
 [1.9.6]: https://github.com/BetterWright/betterwright/compare/v1.9.5...v1.9.6

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.9.8
+generated_by: betterwright@1.9.9
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- release BetterWright 1.9.9
- finalize the autonomous MCP `browser_download` changelog entry
- align package, lockfile, and generated browser-skill versions

## User impact

MCP hosts can use the dedicated `browser_download` tool under the default `ask` policy without relying on elicitation support. The ordinary `browser` tool remains unable to download by default, and the deployer-level `deny` policy still blocks downloads.

## Verification

- `npm ci`
- `npm run release:check`
- `npm run build:tools && node scripts/check-versions.js --tag v1.9.9`
- 833 runnable unit tests passed; 3 opt-in live CAPTCHA demos skipped
- package smoke test passed for `betterwright-1.9.9.tgz`
