### PR TITLE
Release BetterWright 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-08-27
+
 ### Changed
 
 - **MCP snippets now have 2 minutes** before the worker restarts (was 30
   seconds). The JS API default is unchanged. Override with
-  `BETTERWRIGHT_TIMEOUT_SECONDS` (minimum 5).
+  `BETTERWRIGHT_TIMEOUT_SECONDS` (minimum 5). (#145)
 
 ## [1.10.1] - 2026-08-26
 
@@ -1161,7 +1163,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.10.2...HEAD
+[1.10.2]: https://github.com/BetterWright/betterwright/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/BetterWright/betterwright/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/BetterWright/betterwright/compare/v1.9.9...v1.10.0
 [1.9.9]: https://github.com/BetterWright/betterwright/compare/v1.9.8...v1.9.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP snippets now have 2 minutes** before the worker restarts (was 30
+  seconds). The JS API default is unchanged. Override with
+  `BETTERWRIGHT_TIMEOUT_SECONDS` (minimum 5).
+
 ## [1.10.1] - 2026-08-26
 
 ### Fixed

--- a/SETUP.md
+++ b/SETUP.md
@@ -251,7 +251,9 @@ It reports the two things that actually fail: a missing
 usually swallow the error), and a missing browser.
 
 The server keeps one browser alive for its lifetime, so pages and logins persist
-across tool calls.
+across tool calls. Each `browser`, `browser_batch`, `browser_download`, and
+`browser_login` snippet has two minutes before the worker restarts. Set
+`BETTERWRIGHT_TIMEOUT_SECONDS` to change that (minimum 5).
 
 BetterChromium (`~/.betterwright/chromium/`) is the default backend on
 supported macOS arm64, Linux x64, and Windows x64 hosts. Linux hosts without
@@ -389,6 +391,7 @@ or the MCP env vars):
 | Disable all downloads | `downloadPolicy: "deny"` | `BETTERWRIGHT_DOWNLOAD_POLICY=deny` |
 | Block public search-result UIs | `publicSearchPolicy: "block"` | `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block` |
 | Act as a second identity | `--profile social` / `profile: "social"` | `BETTERWRIGHT_PROFILE=social` (the CLI reads it too) |
+| Per-snippet timeout (MCP default 120s) | `defaultTimeout` (JS API default 30) | `BETTERWRIGHT_TIMEOUT_SECONDS=120` |
 
 A **profile** is a separate browser identity inside the same home: its own
 cookie jar, its own session daemon, its own `exec` history — so two agents (or

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.10.1
+generated_by: betterwright@1.10.2
 ---
 
 # BetterWright browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -39,6 +39,7 @@
 //     BETTERWRIGHT_TIMEZONE=<IANA tz>      pin the browser timezone to the egress
 //                                          geography (unset: host timezone)
 //     BETTERWRIGHT_LOCALE=<locale>         browser locale for the same identity
+//     BETTERWRIGHT_TIMEOUT_SECONDS=120     per-snippet timeout (default 120)
 //     BETTERWRIGHT_LIVE_VIEW_HOST=...      live-view bind host (default 127.0.0.1)
 //     BETTERWRIGHT_LIVE_VIEW_PORT=...      live-view port (default ephemeral)
 //     BETTERWRIGHT_LIVE_VIEW=1             allow a non-loopback live-view host
@@ -113,6 +114,24 @@ export function headlessFromEnv(env = process.env) {
   // explicit BETTERWRIGHT_HEADLESS=0/1 when the deployer sets one.
   if (!String(env.BETTERWRIGHT_HEADLESS || "").trim()) return "auto";
   return boolEnv(env, "BETTERWRIGHT_HEADLESS");
+}
+
+const DEFAULT_MCP_TIMEOUT_SECONDS = 120;
+
+/**
+ * Per-snippet wall clock for MCP `browser` / `browser_batch` /
+ * `browser_download` / `browser_login`. The JS API default is 30s; MCP
+ * snippets routinely include navigation plus extraction, so the server
+ * uses 2 minutes unless the deployer overrides it.
+ */
+export function timeoutFromEnv(env = process.env) {
+  const raw = String(env.BETTERWRIGHT_TIMEOUT_SECONDS || "").trim();
+  if (!raw) return DEFAULT_MCP_TIMEOUT_SECONDS;
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds < 5) {
+    throw new Error("BETTERWRIGHT_TIMEOUT_SECONDS must be a number of seconds >= 5.");
+  }
+  return seconds;
 }
 
 /**
@@ -604,6 +623,7 @@ export async function runMcpServer(env = process.env, options: any = {}) {
     policy: policyFromEnv(env),
     headless: headlessFromEnv(env),
     downloadPolicy,
+    defaultTimeout: timeoutFromEnv(env),
   };
   // A named profile is a separate identity, so two MCP servers sharing one
   // home (a "social" one holding the logins, a "research" one that only

--- a/tests/node/mcp-server.test.ts
+++ b/tests/node/mcp-server.test.ts
@@ -13,6 +13,7 @@ import {
   liveViewFromEnv,
   loginOptionsFromArgs,
   policyFromEnv,
+  timeoutFromEnv,
 } from "../../dist/src/mcp-server.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
@@ -394,6 +395,19 @@ test("headlessFromEnv defaults to auto and honors explicit values", () => {
   assert.equal(headlessFromEnv({}), "auto");
   assert.equal(headlessFromEnv({ BETTERWRIGHT_HEADLESS: "0" }), false);
   assert.equal(headlessFromEnv({ BETTERWRIGHT_HEADLESS: "true" }), true);
+});
+
+test("timeoutFromEnv defaults to 120 seconds and rejects junk", () => {
+  assert.equal(timeoutFromEnv({}), 120);
+  assert.equal(timeoutFromEnv({ BETTERWRIGHT_TIMEOUT_SECONDS: "180" }), 180);
+  assert.throws(
+    () => timeoutFromEnv({ BETTERWRIGHT_TIMEOUT_SECONDS: "4" }),
+    /must be a number of seconds >= 5/,
+  );
+  assert.throws(
+    () => timeoutFromEnv({ BETTERWRIGHT_TIMEOUT_SECONDS: "soon" }),
+    /must be a number of seconds >= 5/,
+  );
 });
 
 test("contentForResult separates screenshots from file paths", async () => {

--- a/types/mcp-server.d.ts
+++ b/types/mcp-server.d.ts
@@ -39,6 +39,11 @@ export function headlessFromEnv(
   env?: Record<string, string | undefined>,
 ): HeadlessMode;
 
+/** Read BETTERWRIGHT_TIMEOUT_SECONDS; defaults to 120. */
+export function timeoutFromEnv(
+  env?: Record<string, string | undefined>,
+): number;
+
 /** Read BETTERWRIGHT_LIVE_VIEW / _HOST / _PORT for the browser_handoff tool. */
 export function liveViewFromEnv(env?: Record<string, string | undefined>): {
   enabled: boolean;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

MCP `browser` / `browser_batch` / `browser_download` / `browser_login` snippets inherited BetterWright's JS API default of 30 seconds, which is too short for a typical navigate-and-extract call. The MCP server now defaults to **120 seconds**. Override with `BETTERWRIGHT_TIMEOUT_SECONDS` (minimum 5). The JS API default is unchanged.

This branch is the **1.10.2** release commit. After merge to `main`, tag `v1.10.2` from that commit and publish the matching GitHub Release so `publish-npm.yml` can cut the npm package.

## Checklist

- [x] `npm run release:check` passes locally (versions, lint, typecheck, build,
      unit tests, published declarations, tarball).
      `betterwright-1.10.2.tgz`, 119 files. Unit suite: 815 pass, 0 fail, 20 skipped.
- [x] **Every browser connection still goes through the guard proxy.** No new
      launch path, transport, or fetch bypasses the worker's SOCKS guard
      (`src/guard-proxy.ts`) — the network floor is the security boundary.
- [x] **No secret value reaches the model sandbox.** New output channels,
      result envelopes, log lines, and MCP/agent tool results go through
      redaction; the vault still fills without returning values to snippet code.
- [x] **Dependency pins are still mirrored everywhere.** playwright-core,
      tldts, and patchright-core are exact-pinned in
      `package.json`, restated in `src/doctor.ts`, and referenced in
      `.github/workflows/publish-npm.yml`. `npm run check:versions` is green.
- [x] **Public API changes update `types/*.d.ts` in this same commit.** The
      published declarations are hand-written, not generated —
      `npm run test:types` compiles against them.
- [x] The two branch-protected CI job names, "Worker copies in sync" and
      "Node tests", are unchanged, and any new action is SHA-pinned with a
      trailing `# vX.Y.Z` comment.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js` directly —
      that module runs import side effects (stdin readline, ready handshake).
- [x] User-visible behaviour is reflected in `CHANGELOG.md` and, where it
      changes a command or an option, in `docs/` or the help text in
      `src/cli-help.ts`.
- [x] Nothing private is being committed: no handoff or `internal/` notes, no
      profile, vault, or artifact directory, no routable IP addresses in prose
      (`npm run check:package` enforces the last two for the tarball).

## How it was verified

- `npm run release:check` on 1.10.2 (`991acfd`)
- Unit suite: 815 pass, 0 fail, 20 skipped
- Package smoke test: `betterwright-1.10.2.tgz`, 119 files
- GitHub CI on `991acfd`: all 10 checks green, including required "Worker copies in sync" and "Node tests"

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c86bf189-c63d-4017-80d6-64de7d846426?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c86bf189-c63d-4017-80d6-64de7d846426&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

