### PR TITLE
release: BetterWright 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Releases before 1.1.3 predate this file; their notes live on the
   optional `${apiKey}` placeholder, headers, and a key or key-env var. The
   name then works everywhere a built-in provider name does, including
   `provider: { provider: "<name>" }` in code. `--remove <name>` deletes it.
+- **An orange terminal theme.** The CLI paints its output when stdout is a
+  color terminal: the wordmark, command names, flags, success marks, menu
+  numbers, and quoted commands in BetterWright orange; failures stay red and
+  warnings yellow. Applied across help, `doctor`, `init`, `configure`, and
+  `vault`. Piped output, `--json`, NO_COLOR, and TERM=dumb get exactly the
+  plain bytes they always did; FORCE_COLOR overrides in either direction.
 - **The `betterwright/sdk` entrypoint**, a curated TypeScript import for
   embedding: the client, policy, vault, agent, and provider helpers together,
   plus a new `withBrowser(options?, fn)` helper that constructs a client, runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ### Added
 
+- **First-run onboarding.** A bare `betterwright` on a terminal with nothing
+  installed now opens with a welcome card and offers the guided setup
+  (`betterwright init`) before starting the console: browser download, agent
+  wiring, and a verified page load. The offer happens at most once; declining
+  is remembered in `<home>/first-run.json`, and installs done by hand are
+  detected and never prompted. Scripted entry points (`exec`, `run`, `mcp`,
+  pipes) are untouched.
+
 - **`betterwright configure`** sets up the browser backend from the CLI: an
   interactive picker over the managed fork, the nine built-in cloud providers,
   a raw CDP URL, or a local binary, with non-interactive flags (`--browser`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Added
+
+- **`betterwright configure`** sets up the browser backend from the CLI: an
+  interactive picker over the managed fork, the nine built-in cloud providers,
+  a raw CDP URL, or a local binary, with non-interactive flags (`--browser`,
+  `--browser-key`, `--key-env`, `--managed`, `--show`, `--test`) for scripts.
+  The choice is persisted as `browser.default` in `<home>/config.json`
+  (written owner-only) and applies to every entry point: the JS API, the CLI,
+  MCP, and the daemon. Precedence for one launch: the explicit `provider`
+  option, then `BETTERWRIGHT_CDP_URL`, then the configured default, then the
+  managed fork.
+- **Custom named providers.** `betterwright configure --add <name>` registers
+  any CDP service under a name of your own, as a connect-URL template with an
+  optional `${apiKey}` placeholder, headers, and a key or key-env var. The
+  name then works everywhere a built-in provider name does, including
+  `provider: { provider: "<name>" }` in code. `--remove <name>` deletes it.
+- **The `betterwright/sdk` entrypoint**, a curated TypeScript import for
+  embedding: the client, policy, vault, agent, and provider helpers together,
+  plus a new `withBrowser(options?, fn)` helper that constructs a client, runs
+  the callback, and always closes it. The root `betterwright` export is
+  unchanged.
+
 ## [1.11.0] - 2026-08-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ### Fixed
 
+- **The `ask` tool asks the person at the terminal.** When a host provides an
+  `askUser` callback (the interactive console always does), the question goes
+  there. It used to wait in the live-view chat whenever a live-view surface
+  existed, even one nobody had open, so the console showed no question and
+  swallowed replies as steering until the ask timed out.
 - **`betterwright run --browser steel script.js` runs the file.** `--browser`
   and `--browser-key` were missing from the value-flag list, so the provider
   name was read as the script positional. Both now consume their value in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Releases before 1.1.3 predate this file; their notes live on the
   warnings yellow. Applied across help, `doctor`, `init`, `configure`, and
   `vault`. Piped output, `--json`, NO_COLOR, and TERM=dumb get exactly the
   plain bytes they always did; FORCE_COLOR overrides in either direction.
+- **A live working indicator.** While a task runs, the interactive console's
+  steering prompt animates a spinner with the current phase and how long it
+  has been in it ("reasoning · 12s", "browsing · 3s"), and `exec` shows the
+  same spinner on stderr between step lines. Phases come from a new optional
+  `onPhase` callback on `runAgentTask`, fired at the start of each model turn
+  and each tool batch. TTY only; piped output is unchanged.
 - **The `betterwright/sdk` entrypoint**, a curated TypeScript import for
   embedding: the client, policy, vault, agent, and provider helpers together,
   plus a new `withBrowser(options?, fn)` helper that constructs a client, runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-31
+
+BetterWright 2.0 contains no breaking changes: every 1.x API, CLI command,
+flag, and config file keeps working unchanged. The major version marks the
+new setup experience (first-run onboarding, `configure`, the SDK entrypoint)
+rather than a compatibility break.
+
 ### Added
 
 - **First-run onboarding.** A bare `betterwright` on a terminal with nothing
@@ -1240,7 +1247,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/BetterWright/betterwright/compare/v1.11.0...v2.0.0
 [1.11.0]: https://github.com/BetterWright/betterwright/compare/v1.10.3...v1.11.0
 [1.10.3]: https://github.com/BetterWright/betterwright/compare/v1.10.2...v1.10.3
 [1.10.2]: https://github.com/BetterWright/betterwright/compare/v1.10.1...v1.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Releases before 1.1.3 predate this file; their notes live on the
   the callback, and always closes it. The root `betterwright` export is
   unchanged.
 
+### Fixed
+
+- **`betterwright run --browser steel script.js` runs the file.** `--browser`
+  and `--browser-key` were missing from the value-flag list, so the provider
+  name was read as the script positional. Both now consume their value in
+  every command's argument parsing.
+
 ## [1.11.0] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ await bw.close();
 returns one result envelope. Full API: [docs/javascript.md](docs/javascript.md)
 · [docs/browser-api.md](docs/browser-api.md).
 
+`betterwright/sdk` is the same API as a curated entrypoint, with a
+`withBrowser(fn)` helper that closes the client for you when your callback
+returns or throws: [docs/sdk.md](docs/sdk.md).
+
 `page` and `context` are restricted Playwright wrappers. Request interception
 (`page.route`, `context.route`, `unroute`, and `routeFromHAR`) is unavailable
 because BetterWright's worker-owned routing enforces network policy. For

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@1.11.0
+generated_by: betterwright@2.0.0
 ---
 
 # BetterWright browser

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -6,6 +6,8 @@
 //   betterwright setup            install the managed browser for this host
 //   betterwright update           refresh the managed browser for this host
 //   betterwright doctor           report runtime readiness
+//   betterwright configure        choose the browser backend (cloud provider,
+//                                 CDP endpoint, own binary, or the managed fork)
 //   betterwright run <file|-|-c>  execute a Playwright snippet in the
 //                                 persistent session (tabs/state survive calls)
 //   betterwright repl             run blank-line-separated snippets from stdin
@@ -1942,6 +1944,10 @@ async function main() {
       return cmdUpdate(flags);
     case "doctor":
       return cmdDoctor(flags);
+    case "configure": {
+      const { runConfigure } = await import("../src/configure.js");
+      return runConfigure(rest);
+    }
     case "vault": {
       const { runVaultCommand } = await import("../src/vault-cli.js");
       return runVaultCommand(rest);

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -1987,6 +1987,16 @@ async function main() {
       console.log(styler().help(MAIN_USAGE));
       return 0;
     }
+    // First launch on a TTY with nothing installed: offer the guided init
+    // before dropping into a console whose first task could only fail. Every
+    // other entry point (mcp, __daemon, exec, run, non-TTY) is untouched.
+    const { maybeOfferFirstRunSetup } = await import("../src/onboard.js");
+    const firstRun = await maybeOfferFirstRunSetup({
+      doctorReport,
+      version: packageVersion(),
+      runInit: () => cmdInit(flags),
+    });
+    if (firstRun !== null) return firstRun;
     return cmdInteractive(flags);
   }
   const command = first;

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -56,6 +56,7 @@ import {
   makeLineReader,
   readExecTaskFromStdin,
 } from "../src/cli-io.js";
+import { createSpinner, formatElapsed, phaseLabel, SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../src/cli-spinner.js";
 import { cliPaint } from "../src/cli-theme.js";
 import {
   daemonLogPath,
@@ -945,6 +946,16 @@ async function cmdInteractive(flags) {
   const nextLine = makeLineReader(rl);
   rl.on("SIGINT", () => rl.close());
   let taskRunning = false;
+  // The steering prompt doubles as the working indicator: a spinner frame,
+  // the current phase, and how long it has been in it animate in front of
+  // "steer ▸", so a long model call never looks like a hang.
+  let phaseStartedAt = 0;
+  let spinnerLabel = "reasoning";
+  let spinnerFrame = 0;
+  let spinnerTimer = null;
+  // While the ask tool holds the line ("answer ▸"), the animation must not
+  // repaint the prompt out from under the user's reply.
+  let promptHeld = false;
 
   const clearInputPrompt = () => {
     if (!process.stdout.isTTY) return;
@@ -956,8 +967,10 @@ async function cmdInteractive(flags) {
     readline.cursorTo(process.stdout, 0);
   };
   const showSteeringPrompt = () => {
-    if (!taskRunning || !process.stdout.isTTY) return;
-    rl.setPrompt(`${dim("steer ")}${accent("▸ ")}`);
+    if (!taskRunning || promptHeld || !process.stdout.isTTY) return;
+    const frame = SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length];
+    const elapsed = formatElapsed(Date.now() - phaseStartedAt);
+    rl.setPrompt(`${accent(frame)} ${dim(`${spinnerLabel} · ${elapsed} · steer `)}${accent("▸ ")}`);
     rl.prompt(true);
   };
   const writeInteractive = (
@@ -976,9 +989,22 @@ async function cmdInteractive(flags) {
   };
   const beginTaskInput = () => {
     taskRunning = true;
+    phaseStartedAt = Date.now();
+    spinnerLabel = "reasoning";
+    spinnerFrame = 0;
+    if (process.stdout.isTTY && !spinnerTimer) {
+      spinnerTimer = setInterval(() => {
+        spinnerFrame += 1;
+        // prompt(true) preserves whatever steering text is mid-typing.
+        showSteeringPrompt();
+      }, SPINNER_INTERVAL_MS);
+      spinnerTimer.unref?.();
+    }
     showSteeringPrompt();
   };
   const endTaskInput = () => {
+    if (spinnerTimer) clearInterval(spinnerTimer);
+    spinnerTimer = null;
     clearInputPrompt();
     taskRunning = false;
   };
@@ -1160,6 +1186,13 @@ async function cmdInteractive(flags) {
           history,
           drainSteering: () => steering.splice(0, steering.length),
           liveView: liveViewCliOptions(process.argv),
+          onPhase: (event) => {
+            const label = phaseLabel(event);
+            if (label === spinnerLabel) return;
+            spinnerLabel = label;
+            phaseStartedAt = Date.now();
+            showSteeringPrompt();
+          },
           onStep: ({ step, tool, note, url }) => {
             // `ask` is rendered by the askUser handler below; skip it here.
             if (tool === "ask") return;
@@ -1193,7 +1226,13 @@ async function cmdInteractive(flags) {
               for (const [i, option] of options.entries())
                 writeInteractive(`      ${i + 1}. `, option, dim);
             }
-            const ans = await nextLine("  answer ▸ ");
+            promptHeld = true;
+            let ans;
+            try {
+              ans = await nextLine("  answer ▸ ");
+            } finally {
+              promptHeld = false;
+            }
             showSteeringPrompt();
             return ans === null ? "" : ans.trim();
           },
@@ -1297,17 +1336,29 @@ async function cmdExec(flags) {
   const session = sessionName(flagValue(argv, "--session", "default"));
   const fresh = flags.has("--fresh");
   const home = defaultDaemonHome();
+  // Step lines share stderr with a spinner that fills the silence between
+  // them (a single model call can run for tens of seconds). The spinner owns
+  // the current line, so every stderr write goes through `progress`, which
+  // erases it first; the next tick redraws it under the new line.
+  const spinner = createSpinner({
+    stream: process.stderr,
+    paint: cliPaint({ stream: process.stderr }),
+  });
+  const progress = (text) => {
+    spinner.clear();
+    process.stderr.write(text);
+  };
   const onStep = ({ step, tool, note, url }) => {
     if (url && (tool === "handoff" || tool === "liveView")) {
-      process.stderr.write(`\n  ▶ ${tool === "handoff" ? "HANDOFF" : "LIVE VIEW"}: ${url}\n`);
-      if (tool === "handoff") process.stderr.write(`    ${note}\n\n`);
+      progress(`\n  ▶ ${tool === "handoff" ? "HANDOFF" : "LIVE VIEW"}: ${url}\n`);
+      if (tool === "handoff") progress(`    ${note}\n\n`);
       return;
     }
     if (tool === "liveView" && note) {
-      process.stderr.write(`  ! ${note}\n`);
+      progress(`  ! ${note}\n`);
       return;
     }
-    process.stderr.write(`  [${step}] ${tool}${note ? `: ${note}` : ""}\n`);
+    progress(`  [${step}] ${tool}${note ? `: ${note}` : ""}\n`);
   };
 
   let result;
@@ -1324,15 +1375,16 @@ async function cmdExec(flags) {
       let interrupting = false;
       const onSigint = () => {
         if (interrupting) {
-          process.stderr.write("\n  ! giving up on the interrupt; the run may still be stopping\n");
+          progress("\n  ! giving up on the interrupt; the run may still be stopping\n");
           process.exit(130);
         }
         interrupting = true;
-        process.stderr.write("\n  ! stopping the run — the transcript is kept, so you can resume it\n");
+        progress("\n  ! stopping the run — the transcript is kept, so you can resume it\n");
         void interruptSession(channel, session, { wait: false });
       };
       process.on("SIGINT", onSigint);
       try {
+        spinner.start();
         // The agent loop runs in the daemon, so the conversation and the
         // browser session both persist for the next exec in this session.
         result = await execTask(
@@ -1349,7 +1401,7 @@ async function cmdExec(flags) {
           },
           {
             onStep,
-            onNotice: (note) => process.stderr.write(`  ! ${note}\n`),
+            onNotice: (note) => progress(`  ! ${note}\n`),
             // The run belongs to the daemon, not to this socket. If the pipe
             // breaks mid-task, get back to the same run rather than losing it.
             reconnect: async () => {
@@ -1371,6 +1423,7 @@ async function cmdExec(flags) {
             .catch(() => {});
         }
       } catch (error) {
+        spinner.stop();
         // Config problems (missing credentials, missing SDK) read better as a
         // plain line than a stack trace.
         console.error(error?.message || String(error));
@@ -1379,6 +1432,7 @@ async function cmdExec(flags) {
         }
         return 1;
       } finally {
+        spinner.stop();
         process.off("SIGINT", onSigint);
         channel.end();
       }
@@ -1409,18 +1463,23 @@ async function cmdExec(flags) {
         headless: !flags.has("--headed"),
         liveView: liveViewCliOptions(argv),
         onStep,
+        onPhase: (event) => spinner.setLabel(phaseLabel(event)),
       };
       // The same identity the daemon would have used, so a one-shot exec
       // sees the same logins instead of silently acting as the default.
       const profile = cliProfile();
       if (profile) taskOptions.profile = profile;
+      spinner.start();
       const full = await runAgentTask(taskOptions);
       saveTranscript(home, session, full.transcript, {}, cliProfile());
       const { transcript: _transcript, ...summary } = full;
       result = { ...summary, session, resumedMessages: history.length };
     } catch (error) {
+      spinner.stop();
       console.error(error?.message || String(error));
       return 1;
+    } finally {
+      spinner.stop();
     }
   }
   process.stderr.write(

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -56,6 +56,7 @@ import {
   makeLineReader,
   readExecTaskFromStdin,
 } from "../src/cli-io.js";
+import { cliPaint } from "../src/cli-theme.js";
 import {
   daemonLogPath,
   daemonProfilesInHome,
@@ -332,7 +333,8 @@ async function cmdDoctor(flags) {
   }
   const checks = doctorChecks(report);
   const quiet = flags.has("--quiet");
-  const text = formatDoctorChecks(checks, { quiet });
+  const paint = styler();
+  const text = formatDoctorChecks(checks, { quiet, paint });
   if (text) console.log(text);
   const problems = checks.filter((check) => check.status === "fail");
   const warnings = checks.filter((check) => check.status === "warn");
@@ -340,11 +342,13 @@ async function cmdDoctor(flags) {
   if (report.ready && !problems.length) {
     console.log(
       warnings.length
-        ? `BetterWright is ready. ${warnings.length} optional thing${warnings.length === 1 ? "" : "s"} above ${warnings.length === 1 ? "is" : "are"} not set up.`
-        : "BetterWright is ready.",
+        ? `${paint.accentBold("BetterWright is ready.")} ${warnings.length} optional thing${warnings.length === 1 ? "" : "s"} above ${warnings.length === 1 ? "is" : "are"} not set up.`
+        : paint.accentBold("BetterWright is ready."),
     );
   } else {
-    console.log("Not ready — fix the ✗ lines above, then run `betterwright doctor` again.");
+    console.log(
+      paint.status(`${paint.red("Not ready")} — fix the ✗ lines above, then run \`betterwright doctor\` again.`),
+    );
   }
   return report.ready && !problems.length ? 0 : 1;
 }
@@ -832,13 +836,10 @@ function formatDuration(ms) {
   return n < 1000 ? `${n}ms` : `${(n / 1000).toFixed(1)}s`;
 }
 
-// ANSI helpers that no-op when stdout is not a TTY or NO_COLOR is set.
+// The one paint set for this process; src/cli-theme.ts owns the rules
+// (orange accent, TTY/NO_COLOR gating, identity when off).
 function styler() {
-  const on = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
-  return {
-    dim: (s) => (on ? `\x1b[2m${s}\x1b[0m` : s),
-    bold: (s) => (on ? `\x1b[1m${s}\x1b[0m` : s),
-  };
+  return cliPaint();
 }
 
 const INTERACTIVE_HELP = `Commands:
@@ -890,7 +891,7 @@ async function cmdInteractive(flags) {
     runAgentTask,
   } = await import("../src/agent.js");
   const argv = process.argv;
-  const { dim, bold } = styler();
+  const { dim, bold, accent, accentBold } = styler();
   const removedFlag = removedModelFlagMessage(argv);
   if (removedFlag) {
     console.error(removedFlag);
@@ -918,7 +919,7 @@ async function cmdInteractive(flags) {
       });
       if (view?.ok && view.url) {
         if (!quiet || !view.alreadyRunning) {
-          console.log(`\n  ${bold("▶ Watch live:")} ${view.url}\n`);
+          console.log(`\n  ${accentBold("▶ Watch live:")} ${view.url}\n`);
         }
         interactiveLiveView = opts;
         return view;
@@ -956,7 +957,7 @@ async function cmdInteractive(flags) {
   };
   const showSteeringPrompt = () => {
     if (!taskRunning || !process.stdout.isTTY) return;
-    rl.setPrompt(dim("steer ▸ "));
+    rl.setPrompt(`${dim("steer ")}${accent("▸ ")}`);
     rl.prompt(true);
   };
   const writeInteractive = (
@@ -984,7 +985,7 @@ async function cmdInteractive(flags) {
 
   const modelLabel = () => model || "(choose a model)";
   const reasoningLabel = () => modelOptions.effort || "model default";
-  console.log(`${bold("BetterWright")} — interactive agent console`);
+  console.log(`${accentBold("BetterWright")} — interactive agent console`);
   console.log(
     dim(
       `model ${modelLabel()} · reasoning ${reasoningLabel()} · session ${session}` +
@@ -1902,7 +1903,7 @@ async function main() {
       return 0;
     }
     if (wantsHelp(tokens)) {
-      console.log(MAIN_USAGE);
+      console.log(styler().help(MAIN_USAGE));
       return 0;
     }
     return cmdInteractive(flags);
@@ -1917,7 +1918,7 @@ async function main() {
   // `exec` and `vault` are excluded because they own their own help text —
   // exec's lives beside its flag parsing, vault's beside its subcommands.
   if (wantsHelp(rest) && !["exec", "vault"].includes(command)) {
-    console.log(helpFor(command));
+    console.log(styler().help(helpFor(command)));
     return 0;
   }
   if (command === "help") {
@@ -1925,14 +1926,14 @@ async function main() {
     // route to them rather than duplicating the text in the help table.
     if (positional === "vault") {
       const { VAULT_USAGE } = await import("../src/vault-cli.js");
-      console.log(VAULT_USAGE);
+      console.log(styler().help(VAULT_USAGE));
       return 0;
     }
     if (positional === "exec") {
-      console.log(EXEC_USAGE);
+      console.log(styler().help(EXEC_USAGE));
       return 0;
     }
-    console.log(positional ? helpFor(positional) : MAIN_USAGE);
+    console.log(styler().help(positional ? helpFor(positional) : MAIN_USAGE));
     return 0;
   }
   switch (command) {
@@ -2010,7 +2011,7 @@ async function main() {
       return runSessionDaemon(process.argv);
     }
     default:
-      console.error(`Unknown command "${command}".\n\n${MAIN_USAGE}`);
+      console.error(`Unknown command "${command}".\n\n${cliPaint({ stream: process.stderr }).help(MAIN_USAGE)}`);
       return 1;
   }
 }

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -966,26 +966,48 @@ async function cmdInteractive(flags) {
     }
     readline.cursorTo(process.stdout, 0);
   };
+  // Readline repaints a prompt as several small writes (clear, text, cursor
+  // moves), and a terminal is free to paint between them — at eight repaints
+  // a second that shows up as flicker. Cork batches each repaint into one
+  // flush so the terminal only ever sees complete lines.
+  const paintAtomically = (draw) => {
+    if (!process.stdout.isTTY) {
+      draw();
+      return;
+    }
+    process.stdout.cork();
+    try {
+      draw();
+    } finally {
+      process.stdout.uncork();
+    }
+  };
   const showSteeringPrompt = () => {
     if (!taskRunning || promptHeld || !process.stdout.isTTY) return;
     const frame = SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length];
     const elapsed = formatElapsed(Date.now() - phaseStartedAt);
-    rl.setPrompt(`${accent(frame)} ${dim(`${spinnerLabel} · ${elapsed} · steer `)}${accent("▸ ")}`);
-    rl.prompt(true);
+    paintAtomically(() => {
+      rl.setPrompt(`${accent(frame)} ${dim(`${spinnerLabel} · ${elapsed} · steer `)}${accent("▸ ")}`);
+      rl.prompt(true);
+    });
   };
   const writeInteractive = (
     prefix,
     text,
     style = (value) => value,
   ) => {
-    if (taskRunning) clearInputPrompt();
-    const wrapped = formatHangingText(prefix, text, {
-      columns: process.stdout.columns || 100,
+    // One flush for erase + line + fresh prompt, so a burst of step lines
+    // never shows a half-cleared prompt between them.
+    paintAtomically(() => {
+      if (taskRunning) clearInputPrompt();
+      const wrapped = formatHangingText(prefix, text, {
+        columns: process.stdout.columns || 100,
+      });
+      process.stdout.write(
+        `${wrapped.split("\n").map((line) => style(line)).join("\n")}\n`,
+      );
+      showSteeringPrompt();
     });
-    process.stdout.write(
-      `${wrapped.split("\n").map((line) => style(line)).join("\n")}\n`,
-    );
-    showSteeringPrompt();
   };
   const beginTaskInput = () => {
     taskRunning = true;

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ whole path works by loading a real page.
 | [Integration guide (SETUP.md)](../SETUP.md) | Wiring BetterWright into any host — written to be followed by an AI agent |
 | [The built-in agent](agent.md) | `betterwright exec`, the interactive console, model adapters, `runAgentTask()` |
 | [JavaScript API](javascript.md) | `BetterWright`, `NetworkPolicy`, the result envelope, vault API |
+| [SDK entrypoint](sdk.md) | `betterwright/sdk`: the curated export list and the `withBrowser` helper |
 | [Browser API](browser-api.md) | Every sandboxed global inside a snippet: `page`, `snapshot`, `screenshot`, `human`, … |
 | [CAPTCHA recipes](browser-recipes.md) | Manual fallbacks for CAPTCHA interactions |
 | [Sessions & the daemon](sessions.md) | Persistence, concurrency, interrupting a run, reconnecting |

--- a/docs/browser-providers.md
+++ b/docs/browser-providers.md
@@ -43,6 +43,57 @@ betterwright run … --browser wss://browser.example.com/devtools/abc
 
 `BETTERWRIGHT_CDP_URL` is the host-level shorthand for `{ cdpUrl }`.
 
+## Configuring a default
+
+Passing `--browser` on every call gets old. `betterwright configure` writes the
+choice once, into the `browser` section of `<BETTERWRIGHT_HOME>/config.json`,
+and every later launch picks it up. Run it with no flags on a terminal and it
+lists the current setting, the built-in providers, any custom ones you added,
+a custom CDP endpoint, and your own Chromium binary, then offers to connect
+once so you find out immediately whether the key works.
+
+The same choices are available without prompting:
+
+```bash
+betterwright configure --show                      # current setting (--json for scripts)
+betterwright configure --browser steel --key-env STEEL_API_KEY
+betterwright configure --browser browserbase --browser-key bb_live_…
+betterwright configure --browser wss://browser.example.com/devtools/abc
+betterwright configure --browser /opt/chrome/chrome  # a local binary
+betterwright configure --managed                   # back to the managed fork
+betterwright configure --test                      # connect and print the version
+```
+
+Precedence for one launch, first hit wins:
+
+1. the explicit `provider` option, or `--browser` on the command line
+2. `BETTERWRIGHT_CDP_URL`
+3. the configured default
+4. the managed BetterChromium fork
+
+### Custom named providers
+
+Any service that speaks CDP can have a name of its own, so it works as
+`--browser <name>` everywhere a built-in provider does:
+
+```bash
+betterwright configure --add my-cloud \
+  --cdp-url 'wss://cdp.my-cloud.example/connect?token=${apiKey}' \
+  --key-env MY_CLOUD_TOKEN --display-name "My Cloud" --docs https://my-cloud.example/docs
+betterwright configure --remove my-cloud
+```
+
+`${apiKey}` in the connect URL (and in any header value) is replaced with the
+key at launch. A template with no `${apiKey}` needs no key at all.
+
+### Where keys are stored
+
+`--browser-key` stores the key in `config.json`, which is written owner-only
+(mode 0600) because of exactly this. `--key-env NAME` stores only the variable
+name, so the key stays in your environment and out of the file; the launch
+fails with a clear message when the variable is unset. Provider credentials
+are redacted from result envelopes either way.
+
 ## Named providers
 
 | Provider      | `provider:`      | API key env var          | Key format / notes |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,8 +75,9 @@ entirely, the **provider option** swaps in a browser you supply: a local
 Chromium binary (`provider: { executablePath }`, still on the guard proxy),
 any CDP endpoint (`provider: { cdpUrl }` / `BETTERWRIGHT_CDP_URL`), or a
 cloud browser from Browser Use, Kernel, Browserbase, Steel, Anchor,
-Hyperbrowser, Browserless, Bright Data, or Oxylabs. See
-[browser-providers.md](browser-providers.md).
+Hyperbrowser, Browserless, Bright Data, or Oxylabs. `betterwright configure`
+walks you through the choice and persists a default; custom CDP services can
+be added there by name. See [browser-providers.md](browser-providers.md).
 
 ### BetterChromium backend (macOS arm64 / Linux x64 / Windows x64)
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,105 @@
+# The SDK entrypoint
+
+`betterwright/sdk` is the import for driving BetterWright from your own code.
+It carries the exports meant for programmatic use, plus one helper,
+`withBrowser`, that owns the client's lifetime for you.
+
+The root import, `betterwright`, is unchanged and stays the compatibility
+surface. It still exports everything it always has, including lower-level
+pieces most integrations never touch (CAPTCHA scoring, challenge detection,
+skill loading), so existing code keeps working and nothing has to move.
+
+## Install
+
+```bash
+npm install betterwright
+npx betterwright setup    # downloads the managed BetterChromium build once
+```
+
+Node 22.18 or newer. The package is ESM, so use `import`, or `await import()`
+from CommonJS.
+
+## A complete example
+
+```ts
+import { BrowserError, withBrowser } from "betterwright/sdk";
+
+const title = await withBrowser({ headless: false }, async (bw) => {
+  await bw.run("await page.goto('https://example.com')", { note: "Opening example.com" });
+
+  const result = await bw.run<string>("return page.title()");
+  if (!result.ok) throw new BrowserError(result.error);
+
+  await bw.run("return screenshot({ kind: 'proof', name: 'example-home' })");
+  return result.result;
+});
+
+console.log(title);
+```
+
+`withBrowser` constructs a `BetterWright`, awaits your function, and closes the
+client in a `finally`, so the worker process and the browser are released even
+when the function throws. It resolves with whatever your function returned.
+Pass the callback alone, `withBrowser(fn)`, to take the default options.
+
+The string each `run()` call takes is Playwright code, executed inside the
+worker sandbox where `page`, `snapshot`, `screenshot`, `human`, and
+`credentials` live. [browser-api.md](browser-api.md) documents those globals
+and the result envelope `run()` returns.
+
+## What it exports
+
+Browser client:
+
+| Export | What it is |
+| --- | --- |
+| `withBrowser(options?, fn)` | Run `fn` with a client and close that client afterwards. |
+| `BetterWright` | The client itself: `run()`, sessions, live view, downloads, credential filling. Full reference in [javascript.md](javascript.md). |
+| `BrowserError` | The error type to throw when a result envelope comes back with `ok: false`. |
+| `validateCredentialMatchMode(value)` | Returns the value when it is one of the four credential URL scopes, and throws a `TypeError` otherwise. |
+
+Network policy:
+
+| Export | What it is |
+| --- | --- |
+| `NetworkPolicy` | The allow/deny rules a client enforces on every request. See [network-policy.md](network-policy.md). |
+| `METADATA_ADDRESSES` | The cloud metadata IP addresses in the unliftable network floor. |
+| `METADATA_HOSTNAMES` | The hostnames in that same floor. |
+
+Credential vault:
+
+| Export | What it is |
+| --- | --- |
+| `createLocalCredentialVault(options?)` | The encrypted local vault, including the owner-only reads behind `betterwright vault`. See [credentials.md](credentials.md). |
+| `LocalCredentialVault` | The vault class, for passing an instance to the client. |
+| `LocalCredentialVaultError` | The error type vault operations throw. |
+| `VAULT_CATEGORIES` | The credential categories a record can use. |
+| `VAULT_MATCH_MODES` | The URL scopes a stored credential can be filled on. |
+
+Built-in agent:
+
+| Export | What it is |
+| --- | --- |
+| `runAgentTask(options)` | The task loop behind `betterwright exec`: a task in, one result out. See [agent.md](agent.md). |
+| `resolveModel(model, options?)` | Turn a model id, or an object with a `complete` method, into a model adapter. |
+| `resolveModelSelection(model, options?)` | The same, for a bare user-typed id: it searches the running and configured endpoint catalogs and resolves only when one source has it. |
+
+Browser providers:
+
+| Export | What it is |
+| --- | --- |
+| `BROWSER_PROVIDER_NAMES` | The named cloud providers `provider: { provider }` accepts. |
+| `browserProviderInfo(name)` | Display name, docs URL, and API-key environment variable for one of them, or `null`. |
+| `describeCdpUrl(value)` | A CDP URL with its credentials and key-like query values masked, for logging. |
+
+Bringing your own browser, and what each provider changes about the guard
+proxy, is covered in [browser-providers.md](browser-providers.md).
+
+The entrypoint also exports the public types, so
+`import type { BetterWrightOptions, RunResult } from "betterwright/sdk"` works
+without a second import path.
+
+## Runnable example
+
+[examples/typescript/sdk.ts](../examples/typescript/sdk.ts) is the code above as
+a file you can run with `node examples/typescript/sdk.ts`.

--- a/examples/typescript/sdk.ts
+++ b/examples/typescript/sdk.ts
@@ -1,0 +1,19 @@
+// The quickstart run through the SDK entrypoint: withBrowser closes the
+// client for you, on the way out and on a thrown error.
+//
+//   node examples/typescript/sdk.ts
+
+import { BrowserError, withBrowser } from "betterwright/sdk";
+
+const title = await withBrowser(async (bw) => {
+  await bw.run("await page.goto('https://example.com')", { note: "Opening example.com" });
+
+  const result = await bw.run<string>("return page.title()");
+  if (!result.ok) throw new BrowserError(result.error);
+
+  const proof = await bw.run("return screenshot({ kind: 'proof', name: 'example-home' })");
+  console.log("Proof:", proof.artifacts?.[0]?.media);
+  return result.result;
+});
+
+console.log("Title:", title);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "1.11.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
       "import": "./dist/src/mcp-server.js",
       "default": "./dist/src/mcp-server.js"
     },
+    "./sdk": {
+      "types": "./types/sdk.d.ts",
+      "import": "./dist/src/sdk.js",
+      "default": "./dist/src/sdk.js"
+    },
     "./skills": {
       "types": "./types/skills.d.ts",
       "import": "./dist/src/skills.js",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1008,10 +1008,13 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
           try {
             const remainingSeconds = Math.max(5, Math.floor((deadline - Date.now()) / 1000));
             let reply = "";
-            // Prefer the live-view chat when the viewer surface is available;
-            // fall back to the host's askUser (CLI) when it is not.
+            // A host-provided askUser is someone actually at a terminal, so
+            // the question goes there. The live-view chat handles the rest:
+            // exec-style runs where a viewer URL is the only human surface.
+            // Preferring live view when both exist parked the question in a
+            // chat nobody had open while the console sat on a silent prompt.
             const canLiveAsk =
-              withHandoff && isCallable(browser.waitForAsk);
+              !askUser && withHandoff && isCallable(browser.waitForAsk);
             if (canLiveAsk) {
               const view = await withinDeadline(() => ensureAgentLiveView(), deadline, stopSignal);
               if (view?.url) {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -101,6 +101,10 @@ function isStepCallback(value: UntrustedValue): value is NonNullable<RunAgentTas
   return isCallable(value);
 }
 
+function isPhaseCallback(value: UntrustedValue): value is NonNullable<RunAgentTaskOptions["onPhase"]> {
+  return isCallable(value);
+}
+
 /**
  * Close an unfinished turn so the transcript stays a valid conversation.
  *
@@ -674,6 +678,7 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
   const session = String(options.session || "default");
   const stopSignal = options.signal instanceof AbortSignal ? options.signal : null;
   const onStep = isStepCallback(options.onStep) ? options.onStep : () => {};
+  const onPhase = isPhaseCallback(options.onPhase) ? options.onPhase : () => {};
   const askUser = isCallable(options.askUser) ? options.askUser : null;
   const drainSteering = isCallable(options.drainSteering) ? options.drainSteering : null;
   const maxDurationMs = options.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
@@ -903,6 +908,10 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
       }
       // Human guidance lands at turn boundaries (never mid-browser step).
       appendHumanGuidance(await collectHumanGuidance());
+      // The two long silences in a run are the model turn and the tool batch
+      // that follows it. Announce each so a live UI can say which one the
+      // user is waiting on; step events only fire once a tool has news.
+      onPhase({ phase: "reasoning", step: steps });
       let response;
       try {
         response = await completeWithRetry(
@@ -957,6 +966,7 @@ export async function runAgentTask(options: RunAgentTaskOptions) {
         break;
       }
 
+      onPhase({ phase: "acting", step: steps, tools: toolCalls.map((call) => call.name) });
       const results = [];
       for (const call of toolCalls) {
         if (call.name === "done") {

--- a/src/browser-config.ts
+++ b/src/browser-config.ts
@@ -1,0 +1,403 @@
+// Persistent browser-provider settings: <home>/config.json, `browser` section.
+//
+// This is where `betterwright configure` writes and every launch reads. Two
+// things live here:
+//
+//   - `default`: the provider a launch uses when nothing explicit was given —
+//     the same shapes the `provider` option accepts (a named cloud provider,
+//     a CDP endpoint, or a local Chromium binary), plus `keyEnv` so a config
+//     can point at an environment variable instead of storing the key.
+//   - `custom`: user-defined named providers. Each maps a name to a CDP
+//     connect-URL template (`${apiKey}` is substituted at launch), so any
+//     service that speaks CDP becomes `--browser <name>` without a
+//     BetterWright release.
+//
+// Expansion happens on the client side, before the worker sees the option:
+// the worker's resolveBrowserProvider stays a pure validator with no
+// filesystem access. Precedence for one launch, first hit wins:
+//
+//   explicit `provider` option (CLI --browser included)
+//   > BETTERWRIGHT_CDP_URL
+//   > config `browser.default`
+//   > the managed BetterChromium fork.
+//
+// The config file is written owner-only (writePrivate) because `default` and
+// `custom` entries may carry API keys; `keyEnv` is the documented way to keep
+// keys out of the file entirely.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { BROWSER_PROVIDER_NAMES } from "./browser-providers.js";
+import { writePrivate } from "./fs-private.js";
+import { defaultHome } from "./home.js";
+import {
+  isRecord,
+  isString,
+  type UntrustedValue,
+  untrustedEntries,
+  untrustedField,
+} from "./untrusted-value.js";
+
+const CONFIG_FILE = "config.json";
+// biome-ignore lint/suspicious/noTemplateCurlyInString: the literal token custom cdpUrl templates carry
+const API_KEY_PLACEHOLDER = "${apiKey}";
+// Lowercase, dash-separated, bounded: a custom name has to survive as a CLI
+// flag value, a config key, and an error message.
+const CUSTOM_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
+// Reserved by the provider layer: "cdp" labels an explicit-endpoint plan.
+const RESERVED_NAMES = new Set(["cdp", "managed", "local", "none", "default"]);
+
+/** A user-defined named provider: a CDP endpoint template plus key source. */
+export interface CustomProviderDefinition {
+  /** wss:// (or loopback ws://) connect URL; `${apiKey}` substituted at launch. */
+  cdpUrl: string;
+  /** Extra WebSocket headers; values may also carry `${apiKey}`. */
+  headers?: Record<string, string>;
+  /** Environment variable the API key is read from. */
+  keyEnv?: string;
+  /** API key stored in the config file (owner-only); prefer keyEnv. */
+  apiKey?: string;
+  /** Human label for menus and errors. */
+  displayName?: string;
+  /** Where the service documents its CDP endpoint. */
+  docs?: string;
+}
+
+/**
+ * The persisted default provider: the `provider` option shapes, plus
+ * `keyEnv` so the key can live in the environment instead of the file.
+ */
+export interface DefaultBrowserRef {
+  provider?: string;
+  cdpUrl?: string;
+  executablePath?: string;
+  headers?: Record<string, string>;
+  keyEnv?: string;
+  apiKey?: string;
+  sessionOptions?: Record<string, UntrustedValue>;
+}
+
+/** The sanitized `browser` section of <home>/config.json. */
+export interface BrowserFileConfig {
+  default?: DefaultBrowserRef;
+  custom: Record<string, CustomProviderDefinition>;
+}
+
+export function browserConfigPath(home = defaultHome()) {
+  return path.join(home, CONFIG_FILE);
+}
+
+function readConfigFile(home): UntrustedValue & object {
+  try {
+    const parsed: UntrustedValue = JSON.parse(
+      fs.readFileSync(browserConfigPath(home), "utf8"),
+    );
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {}; // missing or malformed config is simply "no defaults"
+  }
+}
+
+function cleanString(value: UntrustedValue): string {
+  return isString(value) ? value.trim() : "";
+}
+
+function cleanHeaders(value: UntrustedValue): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+  const headers: Record<string, string> = {};
+  for (const [key, entry] of untrustedEntries(value)) {
+    const name = String(key || "").trim();
+    if (name && isString(entry)) headers[name] = entry;
+  }
+  return Object.keys(headers).length ? headers : undefined;
+}
+
+function cleanCustomDefinition(value: UntrustedValue): CustomProviderDefinition | null {
+  if (!isRecord(value)) return null;
+  const cdpUrl = cleanString(untrustedField(value, "cdpUrl"));
+  if (!cdpUrl) return null;
+  const definition: CustomProviderDefinition = { cdpUrl };
+  const headers = cleanHeaders(untrustedField(value, "headers"));
+  if (headers) definition.headers = headers;
+  const keyEnv = cleanString(untrustedField(value, "keyEnv"));
+  if (keyEnv) definition.keyEnv = keyEnv;
+  const apiKey = cleanString(untrustedField(value, "apiKey"));
+  if (apiKey) definition.apiKey = apiKey;
+  const displayName = cleanString(untrustedField(value, "displayName"));
+  if (displayName) definition.displayName = displayName;
+  const docs = cleanString(untrustedField(value, "docs"));
+  if (docs) definition.docs = docs;
+  return definition;
+}
+
+function cleanDefaultRef(value: UntrustedValue): DefaultBrowserRef | undefined {
+  if (!isRecord(value)) return undefined;
+  const ref: DefaultBrowserRef = {};
+  const provider = cleanString(untrustedField(value, "provider"));
+  if (provider) ref.provider = provider.toLowerCase();
+  const cdpUrl = cleanString(untrustedField(value, "cdpUrl"));
+  if (cdpUrl) ref.cdpUrl = cdpUrl;
+  const executablePath = cleanString(untrustedField(value, "executablePath"));
+  if (executablePath) ref.executablePath = executablePath;
+  const headers = cleanHeaders(untrustedField(value, "headers"));
+  if (headers) ref.headers = headers;
+  const keyEnv = cleanString(untrustedField(value, "keyEnv"));
+  if (keyEnv) ref.keyEnv = keyEnv;
+  const apiKey = cleanString(untrustedField(value, "apiKey"));
+  if (apiKey) ref.apiKey = apiKey;
+  const sessionOptions = untrustedField(value, "sessionOptions");
+  if (isRecord(sessionOptions)) {
+    // SAFETY: isRecord confirmed a plain object; the values stay UntrustedValue
+    // and pass to the provider's create-session request verbatim, unread here.
+    ref.sessionOptions = sessionOptions as Record<string, UntrustedValue>;
+  }
+  // Exactly one kind, same rule the provider layer enforces; a ref that sets
+  // none (or several) is a hand-edit gone wrong and reads as "no default".
+  const kinds = [ref.provider, ref.cdpUrl, ref.executablePath].filter(Boolean).length;
+  return kinds === 1 ? ref : undefined;
+}
+
+/**
+ * Read the sanitized `browser` section of <home>/config.json. Unknown keys
+ * and malformed entries are dropped so a typo can't smuggle unexpected
+ * options into a launch.
+ */
+export function loadBrowserConfig(home = defaultHome()): BrowserFileConfig {
+  const section = untrustedField(readConfigFile(home), "browser");
+  const config: BrowserFileConfig = { custom: {} };
+  if (!isRecord(section)) return config;
+  const fallback = cleanDefaultRef(untrustedField(section, "default"));
+  if (fallback) config.default = fallback;
+  const custom = untrustedField(section, "custom");
+  if (isRecord(custom)) {
+    for (const [name, value] of untrustedEntries(custom)) {
+      const key = String(name || "").trim().toLowerCase();
+      const definition = cleanCustomDefinition(value);
+      if (CUSTOM_NAME_PATTERN.test(key) && definition) config.custom[key] = definition;
+    }
+  }
+  return config;
+}
+
+// Read-modify-write via Maps so unrelated config keys (and their order)
+// survive without ever typing the untrusted file as a dictionary — the same
+// discipline live-view-config.ts uses for its section.
+function writeBrowserSection(home, mutate: (section: Map<string, UntrustedValue>) => void) {
+  const config = readConfigFile(home);
+  const existing = untrustedField(config, "browser");
+  const section = new Map(isRecord(existing) ? untrustedEntries(existing) : []);
+  mutate(section);
+  const next = new Map(untrustedEntries(config));
+  if (section.size) next.set("browser", Object.fromEntries(section));
+  else next.delete("browser");
+  fs.mkdirSync(home, { recursive: true });
+  const file = browserConfigPath(home);
+  writePrivate(file, `${JSON.stringify(Object.fromEntries(next), null, 2)}\n`);
+  return file;
+}
+
+/**
+ * Persist (or with null, clear) the default provider for this home.
+ * Validates the ref the same way a launch will, so a bad choice fails here
+ * with the command that made it rather than at the next launch.
+ */
+export function saveDefaultBrowser(ref: DefaultBrowserRef | null, home = defaultHome()) {
+  if (ref != null) {
+    const cleaned = cleanDefaultRef(ref);
+    if (!cleaned) {
+      throw new TypeError(
+        "The default browser must set exactly one of provider, cdpUrl, or executablePath.",
+      );
+    }
+    if (cleaned.provider && !BROWSER_PROVIDER_NAMES.includes(cleaned.provider)) {
+      const custom = loadBrowserConfig(home).custom;
+      if (!custom[cleaned.provider]) {
+        throw new TypeError(
+          `Unknown provider ${JSON.stringify(cleaned.provider)}. Built-in: ` +
+            `${BROWSER_PROVIDER_NAMES.join(", ")}. Add a custom one first ` +
+            "(betterwright configure).",
+        );
+      }
+    }
+    ref = cleaned;
+  }
+  return writeBrowserSection(home, (section) => {
+    if (ref == null) section.delete("default");
+    else section.set("default", ref);
+  });
+}
+
+/** Validate and persist a custom named provider. */
+export function saveCustomProvider(
+  name: string,
+  definition: CustomProviderDefinition,
+  home = defaultHome(),
+) {
+  const key = String(name || "").trim().toLowerCase();
+  if (!CUSTOM_NAME_PATTERN.test(key)) {
+    throw new TypeError(
+      "A custom provider name is 1-32 characters of lowercase letters, digits, and dashes.",
+    );
+  }
+  if (BROWSER_PROVIDER_NAMES.includes(key) || RESERVED_NAMES.has(key)) {
+    throw new TypeError(`${JSON.stringify(key)} is a built-in provider name; pick another.`);
+  }
+  const cleaned = cleanCustomDefinition(definition);
+  if (!cleaned) {
+    throw new TypeError("A custom provider needs a cdpUrl (wss:// connect URL).");
+  }
+  assertTemplateParses(cleaned.cdpUrl, key);
+  return {
+    name: key,
+    file: writeBrowserSection(home, (section) => {
+      const existing = untrustedField(Object.fromEntries(section), "custom");
+      const custom = new Map(isRecord(existing) ? untrustedEntries(existing) : []);
+      custom.set(key, cleaned);
+      section.set("custom", Object.fromEntries(custom));
+    }),
+  };
+}
+
+/** Remove a custom provider; true when something was actually removed. */
+export function removeCustomProvider(name: string, home = defaultHome()) {
+  const key = String(name || "").trim().toLowerCase();
+  let removed = false;
+  writeBrowserSection(home, (section) => {
+    const existing = untrustedField(Object.fromEntries(section), "custom");
+    const custom = new Map(isRecord(existing) ? untrustedEntries(existing) : []);
+    removed = custom.delete(key);
+    if (custom.size) section.set("custom", Object.fromEntries(custom));
+    else section.delete("custom");
+  });
+  return removed;
+}
+
+// A template must parse as a ws(s) URL once the key is substituted; checked
+// at save time so `configure` rejects it with context instead of the next
+// launch failing. The loopback-only rule for plaintext ws:// is enforced by
+// the provider layer at launch, where it also covers hand-edited configs.
+function assertTemplateParses(template: string, name: string) {
+  const candidate = substituteApiKey(template, "placeholder-key");
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    throw new TypeError(`The ${name} cdpUrl is not a valid URL: ${template}`);
+  }
+  if (!["ws:", "wss:"].includes(url.protocol)) {
+    throw new TypeError(`The ${name} cdpUrl must be a ws:// or wss:// URL.`);
+  }
+}
+
+// Literal substitution: provider keys are URL-safe tokens in practice, and a
+// template author who needs percent-encoding can encode around the
+// placeholder. The result is re-validated as a URL by the provider layer.
+function substituteApiKey(template: string, apiKey: string) {
+  return template.split(API_KEY_PLACEHOLDER).join(apiKey);
+}
+
+function resolveKey(choiceKey, definitionKeyEnv, definitionKey, env, what) {
+  const key =
+    cleanString(choiceKey) ||
+    (definitionKeyEnv ? cleanString(env?.[definitionKeyEnv]) : "") ||
+    cleanString(definitionKey);
+  return { key, keyEnv: definitionKeyEnv, what };
+}
+
+/**
+ * Expand a provider choice into the shapes the worker's
+ * resolveBrowserProvider accepts, resolving custom names and keyEnv
+ * indirection against this home's config. Built-in names, explicit CDP
+ * endpoints, and local binaries pass through (with keyEnv resolved to an
+ * apiKey when the ref carries one).
+ *
+ * Throws for a named provider that is neither built-in nor configured, and
+ * for a custom provider whose template needs a key nobody supplied.
+ */
+export function expandProviderChoice(
+  choice: UntrustedValue,
+  { home = defaultHome(), env = process.env, config = null }: any = {},
+) {
+  if (choice == null || choice === false) return choice ?? null;
+  if (isString(choice)) choice = { provider: choice };
+  if (!isRecord(choice)) return choice; // let the provider layer report the type error
+  const name = cleanString(untrustedField(choice, "provider")).toLowerCase();
+  if (!name) return expandKeyEnv(choice, env);
+  if (BROWSER_PROVIDER_NAMES.includes(name)) return expandKeyEnv(choice, env);
+
+  const browserConfig: BrowserFileConfig = config ?? loadBrowserConfig(home);
+  const definition = browserConfig.custom[name];
+  if (!definition) {
+    const custom = Object.keys(browserConfig.custom);
+    throw new TypeError(
+      `Unknown browser provider ${JSON.stringify(name)}. Built-in: ` +
+        `${BROWSER_PROVIDER_NAMES.join(", ")}.` +
+        (custom.length ? ` Configured: ${custom.join(", ")}.` : "") +
+        " Add your own with `betterwright configure`, or pass { cdpUrl }.",
+    );
+  }
+  const { key } = resolveKey(
+    untrustedField(choice, "apiKey"),
+    definition.keyEnv,
+    definition.apiKey,
+    env,
+    name,
+  );
+  const template = definition.cdpUrl;
+  const needsKey =
+    template.includes(API_KEY_PLACEHOLDER) ||
+    Object.values(definition.headers || {}).some((value) =>
+      value.includes(API_KEY_PLACEHOLDER),
+    );
+  if (needsKey && !key) {
+    throw new TypeError(
+      `The ${definition.displayName || name} provider needs an API key: pass one, ` +
+        (definition.keyEnv
+          ? `set ${definition.keyEnv}, `
+          : "") +
+        "or re-run `betterwright configure`.",
+    );
+  }
+  const cdpUrl = substituteApiKey(template, key);
+  if (!definition.headers) return { cdpUrl };
+  const headers: Record<string, string> = {};
+  for (const [header, value] of Object.entries(definition.headers)) {
+    headers[header] = substituteApiKey(value, key);
+  }
+  return { cdpUrl, headers };
+}
+
+// A built-in named ref may carry keyEnv (from a stored default); resolve it
+// to an apiKey here because the provider layer only knows its own fixed env
+// var. An explicit apiKey wins; strip keyEnv either way — the worker's
+// validator does not know the field.
+function expandKeyEnv(choice: UntrustedValue & object, env) {
+  const keyEnv = cleanString(untrustedField(choice, "keyEnv"));
+  if (!keyEnv) return choice;
+  // SAFETY: the callers hold isRecord(choice); the spread only re-keys the
+  // same untrusted fields so keyEnv can be dropped.
+  const { keyEnv: _dropped, ...rest } = choice as Record<string, UntrustedValue>;
+  const apiKey = cleanString(untrustedField(choice, "apiKey")) || cleanString(env?.[keyEnv]);
+  if (!apiKey) {
+    throw new TypeError(
+      `The configured browser reads its API key from ${keyEnv}, which is not set. ` +
+        "Set it, or re-run `betterwright configure`.",
+    );
+  }
+  return { ...rest, apiKey };
+}
+
+/**
+ * The persisted default provider for this home, expanded and ready for the
+ * `provider` option — or null when the config names none and every launch
+ * should use the managed fork.
+ */
+export function configuredDefaultProvider({
+  home = defaultHome(),
+  env = process.env,
+}: any = {}) {
+  const config = loadBrowserConfig(home);
+  if (!config.default) return null;
+  return expandProviderChoice(config.default, { home, env, config });
+}

--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -41,6 +41,10 @@ export const VALUE_FLAGS = new Set([
   "--api-key-env",
   "--base-url",
   "--block-host",
+  // `run --browser steel script.js` must read script.js as the file, not
+  // steel: the browser choice and its key are values, never positionals.
+  "--browser",
+  "--browser-key",
   "--category",
   "--delay",
   "--effort",

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -12,6 +12,7 @@ export const COMMAND_SUMMARIES = [
   ["setup", "download the managed browser for this host"],
   ["update", "download or refresh the managed browser for this host"],
   ["doctor", "check that everything needed is installed and reachable"],
+  ["configure", "choose the browser backend: cloud provider, custom CDP, or managed"],
   ["run", "run one Playwright snippet in the persistent session"],
   ["repl", "run blank-line-separated snippets from stdin"],
   ["exec", "hand a whole task to BetterWright's own browser agent"],
@@ -89,6 +90,45 @@ Options:
 
 Exit code is 0 when ready, 1 otherwise.`,
 
+  configure: `Usage: betterwright configure
+       betterwright configure --browser <name|wss-url|path> [--browser-key <key> | --key-env <NAME>]
+       betterwright configure --show [--json]
+
+Choose the browser every launch uses: the managed BetterChromium fork, a cloud
+provider, any CDP endpoint, or your own Chromium binary. With no options on a
+terminal it walks you through the choices and offers to connect once; the flags
+do the same things without prompting. The choice is stored in the browser
+section of <BETTERWRIGHT_HOME>/config.json, written owner-only.
+
+Options:
+  --show                 print the current setting (the default with no terminal)
+  --json                 machine-readable output for --show; stored keys are
+                         masked either way
+  --browser <value>      set the default. A provider name (browser-use, kernel,
+                         browserbase, steel, anchor, hyperbrowser, browserless,
+                         brightdata, oxylabs, or one you added), a wss:// CDP
+                         endpoint, or an absolute path to a Chromium binary
+  --browser-key <key>    store that provider's API key in the config file
+  --key-env <NAME>       read that provider's API key from this environment
+                         variable instead, so it never enters the file
+                         (mutually exclusive with --browser-key)
+  --managed, --reset     clear the default; launches use the managed fork again
+  --add <name>           add a custom provider named <name>, with
+    --cdp-url <template>   its connect URL, where \${apiKey} is replaced with
+                           the key at launch
+    --key-env <NAME> | --browser-key <key>   where its key comes from
+    --docs <url>           where the service documents its endpoint
+    --display-name <label> how menus and errors name it
+  --remove <name>        delete a custom provider
+  --test                 after setting (or on its own) connect to the configured
+                         browser and print its version
+  --no-test              do not offer the connection test in the interactive flow
+
+Precedence at launch: --browser / the provider option, then
+BETTERWRIGHT_CDP_URL, then this default, then the managed fork.
+Exit code is 0 on success, 1 on a bad value or a failed connection test.
+Details: docs/browser-providers.md`,
+
   run: `Usage: betterwright run -c "<javascript>"
        betterwright run <file>
        betterwright run -            read the snippet from stdin
@@ -113,8 +153,11 @@ Options:
   --stealth              isolated-world driver (needs patchright-core)
   --browser <name|url>   use a cloud browser provider (browser-use, kernel,
                          browserbase, steel, anchor, hyperbrowser, browserless,
-                         brightdata, oxylabs) or any wss:// CDP endpoint
-                         instead of the managed BetterChromium fork
+                         brightdata, oxylabs, or one added with
+                         \`betterwright configure --add\`) or any wss:// CDP
+                         endpoint instead of the managed BetterChromium fork.
+                         \`betterwright configure\` sets a default so you do
+                         not have to pass this every time
   --browser-key <key>    provider API key (or its env var, e.g.
                          BROWSERBASE_API_KEY); BETTERWRIGHT_CDP_URL is the
                          env shorthand for --browser <url>

--- a/src/cli-spinner.ts
+++ b/src/cli-spinner.ts
@@ -1,0 +1,104 @@
+// A working indicator for the CLI's two live surfaces: the interactive
+// console (which animates its readline prompt) and exec's stderr stream.
+//
+// The agent can sit inside one model call for ten seconds or more with
+// nothing to print. Without a pulse on screen that silence reads as a hang.
+// The console builds its own prompt string from these frames because readline
+// owns the input line there; exec gets the self-contained stream spinner.
+//
+// Same contract as the theme: animation only on a TTY. Piped and redirected
+// output keeps exactly the plain lines it always had.
+
+import type { CliPaint } from "./cli-theme.js";
+
+export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+export const SPINNER_INTERVAL_MS = 120;
+
+// What each agent phase should read as while the user waits on it. The
+// acting label comes from the first tool in the batch; a batch rarely mixes
+// tools, and the step line that follows names each one anyway.
+const ACTING_LABELS = {
+  browser: "browsing",
+  login: "logging in",
+  ask: "waiting for your answer",
+  handoff: "waiting for your hands",
+  live_view: "opening live view",
+  done: "finishing",
+};
+
+/** The wait label for a runAgentTask onPhase event: "reasoning", "browsing", … */
+export function phaseLabel(event: { phase?: string; tools?: string[] } = {}): string {
+  if (event.phase !== "acting") return "reasoning";
+  return ACTING_LABELS[event.tools?.[0] ?? ""] || "working";
+}
+
+/** Whole-second elapsed time for a live counter: "7s", then "1m 07s". */
+export function formatElapsed(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, "0")}s`;
+}
+
+/**
+ * A spinner that owns the current line of `stream`: "  ⠹ working · 12s".
+ * `clear()` erases it so a real line can be written in its place; the next
+ * tick redraws it below. Every method is a no-op when the stream is not a
+ * TTY, so callers never have to guard.
+ */
+export function createSpinner({
+  stream,
+  paint,
+  label = "working",
+}: {
+  stream: NodeJS.WriteStream;
+  paint: CliPaint;
+  label?: string;
+}) {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let startedAt = 0;
+  let tick = 0;
+  let visible = false;
+  let current = label;
+
+  const render = () => {
+    const frame = SPINNER_FRAMES[tick % SPINNER_FRAMES.length];
+    tick += 1;
+    const elapsed = formatElapsed(Date.now() - startedAt);
+    stream.write(`\r\x1b[2K  ${paint.accent(frame)} ${paint.dim(`${current} · ${elapsed}`)}`);
+    visible = true;
+  };
+  const clear = () => {
+    if (!visible) return;
+    stream.write("\r\x1b[2K");
+    visible = false;
+  };
+
+  return {
+    start() {
+      if (!stream.isTTY || timer) return;
+      startedAt = Date.now();
+      tick = 0;
+      render();
+      timer = setInterval(render, SPINNER_INTERVAL_MS);
+      // The spinner must never keep the process alive on its own.
+      timer.unref?.();
+    },
+    /** Erase the spinner line so the caller can print a real line. */
+    clear,
+    /**
+     * Change what the wait is called ("reasoning" → "browsing"). The counter
+     * restarts so it reads as time spent in this phase, not the whole run.
+     */
+    setLabel(text: string) {
+      if (text === current) return;
+      current = text;
+      startedAt = Date.now();
+      if (timer) render();
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+      clear();
+    },
+  };
+}

--- a/src/cli-theme.ts
+++ b/src/cli-theme.ts
@@ -1,0 +1,150 @@
+// The CLI's one theme: BetterWright orange on a quiet terminal.
+//
+// Color is applied at the output sink, never inside the strings a function
+// builds or returns. Tests inject their own `log` and assert on plain text;
+// `--json` pipes into parsers; NO_COLOR and non-TTY streams must see exactly
+// the bytes they always did. Painting at the last moment keeps all of that
+// true with one rule instead of a hundred call-site decisions.
+//
+// The palette is deliberately small. Orange is the brand: the wordmark,
+// success marks, command names, and prompt markers. Red and yellow keep their
+// universal meanings (failure, attention) so a problem never has to compete
+// with the theme for the reader's eye.
+
+// Truecolor BetterWright orange, with the closest xterm-256 fallback.
+const ORANGE_TRUECOLOR = "38;2;255;135;35";
+const ORANGE_256 = "38;5;208";
+
+function colorEnabled(stream, env) {
+  if (String(env.FORCE_COLOR ?? "") === "0") return false;
+  if (env.FORCE_COLOR) return true;
+  if (env.NO_COLOR) return false;
+  if (env.TERM === "dumb") return false;
+  return Boolean(stream?.isTTY);
+}
+
+function truecolorEnabled(env) {
+  return /truecolor|24bit/i.test(String(env.COLORTERM ?? ""));
+}
+
+/** Everything a command needs to paint output. All identity when `on` is false. */
+export interface CliPaint {
+  on: boolean;
+  accent: (text: string) => string;
+  accentBold: (text: string) => string;
+  heading: (text: string) => string;
+  bold: (text: string) => string;
+  dim: (text: string) => string;
+  red: (text: string) => string;
+  yellow: (text: string) => string;
+  /** Paint one already-built output line: status glyphs, `commands`, menu numbers. */
+  status: (line: string) => string;
+  /** Paint a block of help text: wordmark, headings, flags, command names. */
+  help: (text: string) => string;
+}
+
+const IDENTITY = (text) => String(text);
+
+// One leading glyph per line, colored by what it means. `·` and the fix arrow
+// stay dim: they are narration, not results.
+const GLYPH_STYLES = [
+  { pattern: /^(\s*)(✓)( |$)/, color: "accent" },
+  { pattern: /^(\s*)(✗)( |$)/, color: "red" },
+  { pattern: /^(\s*)(!)( |$)/, color: "yellow" },
+  { pattern: /^(\s*)([·▸▶?])( |$)/, color: "accent" },
+  { pattern: /^(\s*)(→)( |$)/, color: "dim" },
+] as const;
+
+function paintStatusLine(line, paint) {
+  let painted = String(line);
+  for (const { pattern, color } of GLYPH_STYLES) {
+    const match = painted.match(pattern);
+    if (!match) continue;
+    painted = `${match[1]}${paint[color](match[2])}${painted.slice(match[1].length + match[2].length)}`;
+    break;
+  }
+  // Interactive menu rows: "   3) Steel (steel)".
+  painted = painted.replace(/^(\s+)(\d+\))( )/, (_, lead, number, gap) => `${lead}${paint.accent(number)}${gap}`);
+  // `betterwright doctor` and friends, quoted mid-sentence.
+  painted = painted.replace(/`([^`]+)`/g, (_, command) => `\`${paint.accent(command)}\``);
+  return painted;
+}
+
+function paintHelpLine(line, paint) {
+  // The wordmark line at the top of the main usage text.
+  if (/^betterwright — /.test(line)) {
+    return `${paint.accentBold("betterwright")}${paint.dim(line.slice("betterwright".length))}`;
+  }
+  if (/^(Usage|Shell note):/.test(line)) {
+    const label = line.slice(0, line.indexOf(":") + 1);
+    return `${paint.dim(label)}${line.slice(label.length)}`;
+  }
+  // Bare section headings: "Commands:", "Options:", "Categories: …".
+  if (/^[A-Z][A-Za-z ]*:/.test(line)) {
+    const label = line.slice(0, line.indexOf(":") + 1);
+    return `${paint.bold(label)}${paintStatusLine(line.slice(label.length), paint)}`;
+  }
+  // Flag rows: "  --browser <value>      set the default…".
+  const flagRow = line.match(/^(\s+)(--[\w-]+(?:, --[\w-]+)*)/);
+  if (flagRow) {
+    return `${flagRow[1]}${paint.accent(flagRow[2])}${paintStatusLine(line.slice(flagRow[1].length + flagRow[2].length), paint)}`;
+  }
+  // Command rows: "  configure  choose the browser backend…" (two-space
+  // indent, a short lowercase name, at least two spaces of padding after).
+  const commandRow = line.match(/^( {2})([a-z][a-z-]{1,14})( {2,})/);
+  if (commandRow) {
+    return `${commandRow[1]}${paint.accent(commandRow[2])}${line.slice(commandRow[1].length + commandRow[2].length)}`;
+  }
+  return paintStatusLine(line, paint);
+}
+
+/**
+ * The paint set for one stream. Colors turn on only for a TTY without
+ * NO_COLOR (FORCE_COLOR overrides both ways), so piped, redirected, and
+ * test-captured output is always plain text.
+ */
+export function cliPaint({ stream = process.stdout, env = process.env }: any = {}): CliPaint {
+  if (!colorEnabled(stream, env)) {
+    return {
+      on: false,
+      accent: IDENTITY,
+      accentBold: IDENTITY,
+      heading: IDENTITY,
+      bold: IDENTITY,
+      dim: IDENTITY,
+      red: IDENTITY,
+      yellow: IDENTITY,
+      status: IDENTITY,
+      help: IDENTITY,
+    };
+  }
+  const orange = truecolorEnabled(env) ? ORANGE_TRUECOLOR : ORANGE_256;
+  const wrap = (code) => (text) => `\x1b[${code}m${text}\x1b[0m`;
+  const paint: CliPaint = {
+    on: true,
+    accent: wrap(orange),
+    accentBold: wrap(`1;${orange}`),
+    heading: wrap(`1;${orange}`),
+    bold: wrap("1"),
+    dim: wrap("2"),
+    red: wrap("31"),
+    yellow: wrap("33"),
+    status: (line) => paintStatusLine(line, paint),
+    help: (text) =>
+      String(text)
+        .split("\n")
+        .map((line) => paintHelpLine(line, paint))
+        .join("\n"),
+  };
+  return paint;
+}
+
+/** A console.log that paints status glyphs, for commands' default sinks. */
+export function paintedLog(paint: CliPaint) {
+  return (line = "") => console.log(paint.status(line));
+}
+
+/** The stderr twin: glyphs and quoting painted, nothing else. */
+export function paintedError(paint: CliPaint) {
+  return (line = "") => console.error(paint.status(line));
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,10 @@ import { fileURLToPath } from "node:url";
 // implementation against them turns a drift between the two into a compile
 // error instead of something only a consumer would notice.
 import type { BetterWrightOptions, LiveViewOptions } from "../types/public.js";
+import {
+  configuredDefaultProvider,
+  expandProviderChoice,
+} from "./browser-config.js";
 import { resolveChromiumArgs } from "./chromium-args.js";
 import {
   assertRotationPreservesMatchMode,
@@ -87,12 +91,20 @@ function resolveHeadless(headless) {
   return headless !== false;
 }
 
-function resolveProviderOption(options) {
+function resolveProviderOption(options, home) {
   // Explicit option wins; BETTERWRIGHT_CDP_URL is the host-level shorthand
-  // for "attach to this CDP endpoint" (validated in the worker).
-  if (Object.hasOwn(options, "provider")) return options.provider ?? null;
+  // for "attach to this CDP endpoint" (validated in the worker); beneath
+  // both sits the default persisted by `betterwright configure`. Custom
+  // provider names expand here, on the client side, so the worker's
+  // validator stays free of filesystem access.
+  if (Object.hasOwn(options, "provider")) {
+    return options.provider == null
+      ? null
+      : expandProviderChoice(options.provider, { home });
+  }
   const env = String(process.env.BETTERWRIGHT_CDP_URL || "").trim();
-  return env ? { cdpUrl: env } : null;
+  if (env) return { cdpUrl: env };
+  return configuredDefaultProvider({ home });
 }
 
 /** The managed-browser legacy toggles are gone; reject them with the fix. */
@@ -367,7 +379,9 @@ export class BetterWright {
    *   apiKey?, sessionOptions? }` mints a cloud browser over that provider's
    *   API. Remote browsers run outside the guard proxy — the launch warning
    *   says so. BETTERWRIGHT_CDP_URL is the host-level shorthand for
-   *   `{ cdpUrl }`. See docs/browser-providers.md.
+   *   `{ cdpUrl }`; beneath both sits the default saved by `betterwright
+   *   configure`, where custom provider names are defined too. See
+   *   docs/browser-providers.md.
    * @param {string} [options.upstreamProxy] http:// or socks5:// egress proxy
    *   chained through the local policy guard (the IP layer): targets observe
    *   the upstream IP while policy and DNS-rebinding checks stay local.
@@ -432,7 +446,7 @@ export class BetterWright {
       ? options.credentialCapture !== false
       : false;
     assertNoLegacyBrowserOptions();
-    this.provider = resolveProviderOption(options);
+    this.provider = resolveProviderOption(options, this.home);
     this.browserFlavor = "chromium-fork";
     this.headless = resolveHeadless(options.headless);
     this.fingerprintNoise = options.fingerprintNoise !== false;

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,0 +1,586 @@
+// `betterwright configure` — choose the browser backend once, for this home.
+//
+// The provider layer has always accepted a cloud browser, a CDP endpoint, or a
+// local Chromium binary, but every launch had to say so again: a flag on
+// run/repl/exec, or BETTERWRIGHT_CDP_URL exported in the right shell. This
+// command writes the choice to <home>/config.json (browser-config.ts) so it
+// holds for every launch, and it offers to connect once, because "saved" and
+// "works" are different claims.
+//
+// API keys are why the interactive flow asks two questions instead of one: a
+// pasted key lands in the config file (owner-only), while `keyEnv` names an
+// environment variable and keeps the key out of the file entirely. Both are
+// offered every time, for built-in and custom providers alike.
+
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+import {
+  type BrowserFileConfig,
+  browserConfigPath,
+  type CustomProviderDefinition,
+  type DefaultBrowserRef,
+  expandProviderChoice,
+  loadBrowserConfig,
+  removeCustomProvider,
+  saveCustomProvider,
+  saveDefaultBrowser,
+} from "./browser-config.js";
+import {
+  BROWSER_PROVIDER_NAMES,
+  browserProviderInfo,
+  describeCdpUrl,
+  resolveBrowserProvider,
+} from "./browser-providers.js";
+import { flagValue } from "./cli-flags.js";
+import { defaultHome } from "./home.js";
+import { isCallable } from "./untrusted-value.js";
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: the literal token custom cdpUrl templates carry
+const API_KEY_PLACEHOLDER = "${apiKey}";
+// Long enough for a cloud provider to hand back a browser, short enough that a
+// wrong endpoint fails while the user is still watching.
+const CONNECT_TIMEOUT_MS = 10_000;
+
+/** A menu row, and what picking it means. */
+interface ConfigureChoice {
+  kind: "managed" | "provider" | "cdp" | "local" | "add";
+  label: string;
+  name?: string;
+  custom?: CustomProviderDefinition;
+}
+
+function hasFlag(argv, flag) {
+  return argv.some((token) => token === flag || token.startsWith(`${flag}=`));
+}
+
+function trimmed(value) {
+  return String(value ?? "").trim();
+}
+
+function envKeyState(env, name) {
+  return trimmed(env?.[name]) ? "set" : "not set";
+}
+
+/**
+ * One line describing a stored default: what it points at, and where its key
+ * comes from. Never prints a key, only its source.
+ */
+export function describeDefaultBrowser(ref: DefaultBrowserRef, { env = process.env, custom = {} }: any = {}) {
+  if (!ref) return "the managed BetterChromium fork";
+  if (ref.cdpUrl) return `CDP endpoint ${describeCdpUrl(ref.cdpUrl)}`;
+  if (ref.executablePath) return `local Chromium at ${ref.executablePath}`;
+  const info = browserProviderInfo(ref.provider);
+  const definition = custom[ref.provider];
+  const label = info?.name || definition?.displayName || ref.provider;
+  const keyEnv = ref.keyEnv || definition?.keyEnv || info?.keyEnv;
+  let key = "";
+  if (ref.apiKey || (!ref.keyEnv && definition?.apiKey)) {
+    key = ", API key stored in the config file";
+  } else if (keyEnv) {
+    key = `, API key from ${keyEnv} (${envKeyState(env, keyEnv)})`;
+  }
+  return `${label} (${ref.provider}${info ? "" : ", custom"})${key}`;
+}
+
+function describeCustomProvider(name, definition: CustomProviderDefinition, env) {
+  const label = definition.displayName ? `${definition.displayName} (${name})` : name;
+  const key = definition.apiKey
+    ? "API key stored in the config file"
+    : definition.keyEnv
+      ? `API key from ${definition.keyEnv} (${envKeyState(env, definition.keyEnv)})`
+      : "no API key configured";
+  return `${label}: ${describeCdpUrl(definition.cdpUrl)}, ${key}`;
+}
+
+function summaryLines(config, env, home) {
+  const lines = [`  Config file: ${browserConfigPath(home)}`];
+  lines.push(`  Default:     ${describeDefaultBrowser(config.default, { env, custom: config.custom })}`);
+  const names = Object.keys(config.custom);
+  if (names.length) {
+    lines.push("  Custom providers:");
+    for (const name of names) {
+      lines.push(`    · ${describeCustomProvider(name, config.custom[name], env)}`);
+    }
+  }
+  return lines;
+}
+
+/** A stored entry as `--json` reports it: key sources, never keys. */
+interface MaskedBrowserEntry {
+  provider?: string;
+  cdpUrl?: string;
+  executablePath?: string;
+  headers?: Record<string, string>;
+  displayName?: string;
+  docs?: string;
+  keyEnv?: string;
+  keyEnvSet?: boolean;
+  apiKey?: string;
+}
+
+// Copied field by field rather than spread-and-overwrite, so a field added to
+// the config later cannot reach this output before someone decides it is safe.
+function maskEntry(entry, env): MaskedBrowserEntry {
+  const masked: MaskedBrowserEntry = {};
+  if (entry.provider) masked.provider = entry.provider;
+  if (entry.cdpUrl) masked.cdpUrl = entry.cdpUrl;
+  if (entry.executablePath) masked.executablePath = entry.executablePath;
+  if (entry.headers) masked.headers = entry.headers;
+  if (entry.displayName) masked.displayName = entry.displayName;
+  if (entry.docs) masked.docs = entry.docs;
+  if (entry.keyEnv) {
+    masked.keyEnv = entry.keyEnv;
+    masked.keyEnvSet = Boolean(trimmed(env?.[entry.keyEnv]));
+  }
+  if (entry.apiKey) masked.apiKey = "***";
+  return masked;
+}
+
+function showConfig({ home, env, log, json }) {
+  const config = loadBrowserConfig(home);
+  if (json) {
+    const custom: Record<string, MaskedBrowserEntry> = {};
+    for (const [name, definition] of Object.entries(config.custom)) {
+      custom[name] = maskEntry(definition, env);
+    }
+    log(
+      JSON.stringify(
+        {
+          file: browserConfigPath(home),
+          default: config.default ? maskEntry(config.default, env) : null,
+          custom,
+        },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+  log("");
+  log("Browser backend");
+  log("");
+  for (const line of summaryLines(config, env, home)) log(line);
+  log("");
+  log("  Change it with `betterwright configure`.");
+  log("");
+  return 0;
+}
+
+function assertCdpUrl(value) {
+  let url: URL;
+  try {
+    url = new URL(trimmed(value));
+  } catch {
+    throw new TypeError(`Not a URL: ${value}. A CDP endpoint looks like wss://host/path.`);
+  }
+  if (!["ws:", "wss:"].includes(url.protocol)) {
+    throw new TypeError(
+      `A CDP endpoint must be a ws:// or wss:// URL; ${url.protocol}// is not one. ` +
+        "Remote endpoints must use wss://; plaintext ws:// is only allowed on loopback.",
+    );
+  }
+  return url.href;
+}
+
+// `--browser <value>`: a URL is an endpoint, an absolute path is a binary,
+// anything else names a provider (saveDefaultBrowser rejects unknown names).
+function defaultRefFromValue(value, { apiKey, keyEnv }): DefaultBrowserRef {
+  const wanted = trimmed(value);
+  if (!wanted) {
+    throw new TypeError(
+      "--browser needs a provider name, a wss:// CDP endpoint, or an absolute path to a Chromium binary.",
+    );
+  }
+  // Any scheme, not just ws(s), so `--browser https://…` gets the protocol
+  // error rather than "unknown provider".
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(wanted)) {
+    if (apiKey || keyEnv) {
+      throw new TypeError("--browser-key and --key-env apply to a named provider, not a CDP endpoint.");
+    }
+    return { cdpUrl: assertCdpUrl(wanted) };
+  }
+  if (path.isAbsolute(wanted)) {
+    if (apiKey || keyEnv) {
+      throw new TypeError("--browser-key and --key-env apply to a named provider, not a local binary.");
+    }
+    if (!fs.existsSync(wanted)) throw new TypeError(`No Chromium binary at ${wanted}.`);
+    return { executablePath: wanted };
+  }
+  const ref: DefaultBrowserRef = { provider: wanted.toLowerCase() };
+  if (apiKey) ref.apiKey = apiKey;
+  if (keyEnv) ref.keyEnv = keyEnv;
+  return ref;
+}
+
+// The default connection test: a real CDP handshake through playwright-core,
+// injectable so tests never open a socket.
+async function connectOverCdp({ cdpUrl, headers, timeout }: any) {
+  const { chromium } = await import("playwright-core");
+  const browser = Object.keys(headers || {}).length
+    ? await chromium.connectOverCDP(cdpUrl, { timeout, headers })
+    : await chromium.connectOverCDP(cdpUrl, { timeout });
+  try {
+    return { version: browser.version() };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+/**
+ * Resolve the configured default the way a launch would, mint a session if the
+ * provider needs one, and connect. Returns 0 when the browser answered.
+ */
+async function testConnection({ home, env, log, fail, connect, fetchJson }) {
+  const config = loadBrowserConfig(home);
+  if (!config.default) {
+    log("  · No default is configured, so launches use the managed BetterChromium fork.");
+    return 0;
+  }
+  let plan;
+  try {
+    const expanded = expandProviderChoice(config.default, { home, env, config });
+    plan = resolveBrowserProvider(expanded, { env })?.plan;
+  } catch (error) {
+    fail(`  ✗ ${error?.message || error}`);
+    return 1;
+  }
+  if (!plan) {
+    log("  · Nothing to connect to.");
+    return 0;
+  }
+  if (plan.kind === "local") {
+    // resolveBrowserProvider already checked the path exists and is absolute.
+    log(`  ✓ Chromium binary found at ${plan.executablePath}.`);
+    return 0;
+  }
+  log(`  · Connecting to ${plan.endpointLabel || plan.provider}…`);
+  let live = plan;
+  try {
+    // A session-minting provider bills for this; the finally below releases it.
+    if (plan.create) live = await plan.create({ fetchJson });
+    const result = await connect({
+      cdpUrl: live.cdpUrl,
+      headers: live.headers || {},
+      timeout: CONNECT_TIMEOUT_MS,
+    });
+    const version = trimmed(result?.version) || "connected";
+    log(`  ✓ ${version}`);
+    return 0;
+  } catch (error) {
+    // First line only: playwright-core appends a multi-line call log that
+    // repeats the endpoint this command already printed.
+    const detail = String(error?.message || error).split("\n")[0];
+    fail(`  ✗ Could not connect: ${detail}`);
+    fail("    The choice is saved but unverified.");
+    return 1;
+  } finally {
+    if (live && live !== plan) {
+      try {
+        await live.end?.();
+      } catch {
+        /* releasing the probe session is best-effort */
+      }
+    }
+  }
+}
+
+function createPrompter() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return {
+    async ask(question) {
+      return new Promise((resolve) => rl.question(question, (answer) => resolve(answer)));
+    },
+    close() {
+      rl.close();
+    },
+  };
+}
+
+// `confirm` is derived from `ask` when the prompter does not provide one, so a
+// scripted prompter only has to answer questions in order.
+async function askConfirm(prompt, question, fallback = true) {
+  if (isCallable(prompt.confirm)) return prompt.confirm(question, fallback);
+  const answer = trimmed(await prompt.ask(`${question} ${fallback ? "[Y/n]" : "[y/N]"} `));
+  if (!answer) return fallback;
+  return /^y(es)?$/i.test(answer);
+}
+
+function menuChoices(config: BrowserFileConfig): ConfigureChoice[] {
+  const choices: ConfigureChoice[] = [
+    { kind: "managed", label: "Managed BetterChromium (recommended default)" },
+  ];
+  for (const name of BROWSER_PROVIDER_NAMES) {
+    const info = browserProviderInfo(name);
+    choices.push({ kind: "provider", name, label: `${info.name} (${name})` });
+  }
+  for (const [name, definition] of Object.entries(config.custom)) {
+    choices.push({
+      kind: "provider",
+      name,
+      custom: definition,
+      label: `${definition.displayName || name} (${name}, configured)`,
+    });
+  }
+  choices.push({ kind: "cdp", label: "Custom CDP endpoint (any wss:// URL)" });
+  choices.push({ kind: "local", label: "Your own Chromium binary (executablePath)" });
+  choices.push({ kind: "add", label: "Add a custom provider…" });
+  return choices;
+}
+
+/**
+ * Ask where one provider's API key comes from. The environment variable is
+ * offered as the default because a key named there never enters the config
+ * file; pasting is the fallback for people who do not want to export anything.
+ */
+async function askKeySource(prompt, { log, env, label, keyEnv }) {
+  log("");
+  log(`  ${label} needs an API key.`);
+  log("    1) Paste it now (stored in the config file, readable only by you)");
+  log(`    2) Read it from an environment variable${keyEnv ? ` (${keyEnv})` : ""}`);
+  const answer = trimmed(await prompt.ask("  Key [2]: ")) || "2";
+  if (answer === "1") {
+    // Asked with plain readline echo: raw-mode masking is a terminal
+    // compatibility problem this command does not need to own.
+    const key = trimmed(await prompt.ask(`  ${label} API key: `));
+    if (!key) throw new TypeError("No API key entered.");
+    return { apiKey: key };
+  }
+  if (answer !== "2") throw new TypeError(`"${answer}" is not 1 or 2.`);
+  const suggestion = keyEnv || "";
+  const name =
+    trimmed(await prompt.ask(`  Environment variable${suggestion ? ` [${suggestion}]` : ""}: `)) ||
+    suggestion;
+  if (!name) throw new TypeError("No environment variable named.");
+  if (!trimmed(env?.[name])) {
+    log(`  ! ${name} is not set in this shell. Saved anyway; set it before the next launch.`);
+  }
+  return { keyEnv: name };
+}
+
+function customNeedsKey(definition: CustomProviderDefinition) {
+  return (
+    definition.cdpUrl.includes(API_KEY_PLACEHOLDER) ||
+    Object.values(definition.headers || {}).some((value) => value.includes(API_KEY_PLACEHOLDER))
+  );
+}
+
+async function chooseBuiltInProvider(prompt, choice, { home, env, log }) {
+  const info = browserProviderInfo(choice.name);
+  const source = await askKeySource(prompt, {
+    log,
+    env,
+    label: info.name,
+    keyEnv: info.keyEnv,
+  });
+  saveDefaultBrowser({ provider: choice.name, ...source }, home);
+  log(`  ✓ Default browser: ${info.name} (${choice.name}).`);
+  if (info.docs) log(`    Docs: ${info.docs}`);
+  return true;
+}
+
+function chooseCustomProvider(choice, { home, env, log }) {
+  saveDefaultBrowser({ provider: choice.name }, home);
+  log(`  ✓ Default browser: ${choice.custom.displayName || choice.name} (${choice.name}).`);
+  const available =
+    choice.custom.apiKey || (choice.custom.keyEnv && trimmed(env?.[choice.custom.keyEnv]));
+  if (customNeedsKey(choice.custom) && !available) {
+    log(
+      `  ! ${choice.name} has no API key available` +
+        (choice.custom.keyEnv ? ` (${choice.custom.keyEnv} is not set)` : "") +
+        ". Set it, or re-add the provider with a key.",
+    );
+  }
+  return true;
+}
+
+async function chooseCdpEndpoint(prompt, { home, log }) {
+  log("");
+  log("  A CDP endpoint is the WebSocket a browser exposes (wss://, or ws:// on loopback).");
+  const cdpUrl = assertCdpUrl(await prompt.ask("  Endpoint: "));
+  saveDefaultBrowser({ cdpUrl }, home);
+  log(`  ✓ Default browser: ${describeCdpUrl(cdpUrl)}`);
+  return true;
+}
+
+async function chooseLocalBinary(prompt, { home, log }) {
+  log("");
+  const executablePath = trimmed(await prompt.ask("  Absolute path to the Chromium binary: "));
+  if (!path.isAbsolute(executablePath)) {
+    throw new TypeError(`${executablePath || "That"} is not an absolute path.`);
+  }
+  if (!fs.existsSync(executablePath)) throw new TypeError(`No file at ${executablePath}.`);
+  saveDefaultBrowser({ executablePath }, home);
+  log(`  ✓ Default browser: local Chromium at ${executablePath}`);
+  return false; // nothing remote to connect to
+}
+
+async function addCustomProvider(prompt, { home, env, log }) {
+  log("");
+  log("  A custom provider is a name for a CDP connect URL.");
+  log(`  Put ${API_KEY_PLACEHOLDER} where the key belongs and it is substituted at launch.`);
+  const name = trimmed(await prompt.ask("  Name (lowercase, e.g. my-cloud): "));
+  const cdpUrl = trimmed(await prompt.ask("  Connect URL: "));
+  const definition: CustomProviderDefinition = { cdpUrl };
+  if (customNeedsKey(definition)) {
+    const suggestion = `${name.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
+    Object.assign(definition, await askKeySource(prompt, { log, env, label: name, keyEnv: suggestion }));
+  }
+  const saved = saveCustomProvider(name, definition, home);
+  log(`  ✓ Saved the custom provider "${saved.name}".`);
+  if (!(await askConfirm(prompt, `  Make ${saved.name} the default browser?`, true))) return false;
+  saveDefaultBrowser({ provider: saved.name }, home);
+  log(`  ✓ Default browser: ${saved.name}.`);
+  return true;
+}
+
+/** The interactive menu. Returns the process exit code. */
+async function configureInteractively({ home, env, log, connect, fetchJson, prompt, offerTest }) {
+  const io = prompt || createPrompter();
+  try {
+    const config = loadBrowserConfig(home);
+    log("");
+    log("Browser backend");
+    log("");
+    for (const line of summaryLines(config, env, home)) log(line);
+    log("");
+    const choices = menuChoices(config);
+    choices.forEach((choice, index) => {
+      log(`  ${String(index + 1).padStart(2)}) ${choice.label}`);
+    });
+    log("");
+    const answer = trimmed(await io.ask("  Choice (Enter to keep the current setting): "));
+    if (!answer) {
+      log("  · Nothing changed.");
+      return 0;
+    }
+    const choice = /^\d+$/.test(answer) ? choices[Number(answer) - 1] : undefined;
+    if (!choice) {
+      log(`  ✗ "${answer}" is not one of the choices above.`);
+      return 1;
+    }
+
+    let remote = false;
+    if (choice.kind === "managed") {
+      saveDefaultBrowser(null, home);
+      log("  ✓ Default browser: the managed BetterChromium fork. Launches use it again.");
+    } else if (choice.kind === "provider") {
+      remote = choice.custom
+        ? chooseCustomProvider(choice, { home, env, log })
+        : await chooseBuiltInProvider(io, choice, { home, env, log });
+    } else if (choice.kind === "cdp") {
+      remote = await chooseCdpEndpoint(io, { home, log });
+    } else if (choice.kind === "local") {
+      remote = await chooseLocalBinary(io, { home, log });
+    } else {
+      remote = await addCustomProvider(io, { home, env, log });
+    }
+
+    if (remote && offerTest && (await askConfirm(io, "  Test the connection now?", true))) {
+      log("");
+      return testConnection({ home, env, log, fail: log, connect, fetchJson });
+    }
+    return 0;
+  } catch (error) {
+    log(`  ✗ ${error?.message || error}`);
+    return 1;
+  } finally {
+    if (!prompt) io.close();
+  }
+}
+
+/**
+ * `betterwright configure`. With no flags on a terminal this is the menu;
+ * every flag form below works without one.
+ *
+ * @param {string[]} argv tokens after the subcommand
+ * @param {object} options home, env, log/error sinks, and the injectable
+ *   `prompt` and `connect` seams the tests drive.
+ */
+export async function runConfigure(argv: string[] = [], options: any = {}) {
+  const home = options.home || defaultHome();
+  const env = options.env || process.env;
+  const log = options.log || ((line) => console.log(line));
+  const fail = options.error || ((line) => console.error(line));
+  const connect = options.connect || connectOverCdp;
+  const fetchJson = options.fetchJson;
+
+  const apiKey = flagValue(argv, "--browser-key");
+  const keyEnv = flagValue(argv, "--key-env");
+  if (apiKey !== undefined && keyEnv !== undefined) {
+    fail(
+      "Pass either --browser-key (stored in the config file) or --key-env (read from the environment), not both.",
+    );
+    return 1;
+  }
+  const browser = flagValue(argv, "--browser");
+  const add = flagValue(argv, "--add");
+  const remove = flagValue(argv, "--remove");
+  const managed = hasFlag(argv, "--managed") || hasFlag(argv, "--reset");
+  const wantsTest = hasFlag(argv, "--test");
+  const wantsJson = hasFlag(argv, "--json");
+  const wantsShow = hasFlag(argv, "--show");
+  const acts = managed || [browser, add, remove].some((value) => value !== undefined);
+  if (!acts && (apiKey !== undefined || keyEnv !== undefined)) {
+    fail("--browser-key and --key-env set the key for --browser or --add; neither was given.");
+    return 1;
+  }
+
+  if (!acts && !wantsTest && !wantsShow && !wantsJson) {
+    if (options.prompt || process.stdin.isTTY) {
+      return configureInteractively({
+        home,
+        env,
+        log,
+        connect,
+        fetchJson,
+        prompt: options.prompt,
+        offerTest: !hasFlag(argv, "--no-test"),
+      });
+    }
+    return showConfig({ home, env, log, json: false });
+  }
+
+  try {
+    if (remove !== undefined) {
+      const name = trimmed(remove).toLowerCase();
+      log(
+        removeCustomProvider(name, home)
+          ? `✓ Removed the custom provider "${name}".`
+          : `· No custom provider named "${name}".`,
+      );
+    }
+    if (add !== undefined) {
+      const cdpUrl = flagValue(argv, "--cdp-url");
+      if (cdpUrl === undefined) {
+        fail("--add needs --cdp-url <wss://… connect URL>.");
+        return 1;
+      }
+      const definition: CustomProviderDefinition = { cdpUrl: trimmed(cdpUrl) };
+      if (keyEnv) definition.keyEnv = keyEnv;
+      if (apiKey) definition.apiKey = apiKey;
+      const docs = flagValue(argv, "--docs");
+      if (docs) definition.docs = docs;
+      const displayName = flagValue(argv, "--display-name");
+      if (displayName) definition.displayName = displayName;
+      const saved = saveCustomProvider(add, definition, home);
+      log(`✓ Saved the custom provider "${saved.name}" to ${saved.file}.`);
+    }
+    if (managed) {
+      saveDefaultBrowser(null, home);
+      log("✓ Default browser: the managed BetterChromium fork.");
+    } else if (browser !== undefined) {
+      const ref = defaultRefFromValue(browser, { apiKey, keyEnv });
+      saveDefaultBrowser(ref, home);
+      log(`✓ Default browser: ${describeDefaultBrowser(ref, { env, custom: loadBrowserConfig(home).custom })}`);
+    }
+  } catch (error) {
+    fail(`✗ ${error?.message || error}`);
+    return 1;
+  }
+
+  if (wantsTest) return testConnection({ home, env, log, fail, connect, fetchJson });
+  if (!acts) return showConfig({ home, env, log, json: wantsJson });
+  return 0;
+}

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -34,6 +34,7 @@ import {
   resolveBrowserProvider,
 } from "./browser-providers.js";
 import { flagValue } from "./cli-flags.js";
+import { type CliPaint, cliPaint, paintedError, paintedLog } from "./cli-theme.js";
 import { defaultHome } from "./home.js";
 import { isCallable } from "./untrusted-value.js";
 
@@ -138,7 +139,7 @@ function maskEntry(entry, env): MaskedBrowserEntry {
   return masked;
 }
 
-function showConfig({ home, env, log, json }) {
+function showConfig({ home, env, log, json, paint }) {
   const config = loadBrowserConfig(home);
   if (json) {
     const custom: Record<string, MaskedBrowserEntry> = {};
@@ -159,7 +160,7 @@ function showConfig({ home, env, log, json }) {
     return 0;
   }
   log("");
-  log("Browser backend");
+  log(paint.heading("Browser backend"));
   log("");
   for (const line of summaryLines(config, env, home)) log(line);
   log("");
@@ -436,12 +437,12 @@ async function addCustomProvider(prompt, { home, env, log }) {
 }
 
 /** The interactive menu. Returns the process exit code. */
-async function configureInteractively({ home, env, log, connect, fetchJson, prompt, offerTest }) {
+async function configureInteractively({ home, env, log, connect, fetchJson, prompt, offerTest, paint }) {
   const io = prompt || createPrompter();
   try {
     const config = loadBrowserConfig(home);
     log("");
-    log("Browser backend");
+    log(paint.heading("Browser backend"));
     log("");
     for (const line of summaryLines(config, env, home)) log(line);
     log("");
@@ -501,8 +502,9 @@ async function configureInteractively({ home, env, log, connect, fetchJson, prom
 export async function runConfigure(argv: string[] = [], options: any = {}) {
   const home = options.home || defaultHome();
   const env = options.env || process.env;
-  const log = options.log || ((line) => console.log(line));
-  const fail = options.error || ((line) => console.error(line));
+  const paint: CliPaint = options.paint || cliPaint();
+  const log = options.log || paintedLog(paint);
+  const fail = options.error || paintedError(paint);
   const connect = options.connect || connectOverCdp;
   const fetchJson = options.fetchJson;
 
@@ -537,9 +539,10 @@ export async function runConfigure(argv: string[] = [], options: any = {}) {
         fetchJson,
         prompt: options.prompt,
         offerTest: !hasFlag(argv, "--no-test"),
+        paint,
       });
     }
-    return showConfig({ home, env, log, json: false });
+    return showConfig({ home, env, log, json: false, paint });
   }
 
   try {
@@ -581,6 +584,6 @@ export async function runConfigure(argv: string[] = [], options: any = {}) {
   }
 
   if (wantsTest) return testConnection({ home, env, log, fail, connect, fetchJson });
-  if (!acts) return showConfig({ home, env, log, json: wantsJson });
+  if (!acts) return showConfig({ home, env, log, json: wantsJson, paint });
   return 0;
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadCodexAuth, loadGrokAuth } from "./auth.js";
+import { configuredDefaultProvider } from "./browser-config.js";
 import { browserProviderInfo, resolveBrowserProvider } from "./browser-providers.js";
 import { chromiumNeedsSoftwareGpu } from "./browser-runtime.js";
 import {
@@ -75,7 +76,14 @@ export async function doctorReport() {
   let provider = null;
   let providerError = null;
   try {
-    const resolved = resolveBrowserProvider(undefined);
+    // The same ladder a launch walks: the env shorthand (which
+    // resolveBrowserProvider reads itself), then the default persisted by
+    // `betterwright configure`. A configured default whose key is missing
+    // throws here and is reported as the provider problem it is.
+    const configured = String(process.env.BETTERWRIGHT_CDP_URL || "").trim()
+      ? undefined
+      : configuredDefaultProvider();
+    const resolved = resolveBrowserProvider(configured ?? undefined);
     if (resolved?.plan) {
       const plan = resolved.plan;
       provider = plan.provider

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -438,8 +438,16 @@ export function doctorChecks(
 
 const STATUS_MARK = { ok: "✓", warn: "!", fail: "✗" };
 
-/** Render doctorChecks() rows as the text `betterwright doctor` prints. */
-export function formatDoctorChecks(checks, { quiet = false }: any = {}) {
+const STATUS_COLOR = { ok: "accent", warn: "yellow", fail: "red" };
+
+/**
+ * Render doctorChecks() rows as the text `betterwright doctor` prints.
+ * `paint` (a CliPaint from cli-theme.ts) is optional so callers that want
+ * plain text — tests, files, pipes — pass nothing and get the same bytes
+ * as always.
+ */
+export function formatDoctorChecks(checks, { quiet = false, paint = null }: any = {}) {
+  const tint = (color, text) => (paint ? paint[color](text) : text);
   const lines = [];
   let group = null;
   for (const check of checks) {
@@ -447,10 +455,12 @@ export function formatDoctorChecks(checks, { quiet = false }: any = {}) {
     if (check.group !== group) {
       group = check.group;
       if (lines.length) lines.push("");
-      lines.push(group);
+      lines.push(tint("bold", group));
     }
-    lines.push(`  ${STATUS_MARK[check.status]} ${`${check.label}:`.padEnd(16)} ${check.detail}`);
-    if (check.fix) lines.push(`      → ${check.fix}`);
+    lines.push(
+      `  ${tint(STATUS_COLOR[check.status], STATUS_MARK[check.status])} ${`${check.label}:`.padEnd(16)} ${check.detail}`,
+    );
+    if (check.fix) lines.push(tint("dim", `      → ${check.fix}`));
   }
   return lines.join("\n");
 }

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -21,6 +21,8 @@ import path from "node:path";
 import readline from "node:readline";
 import { promisify } from "node:util";
 
+import { cliPaint, paintedLog } from "./cli-theme.js";
+
 const execFileAsync = promisify(execFile);
 
 const CODEX_BEGIN_PREFIX = "<!-- betterwright:begin";
@@ -230,7 +232,7 @@ export async function runInit({
   verify,
   version = null,
   home = os.homedir(),
-  log = (line) => console.log(line),
+  log = paintedLog(cliPaint()),
 }: any = {}) {
   const assumeYes = flags.has("--yes");
   const interactive = !assumeYes && Boolean(process.stdin.isTTY);
@@ -240,7 +242,7 @@ export async function runInit({
 
   try {
     log("");
-    log("Setting up BetterWright.");
+    log(cliPaint().heading("Setting up BetterWright."));
     log("");
 
     // 1. Runtime. Nothing below can work without it, and the failure is much

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -432,6 +432,7 @@ export async function runInit({
     }
     log("");
     log("  Saved passwords:  betterwright vault list");
+    log("  Other browsers:   betterwright configure   (cloud providers, custom CDP)");
     log("  Anything wrong:   betterwright doctor");
     for (const note of notes) {
       log("");

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -22,6 +22,7 @@ import readline from "node:readline";
 import { promisify } from "node:util";
 
 import { cliPaint, paintedLog } from "./cli-theme.js";
+import { defaultHome } from "./home.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -210,6 +211,126 @@ function createPrompter({ interactive, log }) {
     },
     log,
   };
+}
+
+// --- First-run onboarding -------------------------------------------------
+//
+// A bare `betterwright` is the most likely first command someone ever runs,
+// and without a browser installed the console can only fail on its first
+// task. So the console checks a one-time marker in the BetterWright home and,
+// when nothing is installed yet, offers the same guided init before starting.
+// The marker (not readiness) is the gate so the offer happens at most once:
+// declining it is remembered, and someone who set up by hand never sees it.
+
+export function firstRunMarkerPath(home = defaultHome()) {
+  return path.join(home, "first-run.json");
+}
+
+function writeFirstRunMarker(home, version, setup) {
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(
+    firstRunMarkerPath(home),
+    `${JSON.stringify({ setup, version, at: new Date().toISOString() }, null, 2)}\n`,
+  );
+}
+
+// The welcome card follows the bast.sh first-run look: a rounded box, one
+// accent glyph beside a bold title, a one-line pitch, then a legend whose
+// markers carry the accent while the text stays dim. Painted here rather than
+// at the log sink because box-drawing rows match none of the status-glyph
+// patterns paintedLog knows.
+export function welcomeCardLines(paint = cliPaint()) {
+  const rows = [
+    {
+      text: "◆  Welcome to BetterWright",
+      render: `${paint.accentBold("◆")}  ${paint.bold("Welcome to BetterWright")}`,
+    },
+    { text: "" },
+    { text: "A persistent, policy-guarded browser for your coding agents." },
+    { text: "" },
+    { text: "First run: the managed browser is not installed yet." },
+    { text: "Guided setup takes about a minute:" },
+    { text: "" },
+    ...[
+      ["1", "download the managed browser (~200 MB, once)"],
+      ["2", "wire the coding agents found on this machine"],
+      ["3", "verify everything with a real page load"],
+    ].map(([key, what]) => ({
+      text: `${key}   ${what}`,
+      render: `${paint.accent(key)}   ${paint.dim(what)}`,
+    })),
+  ];
+  const width = Math.max(...rows.map((row) => row.text.length));
+  const bar = "─".repeat(width + 2);
+  return [
+    paint.dim(`╭${bar}╮`),
+    ...rows.map((row) => {
+      const pad = " ".repeat(width - row.text.length);
+      return `${paint.dim("│")} ${row.render ?? paint.dim(row.text)}${pad} ${paint.dim("│")}`;
+    }),
+    paint.dim(`╰${bar}╯`),
+  ];
+}
+
+/**
+ * Offer guided setup on the first interactive console launch.
+ * Returns null to continue into the console, or an exit code when the accepted
+ * setup failed (a console with no browser would only fail more confusingly).
+ *
+ * @param {object} options
+ * @param {string} options.home BetterWright home (marker location)
+ * @param {boolean} options.isTTY both stdin and stdout are terminals
+ * @param {Function} options.doctorReport
+ * @param {Function} options.runInit async () => number, the wired `init` command
+ * @param {Function} [options.confirm] async (question) => boolean, for tests
+ */
+export async function maybeOfferFirstRunSetup({
+  home = defaultHome(),
+  isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+  doctorReport,
+  runInit,
+  version = null,
+  log = paintedLog(cliPaint()),
+  confirm = null,
+}: any = {}) {
+  // Scripted and piped invocations must never block on a prompt.
+  if (!isTTY) return null;
+  if (fs.existsSync(firstRunMarkerPath(home))) return null;
+  const report = await doctorReport();
+  if (report.ready) {
+    // Set up by hand before ever opening the console. Record that quietly so
+    // later launches skip the doctor check.
+    writeFirstRunMarker(home, version, "already-ready");
+    return null;
+  }
+  const paint = cliPaint();
+  log("");
+  for (const line of welcomeCardLines(paint)) log(`  ${line}`);
+  log("");
+  let accepted;
+  const question = `  ${paint.accent("▸")} Run guided setup now?`;
+  if (confirm) {
+    accepted = await confirm(question);
+  } else {
+    const prompt = createPrompter({ interactive: true, log });
+    try {
+      accepted = await prompt.confirm(question, true);
+    } finally {
+      prompt.close();
+    }
+  }
+  if (!accepted) {
+    // Remembered: the console never asks twice. `betterwright init` stays
+    // available for when they want it.
+    writeFirstRunMarker(home, version, "declined");
+    log("  Skipping setup. Run `betterwright init` anytime for the guided path.");
+    log("");
+    return null;
+  }
+  const code = await runInit();
+  if (code !== 0) return code; // no marker: a failed download should offer again
+  writeFirstRunMarker(home, version, "completed");
+  return null;
 }
 
 /**

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,55 @@
+// The SDK entrypoint: the curated surface for driving BetterWright from your
+// own code.
+//
+// The root export stays the compatibility surface and keeps everything it has
+// ever exported, including internals a consumer rarely needs (CAPTCHA scoring,
+// challenge detection, skill loading), so a reader cannot tell from it which
+// exports are the supported ones. This file is that shorter list, plus
+// `withBrowser` for the client lifetime every integration hand-writes.
+
+import { BetterWright } from "./client.js";
+import { isCallable } from "./untrusted-value.js";
+
+export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
+export {
+  BROWSER_PROVIDER_NAMES,
+  browserProviderInfo,
+  describeCdpUrl,
+} from "./browser-providers.js";
+export {
+  BetterWright,
+  BrowserError,
+  validateCredentialMatchMode,
+} from "./client.js";
+export {
+  METADATA_ADDRESSES,
+  METADATA_HOSTNAMES,
+  NetworkPolicy,
+} from "./policy.js";
+export { agentSystemPrompt } from "./prompt.js";
+export {
+  createLocalCredentialVault,
+  LocalCredentialVault,
+  LocalCredentialVaultError,
+  VAULT_CATEGORIES,
+  VAULT_MATCH_MODES,
+} from "./vault.js";
+
+/**
+ * Run `fn` against a client and close that client afterwards, including when
+ * `fn` throws. Resolves with whatever `fn` returned.
+ *
+ * A client owns a worker process and a browser, so the close is the one step a
+ * caller cannot skip, and every integration writes the same try/finally around
+ * it. Also callable as `withBrowser(fn)` for the default options.
+ */
+export async function withBrowser(options, fn) {
+  const shorthand = isCallable(options);
+  const callback = shorthand ? options : fn;
+  const bw = new BetterWright(shorthand ? {} : options);
+  try {
+    return await callback(bw);
+  } finally {
+    await bw.close();
+  }
+}

--- a/src/vault-cli.ts
+++ b/src/vault-cli.ts
@@ -23,6 +23,7 @@ import { spawn } from "node:child_process";
 
 import { flagValue, positionalArgs } from "./cli-flags.js";
 import { wantsHelp } from "./cli-help.js";
+import { cliPaint, paintedError, paintedLog } from "./cli-theme.js";
 import { defaultHome } from "./home.js";
 import { createLocalCredentialVault, VAULT_CATEGORIES } from "./vault.js";
 import {
@@ -204,7 +205,7 @@ async function confirm(question) {
  * @param {{home?: string, log?: Function, error?: Function}} [io]
  */
 export async function runVaultCommand(rest: any[] = [], io: any = {}) {
-  const fail = io.error || ((line) => console.error(line));
+  const fail = io.error || paintedError(cliPaint({ stream: process.stderr }));
   try {
     return await dispatchVaultCommand(rest, io);
   } catch (error) {
@@ -226,8 +227,8 @@ export async function runVaultCommand(rest: any[] = [], io: any = {}) {
 }
 
 async function dispatchVaultCommand(rest, io) {
-  const log = io.log || ((line) => console.log(line));
-  const fail = io.error || ((line) => console.error(line));
+  const log = io.log || paintedLog(cliPaint());
+  const fail = io.error || paintedError(cliPaint({ stream: process.stderr }));
   const flags = new Set(rest.filter((token) => token.startsWith("--")));
   const json = flags.has("--json");
   const positional = positionalArgs(rest);
@@ -235,7 +236,7 @@ async function dispatchVaultCommand(rest, io) {
   const vault = createLocalCredentialVault({ home: io.home || defaultHome() });
 
   if (wantsHelp(rest) || subcommand === "help") {
-    log(VAULT_USAGE);
+    log(cliPaint().help(VAULT_USAGE));
     return 0;
   }
 

--- a/tests/node/agent.test.ts
+++ b/tests/node/agent.test.ts
@@ -1748,6 +1748,34 @@ test("ask tool waits on live-view chat when liveView is available", async () => 
   assert.match(toolTurn.results[0].content, /account ending 999/);
 });
 
+test("ask goes to askUser, not the live-view chat, when the host provides one", async () => {
+  // Regression: with both surfaces available the question used to wait in
+  // the live-view chat, which the person at the terminal had never opened,
+  // while their console showed only a working prompt.
+  const browser = liveViewBrowser();
+  const asked = [];
+  const model = scriptedModel([
+    { text: "", toolCalls: [{ id: "a1", name: "ask", input: { question: "Proceed?", options: [] } }] },
+    { text: "", toolCalls: [{ id: "d1", name: "done", input: { answer: "ok" } }] },
+  ]);
+  const result = await runAgentTask({
+    task: "sign in",
+    model,
+    browser,
+    liveView: true,
+    onStep: () => {},
+    askUser: async ({ question }) => {
+      asked.push(question);
+      return "yes";
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(asked, ["Proceed?"]);
+  assert.equal(browser.calls.asks.length, 0);
+  const toolTurn = result.transcript.find((message) => message.role === "tool");
+  assert.match(toolTurn.results[0].content, /User answered: yes/);
+});
+
 // --- Tool schema parity across the three surfaces --------------------------
 
 // Drop the keys a surface layers on top of the shared field schemas, so the

--- a/tests/node/agent.test.ts
+++ b/tests/node/agent.test.ts
@@ -163,6 +163,30 @@ test("runAgentTask drives browser then finishes on done", async () => {
   assert.match(toolTurn.results[0].content, /"result":"HN"/);
 });
 
+test("runAgentTask announces each model turn and tool batch through onPhase", async () => {
+  const browser = fakeBrowser({ runs: [{ ok: true, result: "HN", artifacts: [], durationMs: 9 }] });
+  const model = scriptedModel([
+    { text: "checking", toolCalls: [{ id: "c1", name: "browser", input: { code: "1", note: "read" } }] },
+    { text: "", toolCalls: [{ id: "c2", name: "done", input: { answer: "The answer" } }] },
+  ]);
+  const phases = [];
+
+  const result = await runAgentTask({
+    task: "get the title",
+    model,
+    browser,
+    onPhase: (event) => phases.push(event),
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(phases, [
+    { phase: "reasoning", step: 1 },
+    { phase: "acting", step: 1, tools: ["browser"] },
+    { phase: "reasoning", step: 2 },
+    { phase: "acting", step: 2, tools: ["done"] },
+  ]);
+});
+
 test("successful browser observations omit empty optional fields", async () => {
   const browser = fakeBrowser({
     runs: [{ ok: true, result: "Example Domain", artifacts: [], durationMs: 7 }],

--- a/tests/node/browser-config.test.ts
+++ b/tests/node/browser-config.test.ts
@@ -1,0 +1,192 @@
+/** biome-ignore-all lint/suspicious/noTemplateCurlyInString: `${apiKey}` is the literal placeholder custom cdpUrl templates carry */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+import {
+  browserConfigPath,
+  configuredDefaultProvider,
+  expandProviderChoice,
+  loadBrowserConfig,
+  removeCustomProvider,
+  saveCustomProvider,
+  saveDefaultBrowser,
+} from "../../dist/src/browser-config.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+function writeConfig(home, config) {
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(browserConfigPath(home), JSON.stringify(config));
+}
+
+test("missing or malformed config reads as no defaults", () => {
+  const home = makeTempDir("bw-config-");
+  assert.deepEqual(loadBrowserConfig(home), { custom: {} });
+  fs.writeFileSync(browserConfigPath(home), "{not json");
+  assert.deepEqual(loadBrowserConfig(home), { custom: {} });
+  fs.writeFileSync(browserConfigPath(home), JSON.stringify([1, 2]));
+  assert.deepEqual(loadBrowserConfig(home), { custom: {} });
+});
+
+test("load drops malformed defaults, bad names, and unknown keys", () => {
+  const home = makeTempDir("bw-config-");
+  writeConfig(home, {
+    browser: {
+      default: { provider: "steel", cdpUrl: "wss://two-kinds" },
+      custom: {
+        "Bad Name": { cdpUrl: "wss://x" },
+        ok: { cdpUrl: "wss://ok.example", surprise: true, keyEnv: "OK_KEY" },
+        "no-url": { keyEnv: "X" },
+      },
+    },
+  });
+  const config = loadBrowserConfig(home);
+  assert.equal(config.default, undefined);
+  assert.deepEqual(Object.keys(config.custom), ["ok"]);
+  assert.deepEqual(config.custom.ok, { cdpUrl: "wss://ok.example", keyEnv: "OK_KEY" });
+});
+
+test("saveDefaultBrowser round-trips and preserves unrelated sections", () => {
+  const home = makeTempDir("bw-config-");
+  writeConfig(home, { liveView: { expose: "lan" } });
+  const file = saveDefaultBrowser({ provider: "steel", keyEnv: "MY_STEEL" }, home);
+  const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+  assert.deepEqual(raw.liveView, { expose: "lan" });
+  assert.deepEqual(loadBrowserConfig(home).default, {
+    provider: "steel",
+    keyEnv: "MY_STEEL",
+  });
+  if (process.platform !== "win32") {
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  }
+  saveDefaultBrowser(null, home);
+  assert.equal(loadBrowserConfig(home).default, undefined);
+  assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf8")).liveView, { expose: "lan" });
+});
+
+test("saveDefaultBrowser validates the ref", () => {
+  const home = makeTempDir("bw-config-");
+  assert.throws(() => saveDefaultBrowser({}, home), /exactly one of/);
+  assert.throws(
+    () => saveDefaultBrowser({ provider: "steel", cdpUrl: "wss://x" }, home),
+    /exactly one of/,
+  );
+  assert.throws(() => saveDefaultBrowser({ provider: "nope" }, home), /Unknown provider/);
+});
+
+test("custom providers save, become valid defaults, and remove", () => {
+  const home = makeTempDir("bw-config-");
+  const { name } = saveCustomProvider(
+    "  DriverDotNet  ",
+    { cdpUrl: "wss://connect.example.com?apiKey=${apiKey}", keyEnv: "DRIVER_KEY" },
+    home,
+  );
+  assert.equal(name, "driverdotnet");
+  assert.equal(
+    loadBrowserConfig(home).custom.driverdotnet.cdpUrl,
+    "wss://connect.example.com?apiKey=${apiKey}",
+  );
+  saveDefaultBrowser({ provider: "driverdotnet" }, home);
+  assert.deepEqual(loadBrowserConfig(home).default, { provider: "driverdotnet" });
+  assert.equal(removeCustomProvider("driverdotnet", home), true);
+  assert.equal(removeCustomProvider("driverdotnet", home), false);
+  assert.deepEqual(loadBrowserConfig(home).custom, {});
+});
+
+test("saveCustomProvider rejects bad names and bad templates", () => {
+  const home = makeTempDir("bw-config-");
+  assert.throws(() => saveCustomProvider("Bad Name", { cdpUrl: "wss://x" }, home), /1-32/);
+  assert.throws(() => saveCustomProvider("steel", { cdpUrl: "wss://x" }, home), /built-in/);
+  assert.throws(() => saveCustomProvider("cdp", { cdpUrl: "wss://x" }, home), /built-in/);
+  assert.throws(() => saveCustomProvider("mine", {}, home), /needs a cdpUrl/);
+  assert.throws(
+    () => saveCustomProvider("mine", { cdpUrl: "https://example.com" }, home),
+    /ws:\/\/ or wss:\/\//,
+  );
+  assert.throws(() => saveCustomProvider("mine", { cdpUrl: "not a url" }, home), /valid URL/);
+});
+
+test("expandProviderChoice passes built-ins and endpoints through", () => {
+  const home = makeTempDir("bw-config-");
+  assert.equal(expandProviderChoice(null, { home }), null);
+  assert.equal(expandProviderChoice(false, { home }), false);
+  const builtIn = { provider: "kernel", apiKey: "k" };
+  assert.equal(expandProviderChoice(builtIn, { home, env: {} }), builtIn);
+  const endpoint = { cdpUrl: "wss://x.example" };
+  assert.equal(expandProviderChoice(endpoint, { home, env: {} }), endpoint);
+  const local = { executablePath: "/opt/chrome" };
+  assert.equal(expandProviderChoice(local, { home, env: {} }), local);
+  assert.deepEqual(expandProviderChoice("steel", { home, env: {} }), { provider: "steel" });
+});
+
+test("expandProviderChoice resolves keyEnv for a stored built-in ref", () => {
+  const home = makeTempDir("bw-config-");
+  const env = { MY_STEEL: "sk-123" };
+  assert.deepEqual(
+    expandProviderChoice({ provider: "steel", keyEnv: "MY_STEEL" }, { home, env }),
+    { provider: "steel", apiKey: "sk-123" },
+  );
+  assert.throws(
+    () => expandProviderChoice({ provider: "steel", keyEnv: "MY_STEEL" }, { home, env: {} }),
+    /MY_STEEL, which is not set/,
+  );
+});
+
+test("expandProviderChoice expands custom names with key substitution", () => {
+  const home = makeTempDir("bw-config-");
+  saveCustomProvider(
+    "mine",
+    {
+      cdpUrl: "wss://connect.example.com?apiKey=${apiKey}",
+      headers: { "x-api-key": "${apiKey}" },
+      keyEnv: "MINE_KEY",
+    },
+    home,
+  );
+  const expanded = expandProviderChoice("mine", { home, env: { MINE_KEY: "sk-9" } });
+  assert.deepEqual(expanded, {
+    cdpUrl: "wss://connect.example.com?apiKey=sk-9",
+    headers: { "x-api-key": "sk-9" },
+  });
+  const explicit = expandProviderChoice(
+    { provider: "mine", apiKey: "override" },
+    { home, env: { MINE_KEY: "sk-9" } },
+  );
+  assert.equal(explicit.cdpUrl, "wss://connect.example.com?apiKey=override");
+  assert.throws(() => expandProviderChoice("mine", { home, env: {} }), /needs an API key/);
+});
+
+test("expandProviderChoice names configured providers in its unknown error", () => {
+  const home = makeTempDir("bw-config-");
+  saveCustomProvider("mine", { cdpUrl: "wss://x.example" }, home);
+  assert.throws(
+    () => expandProviderChoice("missing", { home, env: {} }),
+    /Configured: mine/,
+  );
+});
+
+test("a custom provider with no placeholder needs no key", () => {
+  const home = makeTempDir("bw-config-");
+  saveCustomProvider("open", { cdpUrl: "ws://127.0.0.1:9222/devtools" }, home);
+  assert.deepEqual(expandProviderChoice("open", { home, env: {} }), {
+    cdpUrl: "ws://127.0.0.1:9222/devtools",
+  });
+});
+
+test("configuredDefaultProvider expands the persisted default", () => {
+  const home = makeTempDir("bw-config-");
+  assert.equal(configuredDefaultProvider({ home, env: {} }), null);
+  saveCustomProvider(
+    "mine",
+    { cdpUrl: "wss://connect.example.com?apiKey=${apiKey}", keyEnv: "MINE_KEY" },
+    home,
+  );
+  saveDefaultBrowser({ provider: "mine" }, home);
+  assert.deepEqual(configuredDefaultProvider({ home, env: { MINE_KEY: "sk" } }), {
+    cdpUrl: "wss://connect.example.com?apiKey=sk",
+  });
+  saveDefaultBrowser({ cdpUrl: "wss://direct.example" }, home);
+  assert.deepEqual(configuredDefaultProvider({ home, env: {} }), {
+    cdpUrl: "wss://direct.example",
+  });
+});

--- a/tests/node/cli-flags.test.ts
+++ b/tests/node/cli-flags.test.ts
@@ -113,5 +113,8 @@ test("firstPositional skips value-flag arguments but not assigned or boolean fla
   assert.equal(firstPositional(["--headed", "the task"]), "the task");
   // A value flag's argument must never be mistaken for a positional.
   assert.equal(firstPositional(["--model", "gpt-5.6-sol"]), undefined);
+  // The browser choice is a value: `run --browser steel script.js` runs the file.
+  assert.equal(firstPositional(["--browser", "steel", "script.js"]), "script.js");
+  assert.equal(firstPositional(["--browser", "steel", "--browser-key", "sk-live"]), undefined);
   assert.equal(firstPositional([]), undefined);
 });

--- a/tests/node/cli-spinner.test.ts
+++ b/tests/node/cli-spinner.test.ts
@@ -1,0 +1,148 @@
+// The spinner's contract: animate only on a TTY, own exactly one line, and
+// leave the stream byte-clean when cleared. Streams and paint are injected;
+// mock timers drive the animation, so nothing here depends on wall-clock.
+
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+import {
+  createSpinner,
+  formatElapsed,
+  phaseLabel,
+  SPINNER_FRAMES,
+  SPINNER_INTERVAL_MS,
+} from "../../dist/src/cli-spinner.js";
+import { cliPaint } from "../../dist/src/cli-theme.js";
+
+// Plain paint keeps the assertions readable; painting itself is the theme
+// tests' job.
+const plain = cliPaint({ stream: { isTTY: false }, env: {} });
+
+function fakeStream(isTTY) {
+  return {
+    isTTY,
+    writes: [],
+    write(text) {
+      this.writes.push(text);
+      return true;
+    },
+  };
+}
+
+test("formatElapsed counts whole seconds, then minutes", () => {
+  assert.equal(formatElapsed(0), "0s");
+  assert.equal(formatElapsed(999), "0s");
+  assert.equal(formatElapsed(7_400), "7s");
+  assert.equal(formatElapsed(59_999), "59s");
+  assert.equal(formatElapsed(60_000), "1m 00s");
+  assert.equal(formatElapsed(125_000), "2m 05s");
+  assert.equal(formatElapsed(-5), "0s");
+});
+
+test("phaseLabel names the wait after the phase and its first tool", () => {
+  assert.equal(phaseLabel({ phase: "reasoning", step: 1 }), "reasoning");
+  assert.equal(phaseLabel({ phase: "acting", tools: ["browser"] }), "browsing");
+  assert.equal(phaseLabel({ phase: "acting", tools: ["login"] }), "logging in");
+  assert.equal(phaseLabel({ phase: "acting", tools: ["handoff"] }), "waiting for your hands");
+  assert.equal(phaseLabel({ phase: "acting", tools: ["done"] }), "finishing");
+  // Unknown tools and malformed events still yield something sensible.
+  assert.equal(phaseLabel({ phase: "acting", tools: ["mystery"] }), "working");
+  assert.equal(phaseLabel({ phase: "acting" }), "working");
+  assert.equal(phaseLabel(), "reasoning");
+});
+
+test("setLabel renames the wait and restarts its counter", () => {
+  mock.timers.enable({ apis: ["setInterval", "Date"], now: 0 });
+  try {
+    const stream = fakeStream(true);
+    const spinner = createSpinner({ stream, paint: plain, label: "reasoning" });
+    spinner.start();
+    mock.timers.tick(2000);
+    assert.ok(stream.writes.at(-1).endsWith("reasoning · 2s"));
+
+    spinner.setLabel("browsing");
+    assert.ok(stream.writes.at(-1).endsWith("browsing · 0s"));
+    // Same label again: no redundant redraw.
+    const count = stream.writes.length;
+    spinner.setLabel("browsing");
+    assert.equal(stream.writes.length, count);
+    spinner.stop();
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("every method is a no-op on a non-TTY stream", () => {
+  const stream = fakeStream(false);
+  const spinner = createSpinner({ stream, paint: plain });
+  spinner.start();
+  spinner.clear();
+  spinner.stop();
+  assert.deepEqual(stream.writes, []);
+});
+
+test("start paints the first frame at once; ticks advance frame and elapsed", () => {
+  mock.timers.enable({ apis: ["setInterval", "Date"], now: 0 });
+  try {
+    const stream = fakeStream(true);
+    const spinner = createSpinner({ stream, paint: plain });
+    spinner.start();
+    assert.deepEqual(stream.writes, [`\r\x1b[2K  ${SPINNER_FRAMES[0]} working · 0s`]);
+
+    mock.timers.tick(SPINNER_INTERVAL_MS);
+    assert.equal(stream.writes.at(-1), `\r\x1b[2K  ${SPINNER_FRAMES[1]} working · 0s`);
+
+    // A second in, the counter has moved and the frame index matches the
+    // number of renders so far (one per write).
+    mock.timers.tick(1000);
+    const frames = stream.writes.length - 1;
+    assert.equal(
+      stream.writes.at(-1),
+      `\r\x1b[2K  ${SPINNER_FRAMES[frames % SPINNER_FRAMES.length]} working · 1s`,
+    );
+    spinner.stop();
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("clear erases the line once; stop erases and ends the animation", () => {
+  mock.timers.enable({ apis: ["setInterval", "Date"], now: 0 });
+  try {
+    const stream = fakeStream(true);
+    const spinner = createSpinner({ stream, paint: plain, label: "thinking" });
+    spinner.start();
+    assert.ok(stream.writes.at(-1).endsWith("thinking · 0s"));
+
+    spinner.clear();
+    assert.equal(stream.writes.at(-1), "\r\x1b[2K");
+    // Already cleared: a second clear writes nothing (step lines between
+    // ticks must not stack erase sequences).
+    spinner.clear();
+    assert.equal(stream.writes.length, 2);
+
+    // The next tick redraws below whatever line the caller printed.
+    mock.timers.tick(SPINNER_INTERVAL_MS);
+    assert.ok(stream.writes.at(-1).includes("thinking"));
+
+    spinner.stop();
+    assert.equal(stream.writes.at(-1), "\r\x1b[2K");
+    const count = stream.writes.length;
+    mock.timers.tick(SPINNER_INTERVAL_MS * 5);
+    assert.equal(stream.writes.length, count);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("a color paint accents the frame and dims the label", () => {
+  const paint = cliPaint({ stream: { isTTY: true }, env: { TERM: "xterm-256color" } });
+  const stream = fakeStream(true);
+  const spinner = createSpinner({ stream, paint });
+  spinner.start();
+  assert.equal(
+    stream.writes[0],
+    `\r\x1b[2K  \x1b[38;5;208m${SPINNER_FRAMES[0]}\x1b[0m \x1b[2mworking · 0s\x1b[0m`,
+  );
+  spinner.stop();
+});

--- a/tests/node/cli-theme.test.ts
+++ b/tests/node/cli-theme.test.ts
@@ -1,0 +1,87 @@
+// The theme's one contract: paint on a color TTY, byte-identical text
+// everywhere else. Every stream/env combination is injected, so these tests
+// never depend on how the test runner's own stdout is wired.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cliPaint } from "../../dist/src/cli-theme.js";
+
+const tty = { isTTY: true };
+const pipe = { isTTY: false };
+
+function paintOn(env = {}) {
+  return cliPaint({ stream: tty, env: { TERM: "xterm-256color", ...env } });
+}
+
+test("a non-TTY stream, NO_COLOR, and TERM=dumb all disable color", () => {
+  for (const paint of [
+    cliPaint({ stream: pipe, env: {} }),
+    cliPaint({ stream: tty, env: { NO_COLOR: "1" } }),
+    cliPaint({ stream: tty, env: { TERM: "dumb" } }),
+    cliPaint({ stream: tty, env: { NO_COLOR: "1", FORCE_COLOR: "0" } }),
+  ]) {
+    assert.equal(paint.on, false);
+    const line = "  ✓ Default browser: Steel (steel), see `betterwright configure`";
+    assert.equal(paint.status(line), line);
+    assert.equal(paint.help("Usage: betterwright configure"), "Usage: betterwright configure");
+    assert.equal(paint.accent("x"), "x");
+  }
+});
+
+test("FORCE_COLOR turns color on even without a TTY", () => {
+  const paint = cliPaint({ stream: pipe, env: { FORCE_COLOR: "1" } });
+  assert.equal(paint.on, true);
+  assert.equal(paint.accent("x"), "\x1b[38;5;208mx\x1b[0m");
+});
+
+test("COLORTERM=truecolor upgrades the orange to 24-bit", () => {
+  const paint = paintOn({ COLORTERM: "truecolor" });
+  assert.equal(paint.accent("x"), "\x1b[38;2;255;135;35mx\x1b[0m");
+  assert.equal(paint.accentBold("x"), "\x1b[1;38;2;255;135;35mx\x1b[0m");
+});
+
+test("status lines color the glyph by meaning and leave the text alone", () => {
+  const paint = paintOn();
+  assert.equal(paint.status("  ✓ Node 22.1.0"), "  \x1b[38;5;208m✓\x1b[0m Node 22.1.0");
+  assert.equal(paint.status("  ✗ broken"), "  \x1b[31m✗\x1b[0m broken");
+  assert.equal(paint.status("  ! optional"), "  \x1b[33m!\x1b[0m optional");
+  assert.equal(paint.status("      → betterwright setup"), "      \x1b[2m→\x1b[0m betterwright setup");
+  // Only a leading glyph is a glyph; one mid-sentence is just a character.
+  assert.equal(paint.status("fix the ✗ lines above"), "fix the ✗ lines above");
+});
+
+test("status lines accent backtick commands and menu numbers", () => {
+  const paint = paintOn();
+  assert.equal(
+    paint.status("  run `betterwright doctor` again"),
+    "  run `\x1b[38;5;208mbetterwright doctor\x1b[0m` again",
+  );
+  assert.equal(paint.status("   3) Steel (steel)"), "   \x1b[38;5;208m3)\x1b[0m Steel (steel)");
+});
+
+test("help text paints the wordmark, headings, flags, and command names", () => {
+  const paint = paintOn();
+  const painted = paint.help(
+    [
+      "betterwright — a persistent, policy-guarded browser for AI agents",
+      "",
+      "Usage: betterwright <command> [options]",
+      "",
+      "Commands:",
+      "  configure  choose the browser backend: cloud provider, custom CDP, or managed",
+      "",
+      "Options:",
+      "  --browser <value>      set the default",
+      "",
+      "Plain prose stays plain prose.",
+    ].join("\n"),
+  );
+  const lines = painted.split("\n");
+  assert.ok(lines[0].startsWith("\x1b[1;38;5;208mbetterwright\x1b[0m"), lines[0]);
+  assert.equal(lines[2], "\x1b[2mUsage:\x1b[0m betterwright <command> [options]");
+  assert.equal(lines[4], "\x1b[1mCommands:\x1b[0m");
+  assert.ok(lines[5].startsWith("  \x1b[38;5;208mconfigure\x1b[0m  choose"), lines[5]);
+  assert.equal(lines[8], "  \x1b[38;5;208m--browser\x1b[0m <value>      set the default");
+  assert.equal(lines[10], "Plain prose stays plain prose.");
+});

--- a/tests/node/configure.test.ts
+++ b/tests/node/configure.test.ts
@@ -1,0 +1,277 @@
+/** biome-ignore-all lint/suspicious/noTemplateCurlyInString: `${apiKey}` is the literal placeholder custom cdpUrl templates carry */
+// `betterwright configure` — the flag forms and the scripted menu.
+//
+// Everything here runs against a temp home and injected seams: `prompt`
+// answers the menu, `connect` stands in for the CDP handshake, and `fetchJson`
+// stands in for a provider's create-session API, so a full pass never opens a
+// socket or writes outside the temp directory.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadBrowserConfig } from "../../dist/src/browser-config.js";
+import { BROWSER_PROVIDER_NAMES } from "../../dist/src/browser-providers.js";
+import { runConfigure } from "../../dist/src/configure.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+function recorder() {
+  const out = [];
+  const err = [];
+  return {
+    out,
+    err,
+    log: (line) => out.push(String(line)),
+    error: (line) => err.push(String(line)),
+    stdout: () => out.join("\n"),
+    stderr: () => err.join("\n"),
+  };
+}
+
+// Answers the menu in order; `confirm` is derived from `ask` by runConfigure,
+// so a script is just the strings a person would type.
+function scriptedPrompt(answers) {
+  const asked = [];
+  return {
+    asked,
+    async ask(question) {
+      asked.push(String(question));
+      return answers.shift() ?? "";
+    },
+  };
+}
+
+function menuIndexOf(name) {
+  return 2 + BROWSER_PROVIDER_NAMES.indexOf(name); // 1 is the managed fork
+}
+
+test("--browser <provider> --key-env round-trips through the config file", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const code = await runConfigure(["--browser", "steel", "--key-env", "MY_STEEL"], {
+    home,
+    env: { MY_STEEL: "sk-live" },
+    ...io,
+  });
+  assert.equal(code, 0);
+  assert.deepEqual(loadBrowserConfig(home).default, { provider: "steel", keyEnv: "MY_STEEL" });
+  assert.match(io.stdout(), /Default browser: Steel \(steel\), API key from MY_STEEL \(set\)/);
+});
+
+test("--browser with a URL stores a CDP endpoint and rejects other protocols", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  assert.equal(
+    await runConfigure(["--browser", "wss://cdp.example.com/devtools/abc"], { home, env: {}, ...io }),
+    0,
+  );
+  assert.deepEqual(loadBrowserConfig(home).default, { cdpUrl: "wss://cdp.example.com/devtools/abc" });
+
+  const bad = recorder();
+  assert.equal(await runConfigure(["--browser", "https://cdp.example.com"], { home, env: {}, ...bad }), 1);
+  assert.match(bad.stderr(), /ws:\/\/ or wss:\/\/ URL/);
+  // The bad value changed nothing.
+  assert.deepEqual(loadBrowserConfig(home).default, { cdpUrl: "wss://cdp.example.com/devtools/abc" });
+});
+
+test("--browser-key and --key-env together are refused", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const code = await runConfigure(
+    ["--browser", "steel", "--browser-key", "sk-live", "--key-env", "STEEL_API_KEY"],
+    { home, env: {}, ...io },
+  );
+  assert.equal(code, 1);
+  assert.match(io.stderr(), /not both/);
+  assert.equal(loadBrowserConfig(home).default, undefined);
+});
+
+test("--add saves a custom provider, --remove reports what it did", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const added = await runConfigure(
+    [
+      "--add",
+      "my-cloud",
+      "--cdp-url",
+      "wss://cdp.my-cloud.example/connect?token=${apiKey}",
+      "--key-env",
+      "MY_CLOUD_TOKEN",
+      "--display-name",
+      "My Cloud",
+      "--docs",
+      "https://my-cloud.example/docs",
+    ],
+    { home, env: {}, ...io },
+  );
+  assert.equal(added, 0);
+  assert.deepEqual(loadBrowserConfig(home).custom["my-cloud"], {
+    cdpUrl: "wss://cdp.my-cloud.example/connect?token=${apiKey}",
+    keyEnv: "MY_CLOUD_TOKEN",
+    displayName: "My Cloud",
+    docs: "https://my-cloud.example/docs",
+  });
+
+  // A custom name is a valid --browser value once it exists.
+  assert.equal(await runConfigure(["--browser", "my-cloud"], { home, env: {}, ...io }), 0);
+  assert.deepEqual(loadBrowserConfig(home).default, { provider: "my-cloud" });
+
+  const removed = recorder();
+  assert.equal(await runConfigure(["--remove", "my-cloud"], { home, env: {}, ...removed }), 0);
+  assert.match(removed.stdout(), /Removed the custom provider "my-cloud"/);
+  assert.equal(loadBrowserConfig(home).custom["my-cloud"], undefined);
+
+  const again = recorder();
+  assert.equal(await runConfigure(["--remove", "my-cloud"], { home, env: {}, ...again }), 0);
+  assert.match(again.stdout(), /No custom provider named "my-cloud"/);
+});
+
+test("--add without --cdp-url fails", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  assert.equal(await runConfigure(["--add", "my-cloud"], { home, env: {}, ...io }), 1);
+  assert.match(io.stderr(), /--cdp-url/);
+});
+
+test("--managed clears the default", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  await runConfigure(["--browser", "steel", "--browser-key", "sk-live"], { home, env: {}, ...io });
+  assert.equal(loadBrowserConfig(home).default?.provider, "steel");
+  assert.equal(await runConfigure(["--reset"], { home, env: {}, ...io }), 0);
+  assert.equal(loadBrowserConfig(home).default, undefined);
+  assert.match(io.stdout(), /managed BetterChromium fork/);
+});
+
+test("--show --json masks stored keys and names env vars", async () => {
+  const home = makeTempDir("bw-configure-");
+  const quiet = recorder();
+  await runConfigure(["--browser", "steel", "--key-env", "MY_STEEL"], { home, env: {}, ...quiet });
+  await runConfigure(
+    ["--add", "my-cloud", "--cdp-url", "wss://x.example/${apiKey}", "--browser-key", "super-secret"],
+    { home, env: {}, ...quiet },
+  );
+
+  const io = recorder();
+  assert.equal(await runConfigure(["--show", "--json"], { home, env: { MY_STEEL: "sk-live" }, ...io }), 0);
+  const report = JSON.parse(io.stdout());
+  assert.deepEqual(report.default, {
+    provider: "steel",
+    keyEnv: "MY_STEEL",
+    keyEnvSet: true,
+  });
+  assert.equal(report.custom["my-cloud"].apiKey, "***");
+  assert.doesNotMatch(io.stdout(), /super-secret/);
+
+  const text = recorder();
+  assert.equal(await runConfigure(["--show"], { home, env: {}, ...text }), 0);
+  assert.match(text.stdout(), /Default: {5}Steel \(steel\), API key from MY_STEEL \(not set\)/);
+  assert.doesNotMatch(text.stdout(), /super-secret/);
+});
+
+test("--test connects through the injected hook and reports the version", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const seen = [];
+  const code = await runConfigure(["--browser", "steel", "--browser-key", "sk-live", "--test"], {
+    home,
+    env: {},
+    ...io,
+    connect: async (request) => {
+      seen.push(request);
+      return { version: "Chrome/141.0.0.0" };
+    },
+  });
+  assert.equal(code, 0);
+  assert.equal(seen.length, 1);
+  assert.match(seen[0].cdpUrl, /^wss:\/\/connect\.steel\.dev\/\?apiKey=sk-live$/);
+  assert.equal(seen[0].timeout, 10_000);
+  assert.match(io.stdout(), /Chrome\/141\.0\.0\.0/);
+});
+
+test("a failed test keeps the saved choice and exits 1", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const code = await runConfigure(["--browser", "steel", "--browser-key", "sk-live", "--test"], {
+    home,
+    env: {},
+    ...io,
+    connect: async () => {
+      throw new Error("websocket handshake failed");
+    },
+  });
+  assert.equal(code, 1);
+  assert.match(io.stderr(), /websocket handshake failed/);
+  assert.match(io.stderr(), /saved but unverified/);
+  assert.deepEqual(loadBrowserConfig(home).default, { provider: "steel", apiKey: "sk-live" });
+});
+
+test("a session-minting provider is created and released around the test", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const calls = [];
+  const code = await runConfigure(["--browser", "browserbase", "--browser-key", "bb-live", "--test"], {
+    home,
+    env: {},
+    ...io,
+    fetchJson: async (url, request) => {
+      calls.push(`${request.method} ${url}`);
+      return { id: "session-1", connectUrl: "wss://connect.browserbase.com/session-1" };
+    },
+    connect: async () => ({ version: "Chrome/141.0.0.0" }),
+  });
+  assert.equal(code, 0);
+  assert.deepEqual(calls, [
+    "POST https://api.browserbase.com/v1/sessions",
+    "POST https://api.browserbase.com/v1/sessions/session-1",
+  ]);
+});
+
+test("--test with no default says the managed fork is in use", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  assert.equal(await runConfigure(["--test"], { home, env: {}, ...io }), 0);
+  assert.match(io.stdout(), /managed BetterChromium fork/);
+});
+
+test("the menu saves a built-in provider with an environment variable", async () => {
+  const home = makeTempDir("bw-configure-");
+  const io = recorder();
+  const prompt = scriptedPrompt([
+    String(menuIndexOf("steel")), // pick Steel
+    "2", // read the key from the environment
+    "", // accept the suggested STEEL_API_KEY
+  ]);
+  const code = await runConfigure(["--no-test"], { home, env: {}, prompt, ...io });
+  assert.equal(code, 0);
+  assert.deepEqual(loadBrowserConfig(home).default, {
+    provider: "steel",
+    keyEnv: "STEEL_API_KEY",
+  });
+  assert.match(io.stdout(), /Default browser: Steel \(steel\)/);
+  // The key was never echoed, the unset variable was called out, and --no-test
+  // means nothing was offered.
+  assert.match(io.stdout(), /STEEL_API_KEY is not set in this shell/);
+  assert.equal(prompt.asked.length, 3);
+  assert.doesNotMatch(prompt.asked.join("\n"), /Test the connection/);
+});
+
+test("the menu clears the default when the managed fork is picked", async () => {
+  const home = makeTempDir("bw-configure-");
+  const seed = recorder();
+  await runConfigure(["--browser", "steel", "--browser-key", "sk-live"], { home, env: {}, ...seed });
+  const io = recorder();
+  const code = await runConfigure([], { home, env: {}, prompt: scriptedPrompt(["1"]), ...io });
+  assert.equal(code, 0);
+  assert.equal(loadBrowserConfig(home).default, undefined);
+  assert.match(io.stdout(), /Launches use it again/);
+});
+
+test("an empty menu answer changes nothing", async () => {
+  const home = makeTempDir("bw-configure-");
+  const seed = recorder();
+  await runConfigure(["--browser", "steel", "--browser-key", "sk-live"], { home, env: {}, ...seed });
+  const io = recorder();
+  assert.equal(await runConfigure([], { home, env: {}, prompt: scriptedPrompt([""]), ...io }), 0);
+  assert.match(io.stdout(), /Nothing changed/);
+  assert.equal(loadBrowserConfig(home).default?.provider, "steel");
+});

--- a/tests/node/onboard.test.ts
+++ b/tests/node/onboard.test.ts
@@ -16,8 +16,11 @@ import {
 import {
   agentHostTargets,
   detectAgentHosts,
+  firstRunMarkerPath,
+  maybeOfferFirstRunSetup,
   runInit,
   upsertCodexInstructions,
+  welcomeCardLines,
 } from "../../dist/src/onboard.js";
 
 function tempHome() {
@@ -391,4 +394,116 @@ test("a usable-but-defaultless backend gets a name-one hint, not a false refusal
   // "no model backend is configured" — that is false and offers no route out.
   assert.doesNotMatch(hint, /No model backend is configured/);
   assert.match(hint, /openrouter\/<id>/);
+});
+
+// --- First-run onboarding gate ---------------------------------------------
+
+const NOT_READY_REPORT = { ...READY_REPORT, chromium_fork: null, browser: "unavailable", ready: false };
+
+function firstRunHarness(home, overrides = {}) {
+  const calls = { doctor: 0, init: 0 };
+  return {
+    calls,
+    options: {
+      home,
+      isTTY: true,
+      version: "9.9.9",
+      log: () => {},
+      doctorReport: async () => {
+        calls.doctor += 1;
+        return NOT_READY_REPORT;
+      },
+      runInit: async () => {
+        calls.init += 1;
+        return 0;
+      },
+      confirm: async () => true,
+      ...overrides,
+    },
+  };
+}
+
+function readMarker(home) {
+  return JSON.parse(fs.readFileSync(firstRunMarkerPath(home), "utf8"));
+}
+
+test("first-run offer never fires without a TTY", async () => {
+  const home = tempHome();
+  const { calls, options } = firstRunHarness(home, { isTTY: false });
+  assert.equal(await maybeOfferFirstRunSetup(options), null);
+  assert.equal(calls.doctor, 0);
+  assert.equal(calls.init, 0);
+  assert.equal(fs.existsSync(firstRunMarkerPath(home)), false);
+});
+
+test("accepted first run delegates to init and writes the marker once", async () => {
+  const home = tempHome();
+  const { calls, options } = firstRunHarness(home);
+  assert.equal(await maybeOfferFirstRunSetup(options), null);
+  assert.equal(calls.init, 1);
+  assert.equal(readMarker(home).setup, "completed");
+  assert.equal(readMarker(home).version, "9.9.9");
+  // The marker short-circuits the next launch before any doctor check.
+  assert.equal(await maybeOfferFirstRunSetup(options), null);
+  assert.equal(calls.doctor, 1);
+  assert.equal(calls.init, 1);
+});
+
+test("declining the first-run offer is remembered and never re-asked", async () => {
+  const home = tempHome();
+  const { calls, options } = firstRunHarness(home, { confirm: async () => false });
+  assert.equal(await maybeOfferFirstRunSetup(options), null);
+  assert.equal(calls.init, 0);
+  assert.equal(readMarker(home).setup, "declined");
+  assert.equal(await maybeOfferFirstRunSetup(options), null);
+  assert.equal(calls.doctor, 1);
+});
+
+test("an already-ready install records the marker quietly, no prompt", async () => {
+  const home = tempHome();
+  let asked = false;
+  const { calls, options } = firstRunHarness(home, {
+    doctorReport: async () => {
+      calls.doctor += 1;
+      return READY_REPORT;
+    },
+    confirm: async () => {
+      asked = true;
+      return true;
+    },
+  });
+  // The harness's calls object is created before overrides run; rebuild count.
+  calls.doctor = 0;
+  assert.equal(await maybeOfferFirstRunSetup(options), null);
+  assert.equal(asked, false);
+  assert.equal(calls.init, 0);
+  assert.equal(readMarker(home).setup, "already-ready");
+});
+
+test("a failed init surfaces its exit code and leaves no marker", async () => {
+  const home = tempHome();
+  const { options } = firstRunHarness(home, { runInit: async () => 7 });
+  assert.equal(await maybeOfferFirstRunSetup(options), 7);
+  // No marker: the next launch should offer setup again.
+  assert.equal(fs.existsSync(firstRunMarkerPath(home)), false);
+  assert.equal(await maybeOfferFirstRunSetup({ ...options, runInit: async () => 0 }), null);
+  assert.equal(readMarker(home).setup, "completed");
+});
+
+test("welcome card is a closed box with even edges and no paint bleed", () => {
+  const identity = (text) => String(text);
+  const paint = {
+    accent: identity,
+    accentBold: identity,
+    bold: identity,
+    dim: identity,
+    heading: identity,
+  };
+  const lines = welcomeCardLines(paint);
+  assert.ok(lines[0].startsWith("╭") && lines[0].endsWith("╮"));
+  assert.ok(lines.at(-1).startsWith("╰") && lines.at(-1).endsWith("╯"));
+  const width = lines[0].length;
+  for (const line of lines) assert.equal(line.length, width, line);
+  assert.ok(lines.some((line) => line.includes("Welcome to BetterWright")));
+  assert.ok(lines.some((line) => line.includes("~200 MB")));
 });

--- a/tests/node/sdk.test.ts
+++ b/tests/node/sdk.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as providers from "../../dist/src/browser-providers.js";
+import * as client from "../../dist/src/client.js";
+import * as index from "../../dist/src/index.js";
+import * as sdk from "../../dist/src/sdk.js";
+import { isCallable } from "../../dist/src/untrusted-value.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+// Exports the SDK entrypoint shares with the root export. They must be the
+// same binding, not a copy: `instanceof` checks and the vault's identity
+// comparisons break the moment a consumer mixes the two entrypoints.
+const SHARED_WITH_ROOT = [
+  "BetterWright",
+  "BrowserError",
+  "NetworkPolicy",
+  "METADATA_ADDRESSES",
+  "METADATA_HOSTNAMES",
+  "createLocalCredentialVault",
+  "LocalCredentialVault",
+  "LocalCredentialVaultError",
+  "VAULT_CATEGORIES",
+  "VAULT_MATCH_MODES",
+  "agentSystemPrompt",
+  "runAgentTask",
+  "resolveModel",
+  "resolveModelSelection",
+];
+
+// withBrowser closes the client it constructed, and the callback is the only
+// place a test can reach that client. Wrapping close() there records the call
+// and still runs the real teardown.
+function trackClose(bw, calls) {
+  const close = bw.close.bind(bw);
+  bw.close = async () => {
+    calls.push(bw);
+    await close();
+  };
+}
+
+test("the SDK entrypoint re-exports the root export's bindings, not copies", () => {
+  // Copied out because indexing a namespace import by variable is linted
+  // away; the copies still hold the same references.
+  const sdkExports = { ...sdk };
+  const rootExports = { ...index };
+  for (const name of SHARED_WITH_ROOT) {
+    assert.ok(sdkExports[name], `sdk is missing ${name}`);
+    assert.equal(sdkExports[name], rootExports[name], `sdk.${name} is not the root binding`);
+  }
+  assert.equal(sdk.validateCredentialMatchMode, client.validateCredentialMatchMode);
+  assert.equal(sdk.browserProviderInfo, providers.browserProviderInfo);
+  assert.equal(sdk.BROWSER_PROVIDER_NAMES, providers.BROWSER_PROVIDER_NAMES);
+  assert.equal(sdk.describeCdpUrl, providers.describeCdpUrl);
+});
+
+test("withBrowser is the only export the root export does not have", () => {
+  assert.ok(isCallable(sdk.withBrowser));
+  assert.equal(index.withBrowser, undefined);
+  const added = Object.keys(sdk).filter((name) => !(name in index));
+  assert.deepEqual(added.sort(), [
+    "BROWSER_PROVIDER_NAMES",
+    "browserProviderInfo",
+    "describeCdpUrl",
+    "validateCredentialMatchMode",
+    "withBrowser",
+  ]);
+});
+
+test("withBrowser returns the callback's value and closes the client", async () => {
+  const home = makeTempDir("bw-sdk-with-browser-");
+  const closed = [];
+  const seen = [];
+  const title = await sdk.withBrowser({ home }, async (bw) => {
+    trackClose(bw, closed);
+    seen.push(bw);
+    return "Example Domain";
+  });
+  assert.equal(title, "Example Domain");
+  assert.equal(seen.length, 1);
+  assert.ok(seen[0] instanceof sdk.BetterWright);
+  assert.equal(seen[0].home, home);
+  assert.deepEqual(closed, seen);
+});
+
+test("withBrowser closes the client when the callback throws", async () => {
+  const home = makeTempDir("bw-sdk-with-browser-throws-");
+  const closed = [];
+  await assert.rejects(
+    () =>
+      sdk.withBrowser({ home }, async (bw) => {
+        trackClose(bw, closed);
+        throw new Error("callback failed");
+      }),
+    /callback failed/,
+  );
+  assert.equal(closed.length, 1);
+});
+
+test("withBrowser accepts a callback alone, with the default options", async () => {
+  const closed = [];
+  const home = makeTempDir("bw-sdk-with-browser-default-");
+  process.env.BETTERWRIGHT_HOME = home;
+  try {
+    const result = await sdk.withBrowser(async (bw) => {
+      trackClose(bw, closed);
+      assert.ok(bw instanceof sdk.BetterWright);
+      assert.equal(bw.home, home);
+      return 42;
+    });
+    assert.equal(result, 42);
+  } finally {
+    delete process.env.BETTERWRIGHT_HOME;
+  }
+  assert.equal(closed.length, 1);
+});

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -165,8 +165,10 @@ new BetterWright({ browser: "chromium" });
 new BetterWright({ executablePath: "/opt/chromium" });
 // @ts-expect-error CDP attach goes through the provider option.
 new BetterWright({ connectOverCdp: "http://127.0.0.1:9222" });
-// @ts-expect-error Unknown cloud providers are rejected at the type level.
-new BetterWright({ provider: { provider: "nope" } });
+// Custom provider names from `betterwright configure` are accepted alongside
+// the built-in union (which keeps its completions via the string intersection).
+new BetterWright({ provider: { provider: "driverdotnet" } });
+new BetterWright({ provider: { provider: "steel" } });
 
 void [
   run,

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -67,6 +67,14 @@ export interface AgentStepEvent {
   prompt?: string;
 }
 
+export interface AgentPhaseEvent {
+  /** "reasoning" while a model turn is in flight, "acting" while its tool calls run. */
+  phase: "reasoning" | "acting";
+  step: number;
+  /** The tool names about to run, present on `phase: "acting"`. */
+  tools?: string[];
+}
+
 export interface RunAgentTaskOptions {
   task: string;
   model?: string | AgentModel;
@@ -95,6 +103,11 @@ export interface RunAgentTaskOptions {
    */
   signal?: AbortSignal;
   onStep?: (event: AgentStepEvent) => void;
+  /**
+   * Fired at the start of each model turn ("reasoning") and again when its
+   * tool calls begin ("acting"), so a live UI can label the current wait.
+   */
+  onPhase?: (event: AgentPhaseEvent) => void;
   /**
    * When provided, the loop exposes an `ask` tool so the model can put a
    * question to the user mid-task; the returned string is fed back as the

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -46,9 +46,13 @@ export type CloudBrowserProviderName =
   | "brightdata"
   | "oxylabs";
 
-/** A cloud browser minted over a named provider's API. */
+/**
+ * A cloud browser minted over a named provider's API, or a custom provider
+ * defined in `<home>/config.json` (`betterwright configure`). The union keeps
+ * completion for the built-in names while accepting configured ones.
+ */
 export interface CloudBrowserProvider {
-  provider: CloudBrowserProviderName;
+  provider: CloudBrowserProviderName | (string & {});
   /** Falls back to the provider's env var (e.g. BROWSERBASE_API_KEY). */
   apiKey?: string;
   /** Provider-native create-session fields, passed through verbatim. */
@@ -99,7 +103,11 @@ export interface BetterWrightOptions {
    *   (BETTERWRIGHT_CDP_URL is the env shorthand);
    * - `{ provider, apiKey?, sessionOptions? }` — mint a cloud browser over a
    *   named provider's API: "browser-use", "kernel", "browserbase", "steel",
-   *   "anchor", "hyperbrowser", "browserless", "brightdata", "oxylabs".
+   *   "anchor", "hyperbrowser", "browserless", "brightdata", "oxylabs", or a
+   *   custom name defined with `betterwright configure`.
+   *
+   * When the option is absent, the default saved by `betterwright configure`
+   * (in `<home>/config.json`) applies; BETTERWRIGHT_CDP_URL overrides it.
    *
    * Remote browsers run outside the guard proxy — page traffic cannot be
    * network-policy enforced there; the launch warning says so. Provider

--- a/types/sdk.d.ts
+++ b/types/sdk.d.ts
@@ -1,0 +1,44 @@
+// Hand-written declarations for the SDK entrypoint (see AGENTS.md). The
+// provider helpers are declared here rather than re-exported because
+// src/browser-providers.ts has no published declaration file of its own.
+
+import type { BetterWright } from "./client.js";
+import type { BetterWrightOptions, CloudBrowserProviderName } from "./public.js";
+
+export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
+export { BetterWright, BrowserError, validateCredentialMatchMode } from "./client.js";
+export { METADATA_ADDRESSES, METADATA_HOSTNAMES, NetworkPolicy } from "./policy.js";
+export { agentSystemPrompt } from "./prompt.js";
+export {
+  createLocalCredentialVault,
+  LocalCredentialVault,
+  LocalCredentialVaultError,
+  VAULT_CATEGORIES,
+  VAULT_MATCH_MODES,
+} from "./vault.js";
+export type * from "./public.js";
+
+/** Names of the cloud browser providers `provider: { provider }` accepts. */
+export const BROWSER_PROVIDER_NAMES: readonly CloudBrowserProviderName[];
+
+export interface BrowserProviderInfo {
+  name: string;
+  docs: string;
+  keyEnv: string;
+}
+
+/** Display name, docs URL, and API-key env var, or null for an unknown name. */
+export function browserProviderInfo(name: string): BrowserProviderInfo | null;
+
+/** A CDP URL with its credentials and key-like query values masked, for logs. */
+export function describeCdpUrl(value: string): string;
+
+/**
+ * Run `fn` against a client and close that client afterwards, including when
+ * `fn` throws. Resolves with whatever `fn` returned.
+ */
+export function withBrowser<T>(
+  options: BetterWrightOptions,
+  fn: (bw: BetterWright) => Promise<T>,
+): Promise<T>;
+export function withBrowser<T>(fn: (bw: BetterWright) => Promise<T>): Promise<T>;


### PR DESCRIPTION
## BetterWright 2.0.0

No breaking changes: every 1.x API, CLI command, flag, and config file keeps working unchanged. The major version marks the new setup experience.

### Added
- First-run onboarding: a bare `betterwright` on a TTY with nothing installed shows a welcome card and offers the guided init (browser download, agent wiring, verified page load). Offered at most once; declining is remembered; scripted entry points untouched.
- `betterwright configure`: interactive and flag-driven browser backend setup, persisted as `browser.default` in `<home>/config.json`, honored by CLI, API, MCP, and daemon.
- Custom named CDP providers via `configure --add <name>`.
- Orange terminal theme, painted only on color TTYs; piped/`--json`/NO_COLOR output unchanged.
- Live working indicator: spinner with phase labels ("reasoning · 12s") in the console and on `exec` stderr, backed by a new `onPhase` callback on `runAgentTask`.
- `betterwright/sdk` entrypoint with `withBrowser(options?, fn)`.

### Fixed
- The `ask` tool now asks at the terminal when the host provides `askUser`, instead of waiting in an unopened live-view chat.
- `run --browser <name> script.js` parses correctly (`--browser`/`--browser-key` consume their values).

Full notes in CHANGELOG.md under 2.0.0. `npm run release:check` is green (unit 935 pass / 0 fail, types, lint, package smoke).