### PR TITLE
chore: add Cursor Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "BetterWright",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Cloud Agent bootstrap for BetterWright. Idempotent: safe to re-run against a
+# warm checkout or a fresh pod. Prepares the exact toolchain, dependencies, and
+# managed browser the runtime, CLI, and test harness expect.
+set -euo pipefail
+
+# 1. Node. package.json pins engines >=22.18.0 and .nvmrc records the exact
+#    version; the default image ships nvm, so install/select that version and
+#    make it the default so later terminals inherit it.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh"
+nvm install
+nvm use
+nvm alias default "$(tr -d '[:space:]' < .nvmrc)"
+
+# 2. Dependencies, exactly as locked.
+npm ci
+
+# 3. Compile the TypeScript runtime + CLI into dist/ and the test/benchmark
+#    harness (tsconfig.harness.json), so `node dist/bin/betterwright.js` and the
+#    unit suite are ready without a separate build step.
+npm run build:harness
+
+# 4. Download the pinned, checksum-verified BetterChromium backend into
+#    ~/.betterwright/chromium. Skips the ~200 MB download when already present,
+#    so this stays cheap on re-runs and bakes the browser into the build image.
+node dist/bin/betterwright.js setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,26 @@ because they are enforced by code, not convention.
 - **`src/worker.ts` compiles to an entrypoint with import side effects** (stdin
   readline, ready handshake) — never import the source or
   `dist/src/worker.js` directly from unit tests.
+
+## Cursor Cloud specific instructions
+
+The Cloud Agent environment is defined by `.cursor/environment.json`, whose
+install phase (`.cursor/install.sh`) selects the `.nvmrc` Node (22.18.0, the
+`engines` floor), runs `npm ci`, builds the runtime/CLI and test harness, and
+downloads the pinned BetterChromium backend. So `dist/`, `node_modules`, and the
+browser are already present on a fresh agent — running the built CLI
+(`node dist/bin/betterwright.js …`) and the product work out of the box.
+
+One caveat when running the repo's own npm scripts as a Cloud Agent: the
+platform's non-interactive shell puts a bundled `node` (currently 22.14.x)
+ahead of the pinned toolchain on `PATH`, which is below the `>=22.18.0` floor
+and breaks `npm run lint` (oxlint loads a `.ts` plugin that needs Node's native
+type stripping). Interactive terminals already pick up the pinned Node via nvm;
+for a one-off non-interactive command, activate it explicitly first (a bare
+`nvm use` does not reliably win against the bundled `node`):
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v$(tr -d '[:space:]' < /workspace/.nvmrc)/bin:$PATH"
+node --version   # -> v22.18.0
+npm run lint     # and typecheck / test:unit / release:check
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Adds a repository-managed Cursor Cloud Agent environment so the repo is fully usable in Cloud Agents out of the box. New files:

- `.cursor/environment.json` — runs the install phase.
- `.cursor/install.sh` — idempotent bootstrap: selects the `.nvmrc` Node (`v22.18.0`, the `engines` floor), runs `npm ci`, builds the runtime/CLI and test harness (`npm run build:harness`), and downloads the pinned, checksum-verified BetterChromium backend (`node dist/bin/betterwright.js setup`).
- `AGENTS.md` — a `## Cursor Cloud specific instructions` section documenting a platform quirk (see below).

This means a fresh Cloud Agent already has `node_modules`, `dist/`, and the managed browser, so the CLI and the guarded-browser product work immediately.

**Platform-Node quirk (documented, not worked around in code):** the Cloud Agent platform prepends a bundled `node` (currently `22.14.x`) ahead of the pinned toolchain on `PATH` for non-interactive shells. That is below the `>=22.18.0` floor and breaks `npm run lint`, because `oxlint` loads a `.ts` plugin that needs Node's native type-stripping (added in 22.18). Interactive terminals already pick up the pinned Node via nvm; `AGENTS.md` documents the one-line `PATH` activation for non-interactive agent commands. No project lint/build config was changed.

## Checklist

- [x] `npm run release:check` passes locally (versions, lint, typecheck, build, unit tests, published declarations, tarball).
- [x] **Every browser connection still goes through the guard proxy.** No runtime code changed; this PR only adds environment config and docs.
- [x] **No secret value reaches the model sandbox.** No output channels or runtime code changed; no secrets are committed.
- [x] **Dependency pins are still mirrored everywhere.** No dependency versions changed; `npm run check:versions` is green (part of `release:check`).
- [x] **Public API changes update `types/*.d.ts`.** N/A — no API change.
- [x] The two branch-protected CI job names are unchanged; no CI workflow was touched.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js` directly — no tests changed.
- [x] User-visible behaviour is reflected where relevant — no product behaviour changed; only Cloud Agent setup and operating guidance in `AGENTS.md`.
- [x] Nothing private is being committed — only `.cursor/` config, the install script, and an `AGENTS.md` docs section.

## How it was verified

Validated on the VM and then in fresh Cloud Agents booted from draft builds produced by this exact branch/commit.

- `npm run release:check` → exit 0 under Node `v22.18.0` (versions aligned; biome+oxlint clean; typecheck; `check:build`; `test:unit` 936 pass / 0 fail; `test:types`; package smoke test `betterwright-2.0.0.tgz`).
- Product end-to-end with the managed BetterChromium backend:
  - `betterwright doctor` → `✓ In use: chromium-fork`, `BetterWright is ready.`
  - `betterwright run -c "await page.goto('https://example.com'); return page.title()"` → `{ "ok": true, "result": "Example Domain" }`
  - `betterwright run … return screenshot({kind:'proof'})` → produced a PNG on disk (rendered `example.com`).
- Draft environment build from this commit **SUCCEEDED**; a fresh Cloud Agent booting from that build confirmed: baked `node_modules`/`dist`/browser, product runs out of the box, proof screenshot works, and `npm run lint` exits 0 after the documented Node activation (`v22.18.0`), while the platform default reports `/exec-daemon/node v22.14.0`.

Proof screenshot captured end-to-end through the managed browser:

![BetterWright proof screenshot of example.com rendered via managed BetterChromium](https://cursor.com/artifacts/c/art-51277824-e673-402e-8734-36b9ef95112c)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4530f0fa-406f-47a8-be56-38b03d5e1eb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4530f0fa-406f-47a8-be56-38b03d5e1eb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

