### PR TITLE
feat: connect cloud providers and manage boxes from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Releases before 1.1.3 predate this file; their notes live on the
   Oxylabs stay connect-only and are refused with a clear message. Keys resolve
   from `--browser-key` / `--key-env`, then a saved account, then a matching
   launch default, then the provider's well-known env var. `--session-id` on
-  `run` / `repl` / `exec` attaches to an existing box instead of minting.
+  `run` / `repl` / `exec` attaches to an existing box instead of minting,
+  and disconnect does not stop that box.
 - **SDK session helpers** on `betterwright/sdk`: `createProviderSession`,
   `listProviderSessions`, `getProviderSession`, `stopProviderSession`,
   `REST_BROWSER_PROVIDER_NAMES`, and `lifecycle` on `browserProviderInfo`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Added
+
+- **Connected provider accounts.** `betterwright configure --connect <name>`
+  saves a built-in provider's API key (or `--key-env`) in
+  `browser.accounts` without changing the launch default, so the managed fork
+  can stay the default while `boxes` talks to Kernel, Browserbase, Steel,
+  Anchor, Hyperbrowser, or Browser Use. `--browser <name>` with a key
+  connects the account as well. `--disconnect` forgets a saved key;
+  `--managed` / `--reset` still only clears the launch default.
+  `--show --json` reports connected accounts with stored keys masked.
+- **`betterwright boxes`.** `start`, `list`, `show`, and `stop` drive the six
+  SDK-backed providers' REST session APIs. Browserless, Bright Data, and
+  Oxylabs stay connect-only and are refused with a clear message. Keys resolve
+  from `--browser-key` / `--key-env`, then a saved account, then a matching
+  launch default, then the provider's well-known env var. `--session-id` on
+  `run` / `repl` / `exec` attaches to an existing box instead of minting.
+- **SDK session helpers** on `betterwright/sdk`: `createProviderSession`,
+  `listProviderSessions`, `getProviderSession`, `stopProviderSession`,
+  `REST_BROWSER_PROVIDER_NAMES`, and `lifecycle` on `browserProviderInfo`.
+
+### Changed
+
+- Anchor sessions are released when the browser closes (`DELETE` on the
+  session), matching Kernel / Browserbase / Hyperbrowser. Steel and Browser
+  Use still launch through a connect URL; their REST APIs are used by
+  `boxes` (and by `--session-id` attach).
+
 ## [2.0.0] - 2026-08-31
 
 BetterWright 2.0 contains no breaking changes: every 1.x API, CLI command,

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ step from what it sees, in a browser that must still be there next turn:
 | [**WebMCP page tools**](docs/browser-api.md#page-published-webmcp-tools) | Discover and invoke typed first-party page capabilities; fresh frame-aware lookup, bounded input/output, explicit autosubmit opt-in, and automatic timeout cancellation |
 | [**Launch identity**](docs/launch-identity.md) | Coherent native identity: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; the two public reCAPTCHA v3 score-detector demos in the stealth report return a server-verified 0.9 headed and headless |
 | [**BetterChromium**](docs/chromium-fork.md) | Default browser on supported macOS arm64, Linux x64, and Windows x64 hosts: per-profile-stable canvas/audio farbling, no OS masquerade (Linux runs as Linux). Bring your own executable, CDP endpoint, or cloud browser via the [provider option](docs/browser-providers.md) |
-| [**Browser providers**](docs/browser-providers.md) | Managed fork by default; attach a local executable, a raw CDP endpoint, or a named cloud browser (Kernel, Browserbase, Steel, Anchor, Bright Data, Hyperbrowser, Browserless, Oxylabs, Browser Use) |
+| [**Browser providers**](docs/browser-providers.md) | Managed fork by default; attach a local executable, a raw CDP endpoint, or a named cloud browser. `configure --connect` saves API keys; `betterwright boxes` starts/lists/stops sessions on the six SDK-backed providers |
 | [**Skill packs**](docs/skills.md) | Per-site and per-password-manager guidance the driving agent reads on demand — your own or the built-in loop — surfaced automatically when an open page matches |
 | [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time |
 | [**Operator guidance**](docs/agent-prompt.md) | `betterwright skill` / `agentSystemPrompt()` — decisive action on authorized tasks, with optional confirmation/spending guardrails |
@@ -271,6 +271,8 @@ are all available on their own:
 betterwright setup     # install the managed browser for this host
 betterwright update    # refresh the managed browser for this host
 betterwright doctor    # what is installed, what is missing, how to fix it
+betterwright configure # default browser, connected provider API keys
+betterwright boxes     # start / list / stop cloud browser sessions
 ```
 
 ## Getting a password back out

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -8,6 +8,7 @@
 //   betterwright doctor           report runtime readiness
 //   betterwright configure        choose the browser backend (cloud provider,
 //                                 CDP endpoint, own binary, or the managed fork)
+//   betterwright boxes            start, list, and stop cloud browser boxes
 //   betterwright run <file|-|-c>  execute a Playwright snippet in the
 //                                 persistent session (tabs/state survive calls)
 //   betterwright repl             run blank-line-separated snippets from stdin
@@ -310,7 +311,11 @@ function browserOptionsFromFlags(flags) {
 // as a CDP endpoint; anything else names a cloud provider whose key comes
 // from --browser-key or that provider's env var (docs/browser-providers.md).
 // The name is an arbitrary flag string here; the provider layer validates it.
-type CliCloudProviderChoice = { provider: string; apiKey?: string };
+type CliCloudProviderChoice = {
+  provider: string;
+  apiKey?: string;
+  sessionOptions?: { sessionId: string };
+};
 
 function providerFromFlags(_flags) {
   const named = flagValue(process.argv, "--browser");
@@ -321,6 +326,8 @@ function providerFromFlags(_flags) {
     const key = flagValue(process.argv, "--browser-key");
     const provider: CliCloudProviderChoice = { provider: value };
     if (key) provider.apiKey = String(key);
+    const sessionId = flagValue(process.argv, "--session-id");
+    if (sessionId) provider.sessionOptions = { sessionId: String(sessionId) };
     return provider;
   }
   return undefined; // the client falls back to BETTERWRIGHT_CDP_URL
@@ -2039,6 +2046,10 @@ async function main() {
     case "configure": {
       const { runConfigure } = await import("../src/configure.js");
       return runConfigure(rest);
+    }
+    case "boxes": {
+      const { runBoxesCommand } = await import("../src/boxes-cli.js");
+      return runBoxesCommand(rest);
     }
     case "vault": {
       const { runVaultCommand } = await import("../src/vault-cli.js");

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ whole path works by loading a real page.
 | --- | --- |
 | [Architecture & security model](architecture.md) | The worker process, the RPC loop, what is and isn't a security boundary |
 | [Launch identity](launch-identity.md) | The coherent locale/timezone/geo identity layer; launch modes and egress matching |
-| [Browser providers](browser-providers.md) | Managed fork, local executables, CDP endpoints, and named cloud browsers |
+| [Browser providers](browser-providers.md) | Managed fork, local executables, CDP endpoints, named cloud browsers, connected API keys, and `betterwright boxes` |
 | [Chromium fork](chromium-fork.md) | BetterWright's own Chromium build: farbling, discovery |
 | [Chromium fork patches](chromium-fork-patches.md) | What each source patch in the pinned Chromium 151 build changes, and why |
 | [Headed / headless](attach-mode.md) | Display modes over one persistent profile |

--- a/docs/browser-providers.md
+++ b/docs/browser-providers.md
@@ -38,6 +38,7 @@ CLI equivalents (shared by `run`, `repl`, and `exec`):
 
 ```bash
 betterwright run … --browser browserbase --browser-key bb_live_…
+betterwright run … --browser kernel --session-id sess_1
 betterwright run … --browser wss://browser.example.com/devtools/abc
 ```
 
@@ -58,11 +59,20 @@ The same choices are available without prompting:
 betterwright configure --show                      # current setting (--json for scripts)
 betterwright configure --browser steel --key-env STEEL_API_KEY
 betterwright configure --browser browserbase --browser-key bb_live_…
+betterwright configure --connect kernel --key-env KERNEL_API_KEY
+betterwright configure --disconnect kernel
 betterwright configure --browser wss://browser.example.com/devtools/abc
 betterwright configure --browser /opt/chrome/chrome  # a local binary
 betterwright configure --managed                   # back to the managed fork
 betterwright configure --test                      # connect and print the version
 ```
+
+`--connect` writes the key into `browser.accounts` without changing which
+browser a launch uses. That is how you keep the managed fork as the default
+and still run `betterwright boxes` against Kernel, Browserbase, Steel, Anchor,
+Hyperbrowser, or Browser Use. Setting `--browser <name>` with a key connects
+the account as well. `--managed` / `--reset` clears only the launch default;
+connected accounts stay until `--disconnect`.
 
 Precedence for one launch, first hit wins:
 
@@ -94,19 +104,48 @@ name, so the key stays in your environment and out of the file; the launch
 fails with a clear message when the variable is unset. Provider credentials
 are redacted from result envelopes either way.
 
+`--show --json` reports connected accounts with stored keys masked as `***`.
+
+## Managing boxes
+
+Six of the nine named providers expose a real session lifecycle (create, list,
+get, stop) over REST, matching their official SDKs. The other three allocate a
+browser only for the duration of a WebSocket connection, so there is nothing
+to start or stop.
+
+```bash
+betterwright configure --connect kernel --key-env KERNEL_API_KEY
+betterwright boxes start --browser kernel
+betterwright boxes list
+betterwright boxes show <id> --browser kernel
+betterwright boxes stop <id> --browser kernel
+betterwright run --browser kernel --session-id <id> -c "return page.url()"
+```
+
+`--json` is safe for scripts: CDP URLs go through the same credential masking
+as logs, and the API key is never in the payload. `--status` is passed through
+as the provider's list filter (Browserbase `RUNNING` / `COMPLETED`, …).
+
+From code, the same REST calls are `createProviderSession`,
+`listProviderSessions`, `getProviderSession`, and `stopProviderSession` on
+`betterwright/sdk`.
+
+Browserless, Bright Data, and Oxylabs stay connect-only: `boxes start` (and
+list/show/stop) refuses them with a message that says to connect instead.
+
 ## Named providers
 
-| Provider      | `provider:`      | API key env var          | Key format / notes |
-| ------------- | ---------------- | ------------------------ | ------------------ |
-| Browser Use   | `browser-use`    | `BROWSER_USE_API_KEY`    | Connect URL mints a browser per connection; `sessionOptions.proxyCountryCode` sets the egress country. |
-| Kernel        | `kernel`         | `KERNEL_API_KEY`         | Sessions minted via `POST /browsers` and released on close. |
-| Browserbase   | `browserbase`    | `BROWSERBASE_API_KEY`    | Sessions released on close. `sessionOptions` passes Browserbase's create-session fields. |
-| Steel         | `steel`          | `STEEL_API_KEY`          | Default session per connection; `sessionOptions.sessionId` pins an existing one. |
-| Anchor        | `anchor`         | `ANCHOR_API_KEY`         | Sessions end when the connection drops. |
-| Hyperbrowser  | `hyperbrowser`   | `HYPERBROWSER_API_KEY`   | Sessions stopped on close. |
-| Browserless   | `browserless`    | `BROWSERLESS_API_KEY`    | Launch options (`blockAds`, …) are `sessionOptions` query params. |
-| Bright Data   | `brightdata`     | `BRIGHTDATA_BROWSER_AUTH`| Key is the zone credential `brd-customer-…-zone-…:password` (scraping browser endpoint). |
-| Oxylabs       | `oxylabs`        | `OXYLABS_BROWSER_AUTH`   | Key is `USERNAME:PASSWORD`; params (`p_cc=US`, …) are `sessionOptions` query params. |
+| Provider      | `provider:`      | API key env var          | Launch / boxes |
+| ------------- | ---------------- | ------------------------ | -------------- |
+| Browser Use   | `browser-use`    | `BROWSER_USE_API_KEY`    | Launch is a connect URL (`sessionOptions.proxyCountryCode` sets egress). Boxes speak the v4 browsers API. `--session-id` GETs that browser and attaches. |
+| Kernel        | `kernel`         | `KERNEL_API_KEY`         | Sessions minted via `POST /browsers` and released on close. `boxes` uses the same browsers API. |
+| Browserbase   | `browserbase`    | `BROWSERBASE_API_KEY`    | Sessions released on close (`REQUEST_RELEASE`). `sessionOptions` passes create-session fields. |
+| Steel         | `steel`          | `STEEL_API_KEY`          | Launch is `wss://connect.steel.dev`. Boxes speak the Sessions API. `--session-id` GETs the session, then reconstructs the connect URL. |
+| Anchor        | `anchor`         | `ANCHOR_API_KEY`         | Sessions minted via `POST /api/v1/sessions` and deleted on close. |
+| Hyperbrowser  | `hyperbrowser`   | `HYPERBROWSER_API_KEY`   | Sessions minted via `POST /api/session` and stopped on close. |
+| Browserless   | `browserless`    | `BROWSERLESS_API_KEY`    | Connect-only. Launch options (`blockAds`, …) are `sessionOptions` query params. |
+| Bright Data   | `brightdata`     | `BRIGHTDATA_BROWSER_AUTH`| Connect-only. Key is the zone credential `brd-customer-…-zone-…:password`. |
+| Oxylabs       | `oxylabs`        | `OXYLABS_BROWSER_AUTH`   | Connect-only. Key is `USERNAME:PASSWORD`; params (`p_cc=US`, …) are `sessionOptions` query params. |
 
 Anything else that speaks plain CDP — self-hosted browserless, Lightpanda, a
 tunneled `chrome --remote-debugging-port` — works through `{ cdpUrl }`.
@@ -136,10 +175,15 @@ A remote browser runs on the provider's side of the WebSocket:
   attached or cloud browser must start Chromium with
   `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`; otherwise
   `webmcp.tools()` returns an actionable unsupported-feature error.
-- **Sessions can keep billing.** Providers with a session-stop API (Kernel,
-  Browserbase, Hyperbrowser) are released when the browser closes. Providers
-  without one (Browser Use, Steel, Anchor, Browserless, Bright Data, Oxylabs)
-  end on disconnect or by their own timeout; the launch warning names it.
+- **Sessions can keep billing.** Providers whose *launch* path mints a REST
+  session (Kernel, Browserbase, Anchor, Hyperbrowser) release that session
+  when the browser closes. Steel and Browser Use still launch through a
+  connect URL, so a launch does not create a billed REST session — use
+  `betterwright boxes start` / `stop` when you want one. Browserless, Bright
+  Data, and Oxylabs have no session ids; the browser lasts as long as the
+  WebSocket. The launch warning names the cases that can keep billing after
+  disconnect. A box started with `boxes start` is billed until `boxes stop`
+  (or the provider's own timeout), even if BetterWright is not attached.
 
 Provider credentials (the API key, and any credentials embedded in the CDP
 URL) are registered with the worker's redaction set at launch, so they appear
@@ -147,12 +191,14 @@ as `[redacted]` in every result envelope, event, and artifact path.
 
 ## `sessionOptions`
 
-For REST-minting providers (Kernel, Browserbase, Anchor, Hyperbrowser),
-`sessionOptions` is sent as the create-session body verbatim, so new provider
-features (proxy geography, keepAlive, profile IDs, screen size) work without
-a BetterWright release. For connect-URL providers (Browser Use, Steel,
-Browserless, Oxylabs) selected fields become query parameters as documented
-above.
+For REST-minting launches (Kernel, Browserbase, Anchor, Hyperbrowser) and for
+`boxes start` on every REST-lifecycle provider, `sessionOptions` is sent as
+the create-session body verbatim, so new provider features (proxy geography,
+keepAlive, profile IDs, screen size) work without a BetterWright release.
+`sessionOptions.sessionId` (or `id`) on a REST-lifecycle provider GETs that
+box and attaches instead of minting. For connect-URL launches (Browser Use
+and Steel without a session id, plus Browserless and Oxylabs) selected fields
+become query parameters as documented above.
 
 ## Doctor
 

--- a/docs/browser-providers.md
+++ b/docs/browser-providers.md
@@ -138,7 +138,7 @@ list/show/stop) refuses them with a message that says to connect instead.
 | Provider      | `provider:`      | API key env var          | Launch / boxes |
 | ------------- | ---------------- | ------------------------ | -------------- |
 | Browser Use   | `browser-use`    | `BROWSER_USE_API_KEY`    | Launch is a connect URL (`sessionOptions.proxyCountryCode` sets egress). Boxes speak the v4 browsers API. `--session-id` GETs that browser and attaches. |
-| Kernel        | `kernel`         | `KERNEL_API_KEY`         | Sessions minted via `POST /browsers` and released on close. `boxes` uses the same browsers API. |
+| Kernel        | `kernel`         | `KERNEL_API_KEY`         | Launch mints via `POST /browsers` and releases on close. `--session-id` attaches without taking ownership. `boxes` uses the same browsers API. |
 | Browserbase   | `browserbase`    | `BROWSERBASE_API_KEY`    | Sessions released on close (`REQUEST_RELEASE`). `sessionOptions` passes create-session fields. |
 | Steel         | `steel`          | `STEEL_API_KEY`          | Launch is `wss://connect.steel.dev`. Boxes speak the Sessions API. `--session-id` GETs the session, then reconstructs the connect URL. |
 | Anchor        | `anchor`         | `ANCHOR_API_KEY`         | Sessions minted via `POST /api/v1/sessions` and deleted on close. |
@@ -177,8 +177,10 @@ A remote browser runs on the provider's side of the WebSocket:
   `webmcp.tools()` returns an actionable unsupported-feature error.
 - **Sessions can keep billing.** Providers whose *launch* path mints a REST
   session (Kernel, Browserbase, Anchor, Hyperbrowser) release that session
-  when the browser closes. Steel and Browser Use still launch through a
-  connect URL, so a launch does not create a billed REST session — use
+  when the browser closes. Attaching to an existing box (`--session-id` /
+  `sessionOptions.sessionId`) never takes that ownership: disconnect does
+  not stop the box. Steel and Browser Use still launch through a connect
+  URL, so a launch does not create a billed REST session — use
   `betterwright boxes start` / `stop` when you want one. Browserless, Bright
   Data, and Oxylabs have no session ids; the browser lasts as long as the
   WebSocket. The launch warning names the cases that can keep billing after

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,8 +76,10 @@ Chromium binary (`provider: { executablePath }`, still on the guard proxy),
 any CDP endpoint (`provider: { cdpUrl }` / `BETTERWRIGHT_CDP_URL`), or a
 cloud browser from Browser Use, Kernel, Browserbase, Steel, Anchor,
 Hyperbrowser, Browserless, Bright Data, or Oxylabs. `betterwright configure`
-walks you through the choice and persists a default; custom CDP services can
-be added there by name. See [browser-providers.md](browser-providers.md).
+walks you through the choice and persists a default; `--connect` saves a key
+for `betterwright boxes` (start/list/stop on the six REST-backed providers)
+without changing that default. Custom CDP services can be added by name.
+See [browser-providers.md](browser-providers.md).
 
 ### BetterChromium backend (macOS arm64 / Linux x64 / Windows x64)
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -89,8 +89,13 @@ Browser providers:
 | Export | What it is |
 | --- | --- |
 | `BROWSER_PROVIDER_NAMES` | The named cloud providers `provider: { provider }` accepts. |
-| `browserProviderInfo(name)` | Display name, docs URL, and API-key environment variable for one of them, or `null`. |
+| `REST_BROWSER_PROVIDER_NAMES` | The six of those with create/list/get/stop session APIs. |
+| `browserProviderInfo(name)` | Display name, docs URL, API-key env var, and `lifecycle` (`rest` or `connect`), or `null`. |
 | `describeCdpUrl(value)` | A CDP URL with its credentials and key-like query values masked, for logging. |
+| `createProviderSession(name, options?)` | Start a managed box (`betterwright boxes start`). |
+| `listProviderSessions(name, options?)` | List boxes (`betterwright boxes list`). |
+| `getProviderSession(name, id, options?)` | Fetch one box. |
+| `stopProviderSession(name, id, options?)` | Release a box so the provider stops billing it. |
 
 Bringing your own browser, and what each provider changes about the guard
 proxy, is covered in [browser-providers.md](browser-providers.md).

--- a/src/boxes-cli.ts
+++ b/src/boxes-cli.ts
@@ -106,14 +106,16 @@ function printBox(log, box, { json }) {
   else if (box.cdpUrl) log(`  cdp       ${describeCdpUrl(box.cdpUrl)}`);
 }
 
-function jsonBox(box) {
-  const row: {
-    provider: string;
-    id: string;
-    status?: string;
-    liveViewUrl?: string;
-    cdpUrl?: string;
-  } = { provider: box.provider, id: box.id };
+interface BoxesJsonRow {
+  provider: string;
+  id: string;
+  status?: string;
+  liveViewUrl?: string;
+  cdpUrl?: string;
+}
+
+function jsonBox(box): BoxesJsonRow {
+  const row: BoxesJsonRow = { provider: box.provider, id: box.id };
   if (box.status) row.status = box.status;
   if (box.liveViewUrl) row.liveViewUrl = box.liveViewUrl;
   if (box.endpointLabel) row.cdpUrl = box.endpointLabel;

--- a/src/boxes-cli.ts
+++ b/src/boxes-cli.ts
@@ -1,0 +1,261 @@
+// `betterwright boxes` — start, list, show, and stop cloud browser sessions.
+//
+// Six of the built-in providers expose a real session lifecycle (create /
+// list / get / stop) over REST. The other three allocate a browser only for
+// the duration of a WebSocket connection, so this command refuses start/stop
+// there and tells the user to connect instead.
+//
+// Credentials come from `configure --connect` (or a named default with a
+// key), then the provider's well-known environment variable. Keys are never
+// printed: CDP URLs go through describeCdpUrl, and `--json` masks nothing
+// extra because the payload never includes the key.
+
+import {
+  loadBrowserConfig,
+  resolveConnectedProvider,
+} from "./browser-config.js";
+import {
+  BROWSER_PROVIDER_NAMES,
+  browserProviderInfo,
+  createProviderSession,
+  describeCdpUrl,
+  getProviderSession,
+  listProviderSessions,
+  REST_BROWSER_PROVIDER_NAMES,
+  stopProviderSession,
+} from "./browser-providers.js";
+import { flagValue, positionalArgs } from "./cli-flags.js";
+import { BOXES_USAGE } from "./cli-help.js";
+import { type CliPaint, cliPaint, paintedError, paintedLog } from "./cli-theme.js";
+import { defaultHome } from "./home.js";
+
+function trimmed(value) {
+  return String(value ?? "").trim();
+}
+
+function hasFlag(argv, flag) {
+  return argv.some((token) => token === flag || token.startsWith(`${flag}=`));
+}
+
+function restProviders() {
+  return REST_BROWSER_PROVIDER_NAMES;
+}
+
+function requireRestProviderName(name) {
+  const info = browserProviderInfo(name);
+  if (info?.lifecycle === "rest") return info;
+  if (info) {
+    throw new Error(
+      `${info.name} has no managed sessions to start or stop. ` +
+        "Its browsers exist only for the duration of a WebSocket connection.",
+    );
+  }
+  throw new TypeError(`Unknown browser provider "${name}".`);
+}
+
+function connectedRestProviders(config, env) {
+  const named = new Set(Object.keys(config.accounts));
+  if (config.default?.provider && BROWSER_PROVIDER_NAMES.includes(config.default.provider)) {
+    named.add(config.default.provider);
+  }
+  for (const name of restProviders()) {
+    const info = browserProviderInfo(name);
+    if (info?.keyEnv && trimmed(env?.[info.keyEnv])) named.add(name);
+  }
+  return restProviders().filter((name) => named.has(name));
+}
+
+function pickProvider(argv, extra, { home, env, needOne }) {
+  const flagged = trimmed(flagValue(argv, "--browser"));
+  if (flagged) return flagged.toLowerCase();
+  const positional = trimmed(extra);
+  if (positional) return positional.toLowerCase();
+  const config = loadBrowserConfig(home);
+  const defaultName = config.default?.provider;
+  if (defaultName && restProviders().includes(defaultName)) return defaultName;
+  const connected = connectedRestProviders(config, env);
+  if (connected.length === 1) return connected[0];
+  if (!needOne && connected.length > 1) return "";
+  const rest = restProviders().join(", ");
+  throw new TypeError(
+    connected.length
+      ? `Say which provider with --browser (${connected.join(", ")}).`
+      : `No connected REST provider. Connect one with \`betterwright configure --connect <name>\` ` +
+          `(REST lifecycle: ${rest}).`,
+  );
+}
+
+function credentialFor(name, argv, { home, env }) {
+  return resolveConnectedProvider(name, {
+    home,
+    env,
+    apiKey: flagValue(argv, "--browser-key"),
+    keyEnv: flagValue(argv, "--key-env"),
+  });
+}
+
+function printBox(log, box, { json }) {
+  if (json) return;
+  const info = browserProviderInfo(box.provider);
+  const label = info?.name || box.provider;
+  log(`${box.id}`);
+  log(`  provider  ${label} (${box.provider})`);
+  if (box.status) log(`  status    ${box.status}`);
+  if (box.liveViewUrl) log(`  live      ${box.liveViewUrl}`);
+  if (box.endpointLabel) log(`  cdp       ${box.endpointLabel}`);
+  else if (box.cdpUrl) log(`  cdp       ${describeCdpUrl(box.cdpUrl)}`);
+}
+
+function jsonBox(box) {
+  const row: {
+    provider: string;
+    id: string;
+    status?: string;
+    liveViewUrl?: string;
+    cdpUrl?: string;
+  } = { provider: box.provider, id: box.id };
+  if (box.status) row.status = box.status;
+  if (box.liveViewUrl) row.liveViewUrl = box.liveViewUrl;
+  if (box.endpointLabel) row.cdpUrl = box.endpointLabel;
+  else if (box.cdpUrl) row.cdpUrl = describeCdpUrl(box.cdpUrl);
+  return row;
+}
+
+async function cmdList(argv, extra, io) {
+  const json = hasFlag(argv, "--json");
+  const status = flagValue(argv, "--status");
+  const named = trimmed(flagValue(argv, "--browser")) || trimmed(extra);
+  const providers = named
+    ? [pickProvider(argv, extra, { home: io.home, env: io.env, needOne: true })]
+    : connectedRestProviders(loadBrowserConfig(io.home), io.env);
+  if (named) requireRestProviderName(providers[0]);
+  if (!named && !providers.length) {
+    const provider = pickProvider(argv, extra, { home: io.home, env: io.env, needOne: true });
+    providers.push(provider);
+  }
+  const boxes = [];
+  for (const provider of providers) {
+    const cred = credentialFor(provider, argv, io);
+    const found = await listProviderSessions(provider, {
+      apiKey: cred.apiKey,
+      status,
+      fetchJson: io.fetchJson,
+    });
+    boxes.push(...found);
+  }
+  if (json) {
+    io.log(JSON.stringify({ boxes: boxes.map(jsonBox) }, null, 2));
+    return 0;
+  }
+  if (!boxes.length) {
+    io.log("No boxes.");
+    return 0;
+  }
+  for (const box of boxes) {
+    printBox(io.log, box, { json: false });
+    io.log("");
+  }
+  return 0;
+}
+
+async function cmdStart(argv, extra, io) {
+  const json = hasFlag(argv, "--json");
+  const provider = pickProvider(argv, extra, { home: io.home, env: io.env, needOne: true });
+  const info = requireRestProviderName(provider);
+  const cred = credentialFor(provider, argv, io);
+  const box = await createProviderSession(provider, {
+    apiKey: cred.apiKey,
+    fetchJson: io.fetchJson,
+  });
+  if (json) {
+    io.log(JSON.stringify(jsonBox(box), null, 2));
+    return 0;
+  }
+  io.log(`✓ Started ${info.name} box ${box.id}.`);
+  printBox(io.log, box, { json: false });
+  io.log(`  stop      betterwright boxes stop ${box.id} --browser ${provider}`);
+  if (box.id) {
+    io.log(
+      `  attach    betterwright run --browser ${provider} --session-id ${box.id} -c "return page.url()"`,
+    );
+  }
+  return 0;
+}
+
+async function cmdShow(argv, extra, io) {
+  const json = hasFlag(argv, "--json");
+  const id = trimmed(extra);
+  if (!id) {
+    io.fail("Usage: betterwright boxes show <id> [--browser <name>]");
+    return 1;
+  }
+  const provider = pickProvider(argv, "", { home: io.home, env: io.env, needOne: true });
+  requireRestProviderName(provider);
+  const cred = credentialFor(provider, argv, io);
+  const box = await getProviderSession(provider, id, {
+    apiKey: cred.apiKey,
+    fetchJson: io.fetchJson,
+  });
+  if (json) {
+    io.log(JSON.stringify(jsonBox(box), null, 2));
+    return 0;
+  }
+  printBox(io.log, box, { json: false });
+  return 0;
+}
+
+async function cmdStop(argv, extra, io) {
+  const json = hasFlag(argv, "--json");
+  const id = trimmed(extra);
+  if (!id) {
+    io.fail("Usage: betterwright boxes stop <id> [--browser <name>]");
+    return 1;
+  }
+  const provider = pickProvider(argv, "", { home: io.home, env: io.env, needOne: true });
+  requireRestProviderName(provider);
+  const cred = credentialFor(provider, argv, io);
+  const stopped = await stopProviderSession(provider, id, {
+    apiKey: cred.apiKey,
+    fetchJson: io.fetchJson,
+  });
+  if (json) {
+    io.log(JSON.stringify({ stopped: true, ...stopped }, null, 2));
+    return 0;
+  }
+  io.log(`✓ Stopped ${stopped.provider} box ${stopped.id}.`);
+  return 0;
+}
+
+/**
+ * `betterwright boxes`. Tests inject `home`, `env`, `log`/`error`, and
+ * `fetchJson` so a full start/list/stop pass never opens a socket.
+ */
+export async function runBoxesCommand(argv: string[] = [], options: any = {}) {
+  const home = options.home || defaultHome();
+  const env = options.env || process.env;
+  const paint: CliPaint = options.paint || cliPaint();
+  const log = options.log || paintedLog(paint);
+  const fail = options.error || paintedError(paint);
+  const fetchJson = options.fetchJson;
+  const io = { home, env, log, fail, fetchJson };
+
+  const positionals = positionalArgs(argv);
+  const command = trimmed(positionals[0]).toLowerCase();
+  const extra = positionals[1];
+  if (!command) {
+    fail(BOXES_USAGE);
+    return 1;
+  }
+
+  try {
+    if (command === "list") return await cmdList(argv, extra, io);
+    if (command === "start") return await cmdStart(argv, extra, io);
+    if (command === "show") return await cmdShow(argv, extra, io);
+    if (command === "stop") return await cmdStop(argv, extra, io);
+    fail(`Unknown boxes command "${command}".\n\n${BOXES_USAGE}`);
+    return 1;
+  } catch (error) {
+    fail(`✗ ${error?.message || error}`);
+    return 1;
+  }
+}

--- a/src/browser-config.ts
+++ b/src/browser-config.ts
@@ -1,12 +1,16 @@
 // Persistent browser-provider settings: <home>/config.json, `browser` section.
 //
-// This is where `betterwright configure` writes and every launch reads. Two
+// This is where `betterwright configure` writes and every launch reads. Three
 // things live here:
 //
 //   - `default`: the provider a launch uses when nothing explicit was given —
 //     the same shapes the `provider` option accepts (a named cloud provider,
 //     a CDP endpoint, or a local Chromium binary), plus `keyEnv` so a config
 //     can point at an environment variable instead of storing the key.
+//   - `accounts`: saved API keys for built-in providers, so `boxes` can
+//     start/list/stop sessions without that provider having to be the launch
+//     default. `configure --connect` writes this; a named `--browser` default
+//     with a key writes it too.
 //   - `custom`: user-defined named providers. Each maps a name to a CDP
 //     connect-URL template (`${apiKey}` is substituted at launch), so any
 //     service that speaks CDP becomes `--browser <name>` without a
@@ -28,7 +32,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { BROWSER_PROVIDER_NAMES } from "./browser-providers.js";
+import { BROWSER_PROVIDER_NAMES, browserProviderInfo } from "./browser-providers.js";
 import { writePrivate } from "./fs-private.js";
 import { defaultHome } from "./home.js";
 import {
@@ -82,6 +86,18 @@ export interface DefaultBrowserRef {
 export interface BrowserFileConfig {
   default?: DefaultBrowserRef;
   custom: Record<string, CustomProviderDefinition>;
+  /** Saved API keys for built-in providers, independent of the launch default. */
+  accounts: Record<string, ProviderAccount>;
+}
+
+/**
+ * A stored API-key source for one built-in provider. Used by `boxes` and by
+ * `configure --connect`, so a key can be saved without making that provider
+ * the launch default.
+ */
+export interface ProviderAccount {
+  keyEnv?: string;
+  apiKey?: string;
 }
 
 export function browserConfigPath(home = defaultHome()) {
@@ -131,6 +147,16 @@ function cleanCustomDefinition(value: UntrustedValue): CustomProviderDefinition 
   return definition;
 }
 
+function cleanAccount(value: UntrustedValue): ProviderAccount | null {
+  if (!isRecord(value)) return null;
+  const account: ProviderAccount = {};
+  const keyEnv = cleanString(untrustedField(value, "keyEnv"));
+  if (keyEnv) account.keyEnv = keyEnv;
+  const apiKey = cleanString(untrustedField(value, "apiKey"));
+  if (apiKey) account.apiKey = apiKey;
+  return account.keyEnv || account.apiKey ? account : null;
+}
+
 function cleanDefaultRef(value: UntrustedValue): DefaultBrowserRef | undefined {
   if (!isRecord(value)) return undefined;
   const ref: DefaultBrowserRef = {};
@@ -165,7 +191,7 @@ function cleanDefaultRef(value: UntrustedValue): DefaultBrowserRef | undefined {
  */
 export function loadBrowserConfig(home = defaultHome()): BrowserFileConfig {
   const section = untrustedField(readConfigFile(home), "browser");
-  const config: BrowserFileConfig = { custom: {} };
+  const config: BrowserFileConfig = { custom: {}, accounts: {} };
   if (!isRecord(section)) return config;
   const fallback = cleanDefaultRef(untrustedField(section, "default"));
   if (fallback) config.default = fallback;
@@ -175,6 +201,14 @@ export function loadBrowserConfig(home = defaultHome()): BrowserFileConfig {
       const key = String(name || "").trim().toLowerCase();
       const definition = cleanCustomDefinition(value);
       if (CUSTOM_NAME_PATTERN.test(key) && definition) config.custom[key] = definition;
+    }
+  }
+  const accounts = untrustedField(section, "accounts");
+  if (isRecord(accounts)) {
+    for (const [name, value] of untrustedEntries(accounts)) {
+      const key = String(name || "").trim().toLowerCase();
+      const account = cleanAccount(value);
+      if (BROWSER_PROVIDER_NAMES.includes(key) && account) config.accounts[key] = account;
     }
   }
   return config;
@@ -271,6 +305,140 @@ export function removeCustomProvider(name: string, home = defaultHome()) {
     else section.delete("custom");
   });
   return removed;
+}
+
+/** Persist (or replace) a built-in provider's saved API-key source. */
+export function saveProviderAccount(
+  name: string,
+  account: ProviderAccount,
+  home = defaultHome(),
+) {
+  const key = String(name || "").trim().toLowerCase();
+  if (!BROWSER_PROVIDER_NAMES.includes(key)) {
+    throw new TypeError(
+      `Unknown provider ${JSON.stringify(key)}. Built-in: ${BROWSER_PROVIDER_NAMES.join(", ")}.`,
+    );
+  }
+  const cleaned = cleanAccount(account);
+  if (!cleaned) {
+    throw new TypeError(
+      "A connected provider needs --browser-key (stored in the config file) or --key-env (read from the environment).",
+    );
+  }
+  return {
+    name: key,
+    file: writeBrowserSection(home, (section) => {
+      const existing = untrustedField(Object.fromEntries(section), "accounts");
+      const accounts = new Map(isRecord(existing) ? untrustedEntries(existing) : []);
+      accounts.set(key, cleaned);
+      section.set("accounts", Object.fromEntries(accounts));
+    }),
+  };
+}
+
+/** Remove a saved provider account; true when something was actually removed. */
+export function removeProviderAccount(name: string, home = defaultHome()) {
+  const key = String(name || "").trim().toLowerCase();
+  let removed = false;
+  writeBrowserSection(home, (section) => {
+    const existing = untrustedField(Object.fromEntries(section), "accounts");
+    const accounts = new Map(isRecord(existing) ? untrustedEntries(existing) : []);
+    removed = accounts.delete(key);
+    if (accounts.size) section.set("accounts", Object.fromEntries(accounts));
+    else section.delete("accounts");
+  });
+  return removed;
+}
+
+/** Where a resolved API key came from, for messages that must not print the key. */
+export type ProviderKeySource = "flag" | "account" | "default" | "env";
+
+export interface ResolvedProviderCredential {
+  provider: string;
+  apiKey: string;
+  source: ProviderKeySource;
+  keyEnv?: string;
+}
+
+/**
+ * Resolve an API key for a built-in provider: an explicit flag, then a saved
+ * account, then the launch default if it names this provider, then the
+ * provider's well-known environment variable.
+ */
+export function resolveConnectedProvider(
+  name: string,
+  {
+    home = defaultHome(),
+    env = process.env,
+    apiKey,
+    keyEnv,
+    config = null,
+  }: any = {},
+): ResolvedProviderCredential {
+  const key = String(name || "").trim().toLowerCase();
+  if (!BROWSER_PROVIDER_NAMES.includes(key)) {
+    throw new TypeError(
+      `Unknown provider ${JSON.stringify(name)}. Built-in: ${BROWSER_PROVIDER_NAMES.join(", ")}.`,
+    );
+  }
+  const browserConfig: BrowserFileConfig = config ?? loadBrowserConfig(home);
+  const explicitKey = cleanString(apiKey);
+  if (explicitKey) return { provider: key, apiKey: explicitKey, source: "flag" };
+  const explicitEnv = cleanString(keyEnv);
+  if (explicitEnv) {
+    const fromEnv = cleanString(env?.[explicitEnv]);
+    if (!fromEnv) {
+      throw new TypeError(
+        `The ${key} provider reads its API key from ${explicitEnv}, which is not set.`,
+      );
+    }
+    return { provider: key, apiKey: fromEnv, source: "flag", keyEnv: explicitEnv };
+  }
+  const account = browserConfig.accounts[key];
+  if (account) {
+    const resolved = resolveKey(undefined, account.keyEnv, account.apiKey, env, key);
+    if (resolved.key) {
+      return {
+        provider: key,
+        apiKey: resolved.key,
+        source: "account",
+        keyEnv: account.keyEnv,
+      };
+    }
+    if (account.keyEnv) {
+      throw new TypeError(
+        `The ${key} provider reads its API key from ${account.keyEnv}, which is not set. ` +
+          "Set it, or re-run `betterwright configure --connect`.",
+      );
+    }
+  }
+  const fallback = browserConfig.default;
+  if (fallback?.provider === key) {
+    const resolved = resolveKey(fallback.apiKey, fallback.keyEnv, undefined, env, key);
+    if (resolved.key) {
+      return {
+        provider: key,
+        apiKey: resolved.key,
+        source: "default",
+        keyEnv: fallback.keyEnv,
+      };
+    }
+    if (fallback.keyEnv) {
+      throw new TypeError(
+        `The configured browser reads its API key from ${fallback.keyEnv}, which is not set.`,
+      );
+    }
+  }
+  const info = browserProviderInfo(key);
+  const fromWellKnown = info?.keyEnv ? cleanString(env?.[info.keyEnv]) : "";
+  if (fromWellKnown) {
+    return { provider: key, apiKey: fromWellKnown, source: "env", keyEnv: info.keyEnv };
+  }
+  throw new TypeError(
+    `No API key for ${info?.name || key}. Pass --browser-key, --key-env, ` +
+      `or run \`betterwright configure --connect ${key}\`.` +
+      (info?.keyEnv ? ` The default environment variable is ${info.keyEnv}.` : ""),
+  );
 }
 
 // A template must parse as a ws(s) URL once the key is substituted; checked

--- a/src/browser-providers.ts
+++ b/src/browser-providers.ts
@@ -569,6 +569,9 @@ function resolveNamedProvider(descriptor, name, provider, env) {
   // does not mint a second billed browser. Steel's connect URL can also
   // carry sessionId; REST attach is used when the provider has a get
   // endpoint so a missing id fails here instead of at the WebSocket.
+  // Attach never owns the box — close / failed CDP connect must not stop
+  // it — so the billing-keeps-running warning applies even when the
+  // provider has a stop API.
   if (sessionId && descriptor.get) {
     return {
       kind: "remote",
@@ -576,7 +579,7 @@ function resolveNamedProvider(descriptor, name, provider, env) {
       apiKey,
       create: ({ fetchJson }: any = {}) =>
         attachNamedSession(descriptor, name, apiKey, sessionId, fetchJson),
-      warnings: remoteWarnings(descriptor.displayName, Boolean(descriptor.end)),
+      warnings: remoteWarnings(descriptor.displayName, false),
     };
   }
   if (descriptor.staticEndpoint) {
@@ -635,6 +638,13 @@ async function attachNamedSession(descriptor, name, apiKey, sessionId, fetchJson
   const data = await fetchProviderRecord(descriptor, apiKey, sessionId, fetchJson);
   const plan = await sessionPlanFromPayload(descriptor, name, apiKey, data, fetchJson);
   if (!plan.sessionId) plan.sessionId = sessionId;
+  // sessionPlanFromPayload arms descriptor.end for sessions this launch
+  // minted. An existing box is owned by `boxes stop` (or the provider's
+  // timeout); the worker calls plan.end on CDP connect failure and on
+  // context close, so leaving that callback here would delete the box
+  // the caller meant to keep.
+  plan.end = null;
+  plan.warnings = remoteWarnings(descriptor.displayName, false);
   return plan;
 }
 

--- a/src/browser-providers.ts
+++ b/src/browser-providers.ts
@@ -119,7 +119,13 @@ function isFetchJsonHook(value: UntrustedValue): value is FetchJsonHook {
 
 async function httpJson(fetchJson, method, url, { headers, body }) {
   if (isFetchJsonHook(fetchJson)) {
-    return fetchJson(url, { method, headers, body });
+    const request: {
+      method: string;
+      headers: Record<string, string>;
+      body?: UntrustedValue;
+    } = { method, headers };
+    if (body !== undefined) request.body = body;
+    return fetchJson(url, request);
   }
   const requestHeaders: Record<string, string> = {};
   if (body !== undefined) requestHeaders["content-type"] = "application/json";
@@ -181,8 +187,9 @@ const PROVIDERS = Object.freeze({
     displayName: "Browser Use",
     keyEnv: "BROWSER_USE_API_KEY",
     docs: "https://docs.browser-use.com/cloud",
-    // The static connect URL mints a browser per connection and needs no
-    // session bookkeeping, so no REST call is required.
+    // Launch still uses the connect URL (a browser per WebSocket). Box
+    // management speaks the v4 browsers API the official SDK maps to
+    // client.browsers.create() / .list() / .stop().
     staticEndpoint({ apiKey, sessionOptions = {} }: any = {}) {
       const url = new URL("wss://connect.browser-use.com");
       url.searchParams.set("apiKey", apiKey);
@@ -193,6 +200,25 @@ const PROVIDERS = Object.freeze({
       if (country) url.searchParams.set("proxyCountryCode", country);
       return url.href;
     },
+    request: {
+      method: "POST",
+      url: "https://api.browser-use.com/api/v4/browsers",
+      body: (sessionOptions) => sessionOptions,
+    },
+    headers: (apiKey) => ({ "x-browser-use-api-key": apiKey }),
+    pick: (data) => takeString(data?.cdpUrl, data?.cdp_url, data?.wsEndpoint),
+    id: (data) => takeString(data?.id, data?.session_id, data?.sessionId),
+    liveView: (data) => takeString(data?.liveUrl, data?.live_url, data?.liveViewUrl),
+    list: "https://api.browser-use.com/api/v4/browsers",
+    get: (id) => ({
+      method: "GET",
+      url: `https://api.browser-use.com/api/v4/browsers/${encodeURIComponent(id)}`,
+    }),
+    end: (id) => ({
+      method: "PATCH",
+      url: `https://api.browser-use.com/api/v4/browsers/${encodeURIComponent(id)}`,
+      body: { action: "stop" },
+    }),
   },
   kernel: {
     displayName: "Kernel",
@@ -206,6 +232,13 @@ const PROVIDERS = Object.freeze({
     headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
     pick: (data) => takeString(data?.cdp_ws_url, data?.cdpWsUrl, data?.cdp_url),
     id: (data) => takeString(data?.session_id, data?.sessionId, data?.id),
+    liveView: (data) =>
+      takeString(data?.browser_live_view_url, data?.browserLiveViewUrl, data?.live_view_url),
+    list: "https://api.onkernel.com/browsers",
+    get: (id) => ({
+      method: "GET",
+      url: `https://api.onkernel.com/browsers/${encodeURIComponent(id)}`,
+    }),
     end: (id) => ({
       method: "DELETE",
       url: `https://api.onkernel.com/browsers/${encodeURIComponent(id)}`,
@@ -223,6 +256,13 @@ const PROVIDERS = Object.freeze({
     headers: (apiKey) => ({ "x-bb-api-key": apiKey }),
     pick: (data) => takeString(data?.connectUrl, data?.connect_url),
     id: (data) => takeString(data?.id),
+    liveView: (data) =>
+      takeString(data?.debuggerFullscreenUrl, data?.debugger_fullscreen_url, data?.debugUrl),
+    list: "https://api.browserbase.com/v1/sessions",
+    get: (id) => ({
+      method: "GET",
+      url: `https://api.browserbase.com/v1/sessions/${encodeURIComponent(id)}`,
+    }),
     end: (id) => ({
       method: "POST",
       url: `https://api.browserbase.com/v1/sessions/${encodeURIComponent(id)}`,
@@ -233,8 +273,11 @@ const PROVIDERS = Object.freeze({
     displayName: "Steel",
     keyEnv: "STEEL_API_KEY",
     docs: "https://docs.steel.dev",
-    // Steel's connect URL alone starts a default session; sessionOptions may
-    // pin an existing session id instead.
+    // Launch still uses the connect URL (a default session per connection,
+    // or an existing one via sessionOptions.sessionId). Box management uses
+    // the Sessions API the official SDK maps to client.sessions.create() /
+    // .list() / .release(). Steel's own docs say to build the WebSocket URL
+    // rather than trust websocketUrl on the create response.
     staticEndpoint({ apiKey, sessionOptions = {} }: any = {}) {
       const url = new URL("wss://connect.steel.dev");
       url.searchParams.set("apiKey", apiKey);
@@ -242,6 +285,25 @@ const PROVIDERS = Object.freeze({
       if (sessionId) url.searchParams.set("sessionId", sessionId);
       return url.href;
     },
+    request: {
+      method: "POST",
+      url: "https://api.steel.dev/v1/sessions",
+      body: (sessionOptions) => sessionOptions,
+    },
+    headers: (apiKey) => ({ "steel-api-key": apiKey }),
+    pick: (data) => takeString(data?.websocketUrl, data?.websocket_url),
+    id: (data) => takeString(data?.id, data?.sessionId, data?.session_id),
+    liveView: (data) =>
+      takeString(data?.sessionViewerUrl, data?.session_viewer_url, data?.debugUrl),
+    list: "https://api.steel.dev/v1/sessions",
+    get: (id) => ({
+      method: "GET",
+      url: `https://api.steel.dev/v1/sessions/${encodeURIComponent(id)}`,
+    }),
+    end: (id) => ({
+      method: "POST",
+      url: `https://api.steel.dev/v1/sessions/${encodeURIComponent(id)}/release`,
+    }),
   },
   anchor: {
     displayName: "Anchor Browser",
@@ -253,8 +315,19 @@ const PROVIDERS = Object.freeze({
       body: (sessionOptions) => sessionOptions,
     },
     headers: (apiKey) => ({ "anchor-api-key": apiKey }),
-    pick: (data) => takeString(data?.data?.cdp_url, data?.cdp_url),
-    id: (data) => takeString(data?.data?.id, data?.id),
+    pick: (data) => takeString(data?.data?.cdp_url, data?.cdp_url, data?.data?.cdpUrl),
+    id: (data) => takeString(data?.data?.id, data?.id, data?.data?.session_id),
+    liveView: (data) =>
+      takeString(data?.data?.live_view_url, data?.live_view_url, data?.data?.liveViewUrl),
+    list: "https://api.anchorbrowser.io/api/v1/sessions",
+    get: (id) => ({
+      method: "GET",
+      url: `https://api.anchorbrowser.io/api/v1/sessions/${encodeURIComponent(id)}`,
+    }),
+    end: (id) => ({
+      method: "DELETE",
+      url: `https://api.anchorbrowser.io/api/v1/sessions/${encodeURIComponent(id)}`,
+    }),
   },
   hyperbrowser: {
     displayName: "Hyperbrowser",
@@ -266,8 +339,14 @@ const PROVIDERS = Object.freeze({
       body: (sessionOptions) => sessionOptions,
     },
     headers: (apiKey) => ({ "x-api-key": apiKey }),
-    pick: (data) => takeString(data?.wsEndpoint, data?.ws_endpoint),
+    pick: (data) => takeString(data?.wsEndpoint, data?.ws_endpoint, data?.wsUrl),
     id: (data) => takeString(data?.id, data?.sessionId),
+    liveView: (data) => takeString(data?.liveUrl, data?.live_url, data?.liveViewUrl),
+    list: "https://api.hyperbrowser.ai/api/sessions",
+    get: (id) => ({
+      method: "GET",
+      url: `https://api.hyperbrowser.ai/api/session/${encodeURIComponent(id)}`,
+    }),
     end: (id) => ({
       method: "POST",
       url: `https://api.hyperbrowser.ai/api/session/${encodeURIComponent(id)}/stop`,
@@ -335,10 +414,23 @@ const PROVIDERS = Object.freeze({
 
 export const BROWSER_PROVIDER_NAMES = Object.freeze(Object.keys(PROVIDERS));
 
+export const REST_BROWSER_PROVIDER_NAMES = Object.freeze(
+  BROWSER_PROVIDER_NAMES.filter((name) => providerLifecycleKind(PROVIDERS[name]) === "rest"),
+);
+
+function providerLifecycleKind(descriptor): "rest" | "connect" {
+  return descriptor.list && descriptor.get && descriptor.end ? "rest" : "connect";
+}
+
 export function browserProviderInfo(name) {
   const descriptor = PROVIDERS[String(name || "").trim().toLowerCase()];
   return descriptor
-    ? { name: descriptor.displayName, docs: descriptor.docs, keyEnv: descriptor.keyEnv }
+    ? {
+        name: descriptor.displayName,
+        docs: descriptor.docs,
+        keyEnv: descriptor.keyEnv,
+        lifecycle: providerLifecycleKind(descriptor),
+      }
     : null;
 }
 
@@ -470,6 +562,41 @@ function resolveNamedProvider(descriptor, name, provider, env) {
   const sessionOptions = isSessionOptionsObject(provider.sessionOptions)
     ? provider.sessionOptions
     : {};
+  const sessionId = takeString(
+    untrustedField(sessionOptions, "sessionId"),
+    untrustedField(sessionOptions, "id"),
+  );
+  // Pinning an already-created box: GET the session and attach, so launch
+  // does not mint a second billed browser. Steel's connect URL can also
+  // carry sessionId; REST attach is used when the provider has a get
+  // endpoint so a missing id fails here instead of at the WebSocket.
+  if (sessionId && descriptor.get) {
+    return {
+      kind: "remote",
+      provider: name,
+      apiKey,
+      create: ({ fetchJson }: any = {}) =>
+        attachNamedSession(descriptor, name, apiKey, sessionId, fetchJson),
+      warnings: remoteWarnings(descriptor.displayName, Boolean(descriptor.end)),
+    };
+  }
+  if (descriptor.staticEndpoint) {
+    const endpoint = wssUrl(
+      descriptor.staticEndpoint({ apiKey, sessionOptions }),
+      `the ${name} provider endpoint`,
+    );
+    return {
+      kind: "remote",
+      provider: name,
+      apiKey,
+      cdpUrl: endpoint.href,
+      endpointLabel: describeCdpUrl(endpoint),
+      headers: {},
+      sessionId: sessionId,
+      end: null,
+      warnings: remoteWarnings(descriptor.displayName, null),
+    };
+  }
   if (descriptor.request) {
     // Deferred: the session is minted when the browser actually launches, so
     // a failed client construction never leaves a billed session behind.
@@ -482,21 +609,7 @@ function resolveNamedProvider(descriptor, name, provider, env) {
       warnings: remoteWarnings(descriptor.displayName, Boolean(descriptor.end)),
     };
   }
-  const endpoint = wssUrl(
-    descriptor.staticEndpoint({ apiKey, sessionOptions }),
-    `the ${name} provider endpoint`,
-  );
-  return {
-    kind: "remote",
-    provider: name,
-    apiKey,
-    cdpUrl: endpoint.href,
-    endpointLabel: describeCdpUrl(endpoint),
-    headers: {},
-    sessionId: "",
-    end: null,
-    warnings: remoteWarnings(descriptor.displayName, null),
-  };
+  throw new TypeError(`The ${descriptor.displayName} provider has no connect URL or session API.`);
 }
 
 // A descriptor's request.body is either a literal payload or a builder fed
@@ -516,15 +629,39 @@ async function createNamedSession(descriptor, name, apiKey, sessionOptions, fetc
     headers,
     body,
   });
+  return sessionPlanFromPayload(descriptor, name, apiKey, data, fetchJson);
+}
+
+async function attachNamedSession(descriptor, name, apiKey, sessionId, fetchJson) {
+  const data = await fetchProviderRecord(descriptor, name, apiKey, sessionId, fetchJson);
+  const plan = await sessionPlanFromPayload(descriptor, name, apiKey, data, fetchJson);
+  if (!plan.sessionId) plan.sessionId = sessionId;
+  return plan;
+}
+
+async function fetchProviderRecord(descriptor, name, apiKey, sessionId, fetchJson) {
+  if (!descriptor.get) {
+    throw new Error(`${descriptor.displayName} has no session-lookup API.`);
+  }
+  const headers = descriptor.headers ? descriptor.headers(apiKey) : {};
+  const request = descriptor.get(sessionId);
+  return httpJson(fetchJson, request.method, request.url, {
+    headers,
+    body: request.body,
+  });
+}
+
+async function sessionPlanFromPayload(descriptor, name, apiKey, data, fetchJson) {
+  const box = providerBoxFromPayload(descriptor, name, apiKey, data);
   const endpoint = wssUrl(
-    requireStringField(descriptor.pick(data), "a CDP WebSocket URL", descriptor.displayName),
+    requireStringField(box.cdpUrl, "a CDP WebSocket URL", descriptor.displayName),
     `the ${name} CDP URL`,
   );
-  const sessionId = descriptor.id ? takeString(descriptor.id(data)) : "";
+  const headers = descriptor.headers ? descriptor.headers(apiKey) : {};
   const end =
-    descriptor.end && sessionId
+    descriptor.end && box.id
       ? async () => {
-          const stop = descriptor.end(sessionId);
+          const stop = descriptor.end(box.id);
           await httpJson(fetchJson, stop.method, stop.url, {
             headers,
             body: stop.body,
@@ -538,10 +675,184 @@ async function createNamedSession(descriptor, name, apiKey, sessionOptions, fetc
     cdpUrl: endpoint.href,
     endpointLabel: describeCdpUrl(endpoint),
     headers: {},
-    sessionId,
+    sessionId: box.id,
     end,
     warnings: remoteWarnings(descriptor.displayName, Boolean(end)),
   };
+}
+
+function namedProvider(name) {
+  const key = String(name || "").trim().toLowerCase();
+  const descriptor = PROVIDERS[key];
+  if (!descriptor) {
+    throw new TypeError(
+      `Unknown browser provider ${JSON.stringify(name)}. Supported: ` +
+        `${BROWSER_PROVIDER_NAMES.join(", ")}.`,
+    );
+  }
+  return { name: key, descriptor };
+}
+
+function requireRestProvider(name) {
+  const { name: key, descriptor } = namedProvider(name);
+  if (providerLifecycleKind(descriptor) !== "rest") {
+    throw new Error(connectOnlyLifecycleMessage(descriptor, key));
+  }
+  return { name: key, descriptor };
+}
+
+function connectOnlyLifecycleMessage(descriptor, name) {
+  return (
+    `${descriptor.displayName} has no managed sessions to start or stop. ` +
+    "Its browsers exist only for the duration of a WebSocket connection " +
+    `(connect with \`betterwright run --browser ${name}\` after saving the ` +
+    `key via \`betterwright configure --connect ${name}\`).`
+  );
+}
+
+function listSessionRecords(data: UntrustedValue): UntrustedValue[] {
+  if (Array.isArray(data)) return data;
+  if (!isRecord(data)) return [];
+  for (const key of ["sessions", "browsers", "data", "items"]) {
+    const value = untrustedField(data, key);
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function withStatusQuery(url, status) {
+  const wanted = takeString(status);
+  if (!wanted) return url;
+  const parsed = new URL(url);
+  parsed.searchParams.set("status", wanted);
+  return parsed.href;
+}
+
+function boxCdpUrl(descriptor, name, apiKey, data, id) {
+  if (name === "steel" && id && descriptor.staticEndpoint) {
+    return takeString(descriptor.staticEndpoint({ apiKey, sessionOptions: { sessionId: id } }));
+  }
+  return descriptor.pick ? takeString(descriptor.pick(data)) : "";
+}
+
+function boxStatus(data) {
+  const nested = isRecord(untrustedField(data, "data")) ? untrustedField(data, "data") : data;
+  return takeString(untrustedField(nested, "status"), untrustedField(nested, "state"));
+}
+
+/** One cloud browser box, parsed from a provider create/list/get payload. */
+export interface ProviderBox {
+  provider: string;
+  id: string;
+  status: string;
+  cdpUrl: string;
+  liveViewUrl: string;
+  endpointLabel: string;
+}
+
+function providerBoxFromPayload(descriptor, name, apiKey, data): ProviderBox {
+  const id = descriptor.id ? takeString(descriptor.id(data)) : "";
+  const cdpUrl = boxCdpUrl(descriptor, name, apiKey, data, id);
+  const liveViewUrl = descriptor.liveView ? takeString(descriptor.liveView(data)) : "";
+  let endpointLabel = "";
+  if (cdpUrl) {
+    try {
+      endpointLabel = describeCdpUrl(wssUrl(cdpUrl, `the ${name} CDP URL`));
+    } catch {
+      endpointLabel = describeCdpUrl(cdpUrl);
+    }
+  }
+  return {
+    provider: name,
+    id,
+    status: boxStatus(data),
+    cdpUrl,
+    liveViewUrl,
+    endpointLabel,
+  };
+}
+
+function authHeaders(descriptor, apiKey) {
+  return descriptor.headers ? descriptor.headers(apiKey) : {};
+}
+
+/**
+ * Create a managed box on a REST-lifecycle provider. Steel and Browser Use
+ * launch via a connect URL; this is the Sessions/browsers API used by
+ * `betterwright boxes start`.
+ */
+export async function createProviderSession(
+  name,
+  { apiKey, sessionOptions = {}, fetchJson }: any = {},
+): Promise<ProviderBox> {
+  const { name: key, descriptor } = requireRestProvider(name);
+  if (!descriptor.request) {
+    throw new Error(connectOnlyLifecycleMessage(descriptor, key));
+  }
+  const request = descriptor.request;
+  const headers = authHeaders(descriptor, apiKey);
+  const body = isSessionBodyBuilder(request.body) ? request.body(sessionOptions) : request.body;
+  const data = await httpJson(fetchJson, request.method, request.url, { headers, body });
+  const box = providerBoxFromPayload(descriptor, key, apiKey, data);
+  if (!box.id) {
+    throw new Error(`The ${descriptor.displayName} create-browser response did not include a session id.`);
+  }
+  return box;
+}
+
+/** List boxes on a REST-lifecycle provider. */
+export async function listProviderSessions(
+  name,
+  { apiKey, status, fetchJson }: any = {},
+): Promise<ProviderBox[]> {
+  const { name: key, descriptor } = requireRestProvider(name);
+  const headers = authHeaders(descriptor, apiKey);
+  const data = await httpJson(fetchJson, "GET", withStatusQuery(descriptor.list, status), {
+    headers,
+    body: undefined,
+  });
+  return listSessionRecords(data)
+    .map((entry) => providerBoxFromPayload(descriptor, key, apiKey, entry))
+    .filter((box) => box.id);
+}
+
+/** Fetch one box by id. */
+export async function getProviderSession(
+  name,
+  id,
+  { apiKey, fetchJson }: any = {},
+): Promise<ProviderBox> {
+  const { name: key, descriptor } = requireRestProvider(name);
+  const sessionId = takeString(id);
+  if (!sessionId) {
+    throw new TypeError("A session id is required.");
+  }
+  const data = await fetchProviderRecord(descriptor, key, apiKey, sessionId, fetchJson);
+  const box = providerBoxFromPayload(descriptor, key, apiKey, data);
+  if (!box.id) box.id = sessionId;
+  return box;
+}
+
+/** Stop/release a box so the provider stops billing it. */
+export async function stopProviderSession(
+  name,
+  id,
+  { apiKey, fetchJson }: any = {},
+): Promise<{ provider: string; id: string }> {
+  const { name: key, descriptor } = requireRestProvider(name);
+  const sessionId = takeString(id);
+  if (!sessionId) {
+    throw new TypeError("A session id is required.");
+  }
+  if (!descriptor.end) {
+    throw new Error(connectOnlyLifecycleMessage(descriptor, key));
+  }
+  const stop = descriptor.end(sessionId);
+  await httpJson(fetchJson, stop.method, stop.url, {
+    headers: authHeaders(descriptor, apiKey),
+    body: stop.body,
+  });
+  return { provider: key, id: sessionId };
 }
 
 /**

--- a/src/browser-providers.ts
+++ b/src/browser-providers.ts
@@ -108,10 +108,13 @@ function isLoopbackHost(hostname) {
 
 // Test seam: a fetchJson hook stands in for global fetch, receiving the same
 // request and resolving with the parsed body, so tests never touch the network.
-type FetchJsonHook = (
-  url: string,
-  request: { method: string; headers: Record<string, string>; body?: UntrustedValue },
-) => Promise<UntrustedValue>;
+interface ProviderHttpRequest {
+  method: string;
+  headers: Record<string, string>;
+  body?: UntrustedValue;
+}
+
+type FetchJsonHook = (url: string, request: ProviderHttpRequest) => Promise<UntrustedValue>;
 
 function isFetchJsonHook(value: UntrustedValue): value is FetchJsonHook {
   return isCallable(value);
@@ -119,11 +122,7 @@ function isFetchJsonHook(value: UntrustedValue): value is FetchJsonHook {
 
 async function httpJson(fetchJson, method, url, { headers, body }) {
   if (isFetchJsonHook(fetchJson)) {
-    const request: {
-      method: string;
-      headers: Record<string, string>;
-      body?: UntrustedValue;
-    } = { method, headers };
+    const request: ProviderHttpRequest = { method, headers };
     if (body !== undefined) request.body = body;
     return fetchJson(url, request);
   }
@@ -633,13 +632,13 @@ async function createNamedSession(descriptor, name, apiKey, sessionOptions, fetc
 }
 
 async function attachNamedSession(descriptor, name, apiKey, sessionId, fetchJson) {
-  const data = await fetchProviderRecord(descriptor, name, apiKey, sessionId, fetchJson);
+  const data = await fetchProviderRecord(descriptor, apiKey, sessionId, fetchJson);
   const plan = await sessionPlanFromPayload(descriptor, name, apiKey, data, fetchJson);
   if (!plan.sessionId) plan.sessionId = sessionId;
   return plan;
 }
 
-async function fetchProviderRecord(descriptor, name, apiKey, sessionId, fetchJson) {
+async function fetchProviderRecord(descriptor, apiKey, sessionId, fetchJson) {
   if (!descriptor.get) {
     throw new Error(`${descriptor.displayName} has no session-lookup API.`);
   }
@@ -827,7 +826,7 @@ export async function getProviderSession(
   if (!sessionId) {
     throw new TypeError("A session id is required.");
   }
-  const data = await fetchProviderRecord(descriptor, key, apiKey, sessionId, fetchJson);
+  const data = await fetchProviderRecord(descriptor, apiKey, sessionId, fetchJson);
   const box = providerBoxFromPayload(descriptor, key, apiKey, data);
   if (!box.id) box.id = sessionId;
   return box;

--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -45,6 +45,8 @@ export const VALUE_FLAGS = new Set([
   // steel: the browser choice and its key are values, never positionals.
   "--browser",
   "--browser-key",
+  "--connect",
+  "--disconnect",
   "--category",
   "--delay",
   "--effort",
@@ -65,6 +67,14 @@ export const VALUE_FLAGS = new Set([
   "--query",
   "--reasoning",
   "--session",
+  "--session-id",
+  "--status",
+  "--key-env",
+  "--add",
+  "--remove",
+  "--cdp-url",
+  "--docs",
+  "--display-name",
   "--timezone",
   "--upstream-proxy",
 ]);

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -13,6 +13,7 @@ export const COMMAND_SUMMARIES = [
   ["update", "download or refresh the managed browser for this host"],
   ["doctor", "check that everything needed is installed and reachable"],
   ["configure", "choose the browser backend: cloud provider, custom CDP, or managed"],
+  ["boxes", "start, list, and stop cloud browser boxes"],
   ["run", "run one Playwright snippet in the persistent session"],
   ["repl", "run blank-line-separated snippets from stdin"],
   ["exec", "hand a whole task to BetterWright's own browser agent"],
@@ -92,6 +93,7 @@ Exit code is 0 when ready, 1 otherwise.`,
 
   configure: `Usage: betterwright configure
        betterwright configure --browser <name|wss-url|path> [--browser-key <key> | --key-env <NAME>]
+       betterwright configure --connect <name> [--browser-key <key> | --key-env <NAME>]
        betterwright configure --show [--json]
 
 Choose the browser every launch uses: the managed BetterChromium fork, a cloud
@@ -99,6 +101,10 @@ provider, any CDP endpoint, or your own Chromium binary. With no options on a
 terminal it walks you through the choices and offers to connect once; the flags
 do the same things without prompting. The choice is stored in the browser
 section of <BETTERWRIGHT_HOME>/config.json, written owner-only.
+
+--connect saves a provider API key without changing the launch default, so
+\`betterwright boxes\` can start/list/stop sessions on that account. Setting
+--browser <name> with a key also connects the account.
 
 Options:
   --show                 print the current setting (the default with no terminal)
@@ -112,6 +118,9 @@ Options:
   --key-env <NAME>       read that provider's API key from this environment
                          variable instead, so it never enters the file
                          (mutually exclusive with --browser-key)
+  --connect <name>       save that built-in provider's key without making it
+                         the launch default (alias: \`configure connect <name>\`)
+  --disconnect <name>    forget a saved provider key (alias: disconnect)
   --managed, --reset     clear the default; launches use the managed fork again
   --add <name>           add a custom provider named <name>, with
     --cdp-url <template>   its connect URL, where \${apiKey} is replaced with
@@ -128,6 +137,27 @@ Precedence at launch: --browser / the provider option, then
 BETTERWRIGHT_CDP_URL, then this default, then the managed fork.
 Exit code is 0 on success, 1 on a bad value or a failed connection test.
 Details: docs/browser-providers.md`,
+
+  boxes: `Usage: betterwright boxes <command>
+
+  list [--browser <name>] [--status <s>]   boxes on a connected provider
+  start [--browser <name>]                 create a box (REST providers only)
+  show <id> [--browser <name>]             one box: status, live view, CDP
+  stop <id> [--browser <name>]             release a box so it stops billing
+
+Options:
+  --json                 machine-readable output
+  --browser <name>       which connected provider (kernel, browserbase, steel,
+                         anchor, hyperbrowser, browser-use)
+  --browser-key <key>    API key for this call only (not stored)
+  --key-env <NAME>       read the API key from this environment variable
+  --status <value>       passed through as the provider's list-status filter
+
+Connect a provider first:
+  betterwright configure --connect kernel --key-env KERNEL_API_KEY
+
+Browserless, Bright Data, and Oxylabs have no session lifecycle — they are
+connect-only. Details: docs/browser-providers.md`,
 
   run: `Usage: betterwright run -c "<javascript>"
        betterwright run <file>
@@ -161,6 +191,8 @@ Options:
   --browser-key <key>    provider API key (or its env var, e.g.
                          BROWSERBASE_API_KEY); BETTERWRIGHT_CDP_URL is the
                          env shorthand for --browser <url>
+  --session-id <id>      attach to an existing cloud box instead of minting a
+                         new one (REST providers and Steel)
 
 Network:
   --block-private-network   --block-loopback
@@ -279,6 +311,8 @@ environment; see SETUP.md §6.`,
 
   exec: null, // EXEC_USAGE lives in the bin entrypoint beside its flag parsing
 };
+
+export const BOXES_USAGE = COMMAND_HELP.boxes;
 
 /** Help text for a command, or the main usage when there is nothing specific. */
 export function helpFor(command) {

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -23,9 +23,12 @@ import {
   type DefaultBrowserRef,
   expandProviderChoice,
   loadBrowserConfig,
+  type ProviderAccount,
   removeCustomProvider,
+  removeProviderAccount,
   saveCustomProvider,
   saveDefaultBrowser,
+  saveProviderAccount,
 } from "./browser-config.js";
 import {
   BROWSER_PROVIDER_NAMES,
@@ -33,7 +36,7 @@ import {
   describeCdpUrl,
   resolveBrowserProvider,
 } from "./browser-providers.js";
-import { flagValue } from "./cli-flags.js";
+import { flagValue, positionalArgs } from "./cli-flags.js";
 import { type CliPaint, cliPaint, paintedError, paintedLog } from "./cli-theme.js";
 import { defaultHome } from "./home.js";
 import { isCallable } from "./untrusted-value.js";
@@ -95,9 +98,29 @@ function describeCustomProvider(name, definition: CustomProviderDefinition, env)
   return `${label}: ${describeCdpUrl(definition.cdpUrl)}, ${key}`;
 }
 
+function describeAccount(name, account: ProviderAccount, env) {
+  const info = browserProviderInfo(name);
+  const label = info?.name || name;
+  const keyEnv = account.keyEnv || info?.keyEnv;
+  const key = account.apiKey
+    ? "API key stored in the config file"
+    : keyEnv
+      ? `API key from ${keyEnv} (${envKeyState(env, keyEnv)})`
+      : "no API key configured";
+  const lifecycle = info?.lifecycle === "rest" ? "boxes: start/list/stop" : "connect-only";
+  return `${label} (${name}): ${key} · ${lifecycle}`;
+}
+
 function summaryLines(config, env, home) {
   const lines = [`  Config file: ${browserConfigPath(home)}`];
   lines.push(`  Default:     ${describeDefaultBrowser(config.default, { env, custom: config.custom })}`);
+  const accountNames = Object.keys(config.accounts);
+  if (accountNames.length) {
+    lines.push("  Connected:");
+    for (const name of accountNames) {
+      lines.push(`    · ${describeAccount(name, config.accounts[name], env)}`);
+    }
+  }
   const names = Object.keys(config.custom);
   if (names.length) {
     lines.push("  Custom providers:");
@@ -146,11 +169,16 @@ function showConfig({ home, env, log, json, paint }) {
     for (const [name, definition] of Object.entries(config.custom)) {
       custom[name] = maskEntry(definition, env);
     }
+    const accounts: Record<string, MaskedBrowserEntry> = {};
+    for (const [name, account] of Object.entries(config.accounts)) {
+      accounts[name] = maskEntry({ provider: name, ...account }, env);
+    }
     log(
       JSON.stringify(
         {
           file: browserConfigPath(home),
           default: config.default ? maskEntry(config.default, env) : null,
+          accounts,
           custom,
         },
         null,
@@ -314,7 +342,12 @@ function menuChoices(config: BrowserFileConfig): ConfigureChoice[] {
   ];
   for (const name of BROWSER_PROVIDER_NAMES) {
     const info = browserProviderInfo(name);
-    choices.push({ kind: "provider", name, label: `${info.name} (${name})` });
+    if (!info) continue;
+    choices.push({
+      kind: "provider",
+      name,
+      label: `${info.name} (${name}) — ${info.lifecycle === "rest" ? "boxes" : "connect-only"}`,
+    });
   }
   for (const [name, definition] of Object.entries(config.custom)) {
     choices.push({
@@ -376,7 +409,9 @@ async function chooseBuiltInProvider(prompt, choice, { home, env, log }) {
     keyEnv: info.keyEnv,
   });
   saveDefaultBrowser({ provider: choice.name, ...source }, home);
+  saveProviderAccount(choice.name, source, home);
   log(`  ✓ Default browser: ${info.name} (${choice.name}).`);
+  log(`    Connected for \`betterwright boxes\` too.`);
   if (info.docs) log(`    Docs: ${info.docs}`);
   return true;
 }
@@ -519,13 +554,27 @@ export async function runConfigure(argv: string[] = [], options: any = {}) {
   const browser = flagValue(argv, "--browser");
   const add = flagValue(argv, "--add");
   const remove = flagValue(argv, "--remove");
+  const positionals = positionalArgs(argv);
+  const connectName = trimmed(
+    flagValue(argv, "--connect") ?? (positionals[0] === "connect" ? positionals[1] : undefined),
+  ).toLowerCase();
+  const disconnectName = trimmed(
+    flagValue(argv, "--disconnect") ??
+      (positionals[0] === "disconnect" ? positionals[1] : undefined),
+  ).toLowerCase();
   const managed = hasFlag(argv, "--managed") || hasFlag(argv, "--reset");
   const wantsTest = hasFlag(argv, "--test");
   const wantsJson = hasFlag(argv, "--json");
   const wantsShow = hasFlag(argv, "--show");
-  const acts = managed || [browser, add, remove].some((value) => value !== undefined);
+  const acts =
+    managed ||
+    Boolean(connectName) ||
+    Boolean(disconnectName) ||
+    [browser, add, remove].some((value) => value !== undefined);
   if (!acts && (apiKey !== undefined || keyEnv !== undefined)) {
-    fail("--browser-key and --key-env set the key for --browser or --add; neither was given.");
+    fail(
+      "--browser-key and --key-env set the key for --browser, --add, or --connect; none of those was given.",
+    );
     return 1;
   }
 
@@ -546,6 +595,29 @@ export async function runConfigure(argv: string[] = [], options: any = {}) {
   }
 
   try {
+    if (disconnectName) {
+      log(
+        removeProviderAccount(disconnectName, home)
+          ? `✓ Disconnected ${disconnectName}. The key is no longer in the config file.`
+          : `· No connected provider named "${disconnectName}".`,
+      );
+    }
+    if (connectName) {
+      const account: ProviderAccount = {};
+      if (keyEnv) account.keyEnv = keyEnv;
+      if (apiKey) account.apiKey = apiKey;
+      const saved = saveProviderAccount(connectName, account, home);
+      const info = browserProviderInfo(saved.name);
+      log(
+        `✓ Connected ${info?.name || saved.name} (${saved.name}). ` +
+          (account.apiKey
+            ? "API key stored in the config file."
+            : `API key from ${account.keyEnv}.`) +
+          (info?.lifecycle === "rest"
+            ? ` Manage boxes with \`betterwright boxes list --browser ${saved.name}\`.`
+            : " This provider is connect-only — there are no boxes to start or stop."),
+      );
+    }
     if (remove !== undefined) {
       const name = trimmed(remove).toLowerCase();
       log(
@@ -576,6 +648,9 @@ export async function runConfigure(argv: string[] = [], options: any = {}) {
     } else if (browser !== undefined) {
       const ref = defaultRefFromValue(browser, { apiKey, keyEnv });
       saveDefaultBrowser(ref, home);
+      if (ref.provider && BROWSER_PROVIDER_NAMES.includes(ref.provider) && (ref.apiKey || ref.keyEnv)) {
+        saveProviderAccount(ref.provider, { apiKey: ref.apiKey, keyEnv: ref.keyEnv }, home);
+      }
       log(`✓ Default browser: ${describeDefaultBrowser(ref, { env, custom: loadBrowserConfig(home).custom })}`);
     }
   } catch (error) {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,8 +13,13 @@ import { isCallable } from "./untrusted-value.js";
 export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
 export {
   BROWSER_PROVIDER_NAMES,
+  REST_BROWSER_PROVIDER_NAMES,
   browserProviderInfo,
+  createProviderSession,
   describeCdpUrl,
+  getProviderSession,
+  listProviderSessions,
+  stopProviderSession,
 } from "./browser-providers.js";
 export {
   BetterWright,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,12 +13,12 @@ import { isCallable } from "./untrusted-value.js";
 export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
 export {
   BROWSER_PROVIDER_NAMES,
-  REST_BROWSER_PROVIDER_NAMES,
   browserProviderInfo,
   createProviderSession,
   describeCdpUrl,
   getProviderSession,
   listProviderSessions,
+  REST_BROWSER_PROVIDER_NAMES,
   stopProviderSession,
 } from "./browser-providers.js";
 export {

--- a/tests/node/boxes.test.ts
+++ b/tests/node/boxes.test.ts
@@ -5,17 +5,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { runBoxesCommand } from "../../dist/src/boxes-cli.js";
 import { loadBrowserConfig } from "../../dist/src/browser-config.js";
 import {
-  REST_BROWSER_PROVIDER_NAMES,
   browserProviderInfo,
   createProviderSession,
   getProviderSession,
   listProviderSessions,
+  REST_BROWSER_PROVIDER_NAMES,
   resolveBrowserProvider,
   stopProviderSession,
 } from "../../dist/src/browser-providers.js";
-import { runBoxesCommand } from "../../dist/src/boxes-cli.js";
 import { runConfigure } from "../../dist/src/configure.js";
 import {
   createProviderApiMock,

--- a/tests/node/boxes.test.ts
+++ b/tests/node/boxes.test.ts
@@ -298,6 +298,7 @@ test("kernel --session-id attaches via GET instead of minting", async () => {
     { provider: "kernel", apiKey: MOCK_PROVIDER_KEYS.kernel, sessionOptions: { sessionId: created.id } },
     { env: {} },
   );
+  assert.match(resolved.plan.warnings.join("\n"), /keep running \(and billing\)/);
   const plan = await resolved.plan.create({ fetchJson: api.fetchJson });
   assert.equal(plan.sessionId, created.id);
   assert.equal(plan.cdpUrl, "wss://onkernel.example/devtools/existing");
@@ -306,6 +307,49 @@ test("kernel --session-id attaches via GET instead of minting", async () => {
     `https://api.onkernel.com/browsers/${created.id}`,
   );
   assert.equal(api.calls.at(-1).method, "GET");
+  // Attach must not inherit the mint-on-launch stop callback: the worker
+  // calls plan.end on CDP connect failure and on context close.
+  assert.equal(plan.end, null);
+  assert.match(plan.warnings.join("\n"), /keep running \(and billing\)/);
+  const callsAfterAttach = api.calls.length;
+  if (plan.end) await plan.end();
+  assert.equal(api.calls.length, callsAfterAttach);
+  assert.equal(
+    api.calls.some((call) => call.method === "DELETE"),
+    false,
+  );
+  const stillThere = await getProviderSession("kernel", created.id, {
+    apiKey: MOCK_PROVIDER_KEYS.kernel,
+    fetchJson: api.fetchJson,
+  });
+  assert.equal(stillThere.id, created.id);
+  assert.equal(stillThere.status, "active");
+});
+
+test("steel --session-id attach does not release the box on close", async () => {
+  const api = createProviderApiMock();
+  const created = api.mint("steel", {
+    status: "live",
+    sessionViewerUrl: "https://app.steel.dev/sessions/existing",
+  });
+  const resolved = resolveBrowserProvider(
+    { provider: "steel", apiKey: MOCK_PROVIDER_KEYS.steel, sessionOptions: { sessionId: created.id } },
+    { env: {} },
+  );
+  const plan = await resolved.plan.create({ fetchJson: api.fetchJson });
+  assert.equal(plan.sessionId, created.id);
+  assert.equal(plan.end, null);
+  assert.match(plan.warnings.join("\n"), /keep running \(and billing\)/);
+  if (plan.end) await plan.end();
+  assert.equal(
+    api.calls.some((call) => String(call.url).endsWith("/release")),
+    false,
+  );
+  const stillThere = await getProviderSession("steel", created.id, {
+    apiKey: MOCK_PROVIDER_KEYS.steel,
+    fetchJson: api.fetchJson,
+  });
+  assert.equal(stillThere.id, created.id);
 });
 
 test("steel launch without a session id still uses the connect URL", () => {

--- a/tests/node/boxes.test.ts
+++ b/tests/node/boxes.test.ts
@@ -1,0 +1,503 @@
+// Cloud box management: configure --connect saves a mock API key, then
+// `boxes start/list/show/stop` drive a simulated REST API for every
+// lifecycle provider. No sockets, no real credentials.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadBrowserConfig } from "../../dist/src/browser-config.js";
+import {
+  REST_BROWSER_PROVIDER_NAMES,
+  browserProviderInfo,
+  createProviderSession,
+  getProviderSession,
+  listProviderSessions,
+  resolveBrowserProvider,
+  stopProviderSession,
+} from "../../dist/src/browser-providers.js";
+import { runBoxesCommand } from "../../dist/src/boxes-cli.js";
+import { runConfigure } from "../../dist/src/configure.js";
+import {
+  createProviderApiMock,
+  MOCK_PROVIDER_KEYS,
+} from "./helpers/provider-api-mock.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+function recorder() {
+  const out = [];
+  const err = [];
+  return {
+    out,
+    err,
+    log: (line) => out.push(String(line)),
+    error: (line) => err.push(String(line)),
+    stdout: () => out.join("\n"),
+    stderr: () => err.join("\n"),
+  };
+}
+
+async function connect(home, provider, key) {
+  const io = recorder();
+  const code = await runConfigure(["--connect", provider, "--browser-key", key], {
+    home,
+    env: {},
+    ...io,
+  });
+  assert.equal(code, 0, io.stderr());
+  return io;
+}
+
+const REST = [
+  ["kernel", MOCK_PROVIDER_KEYS.kernel],
+  ["browserbase", MOCK_PROVIDER_KEYS.browserbase],
+  ["steel", MOCK_PROVIDER_KEYS.steel],
+  ["anchor", MOCK_PROVIDER_KEYS.anchor],
+  ["hyperbrowser", MOCK_PROVIDER_KEYS.hyperbrowser],
+  ["browser-use", MOCK_PROVIDER_KEYS["browser-use"]],
+];
+
+test("the six SDK-backed providers advertise REST lifecycle", () => {
+  assert.deepEqual([...REST_BROWSER_PROVIDER_NAMES], [
+    "browser-use",
+    "kernel",
+    "browserbase",
+    "steel",
+    "anchor",
+    "hyperbrowser",
+  ]);
+  for (const [name] of REST) {
+    assert.equal(browserProviderInfo(name).lifecycle, "rest");
+  }
+  for (const name of ["browserless", "brightdata", "oxylabs"]) {
+    assert.equal(browserProviderInfo(name).lifecycle, "connect");
+  }
+});
+
+test("configure --connect saves a key without changing the launch default", async () => {
+  const home = makeTempDir("bw-boxes-connect-");
+  const io = await connect(home, "kernel", MOCK_PROVIDER_KEYS.kernel);
+  assert.match(io.stdout(), /Connected Kernel \(kernel\)/);
+  assert.match(io.stdout(), /boxes list --browser kernel/);
+  const config = loadBrowserConfig(home);
+  assert.equal(config.default, undefined);
+  assert.deepEqual(config.accounts.kernel, { apiKey: MOCK_PROVIDER_KEYS.kernel });
+  assert.doesNotMatch(io.stdout(), new RegExp(MOCK_PROVIDER_KEYS.kernel));
+});
+
+test("configure --show --json masks connected keys", async () => {
+  const home = makeTempDir("bw-boxes-show-");
+  await connect(home, "steel", "super-secret-steel-key");
+  const io = recorder();
+  assert.equal(await runConfigure(["--show", "--json"], { home, env: {}, ...io }), 0);
+  const report = JSON.parse(io.stdout());
+  assert.equal(report.accounts.steel.apiKey, "***");
+  assert.doesNotMatch(io.stdout(), /super-secret-steel-key/);
+});
+
+test("configure --disconnect forgets a saved key", async () => {
+  const home = makeTempDir("bw-boxes-disc-");
+  await connect(home, "kernel", MOCK_PROVIDER_KEYS.kernel);
+  const io = recorder();
+  assert.equal(await runConfigure(["--disconnect", "kernel"], { home, env: {}, ...io }), 0);
+  assert.match(io.stdout(), /Disconnected kernel/);
+  assert.equal(loadBrowserConfig(home).accounts.kernel, undefined);
+});
+
+test("configure connect <name> positional form works", async () => {
+  const home = makeTempDir("bw-boxes-pos-");
+  const io = recorder();
+  assert.equal(
+    await runConfigure(["connect", "browserbase", "--key-env", "BROWSERBASE_API_KEY"], {
+      home,
+      env: { BROWSERBASE_API_KEY: MOCK_PROVIDER_KEYS.browserbase },
+      ...io,
+    }),
+    0,
+  );
+  assert.deepEqual(loadBrowserConfig(home).accounts.browserbase, {
+    keyEnv: "BROWSERBASE_API_KEY",
+  });
+});
+
+test("setting a named default with a key also connects the account", async () => {
+  const home = makeTempDir("bw-boxes-default-");
+  const io = recorder();
+  await runConfigure(["--browser", "hyperbrowser", "--browser-key", MOCK_PROVIDER_KEYS.hyperbrowser], {
+    home,
+    env: {},
+    ...io,
+  });
+  const config = loadBrowserConfig(home);
+  assert.equal(config.default.provider, "hyperbrowser");
+  assert.deepEqual(config.accounts.hyperbrowser, { apiKey: MOCK_PROVIDER_KEYS.hyperbrowser });
+});
+
+for (const [provider, key] of REST) {
+  test(`${provider}: connect, start, list, show, stop against a mock API`, async () => {
+    const home = makeTempDir(`bw-boxes-${provider}-`);
+    await connect(home, provider, key);
+    const api = createProviderApiMock();
+    const io = recorder();
+    const started = await runBoxesCommand(["start", "--browser", provider], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...io,
+    });
+    assert.equal(started, 0, io.stderr());
+    assert.match(io.stdout(), /Started/);
+    assert.doesNotMatch(io.stdout(), new RegExp(key));
+
+    const listed = recorder();
+    assert.equal(
+      await runBoxesCommand(["list", "--json", "--browser", provider], {
+        home,
+        env: {},
+        fetchJson: api.fetchJson,
+        ...listed,
+      }),
+      0,
+      listed.stderr(),
+    );
+    const list = JSON.parse(listed.stdout());
+    assert.equal(list.boxes.length, 1);
+    const id = list.boxes[0].id;
+    assert.ok(id);
+    assert.equal(list.boxes[0].provider, provider);
+    assert.doesNotMatch(listed.stdout(), new RegExp(key));
+    if (list.boxes[0].cdpUrl) {
+      assert.match(list.boxes[0].cdpUrl, /\*\*\*|wss:/);
+      assert.doesNotMatch(list.boxes[0].cdpUrl, new RegExp(key));
+    }
+
+    const shown = recorder();
+    assert.equal(
+      await runBoxesCommand(["show", id, "--browser", provider], {
+        home,
+        env: {},
+        fetchJson: api.fetchJson,
+        ...shown,
+      }),
+      0,
+      shown.stderr(),
+    );
+    assert.match(shown.stdout(), new RegExp(id));
+    assert.doesNotMatch(shown.stdout(), new RegExp(key));
+
+    const stopped = recorder();
+    assert.equal(
+      await runBoxesCommand(["stop", id, "--browser", provider], {
+        home,
+        env: {},
+        fetchJson: api.fetchJson,
+        ...stopped,
+      }),
+      0,
+      stopped.stderr(),
+    );
+    assert.match(stopped.stdout(), /Stopped/);
+
+    const empty = recorder();
+    assert.equal(
+      await runBoxesCommand(["list", "--json", "--browser", provider], {
+        home,
+        env: {},
+        fetchJson: api.fetchJson,
+        ...empty,
+      }),
+      0,
+    );
+    assert.equal(JSON.parse(empty.stdout()).boxes.length, 0);
+  });
+}
+
+test("a wrong mock key is refused with HTTP 401", async () => {
+  const home = makeTempDir("bw-boxes-401-");
+  await connect(home, "kernel", "k_wrong");
+  const api = createProviderApiMock();
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["start", "--browser", "kernel"], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...io,
+    }),
+    1,
+  );
+  assert.match(io.stderr(), /HTTP 401/);
+});
+
+test("connect-only providers cannot start or stop boxes", async () => {
+  for (const name of ["browserless", "brightdata", "oxylabs"]) {
+    const home = makeTempDir(`bw-boxes-${name}-`);
+    const key = name === "brightdata" ? "brd-customer-x-zone-y:pw" : name === "oxylabs" ? "user:pass" : "bl_token";
+    await connect(home, name, key);
+    const io = recorder();
+    assert.equal(
+      await runBoxesCommand(["start", "--browser", name], { home, env: {}, ...io }),
+      1,
+    );
+    assert.match(io.stderr(), /no managed sessions/);
+  }
+});
+
+test("boxes list without a provider walks every connected REST account", async () => {
+  const home = makeTempDir("bw-boxes-all-");
+  await connect(home, "kernel", MOCK_PROVIDER_KEYS.kernel);
+  await connect(home, "steel", MOCK_PROVIDER_KEYS.steel);
+  const api = createProviderApiMock();
+  await runBoxesCommand(["start", "--browser", "kernel"], {
+    home,
+    env: {},
+    fetchJson: api.fetchJson,
+    ...recorder(),
+  });
+  await runBoxesCommand(["start", "--browser", "steel"], {
+    home,
+    env: {},
+    fetchJson: api.fetchJson,
+    ...recorder(),
+  });
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["list", "--json"], { home, env: {}, fetchJson: api.fetchJson, ...io }),
+    0,
+    io.stderr(),
+  );
+  const boxes = JSON.parse(io.stdout()).boxes;
+  assert.equal(boxes.length, 2);
+  assert.deepEqual(boxes.map((box) => box.provider).sort(), ["kernel", "steel"]);
+});
+
+test("boxes start uses a well-known env var when nothing is saved", async () => {
+  const home = makeTempDir("bw-boxes-env-");
+  const api = createProviderApiMock();
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["start", "--browser", "kernel"], {
+      home,
+      env: { KERNEL_API_KEY: MOCK_PROVIDER_KEYS.kernel },
+      fetchJson: api.fetchJson,
+      ...io,
+    }),
+    0,
+    io.stderr(),
+  );
+  assert.match(io.stdout(), /Started Kernel box/);
+});
+
+test("kernel --session-id attaches via GET instead of minting", async () => {
+  const api = createProviderApiMock();
+  const created = api.mint("kernel", {
+    status: "active",
+    cdp_ws_url: "wss://onkernel.example/devtools/existing",
+    browser_live_view_url: "https://live.onkernel.example/existing",
+  });
+  const resolved = resolveBrowserProvider(
+    { provider: "kernel", apiKey: MOCK_PROVIDER_KEYS.kernel, sessionOptions: { sessionId: created.id } },
+    { env: {} },
+  );
+  const plan = await resolved.plan.create({ fetchJson: api.fetchJson });
+  assert.equal(plan.sessionId, created.id);
+  assert.equal(plan.cdpUrl, "wss://onkernel.example/devtools/existing");
+  assert.equal(
+    api.calls.at(-1).url,
+    `https://api.onkernel.com/browsers/${created.id}`,
+  );
+  assert.equal(api.calls.at(-1).method, "GET");
+});
+
+test("steel launch without a session id still uses the connect URL", () => {
+  const resolved = resolveBrowserProvider(
+    { provider: "steel", apiKey: MOCK_PROVIDER_KEYS.steel },
+    { env: {} },
+  );
+  assert.equal(resolved.plan.create, undefined);
+  assert.match(resolved.plan.cdpUrl, /^wss:\/\/connect\.steel\.dev\/\?apiKey=/);
+});
+
+test("boxes stop of an unknown id is a 404", async () => {
+  const home = makeTempDir("bw-boxes-404-");
+  await connect(home, "kernel", MOCK_PROVIDER_KEYS.kernel);
+  const api = createProviderApiMock();
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["stop", "missing", "--browser", "kernel"], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...io,
+    }),
+    1,
+  );
+  assert.match(io.stderr(), /HTTP 404/);
+});
+
+test("boxes without a subcommand prints usage", async () => {
+  const io = recorder();
+  assert.equal(await runBoxesCommand([], { ...io }), 1);
+  assert.match(io.stderr(), /Usage: betterwright boxes/);
+});
+
+test("an unknown boxes command prints usage", async () => {
+  const io = recorder();
+  assert.equal(await runBoxesCommand(["frobnicate"], { ...io }), 1);
+  assert.match(io.stderr(), /Unknown boxes command "frobnicate"/);
+});
+
+test("configure --connect without a key fails before writing", async () => {
+  const home = makeTempDir("bw-boxes-nokey-");
+  const io = recorder();
+  assert.equal(await runConfigure(["--connect", "kernel"], { home, env: {}, ...io }), 1);
+  assert.match(io.stderr(), /--browser-key/);
+  assert.deepEqual(loadBrowserConfig(home).accounts, {});
+});
+
+test("boxes start with no connected provider explains how to connect", async () => {
+  const home = makeTempDir("bw-boxes-none-");
+  const io = recorder();
+  assert.equal(await runBoxesCommand(["start"], { home, env: {}, ...io }), 1);
+  assert.match(io.stderr(), /No connected REST provider/);
+  assert.match(io.stderr(), /configure --connect/);
+});
+
+test("boxes start --json never includes the API key", async () => {
+  const home = makeTempDir("bw-boxes-json-");
+  await connect(home, "kernel", MOCK_PROVIDER_KEYS.kernel);
+  const api = createProviderApiMock();
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["start", "--json", "--browser", "kernel"], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...io,
+    }),
+    0,
+    io.stderr(),
+  );
+  const row = JSON.parse(io.stdout());
+  assert.equal(row.provider, "kernel");
+  assert.ok(row.id);
+  assert.match(row.cdpUrl, /wss:\/\//);
+  assert.doesNotMatch(io.stdout(), new RegExp(MOCK_PROVIDER_KEYS.kernel));
+  assert.equal(row.apiKey, undefined);
+});
+
+test("boxes list --status filters Browserbase sessions", async () => {
+  const home = makeTempDir("bw-boxes-status-");
+  await connect(home, "browserbase", MOCK_PROVIDER_KEYS.browserbase);
+  const api = createProviderApiMock();
+  assert.equal(
+    await runBoxesCommand(["start", "--browser", "browserbase"], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...recorder(),
+    }),
+    0,
+  );
+  const running = recorder();
+  assert.equal(
+    await runBoxesCommand(["list", "--json", "--browser", "browserbase", "--status", "RUNNING"], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...running,
+    }),
+    0,
+  );
+  assert.equal(JSON.parse(running.stdout()).boxes.length, 1);
+  const idle = recorder();
+  assert.equal(
+    await runBoxesCommand(["list", "--json", "--browser", "browserbase", "--status", "COMPLETED"], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...idle,
+    }),
+    0,
+  );
+  assert.equal(JSON.parse(idle.stdout()).boxes.length, 0);
+});
+
+test("boxes --browser-key overrides a saved wrong key", async () => {
+  const home = makeTempDir("bw-boxes-override-");
+  await connect(home, "kernel", "k_wrong");
+  const api = createProviderApiMock();
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["start", "--browser", "kernel", "--browser-key", MOCK_PROVIDER_KEYS.kernel], {
+      home,
+      env: {},
+      fetchJson: api.fetchJson,
+      ...io,
+    }),
+    0,
+    io.stderr(),
+  );
+  assert.match(io.stdout(), /Started Kernel box/);
+});
+
+test("boxes list of a connect-only provider is refused", async () => {
+  const home = makeTempDir("bw-boxes-list-co-");
+  await connect(home, "browserless", "bl_token");
+  const io = recorder();
+  assert.equal(
+    await runBoxesCommand(["list", "--browser", "browserless"], { home, env: {}, ...io }),
+    1,
+  );
+  assert.match(io.stderr(), /no managed sessions/);
+});
+
+test("boxes show and stop require an id", async () => {
+  const home = makeTempDir("bw-boxes-need-id-");
+  await connect(home, "kernel", MOCK_PROVIDER_KEYS.kernel);
+  const show = recorder();
+  assert.equal(await runBoxesCommand(["show"], { home, env: {}, ...show }), 1);
+  assert.match(show.stderr(), /boxes show <id>/);
+  const stop = recorder();
+  assert.equal(await runBoxesCommand(["stop"], { home, env: {}, ...stop }), 1);
+  assert.match(stop.stderr(), /boxes stop <id>/);
+});
+
+test("SDK session helpers round-trip every REST provider against the mock API", async () => {
+  for (const [provider, key] of REST) {
+    const api = createProviderApiMock();
+    const created = await createProviderSession(provider, {
+      apiKey: key,
+      fetchJson: api.fetchJson,
+    });
+    assert.ok(created.id, `${provider} create returned no id`);
+    assert.equal(created.provider, provider);
+    const listed = await listProviderSessions(provider, {
+      apiKey: key,
+      fetchJson: api.fetchJson,
+    });
+    assert.equal(listed.length, 1, `${provider} list`);
+    assert.equal(listed[0].id, created.id);
+    const shown = await getProviderSession(provider, created.id, {
+      apiKey: key,
+      fetchJson: api.fetchJson,
+    });
+    assert.equal(shown.id, created.id);
+    const stopped = await stopProviderSession(provider, created.id, {
+      apiKey: key,
+      fetchJson: api.fetchJson,
+    });
+    assert.deepEqual(stopped, { provider, id: created.id });
+    assert.equal(
+      (await listProviderSessions(provider, { apiKey: key, fetchJson: api.fetchJson })).length,
+      0,
+      `${provider} list after stop`,
+    );
+  }
+});
+
+test("SDK helpers refuse connect-only providers", async () => {
+  await assert.rejects(
+    () => createProviderSession("browserless", { apiKey: "tok" }),
+    /no managed sessions/,
+  );
+});

--- a/tests/node/browser-config.test.ts
+++ b/tests/node/browser-config.test.ts
@@ -9,8 +9,11 @@ import {
   expandProviderChoice,
   loadBrowserConfig,
   removeCustomProvider,
+  removeProviderAccount,
+  resolveConnectedProvider,
   saveCustomProvider,
   saveDefaultBrowser,
+  saveProviderAccount,
 } from "../../dist/src/browser-config.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
@@ -21,11 +24,11 @@ function writeConfig(home, config) {
 
 test("missing or malformed config reads as no defaults", () => {
   const home = makeTempDir("bw-config-");
-  assert.deepEqual(loadBrowserConfig(home), { custom: {} });
+  assert.deepEqual(loadBrowserConfig(home), { custom: {}, accounts: {} });
   fs.writeFileSync(browserConfigPath(home), "{not json");
-  assert.deepEqual(loadBrowserConfig(home), { custom: {} });
+  assert.deepEqual(loadBrowserConfig(home), { custom: {}, accounts: {} });
   fs.writeFileSync(browserConfigPath(home), JSON.stringify([1, 2]));
-  assert.deepEqual(loadBrowserConfig(home), { custom: {} });
+  assert.deepEqual(loadBrowserConfig(home), { custom: {}, accounts: {} });
 });
 
 test("load drops malformed defaults, bad names, and unknown keys", () => {
@@ -44,6 +47,78 @@ test("load drops malformed defaults, bad names, and unknown keys", () => {
   assert.equal(config.default, undefined);
   assert.deepEqual(Object.keys(config.custom), ["ok"]);
   assert.deepEqual(config.custom.ok, { cdpUrl: "wss://ok.example", keyEnv: "OK_KEY" });
+  assert.deepEqual(config.accounts, {});
+});
+
+test("load keeps well-formed accounts and drops unknown or empty ones", () => {
+  const home = makeTempDir("bw-config-accounts-");
+  writeConfig(home, {
+    browser: {
+      accounts: {
+        kernel: { apiKey: "kern_saved", surprise: true },
+        nope: { apiKey: "x" },
+        steel: {},
+        browserbase: { keyEnv: "BROWSERBASE_API_KEY" },
+      },
+    },
+  });
+  assert.deepEqual(loadBrowserConfig(home).accounts, {
+    kernel: { apiKey: "kern_saved" },
+    browserbase: { keyEnv: "BROWSERBASE_API_KEY" },
+  });
+});
+
+test("saveProviderAccount stores a key without changing the launch default", () => {
+  const home = makeTempDir("bw-config-save-account-");
+  saveProviderAccount("kernel", { apiKey: "kern_live_secret" }, home);
+  const loaded = loadBrowserConfig(home);
+  assert.equal(loaded.default, undefined);
+  assert.deepEqual(loaded.accounts, { kernel: { apiKey: "kern_live_secret" } });
+  const onDisk = JSON.parse(fs.readFileSync(browserConfigPath(home), "utf8"));
+  assert.equal(onDisk.browser.accounts.kernel.apiKey, "kern_live_secret");
+  const connected = resolveConnectedProvider("kernel", { home, env: {} });
+  assert.equal(connected.apiKey, "kern_live_secret");
+  assert.equal(connected.source, "account");
+  assert.equal(removeProviderAccount("kernel", home), true);
+  assert.deepEqual(loadBrowserConfig(home).accounts, {});
+  assert.equal(removeProviderAccount("kernel", home), false);
+});
+
+test("saveProviderAccount rejects unknown names and empty credentials", () => {
+  const home = makeTempDir("bw-config-account-validate-");
+  assert.throws(() => saveProviderAccount("nope", { apiKey: "x" }, home), /Unknown provider/);
+  assert.throws(() => saveProviderAccount("kernel", {}, home), /--browser-key/);
+});
+
+test("resolveConnectedProvider prefers --browser-key over a saved account and env", () => {
+  const home = makeTempDir("bw-config-resolve-");
+  saveProviderAccount("browserbase", { apiKey: "saved-bb" }, home);
+  const env = { BROWSERBASE_API_KEY: "env-bb" };
+  const fromFlag = resolveConnectedProvider("browserbase", {
+    home,
+    env,
+    apiKey: "flag-bb",
+  });
+  assert.equal(fromFlag.apiKey, "flag-bb");
+  assert.equal(fromFlag.source, "flag");
+  const fromSaved = resolveConnectedProvider("browserbase", { home, env: {} });
+  assert.equal(fromSaved.apiKey, "saved-bb");
+  assert.equal(fromSaved.source, "account");
+});
+
+test("resolveConnectedProvider reads the well-known env var when nothing is saved", () => {
+  const home = makeTempDir("bw-config-env-");
+  const connected = resolveConnectedProvider("hyperbrowser", {
+    home,
+    env: { HYPERBROWSER_API_KEY: "env-hb" },
+  });
+  assert.equal(connected.apiKey, "env-hb");
+  assert.equal(connected.source, "env");
+  assert.equal(connected.keyEnv, "HYPERBROWSER_API_KEY");
+  assert.throws(
+    () => resolveConnectedProvider("hyperbrowser", { home, env: {} }),
+    /No API key for Hyperbrowser/,
+  );
 });
 
 test("saveDefaultBrowser round-trips and preserves unrelated sections", () => {

--- a/tests/node/browser-providers.test.ts
+++ b/tests/node/browser-providers.test.ts
@@ -119,6 +119,7 @@ test("named providers need a key, from the option or their env var", () => {
     name: "Kernel",
     docs: "https://www.kernel.sh/docs",
     keyEnv: "KERNEL_API_KEY",
+    lifecycle: "rest",
   });
   assert.equal(browserProviderInfo("nope"), null);
 });
@@ -203,21 +204,24 @@ test("kernel and hyperbrowser mint CDP endpoints from their APIs", async () => {
   );
 });
 
-test("anchor reports the nested session fields", async () => {
+test("anchor reports the nested session fields and ends the session", async () => {
   const resolved = resolveBrowserProvider(
     { provider: "anchor", apiKey: "a" },
     { env: {} },
   );
+  const calls = [];
   const plan = await resolved.plan.create({
     fetchJson: async (url, init) => {
-      assert.equal(url, "https://api.anchorbrowser.io/api/v1/sessions");
-      assert.deepEqual(init.headers, { "anchor-api-key": "a" });
+      calls.push({ url, init });
       return { data: { id: "anch_1", cdp_url: "wss://anchor/x" } };
     },
   });
   assert.equal(plan.cdpUrl, "wss://anchor/x");
   assert.equal(plan.sessionId, "anch_1");
-  assert.equal(plan.end, null); // Anchor sessions end on disconnect.
+  assert.deepEqual(calls[0].init.headers, { "anchor-api-key": "a" });
+  await plan.end();
+  assert.equal(calls[1].url, "https://api.anchorbrowser.io/api/v1/sessions/anch_1");
+  assert.equal(calls[1].init.method, "DELETE");
 });
 
 test("a provider whose response lacks a CDP URL fails clearly", async () => {
@@ -243,13 +247,11 @@ test("browser-use, steel, and browserless mint the endpoint with no REST call", 
   assert.equal(bu.plan.create, undefined);
 
   const steel = resolveBrowserProvider(
-    { provider: "steel", apiKey: "st", sessionOptions: { sessionId: "s1" } },
+    { provider: "steel", apiKey: "st" },
     { env: {} },
   );
-  assert.equal(
-    steel.plan.cdpUrl,
-    "wss://connect.steel.dev/?apiKey=st&sessionId=s1",
-  );
+  assert.equal(steel.plan.cdpUrl, "wss://connect.steel.dev/?apiKey=st");
+  assert.equal(steel.plan.create, undefined);
 
   const bl = resolveBrowserProvider(
     { provider: "browserless", apiKey: "tok", sessionOptions: { blockAds: true } },
@@ -259,6 +261,25 @@ test("browser-use, steel, and browserless mint the endpoint with no REST call", 
     bl.plan.cdpUrl,
     "wss://production-sfo.browserless.io/chromium?token=tok&blockAds=true",
   );
+});
+
+test("steel sessionId attaches via GET then reconstructs the connect URL", async () => {
+  const resolved = resolveBrowserProvider(
+    { provider: "steel", apiKey: "st", sessionOptions: { sessionId: "s1" } },
+    { env: {} },
+  );
+  assert.ok(isCallable(resolved.plan.create));
+  const calls = [];
+  const plan = await resolved.plan.create({
+    fetchJson: async (url, init) => {
+      calls.push({ url, init });
+      return { id: "s1", status: "live", sessionViewerUrl: "https://app.steel.dev/sessions/s1" };
+    },
+  });
+  assert.equal(calls[0].url, "https://api.steel.dev/v1/sessions/s1");
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(plan.cdpUrl, "wss://connect.steel.dev/?apiKey=st&sessionId=s1");
+  assert.equal(plan.sessionId, "s1");
 });
 
 test("brightdata and oxylabs take userinfo credentials", () => {

--- a/tests/node/browser-providers.test.ts
+++ b/tests/node/browser-providers.test.ts
@@ -148,6 +148,11 @@ test("REST providers mint the session lazily at launch time", async () => {
   ]);
   assert.equal(plan.cdpUrl, "wss://connect.browserbase.com/devtools/abc");
   assert.equal(plan.sessionId, "sess_1");
+  assert.ok(isCallable(plan.end), "a minted Browserbase session is released on close");
+  assert.equal(
+    plan.warnings.some((warning) => /keep running \(and billing\)/.test(warning)),
+    false,
+  );
   // Releasing the session releases it on the provider, too.
   await plan.end();
   assert.equal(
@@ -179,6 +184,7 @@ test("kernel and hyperbrowser mint CDP endpoints from their APIs", async () => {
     },
   });
   assert.equal(kernelPlan.cdpUrl, "wss://onkernel.com/devtools/s9");
+  assert.ok(isCallable(kernelPlan.end), "a minted Kernel session is released on close");
   await kernelPlan.end();
   assert.equal(kernelCalls[1].url, "https://api.onkernel.com/browsers/s9");
   assert.equal(kernelCalls[1].init.method, "DELETE");
@@ -197,6 +203,7 @@ test("kernel and hyperbrowser mint CDP endpoints from their APIs", async () => {
   assert.equal(hyperCalls[0].url, "https://api.hyperbrowser.ai/api/session");
   assert.deepEqual(hyperCalls[0].init.headers, { "x-api-key": "h" });
   assert.equal(hyperPlan.cdpUrl, "wss://hyper/x");
+  assert.ok(isCallable(hyperPlan.end), "a minted Hyperbrowser session is stopped on close");
   await hyperPlan.end();
   assert.equal(
     hyperCalls[1].url,
@@ -219,6 +226,7 @@ test("anchor reports the nested session fields and ends the session", async () =
   assert.equal(plan.cdpUrl, "wss://anchor/x");
   assert.equal(plan.sessionId, "anch_1");
   assert.deepEqual(calls[0].init.headers, { "anchor-api-key": "a" });
+  assert.ok(isCallable(plan.end), "a minted Anchor session is deleted on close");
   await plan.end();
   assert.equal(calls[1].url, "https://api.anchorbrowser.io/api/v1/sessions/anch_1");
   assert.equal(calls[1].init.method, "DELETE");
@@ -280,6 +288,10 @@ test("steel sessionId attaches via GET then reconstructs the connect URL", async
   assert.equal(calls[0].init.method, "GET");
   assert.equal(plan.cdpUrl, "wss://connect.steel.dev/?apiKey=st&sessionId=s1");
   assert.equal(plan.sessionId, "s1");
+  assert.equal(plan.end, null);
+  assert.match(plan.warnings.join("\n"), /keep running \(and billing\)/);
+  if (plan.end) await plan.end();
+  assert.equal(calls.length, 1, "attach must not POST /release when the browser closes");
 });
 
 test("brightdata and oxylabs take userinfo credentials", () => {

--- a/tests/node/cli-help.test.ts
+++ b/tests/node/cli-help.test.ts
@@ -134,6 +134,15 @@ test("main usage lists every command exactly once", () => {
   }
 });
 
+test("boxes help names REST providers and the connect-only ones", () => {
+  const text = helpFor("boxes");
+  assert.match(text, /betterwright boxes/);
+  assert.match(text, /kernel/);
+  assert.match(text, /browser-use/);
+  assert.match(text, /Browserless, Bright Data, and Oxylabs/);
+  assert.match(text, /configure --connect/);
+});
+
 test("wantsHelp only matches flag forms, so task text is never swallowed", () => {
   assert.equal(wantsHelp(["--help"]), true);
   assert.equal(wantsHelp(["-h"]), true);

--- a/tests/node/configure.test.ts
+++ b/tests/node/configure.test.ts
@@ -54,6 +54,7 @@ test("--browser <provider> --key-env round-trips through the config file", async
   });
   assert.equal(code, 0);
   assert.deepEqual(loadBrowserConfig(home).default, { provider: "steel", keyEnv: "MY_STEEL" });
+  assert.deepEqual(loadBrowserConfig(home).accounts.steel, { keyEnv: "MY_STEEL" });
   assert.match(io.stdout(), /Default browser: Steel \(steel\), API key from MY_STEEL \(set\)/);
 });
 
@@ -139,6 +140,7 @@ test("--managed clears the default", async () => {
   assert.equal(loadBrowserConfig(home).default?.provider, "steel");
   assert.equal(await runConfigure(["--reset"], { home, env: {}, ...io }), 0);
   assert.equal(loadBrowserConfig(home).default, undefined);
+  assert.deepEqual(loadBrowserConfig(home).accounts.steel, { apiKey: "sk-live" });
   assert.match(io.stdout(), /managed BetterChromium fork/);
 });
 
@@ -155,6 +157,11 @@ test("--show --json masks stored keys and names env vars", async () => {
   assert.equal(await runConfigure(["--show", "--json"], { home, env: { MY_STEEL: "sk-live" }, ...io }), 0);
   const report = JSON.parse(io.stdout());
   assert.deepEqual(report.default, {
+    provider: "steel",
+    keyEnv: "MY_STEEL",
+    keyEnvSet: true,
+  });
+  assert.deepEqual(report.accounts.steel, {
     provider: "steel",
     keyEnv: "MY_STEEL",
     keyEnvSet: true,
@@ -247,6 +254,7 @@ test("the menu saves a built-in provider with an environment variable", async ()
     provider: "steel",
     keyEnv: "STEEL_API_KEY",
   });
+  assert.deepEqual(loadBrowserConfig(home).accounts.steel, { keyEnv: "STEEL_API_KEY" });
   assert.match(io.stdout(), /Default browser: Steel \(steel\)/);
   // The key was never echoed, the unset variable was called out, and --no-test
   // means nothing was offered.

--- a/tests/node/daemon-resilience.test.ts
+++ b/tests/node/daemon-resilience.test.ts
@@ -129,6 +129,16 @@ function rawChannel(socketPath): Promise<RawChannel> {
 
 const tick = (ms = 10) => new Promise((resolve) => setTimeout(resolve, ms));
 
+async function waitUntil(predicate, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = predicate();
+    if (value) return value;
+    await tick(10);
+  }
+  return undefined;
+}
+
 /**
  * A stand-in agent loop: emits `steps` progress notes, honours the abort
  * signal between them, and reports how it ended — the same contract
@@ -196,7 +206,11 @@ test("interrupt stops a run, keeps the transcript, and reports it", async () => 
     assert.equal(stopped.ok, true);
     assert.equal(stopped.interrupted, true);
 
-    const final = frames.find((frame) => frame.id === execId && !frame.event);
+    // Interrupt returns on the control channel; the original exec's reply
+    // is a separate write and can lag on a loaded Windows runner.
+    const final = await waitUntil(
+      () => frames.find((frame) => frame.id === execId && !frame.event),
+    );
     assert.ok(final, "the interrupted run still answers its original request");
     assert.equal(final.ok, true);
     assert.equal(final.result.reason, "interrupted");

--- a/tests/node/helpers/provider-api-mock.ts
+++ b/tests/node/helpers/provider-api-mock.ts
@@ -13,11 +13,11 @@ const KEYS = {
   "browser-use": "bu_live_test",
 };
 
-function unauthorized(method, url) {
+function unauthorized(method, url): never {
   throw new Error(`Cloud browser API ${method} ${url} failed with HTTP 401: invalid API key`);
 }
 
-function notFound(method, url) {
+function notFound(method, url): never {
   throw new Error(`Cloud browser API ${method} ${url} failed with HTTP 404: session not found`);
 }
 
@@ -34,22 +34,46 @@ function bearer(request) {
   return header(request, "authorization").replace(/^bearer\s+/i, "");
 }
 
+interface MockSessionRecord {
+  id: string;
+  status: string;
+  provider: string;
+  cdp_url?: string;
+  live_view_url?: string;
+  cdp_ws_url?: string;
+  browser_live_view_url?: string;
+  connectUrl?: string;
+  debuggerFullscreenUrl?: string;
+  sessionViewerUrl?: string;
+  wsEndpoint?: string;
+  liveUrl?: string;
+  cdpUrl?: string;
+}
+
 export function createProviderApiMock(options: { keys?: Record<string, string> } = {}) {
-  const keys = { ...KEYS, ...(options.keys || {}) };
-  const boxes = new Map();
+  const keys = { ...KEYS, ...options.keys };
+  const boxes = new Map<string, Map<string, MockSessionRecord>>();
   let seq = 0;
   const calls = [];
 
-  function store(provider) {
-    if (!boxes.has(provider)) boxes.set(provider, new Map());
-    return boxes.get(provider);
+  function store(provider): Map<string, MockSessionRecord> {
+    const existing = boxes.get(provider);
+    if (existing) return existing;
+    const created = new Map<string, MockSessionRecord>();
+    boxes.set(provider, created);
+    return created;
   }
 
-  function mint(provider, extra = {}) {
+  function mint(provider, extra: Partial<MockSessionRecord> = {}): MockSessionRecord {
     seq += 1;
-    const id = `${provider.replace(/[^a-z]/g, "").slice(0, 6)}_${seq}`;
-    const record = { id, status: extra.status || "running", provider, ...extra };
-    store(provider).set(id, record);
+    const id = extra.id || `${provider.replace(/[^a-z]/g, "").slice(0, 6)}_${seq}`;
+    const record: MockSessionRecord = {
+      id,
+      status: extra.status || "running",
+      provider,
+      ...extra,
+    };
+    store(provider).set(record.id, record);
     return record;
   }
 

--- a/tests/node/helpers/provider-api-mock.ts
+++ b/tests/node/helpers/provider-api-mock.ts
@@ -1,0 +1,242 @@
+// In-process stand-in for the six REST-lifecycle cloud browser APIs.
+//
+// Tests inject this as `fetchJson` so a connect → start → list → show → stop
+// pass never leaves the process. Each provider is keyed by a mock API key;
+// a wrong key throws the same shape of error the real httpJson helper would.
+
+const KEYS = {
+  kernel: "k_live_test",
+  browserbase: "bb_live_test",
+  steel: "st_live_test",
+  anchor: "an_live_test",
+  hyperbrowser: "hb_live_test",
+  "browser-use": "bu_live_test",
+};
+
+function unauthorized(method, url) {
+  throw new Error(`Cloud browser API ${method} ${url} failed with HTTP 401: invalid API key`);
+}
+
+function notFound(method, url) {
+  throw new Error(`Cloud browser API ${method} ${url} failed with HTTP 404: session not found`);
+}
+
+function header(request, name) {
+  const headers = request?.headers || {};
+  const wanted = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (String(key).toLowerCase() === wanted) return String(value);
+  }
+  return "";
+}
+
+function bearer(request) {
+  return header(request, "authorization").replace(/^bearer\s+/i, "");
+}
+
+export function createProviderApiMock(options: { keys?: Record<string, string> } = {}) {
+  const keys = { ...KEYS, ...(options.keys || {}) };
+  const boxes = new Map();
+  let seq = 0;
+  const calls = [];
+
+  function store(provider) {
+    if (!boxes.has(provider)) boxes.set(provider, new Map());
+    return boxes.get(provider);
+  }
+
+  function mint(provider, extra = {}) {
+    seq += 1;
+    const id = `${provider.replace(/[^a-z]/g, "").slice(0, 6)}_${seq}`;
+    const record = { id, status: extra.status || "running", provider, ...extra };
+    store(provider).set(id, record);
+    return record;
+  }
+
+  function requireBox(provider, id, method, url) {
+    const record = store(provider).get(id);
+    if (!record) notFound(method, url);
+    return record;
+  }
+
+  function checkKey(provider, presented, method, url) {
+    if (presented !== keys[provider]) unauthorized(method, url);
+  }
+
+  async function fetchJson(url, request) {
+    calls.push({ url, method: request.method, headers: request.headers, body: request.body });
+    const method = String(request.method || "GET").toUpperCase();
+    const parsed = new URL(url);
+    const path = parsed.pathname.replace(/\/$/, "") || "/";
+
+    if (parsed.host === "api.onkernel.com") {
+      checkKey("kernel", bearer(request), method, url);
+      if (method === "POST" && path === "/browsers") {
+        return mint("kernel", {
+          status: "active",
+          cdp_ws_url: `wss://onkernel.example/devtools/${seq}`,
+          browser_live_view_url: `https://live.onkernel.example/${seq}`,
+        });
+      }
+      if (method === "GET" && path === "/browsers") {
+        return [...store("kernel").values()];
+      }
+      const kernelId = path.match(/^\/browsers\/([^/]+)$/)?.[1];
+      if (kernelId && method === "GET") {
+        return requireBox("kernel", kernelId, method, url);
+      }
+      if (kernelId && method === "DELETE") {
+        requireBox("kernel", kernelId, method, url);
+        store("kernel").delete(kernelId);
+        return null;
+      }
+    }
+
+    if (parsed.host === "api.browserbase.com") {
+      checkKey("browserbase", header(request, "x-bb-api-key"), method, url);
+      if (path === "/v1/sessions" && method === "POST") {
+        const id = `sess_${seq + 1}`;
+        return mint("browserbase", {
+          id,
+          status: "RUNNING",
+          connectUrl: `wss://connect.browserbase.com/devtools/${id}`,
+          debuggerFullscreenUrl: `https://www.browserbase.com/sessions/${id}`,
+        });
+      }
+      if (path === "/v1/sessions" && method === "GET") {
+        const status = parsed.searchParams.get("status");
+        return [...store("browserbase").values()].filter(
+          (row) => !status || row.status === status,
+        );
+      }
+      const bbId = path.match(/^\/v1\/sessions\/([^/]+)$/)?.[1];
+      if (bbId && method === "GET") return requireBox("browserbase", bbId, method, url);
+      if (bbId && method === "POST") {
+        const record = requireBox("browserbase", bbId, method, url);
+        if (request.body?.status === "REQUEST_RELEASE") {
+          store("browserbase").delete(bbId);
+          return { ...record, status: "COMPLETED" };
+        }
+        return record;
+      }
+    }
+
+    if (parsed.host === "api.steel.dev") {
+      checkKey("steel", header(request, "steel-api-key"), method, url);
+      if (path === "/v1/sessions" && method === "POST") {
+        const id = `steel_${seq + 1}`;
+        return mint("steel", {
+          id,
+          status: "live",
+          sessionViewerUrl: `https://app.steel.dev/sessions/${id}`,
+        });
+      }
+      if (path === "/v1/sessions" && method === "GET") {
+        return { sessions: [...store("steel").values()] };
+      }
+      const steelRelease = path.match(/^\/v1\/sessions\/([^/]+)\/release$/)?.[1];
+      if (steelRelease && method === "POST") {
+        requireBox("steel", steelRelease, method, url);
+        store("steel").delete(steelRelease);
+        return { success: true };
+      }
+      const steelId = path.match(/^\/v1\/sessions\/([^/]+)$/)?.[1];
+      if (steelId && method === "GET") return requireBox("steel", steelId, method, url);
+    }
+
+    if (parsed.host === "api.hyperbrowser.ai") {
+      checkKey("hyperbrowser", header(request, "x-api-key"), method, url);
+      if (path === "/api/session" && method === "POST") {
+        const id = `hb_${seq + 1}`;
+        return mint("hyperbrowser", {
+          id,
+          status: "active",
+          wsEndpoint: `wss://hyper.example/${id}`,
+          liveUrl: `https://app.hyperbrowser.ai/live/${id}`,
+        });
+      }
+      if (path === "/api/sessions" && method === "GET") {
+        return { sessions: [...store("hyperbrowser").values()], totalCount: store("hyperbrowser").size };
+      }
+      const hbStop = path.match(/^\/api\/session\/([^/]+)\/stop$/)?.[1];
+      if (hbStop && method === "POST") {
+        requireBox("hyperbrowser", hbStop, method, url);
+        store("hyperbrowser").delete(hbStop);
+        return { success: true };
+      }
+      const hbId = path.match(/^\/api\/session\/([^/]+)$/)?.[1];
+      if (hbId && method === "GET") return requireBox("hyperbrowser", hbId, method, url);
+    }
+
+    if (parsed.host === "api.anchorbrowser.io") {
+      checkKey("anchor", header(request, "anchor-api-key"), method, url);
+      if (path === "/api/v1/sessions" && method === "POST") {
+        const id = `anch_${seq + 1}`;
+        const record = mint("anchor", {
+          id,
+          status: "running",
+          cdp_url: `wss://anchor.example/${id}`,
+          live_view_url: `https://live.anchorbrowser.io/${id}`,
+        });
+        return {
+          data: {
+            id: record.id,
+            cdp_url: record.cdp_url,
+            live_view_url: record.live_view_url,
+          },
+        };
+      }
+      if (path === "/api/v1/sessions" && method === "GET") {
+        return {
+          data: [...store("anchor").values()].map((row) => ({
+            id: row.id,
+            status: row.status,
+            live_view_url: row.live_view_url,
+          })),
+        };
+      }
+      const anchId = path.match(/^\/api\/v1\/sessions\/([^/]+)$/)?.[1];
+      if (anchId && method === "GET") {
+        const row = requireBox("anchor", anchId, method, url);
+        return { data: row };
+      }
+      if (anchId && method === "DELETE") {
+        requireBox("anchor", anchId, method, url);
+        store("anchor").delete(anchId);
+        return { data: { status: "ended" } };
+      }
+    }
+
+    if (parsed.host === "api.browser-use.com") {
+      checkKey("browser-use", header(request, "x-browser-use-api-key"), method, url);
+      if (path === "/api/v4/browsers" && method === "POST") {
+        const id = `bu_${seq + 1}`;
+        return mint("browser-use", {
+          id,
+          status: "active",
+          cdpUrl: `wss://connect.browser-use.com/browsers/${id}`,
+          liveUrl: `https://cloud.browser-use.com/live/${id}`,
+        });
+      }
+      if (path === "/api/v4/browsers" && method === "GET") {
+        return { browsers: [...store("browser-use").values()] };
+      }
+      const buId = path.match(/^\/api\/v4\/browsers\/([^/]+)$/)?.[1];
+      if (buId && method === "GET") return requireBox("browser-use", buId, method, url);
+      if (buId && method === "PATCH") {
+        if (request.body?.action !== "stop") {
+          throw new Error(`Cloud browser API PATCH ${url} failed with HTTP 400: unknown action`);
+        }
+        requireBox("browser-use", buId, method, url);
+        store("browser-use").delete(buId);
+        return { id: buId, status: "stopped" };
+      }
+    }
+
+    throw new Error(`Cloud browser API ${method} ${url} failed with HTTP 404: no mock route`);
+  }
+
+  return { fetchJson, keys, calls, boxes, mint };
+}
+
+export { KEYS as MOCK_PROVIDER_KEYS };

--- a/tests/node/sdk.test.ts
+++ b/tests/node/sdk.test.ts
@@ -51,7 +51,12 @@ test("the SDK entrypoint re-exports the root export's bindings, not copies", () 
   assert.equal(sdk.validateCredentialMatchMode, client.validateCredentialMatchMode);
   assert.equal(sdk.browserProviderInfo, providers.browserProviderInfo);
   assert.equal(sdk.BROWSER_PROVIDER_NAMES, providers.BROWSER_PROVIDER_NAMES);
+  assert.equal(sdk.REST_BROWSER_PROVIDER_NAMES, providers.REST_BROWSER_PROVIDER_NAMES);
   assert.equal(sdk.describeCdpUrl, providers.describeCdpUrl);
+  assert.equal(sdk.createProviderSession, providers.createProviderSession);
+  assert.equal(sdk.listProviderSessions, providers.listProviderSessions);
+  assert.equal(sdk.getProviderSession, providers.getProviderSession);
+  assert.equal(sdk.stopProviderSession, providers.stopProviderSession);
 });
 
 test("withBrowser is the only export the root export does not have", () => {
@@ -60,8 +65,13 @@ test("withBrowser is the only export the root export does not have", () => {
   const added = Object.keys(sdk).filter((name) => !(name in index));
   assert.deepEqual(added.sort(), [
     "BROWSER_PROVIDER_NAMES",
+    "REST_BROWSER_PROVIDER_NAMES",
     "browserProviderInfo",
+    "createProviderSession",
     "describeCdpUrl",
+    "getProviderSession",
+    "listProviderSessions",
+    "stopProviderSession",
     "validateCredentialMatchMode",
     "withBrowser",
   ]);

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -49,6 +49,18 @@ import createBetterWrightPiExtension, {
 import type { NetworkDecision } from "betterwright/policy";
 import type { Guardrails as PromptGuardrails } from "betterwright/prompt";
 import {
+  BROWSER_PROVIDER_NAMES,
+  REST_BROWSER_PROVIDER_NAMES,
+  browserProviderInfo,
+  createProviderSession,
+  describeCdpUrl,
+  getProviderSession,
+  listProviderSessions,
+  type ProviderBox,
+  type ProviderLifecycleKind,
+  stopProviderSession,
+} from "betterwright/sdk";
+import {
   createLocalCredentialVault,
   type VaultAuditEntry,
   type VaultOwnerListResult,
@@ -169,6 +181,29 @@ new BetterWright({ connectOverCdp: "http://127.0.0.1:9222" });
 // the built-in union (which keeps its completions via the string intersection).
 new BetterWright({ provider: { provider: "driverdotnet" } });
 new BetterWright({ provider: { provider: "steel" } });
+
+const restLifecycle: ProviderLifecycleKind = "rest";
+const kernelInfo = browserProviderInfo("kernel");
+const kernelBoxes: Promise<ProviderBox> = createProviderSession("kernel", { apiKey: "k" });
+const kernelList: Promise<ProviderBox[]> = listProviderSessions("kernel", { apiKey: "k" });
+const kernelShown: Promise<ProviderBox> = getProviderSession("kernel", "s1", { apiKey: "k" });
+const kernelStopped: Promise<{ provider: string; id: string }> = stopProviderSession(
+  "kernel",
+  "s1",
+  { apiKey: "k" },
+);
+const maskedCdp: string = describeCdpUrl("wss://host?apiKey=SECRET");
+void [
+  restLifecycle,
+  kernelInfo,
+  kernelBoxes,
+  kernelList,
+  kernelShown,
+  kernelStopped,
+  maskedCdp,
+  BROWSER_PROVIDER_NAMES,
+  REST_BROWSER_PROVIDER_NAMES,
+];
 
 void [
   run,

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -50,7 +50,6 @@ import type { NetworkDecision } from "betterwright/policy";
 import type { Guardrails as PromptGuardrails } from "betterwright/prompt";
 import {
   BROWSER_PROVIDER_NAMES,
-  REST_BROWSER_PROVIDER_NAMES,
   browserProviderInfo,
   createProviderSession,
   describeCdpUrl,
@@ -58,6 +57,7 @@ import {
   listProviderSessions,
   type ProviderBox,
   type ProviderLifecycleKind,
+  REST_BROWSER_PROVIDER_NAMES,
   stopProviderSession,
 } from "betterwright/sdk";
 import {

--- a/types/sdk.d.ts
+++ b/types/sdk.d.ts
@@ -4,6 +4,7 @@
 
 import type { BetterWright } from "./client.js";
 import type { BetterWrightOptions, CloudBrowserProviderName } from "./public.js";
+import type { UntrustedValue } from "./untrusted-value.js";
 
 export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
 export { BetterWright, BrowserError, validateCredentialMatchMode } from "./client.js";
@@ -21,17 +22,62 @@ export type * from "./public.js";
 /** Names of the cloud browser providers `provider: { provider }` accepts. */
 export const BROWSER_PROVIDER_NAMES: readonly CloudBrowserProviderName[];
 
+/** Built-in providers with create/list/get/stop session APIs. */
+export const REST_BROWSER_PROVIDER_NAMES: readonly CloudBrowserProviderName[];
+
+export type ProviderLifecycleKind = "rest" | "connect";
+
 export interface BrowserProviderInfo {
   name: string;
   docs: string;
   keyEnv: string;
+  /** `rest` providers expose start/list/stop; `connect` ones do not. */
+  lifecycle: ProviderLifecycleKind;
 }
 
-/** Display name, docs URL, and API-key env var, or null for an unknown name. */
+/** Display name, docs URL, API-key env var, and lifecycle, or null. */
 export function browserProviderInfo(name: string): BrowserProviderInfo | null;
 
 /** A CDP URL with its credentials and key-like query values masked, for logs. */
 export function describeCdpUrl(value: string): string;
+
+/** One cloud browser session returned by create/list/get. */
+export interface ProviderBox {
+  provider: string;
+  id: string;
+  status: string;
+  cdpUrl: string;
+  liveViewUrl: string;
+  endpointLabel: string;
+}
+
+export interface ProviderSessionRequest {
+  apiKey?: string;
+  sessionOptions?: Record<string, UntrustedValue>;
+  status?: string;
+}
+
+export function createProviderSession(
+  name: string,
+  options?: ProviderSessionRequest,
+): Promise<ProviderBox>;
+
+export function listProviderSessions(
+  name: string,
+  options?: ProviderSessionRequest,
+): Promise<ProviderBox[]>;
+
+export function getProviderSession(
+  name: string,
+  id: string,
+  options?: ProviderSessionRequest,
+): Promise<ProviderBox>;
+
+export function stopProviderSession(
+  name: string,
+  id: string,
+  options?: ProviderSessionRequest,
+): Promise<{ provider: string; id: string }>;
 
 /**
  * Run `fn` against a client and close that client afterwards, including when


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Six of the nine named cloud providers expose a real session lifecycle over REST (matching their official SDKs). This adds a way to save those API keys in BetterWright config and manage the boxes from the CLI, without making the cloud provider the launch default.

## What and why

Users can `configure --connect` a provider API key, then `betterwright boxes start|list|show|stop` against Browserbase, Steel, Hyperbrowser, Kernel, Anchor, and Browser Use. Browserless, Bright Data, and Oxylabs stay connect-only.

```bash
betterwright configure --connect kernel --key-env KERNEL_API_KEY
betterwright boxes start --browser kernel
betterwright boxes list
betterwright run --browser kernel --session-id <id> -c "return page.url()"
```

`--session-id` / `sessionOptions.sessionId` attaches to an existing box and **does not** stop it when BetterWright disconnects. Mint-on-launch (Kernel, Browserbase, Anchor, Hyperbrowser without a session id) still releases on close.

## Checklist

- [x] `npm run release:check` passes locally (versions, lint, typecheck, build,
      unit tests, published declarations, tarball).
- [x] **Every browser connection still goes through the guard proxy.** No new
      launch path, transport, or fetch bypasses the worker's SOCKS guard
      (`src/guard-proxy.ts`) — the network floor is the security boundary.
      Remote providers remain outside it, same as today; boxes only talks to
      the provider control plane via the existing `httpJson` / `fetchJson` seam.
- [x] **No secret value reaches the model sandbox.** Box JSON and logs run CDP
      URLs through `describeCdpUrl`; `--show --json` masks stored keys; the
      payload never includes the API key.
- [x] **Dependency pins are still mirrored everywhere.** No version changes.
- [x] **Public API changes update `types/*.d.ts` in this same commit.**
      `types/sdk.d.ts` adds the session helpers and `lifecycle` on
      `browserProviderInfo`.
- [x] The two branch-protected CI job names, "Worker copies in sync" and
      "Node tests", are unchanged, and any new action is SHA-pinned with a
      trailing `# vX.Y.Z` comment.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js` directly —
      that module runs import side effects (stdin readline, ready handshake).
- [x] User-visible behaviour is reflected in `CHANGELOG.md` and, where it
      changes a command or an option, in `docs/` or the help text in
      `src/cli-help.ts`.
- [x] Nothing private is being committed: no handoff or `internal/` notes, no
      profile, vault, or artifact directory, no routable IP addresses in prose
      (`npm run check:package` enforces the last two for the tarball).

## How it was verified

Local `npm run release:check` (Node 22.22.2): versions, biome+oxlint, typecheck,
check:build, unit tests, test:types, check:package.

In-process mock of all six REST APIs (`tests/node/helpers/provider-api-mock.ts`):
connect → start → list → show → stop per provider, 401/404, connect-only
refusal, env-var keys, `--browser-key` override, `--status` filter, JSON never
contains the mock key, SDK helper round-trips. No real credentials, no sockets.

Attach tests: Kernel/Steel `--session-id` leaves `plan.end` null; simulated
close/failed-connect does not DELETE or POST `/release`; GET still finds the
box. Mint-on-launch still has a callable `plan.end` for Kernel / Browserbase /
Anchor / Hyperbrowser.

## Follow-ups in this PR

- Attach no longer inherits the mint-on-launch stop callback (Greptile P1).
- Daemon interrupt test waits for the original exec reply so Windows Node 24
  is not racing the control-channel round-trip.

## Provider mapping

| Provider | Create | Stop |
|---|---|---|
| Browserbase | `POST /v1/sessions` | `POST` `{status: REQUEST_RELEASE}` |
| Steel | `POST /v1/sessions` | `POST …/release` (CDP URL reconstructed; we do not trust `websocketUrl`) |
| Hyperbrowser | `POST /api/session` | `POST …/stop` |
| Kernel | `POST /browsers` | `DELETE /browsers/{id}` |
| Anchor | `POST /api/v1/sessions` | `DELETE` (also released when a minted launch closes) |
| Browser Use | `POST /api/v4/browsers` | `PATCH` `{action: "stop"}` |

Launch path is unchanged except: Anchor now has an `end` handler, and `--session-id` / `sessionOptions.sessionId` on a REST-lifecycle provider attaches via GET without taking ownership. Steel and Browser Use still launch through a connect URL when no session id is given.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a01b7f-4ffb-48ce-9e5b-9242a42fc7df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a01b7f-4ffb-48ce-9e5b-9242a42fc7df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

