### PR TITLE
release: 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-01
+
+A stability release for the SDK. A worker restart no longer surfaces as a
+false "This browser has been closed." in other sessions, a worker that
+cannot start is reported at once with the reason instead of after a timeout,
+a dying worker can no longer crash the host process, and cloud-provider API
+calls are bounded so `boxes` and provider launches cannot hang. The
+provider-account and `boxes` work queued since 2.0.0 ships here as well.
+
 ### Added
 
 - **Connected provider accounts.** `betterwright configure --connect <name>`
@@ -29,6 +38,10 @@ Releases before 1.1.3 predate this file; their notes live on the
 - **SDK session helpers** on `betterwright/sdk`: `createProviderSession`,
   `listProviderSessions`, `getProviderSession`, `stopProviderSession`,
   `REST_BROWSER_PROVIDER_NAMES`, and `lifecycle` on `browserProviderInfo`.
+- **`BETTERWRIGHT_WORKER_START_TIMEOUT_MS`** sets how long the client gives a
+  freshly spawned worker to print its ready handshake (default 15 s). A cold
+  disk or a small ARM board can need more; the timeout error now names the
+  variable and carries the worker's last stderr lines.
 
 ### Changed
 
@@ -36,6 +49,45 @@ Releases before 1.1.3 predate this file; their notes live on the
   session), matching Kernel / Browserbase / Hyperbrowser. Steel and Browser
   Use still launch through a connect URL; their REST APIs are used by
   `boxes` (and by `--session-id` attach).
+- **Cloud-provider API calls are bounded.** Every REST call a provider launch
+  or `betterwright boxes` makes (create, list, get, stop) times out after 30 s
+  with a message that says so, instead of waiting on the provider forever. A
+  network failure is reported by its cause (`getaddrinfo ENOTFOUND …`,
+  `ECONNREFUSED`, a TLS error) rather than undici's bare `fetch failed`.
+
+### Fixed
+
+- **A worker restart no longer fails concurrent calls with "This browser has
+  been closed."** An execution timeout, a worker-requested restart, or a
+  reconfigure takes the worker down and the next call brings a replacement
+  up. A call from another session that landed during that teardown was told
+  the browser had been closed, although nothing had closed it. Only a final
+  `close()` marks the client closed now; a call that arrives mid-restart waits
+  for the replacement worker. Live-view revival after a crash is unchanged.
+- **A worker that dies at boot fails the call immediately, with its stderr.**
+  The client used to wait out the full start timeout before reporting
+  "Worker did not start", with nothing about why. The call now rejects as
+  soon as the process exits, and the `BrowserError` carries the exit code or
+  signal and the last stderr lines (the missing module, the syntax error, the
+  permission problem).
+- **A worker that hangs at boot is killed, not kept.** When the handshake
+  timed out, the unresponsive child stayed attached as the live worker, so the
+  next call trusted it and only failed after a full execution timeout. The
+  child is now killed at the start timeout and the next call spawns afresh.
+- **Writing to a dying worker cannot crash the host.** The worker's stdin had
+  no error listener, so a write that raced its exit raised EPIPE as an
+  uncaught exception in the host process. The stream now has a listener; the
+  exit path already reports the worker as gone. A spawn failure (`EAGAIN`,
+  `EMFILE`) is reported as a `BrowserError` for the same reason.
+- **`withBrowser` checks its arguments before constructing a client**, so a
+  missing callback or a non-object options bag is a `TypeError` naming the
+  fix, not a worker left behind. When the callback throws and `close()` then
+  fails too, the callback's error is the one reported; a close failure after
+  a successful callback still propagates.
+- **A vault whose `redact()` returns a non-envelope withholds the result.**
+  The client threw a `TypeError` out of `run()` while reading the returned
+  value; it now fails closed the same way a throwing `redact()` does,
+  returning `ok: false` with the redaction-failed error.
 
 ## [2.0.0] - 2026-08-31
 
@@ -1275,7 +1327,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/BetterWright/betterwright/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/BetterWright/betterwright/compare/v1.11.0...v2.0.0
 [1.11.0]: https://github.com/BetterWright/betterwright/compare/v1.10.3...v1.11.0
 [1.10.3]: https://github.com/BetterWright/betterwright/compare/v1.10.2...v1.10.3

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.0.0
+generated_by: betterwright@2.0.1
 ---
 
 # BetterWright browser

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,6 +200,18 @@ export BETTERWRIGHT_PARK_BACKGROUND_PAGES=0
 
 or `new BetterWright({ parkBackgroundPages: false })`.
 
+### Slow hosts
+
+The client gives a freshly spawned worker 15 s to print its ready handshake
+before it gives up and kills it. A cold disk or a small ARM board can need
+longer on the first run:
+
+```bash
+export BETTERWRIGHT_WORKER_START_TIMEOUT_MS=60000
+```
+
+The error you would see otherwise names this variable.
+
 ## Your first run
 
 A snippet is a string of async Playwright JavaScript. The last expression is

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -104,6 +104,49 @@ The entrypoint also exports the public types, so
 `import type { BetterWrightOptions, RunResult } from "betterwright/sdk"` works
 without a second import path.
 
+## Errors, timeouts, and the worker
+
+Knowing which failures come back as a value and which ones throw is most of
+what makes an integration robust.
+
+**Anything that happened inside the browser is a value.** `run()`,
+`fillCredential()`, and the live-view calls resolve with an envelope; when the
+snippet threw, the page navigated away, the call timed out, or the worker died
+mid-call, that envelope is `{ ok: false, error }`. Check `ok` and decide.
+Throwing `BrowserError(result.error)` is the conventional way to turn one into
+an exception.
+
+**The client throws only when it cannot work at all**, and always as a
+`BrowserError` (or a `TypeError` for a bad option at construction):
+
+- the client was closed with `close()` and is then used again;
+- the worker process could not start: the error says why, with the exit code
+  or signal and the worker's last stderr lines (a missing module, a syntax
+  error in a patched install, a permission problem), and it is raised as soon
+  as the process exits rather than after a timeout;
+- the worker started but never printed its ready handshake within the start
+  timeout, 15 s by default. Set `BETTERWRIGHT_WORKER_START_TIMEOUT_MS` higher
+  on a cold disk or a small ARM board; the hung process is killed either way.
+
+**Timeouts restart the worker, not the browser.** Each call takes a `timeout`
+in seconds (default `defaultTimeout`, 30). When it expires the worker is
+restarted, the call resolves `{ ok: false, error: "Execution timed out …" }`,
+and the next call spawns a replacement. Calls from other sessions that land
+during that restart wait for the replacement; they are not told the browser
+has been closed, because it has not. The browser profile, cookies, and
+logins are on disk and survive every restart.
+
+**Provider API calls are bounded.** A cloud-provider launch and every
+`createProviderSession` / `listProviderSessions` / `getProviderSession` /
+`stopProviderSession` call gives the provider 30 s and then fails with a
+message that says so. A network failure names its cause
+(`getaddrinfo ENOTFOUND …`, `ECONNREFUSED`).
+
+**`withBrowser` owns the lifetime.** It closes the client whether your
+function returns or throws. If your function throws and `close()` then fails
+as well, your function's error is the one you see. A missing callback or a
+non-object options bag is a `TypeError` before any client exists.
+
 ## Runnable example
 
 [examples/typescript/sdk.ts](../examples/typescript/sdk.ts) is the code above as

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/browser-providers.ts
+++ b/src/browser-providers.ts
@@ -120,6 +120,30 @@ function isFetchJsonHook(value: UntrustedValue): value is FetchJsonHook {
   return isCallable(value);
 }
 
+/**
+ * Upper bound on one provider API call, request and body together. A session
+ * API that stops answering must surface as an error, not as a `boxes` command
+ * or a browser launch that never returns.
+ */
+export const PROVIDER_HTTP_TIMEOUT_MS = 30_000;
+
+/** The one-line reason a provider API call never produced a response. */
+function describeFetchFailure(method, url, error) {
+  const name = untrustedField(error, "name");
+  if (name === "TimeoutError" || name === "AbortError") {
+    return `Cloud browser API ${method} ${url} timed out after ${PROVIDER_HTTP_TIMEOUT_MS / 1000}s.`;
+  }
+  // undici reports network failures as a bare "fetch failed" TypeError and
+  // keeps the useful part (ENOTFOUND, ECONNREFUSED, a TLS error) in `cause`.
+  const cause = untrustedField(error, "cause");
+  const detail = takeString(
+    untrustedField(cause, "message"),
+    untrustedField(cause, "code"),
+    untrustedField(error, "message"),
+  );
+  return `Cloud browser API ${method} ${url} failed: ${detail || String(error)}`;
+}
+
 async function httpJson(fetchJson, method, url, { headers, body }) {
   if (isFetchJsonHook(fetchJson)) {
     const request: ProviderHttpRequest = { method, headers };
@@ -129,10 +153,20 @@ async function httpJson(fetchJson, method, url, { headers, body }) {
   const requestHeaders: Record<string, string> = {};
   if (body !== undefined) requestHeaders["content-type"] = "application/json";
   Object.assign(requestHeaders, headers);
-  const init: RequestInit = { method, headers: requestHeaders };
+  const init: RequestInit = {
+    method,
+    headers: requestHeaders,
+    signal: AbortSignal.timeout(PROVIDER_HTTP_TIMEOUT_MS),
+  };
   if (body !== undefined) init.body = JSON.stringify(body);
-  const response = await fetch(url, init);
-  const text = await response.text();
+  let response: Response;
+  let text: string;
+  try {
+    response = await fetch(url, init);
+    text = await response.text();
+  } catch (error) {
+    throw new Error(describeFetchFailure(method, url, error));
+  }
   let data = null;
   try {
     data = text ? JSON.parse(text) : null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,7 +49,7 @@ const WORKER_PATH = fileURLToPath(new URL("./worker.js", import.meta.url));
 // never collide with it: session names are trimmed strings, and this is not.
 const HOST_LANE = Symbol("betterwright-host-lane");
 const DEFAULT_TIMEOUT_SECONDS = 30;
-const WORKER_START_TIMEOUT_MS = 15_000;
+const DEFAULT_WORKER_START_TIMEOUT_MS = 15_000;
 const WORKER_RPC_DRAIN_TIMEOUT_MS = 250;
 const PENDING_CREDENTIAL_FINALIZE_ACTIONS = new Set(["commit", "discard"]);
 const DEFINITIVE_GENERATE_FAILURE_CODES = new Set([
@@ -89,6 +89,16 @@ export function displayAvailable() {
 function resolveHeadless(headless) {
   if (headless === "auto" || headless === undefined) return !displayAvailable();
   return headless !== false;
+}
+
+/**
+ * How long a freshly spawned worker gets to print its ready handshake. The
+ * default covers a warm host; a cold disk or a small ARM board can need more,
+ * so `BETTERWRIGHT_WORKER_START_TIMEOUT_MS` raises (or lowers) it per host.
+ */
+function workerStartTimeoutMs() {
+  const raw = Number(process.env.BETTERWRIGHT_WORKER_START_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_WORKER_START_TIMEOUT_MS;
 }
 
 function resolveProviderOption(options, home) {
@@ -307,7 +317,9 @@ export class BetterWright {
   declare _pendingCredentialRecoveries: Map<any, any>;
   declare _workerClosePromises: WeakMap<any, any>;
   declare _workerClosePreservesPending: WeakSet<any>;
+  declare _workerCloseExpected: WeakSet<any>;
   declare _workerCloseBarrier: Promise<any>;
+  declare _dispatchSeq: number;
   declare _vaultRedactionOwner: any;
   declare _ready: any;
   declare _lastConfig: any;
@@ -506,7 +518,11 @@ export class BetterWright {
     this._pendingCredentialRecoveries = new Map();
     this._workerClosePromises = new WeakMap();
     this._workerClosePreservesPending = new WeakSet();
+    // Workers close() is taking down on purpose (final close or restart), so
+    // the exit handler can tell a deliberate teardown from a crash.
+    this._workerCloseExpected = new WeakSet();
     this._workerCloseBarrier = Promise.resolve();
+    this._dispatchSeq = 0;
     this._vaultRedactionOwner = null;
     this._ready = null;
     this._lastConfig = null;
@@ -638,8 +654,27 @@ export class BetterWright {
     );
     this._workerClosePromises.set(child, workerClosePromise);
     this._workerCloseBarrier = workerClosePromise;
+    let ready = false;
     let resolveReady;
-    this._ready = new Promise((resolve) => (resolveReady = resolve));
+    let rejectReady;
+    const readyPromise = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    // Settled by the handshake, by an exit before it, or by a spawn failure.
+    // A rejection that lands after _start has already given up has no
+    // awaiter, so it is marked observed here rather than becoming an
+    // unhandled rejection in the host.
+    readyPromise.catch(() => {});
+    this._ready = readyPromise;
+    const failStart = (message) => rejectReady(new BrowserError(message));
+    // A write to a worker that is already going down raises EPIPE on its
+    // stdin stream. Without a listener that is an uncaught exception in the
+    // host process; the exit path below is what reports the worker as gone.
+    child.stdin.on("error", () => {});
+    child.on("error", (error) => {
+      failStart(`Could not start the BetterWright worker: ${error?.message || error}`);
+    });
     stdout.on("line", (line) => {
       let message;
       try {
@@ -647,8 +682,10 @@ export class BetterWright {
       } catch {
         return;
       }
-      if (message.type === "ready") resolveReady();
-      else if (message.type === "rpc_request") {
+      if (message.type === "ready") {
+        ready = true;
+        resolveReady();
+      } else if (message.type === "rpc_request") {
         const task = this._serviceRpc(message, child);
         rpcTasks.add(task);
         // Custom RPC providers cannot currently be aborted. Their settlement
@@ -675,7 +712,15 @@ export class BetterWright {
     child.on("exit", () => {
       if (this._process === child) this._process = null;
     });
-    child.on("close", () => {
+    child.on("close", (code, signal) => {
+      // A worker that died before its handshake: report it now, with the
+      // stderr that explains it, instead of letting the start timer run out.
+      if (!ready) {
+        const how = signal ? `signal ${signal}` : `exit code ${code}`;
+        failStart(
+          `The BetterWright worker exited before it was ready (${how}).\n${this._stderrTail.slice(-8).join("\n")}`,
+        );
+      }
       void (async () => {
         let drainTimer;
         try {
@@ -697,8 +742,16 @@ export class BetterWright {
           // Unexpected death (crash, OOM-kill) while a live view is up:
           // revive worker + view now, not at the host's next browser call —
           // viewers are already in their reconnect loop. Deliberate closes
-          // set _closed (or cleared the restore state) before this fires.
-          if (!this._closed && (this._process === child || this._process === null)) {
+          // (final or restart) are marked expected before this fires, and a
+          // worker that never came up cannot have hosted the view — reviving
+          // from here would only spawn the same failure in a loop; the next
+          // host call still retries once per generation.
+          if (
+            ready &&
+            !this._closed &&
+            !this._workerCloseExpected.has(child) &&
+            (this._process === child || this._process === null)
+          ) {
             this._scheduleLiveViewRevival();
           }
         }
@@ -706,14 +759,29 @@ export class BetterWright {
     });
 
     let startTimer;
-    const timer = new Promise((_, reject) => {
+    const startTimeoutMs = workerStartTimeoutMs();
+    const timer = new Promise<never>((_, reject) => {
       startTimer = setTimeout(
-        () => reject(new BrowserError(`Worker did not start.\n${this._stderrTail.slice(-8).join("\n")}`)),
-        WORKER_START_TIMEOUT_MS,
+        () =>
+          reject(
+            new BrowserError(
+              `The BetterWright worker did not start within ${Math.round(startTimeoutMs / 1000)}s ` +
+                "(raise BETTERWRIGHT_WORKER_START_TIMEOUT_MS on a slow host).\n" +
+                this._stderrTail.slice(-8).join("\n"),
+            ),
+          ),
+        startTimeoutMs,
       );
     });
     try {
-      await Promise.race([this._ready, timer]);
+      await Promise.race([readyPromise, timer]);
+    } catch (error) {
+      // A worker that never answered must not stay attached as if it were
+      // running: the next call would trust it and only learn otherwise after
+      // a full execution timeout. Drop it so the next call spawns afresh.
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      if (this._process === child) this._process = null;
+      throw error;
     } finally {
       clearTimeout(startTimer);
     }
@@ -1365,8 +1433,9 @@ export class BetterWright {
       this._process.exitCode === null &&
       JSON.stringify(this._lastConfig) !== JSON.stringify(config)
     ) {
-      await this.close();
-      this._closed = false;
+      // A changed config replaces the worker. The live view was bound to the
+      // old config, so it ends here; the browser itself is not closed.
+      await this.close({ restart: true, endLiveView: true });
     }
     await this._start();
     this._lastConfig = config;
@@ -1392,7 +1461,8 @@ export class BetterWright {
    * restarting the worker on timeout and applying vault redaction on the way
    * out. Shared by run() and fillCredential(). */
   async _dispatch(message, timeoutSeconds): Promise<any> {
-    const id = `${process.pid}-${Math.round(performance.now() * 1000)}-${this._pending.size}`;
+    this._dispatchSeq += 1;
+    const id = `${process.pid}-${this._dispatchSeq}`;
     const child = this._process;
     const response: any = await new Promise<any>((resolve) => {
       let settled = false;
@@ -1407,7 +1477,6 @@ export class BetterWright {
       this._pending.set(id, { child, done });
       timer = setTimeout(async () => {
         await this.close({ child, preservePending: true, restart: true });
-        this._closed = false;
         this._scheduleLiveViewRevival();
         done(
           this._attachPendingCredentialRecovery(id, {
@@ -1432,6 +1501,9 @@ export class BetterWright {
     if (isRedactingVault(vault)) {
       try {
         envelope = vault.redact(response);
+        // A vault that hands back something other than an envelope has not
+        // scrubbed anything; treat it exactly like a redaction that threw.
+        if (!isRecord(envelope)) throw new TypeError("redact() did not return an envelope");
       } catch {
         // Fail closed: if redaction itself breaks, the raw response may still
         // carry active secrets, so the whole envelope is withheld rather than
@@ -1456,7 +1528,6 @@ export class BetterWright {
     }
     if (restart) {
       await this.close({ restart: true });
-      this._closed = false;
       this._scheduleLiveViewRevival();
     }
     return envelope;
@@ -1476,9 +1547,15 @@ export class BetterWright {
       child: requestedChild = null,
       preservePending = false,
       restart = false,
+      endLiveView = !restart,
     }: any = {},
   ) {
-    this._closed = true;
+    // Only a final close marks the browser closed. A restart (execution
+    // timeout, worker-requested restart, reconfigure) takes the worker down
+    // and the next call brings a replacement up; a call from another session
+    // that lands in between must wait for that replacement, not be told the
+    // browser is gone.
+    if (!restart) this._closed = true;
     const child = requestedChild || this._process;
     const closesActiveWorker = !requestedChild || this._process === child;
     if (closesActiveWorker) {
@@ -1488,12 +1565,13 @@ export class BetterWright {
     // A final close ends the live view for good: tell viewers (worker
     // teardown alone stays silent so restart reconnects work) and drop the
     // revival state. Restart closes keep both so the view comes back.
-    const endsLiveView = !restart && this._liveViewRestore;
+    const endsLiveView = endLiveView && this._liveViewRestore;
     if (endsLiveView) this._liveViewRestore = null;
     if (!child) {
       await this._workerCloseBarrier;
       return;
     }
+    this._workerCloseExpected.add(child);
     if (preservePending) this._workerClosePreservesPending.add(child);
     if (child.exitCode === null && child.signalCode === null) {
       try {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -8,7 +8,7 @@
 // `withBrowser` for the client lifetime every integration hand-writes.
 
 import { BetterWright } from "./client.js";
-import { isCallable } from "./untrusted-value.js";
+import { isCallable, isRecord, type UntrustedValue } from "./untrusted-value.js";
 
 export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
 export {
@@ -40,6 +40,18 @@ export {
   VAULT_MATCH_MODES,
 } from "./vault.js";
 
+/** What a caller hands to `withBrowser`: a function that takes the client. */
+type BrowserCallback = (bw: BetterWright) => UntrustedValue;
+
+/**
+ * Narrow a caller-supplied value to the callback shape. The callback is
+ * trusted host code, so unlike `UntrustedFunction` it is declared callable
+ * with the client as its argument.
+ */
+function isBrowserCallback(value: UntrustedValue): value is BrowserCallback {
+  return isCallable(value);
+}
+
 /**
  * Run `fn` against a client and close that client afterwards, including when
  * `fn` throws. Resolves with whatever `fn` returned.
@@ -51,10 +63,28 @@ export {
 export async function withBrowser(options, fn) {
   const shorthand = isCallable(options);
   const callback = shorthand ? options : fn;
-  const bw = new BetterWright(shorthand ? {} : options);
+  // Check the arguments before a client exists: a bad call must not leave a
+  // worker process behind, and the message should name the fix.
+  if (!isBrowserCallback(callback)) {
+    throw new TypeError(
+      "withBrowser expects a callback: withBrowser(fn) or withBrowser(options, fn).",
+    );
+  }
+  if (!shorthand && options != null && !isRecord(options)) {
+    throw new TypeError("withBrowser options must be an object.");
+  }
+  const bw = new BetterWright(shorthand ? {} : options || {});
+  let failed = false;
   try {
     return await callback(bw);
+  } catch (error) {
+    failed = true;
+    throw error;
   } finally {
-    await bw.close();
+    // The callback's own error is the one worth reporting: a close failure
+    // on top of it must not replace it. When the callback succeeded, a close
+    // failure is the only thing wrong, and it does propagate.
+    if (failed) await bw.close().catch(() => {});
+    else await bw.close();
   }
 }

--- a/tests/node/browser-providers.test.ts
+++ b/tests/node/browser-providers.test.ts
@@ -5,6 +5,8 @@ import test from "node:test";
 import {
   browserProviderInfo,
   describeCdpUrl,
+  listProviderSessions,
+  PROVIDER_HTTP_TIMEOUT_MS,
   redactProviderSecrets,
   resolveBrowserProvider,
 } from "../../dist/src/browser-providers.js";
@@ -338,4 +340,34 @@ test("provider secrets are registered for result-envelope redaction", () => {
   assert.ok(tracked2.includes("pass"));
   assert.ok(tracked2.includes("K"));
   assert.ok(tracked2.includes("hdr"));
+});
+
+test("provider API calls carry a timeout and name the network failure", async (t) => {
+  const realFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = realFetch;
+  });
+  let seenSignal = null;
+  globalThis.fetch = async (_url, init) => {
+    seenSignal = init?.signal;
+    throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+  };
+  await assert.rejects(
+    () => listProviderSessions("kernel", { apiKey: "k_test" }),
+    new RegExp(`GET https://api\\.onkernel\\.com/browsers timed out after ${PROVIDER_HTTP_TIMEOUT_MS / 1000}s`),
+  );
+  assert.ok(seenSignal instanceof AbortSignal, "fetch must be given an abort signal");
+
+  // undici's bare "fetch failed" carries the real reason in `cause`.
+  globalThis.fetch = async () => {
+    throw Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("getaddrinfo ENOTFOUND api.onkernel.com"), {
+        code: "ENOTFOUND",
+      }),
+    });
+  };
+  await assert.rejects(
+    () => listProviderSessions("kernel", { apiKey: "k_test" }),
+    /GET https:\/\/api\.onkernel\.com\/browsers failed: getaddrinfo ENOTFOUND api\.onkernel\.com/,
+  );
 });

--- a/tests/node/client-worker-lifecycle.test.ts
+++ b/tests/node/client-worker-lifecycle.test.ts
@@ -1,0 +1,158 @@
+// Worker lifecycle from the client's side: what a caller sees when the
+// worker restarts, dies at boot, or hangs at boot. None of these need the
+// managed browser — the worker prints its ready handshake before any launch.
+
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { BetterWright, BrowserError } from "../../dist/src/index.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+function alive(child) {
+  return Boolean(child) && child.exitCode === null && child.signalCode === null;
+}
+
+/** Point every worker this test spawns at a boot hook, restoring the env after. */
+function bootHook(t, home, source) {
+  const hook = path.join(home, "boot-hook.mjs");
+  fs.writeFileSync(hook, source);
+  const previous = process.env.NODE_OPTIONS;
+  process.env.NODE_OPTIONS = `--import=${pathToFileURL(hook).href}`;
+  t.after(() => {
+    if (previous === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = previous;
+  });
+}
+
+test("a restart close keeps the browser open: a call from another lane waits for the replacement worker", async (t) => {
+  const home = makeTempDir("bw-restart-race-");
+  const browser = new BetterWright({ home, headless: true, vault: false });
+  t.after(() => browser.close().catch(() => {}));
+
+  await browser._prepare();
+  const first = browser._process;
+  assert.ok(alive(first));
+
+  // Exactly what the execution-timeout path does — take the worker down as a
+  // restart — while a call from another session lands mid-teardown. It used
+  // to be told "This browser has been closed."; it must wait instead.
+  const restarting = browser.close({ child: first, preservePending: true, restart: true });
+  const config = await browser._prepare();
+  await restarting;
+
+  assert.ok(config.profileDir);
+  assert.equal(browser._closed, false);
+  assert.ok(alive(browser._process));
+  assert.notEqual(browser._process, first);
+  assert.equal(alive(first), false);
+});
+
+test("a final close still refuses new work", async () => {
+  const home = makeTempDir("bw-final-close-");
+  const browser = new BetterWright({ home, headless: true, vault: false });
+  await browser._prepare();
+  await browser.close();
+  assert.equal(browser._closed, true);
+  await assert.rejects(() => browser.run("return 1"), /This browser has been closed/);
+});
+
+test("a worker that dies before its handshake fails the call at once, with its stderr", async (t) => {
+  const home = makeTempDir("bw-worker-boot-crash-");
+  bootHook(t, home, 'throw new Error("boot failure marker 7f3a");\n');
+  const browser = new BetterWright({ home, headless: true, vault: false });
+  t.after(() => browser.close().catch(() => {}));
+
+  const started = Date.now();
+  await assert.rejects(
+    () => browser.run("return 1"),
+    (error: any) =>
+      error instanceof BrowserError &&
+      /exited before it was ready/.test(error.message) &&
+      /boot failure marker 7f3a/.test(error.message),
+  );
+  assert.ok(Date.now() - started < 10_000, "must not wait for the start timeout");
+  assert.equal(browser._process, null);
+});
+
+test("a worker that never answers is killed at the start timeout instead of staying attached", async (t) => {
+  const home = makeTempDir("bw-worker-boot-hang-");
+  // A live interval keeps the process up; the unsettled await stops the
+  // worker entrypoint from ever running, so no handshake is printed.
+  bootHook(t, home, "setInterval(() => {}, 1000);\nawait new Promise(() => {});\n");
+  const previous = process.env.BETTERWRIGHT_WORKER_START_TIMEOUT_MS;
+  process.env.BETTERWRIGHT_WORKER_START_TIMEOUT_MS = "1500";
+  t.after(() => {
+    if (previous === undefined) delete process.env.BETTERWRIGHT_WORKER_START_TIMEOUT_MS;
+    else process.env.BETTERWRIGHT_WORKER_START_TIMEOUT_MS = previous;
+  });
+  const browser = new BetterWright({ home, headless: true, vault: false });
+  t.after(() => browser.close().catch(() => {}));
+
+  const pending = browser.run("return 1");
+  while (!browser._process) await new Promise((resolve) => setTimeout(resolve, 10));
+  const child = browser._process;
+  const exited = once(child, "exit");
+  await assert.rejects(pending, /did not start within 2s/);
+  // The hung child is gone, and nothing is left attached for the next call
+  // to trust.
+  await exited;
+  assert.equal(alive(child), false);
+  assert.equal(browser._process, null);
+});
+
+test("writing to a worker that is going down never escapes as an uncaught error", async (t) => {
+  const home = makeTempDir("bw-worker-epipe-");
+  const browser = new BetterWright({ home, headless: true, vault: false });
+  t.after(() => browser.close().catch(() => {}));
+  await browser._prepare();
+  const child = browser._process;
+  // The deterministic half: the stream has an error listener at all.
+  assert.ok(child.stdin.listenerCount("error") >= 1);
+
+  const uncaught = [];
+  const onUncaught = (error) => uncaught.push(error);
+  process.on("uncaughtException", onUncaught);
+  t.after(() => process.off("uncaughtException", onUncaught));
+
+  // Kill the worker and keep writing until the client notices. Writes that
+  // land after the process is dead but before its exit event runs are the
+  // ones that raise EPIPE on stdin.
+  child.kill("SIGKILL");
+  const closed = once(child, "close");
+  const padding = "x".repeat(64 * 1024);
+  while (child.exitCode === null && child.signalCode === null) {
+    try {
+      browser._send({ type: "test_noop", padding }, child);
+    } catch (error) {
+      assert.match(String(error?.message), /worker is not running/);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+  await closed;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.deepEqual(uncaught, []);
+});
+
+test("a vault whose redact() returns a non-envelope withholds the result instead of crashing the call", async (t) => {
+  const home = makeTempDir("bw-redact-garbage-");
+  const vault = {
+    async handleRequest() {
+      return {};
+    },
+    redact() {
+      return undefined;
+    },
+  };
+  const browser = new BetterWright({ home, headless: true, vault });
+  t.after(() => browser.close().catch(() => {}));
+  await browser._prepare();
+  const status = await browser.liveViewStatus();
+  assert.deepEqual(status, {
+    ok: false,
+    error: "Result withheld: secret redaction failed.",
+  });
+});

--- a/tests/node/sdk.test.ts
+++ b/tests/node/sdk.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
 
 import * as providers from "../../dist/src/browser-providers.js";
@@ -123,4 +124,46 @@ test("withBrowser accepts a callback alone, with the default options", async () 
     delete process.env.BETTERWRIGHT_HOME;
   }
   assert.equal(closed.length, 1);
+});
+
+test("withBrowser rejects a bad call before a client exists", async () => {
+  const home = makeTempDir("bw-sdk-with-browser-bad-call-");
+  await assert.rejects(() => sdk.withBrowser({ home }), {
+    name: "TypeError",
+    message: /expects a callback/,
+  });
+  await assert.rejects(() => sdk.withBrowser("nope", async () => 1), {
+    name: "TypeError",
+    message: /options must be an object/,
+  });
+  // Nothing was constructed, so the home has not been touched.
+  assert.deepEqual(fs.readdirSync(home), []);
+});
+
+test("withBrowser reports the callback's error even when close fails too", async () => {
+  const home = makeTempDir("bw-sdk-with-browser-close-fails-");
+  await assert.rejects(
+    () =>
+      sdk.withBrowser({ home }, async (bw) => {
+        bw.close = async () => {
+          throw new Error("close failed");
+        };
+        throw new Error("callback failed");
+      }),
+    /callback failed/,
+  );
+});
+
+test("withBrowser propagates a close failure when the callback succeeded", async () => {
+  const home = makeTempDir("bw-sdk-with-browser-close-only-fails-");
+  await assert.rejects(
+    () =>
+      sdk.withBrowser({ home }, async (bw) => {
+        bw.close = async () => {
+          throw new Error("close failed");
+        };
+        return 1;
+      }),
+    /close failed/,
+  );
 });


### PR DESCRIPTION
A stability release for the SDK, plus the provider-account and `boxes` work queued since 2.0.0.

### Fixed
- A worker restart (execution timeout, worker-requested restart, reconfigure) no longer fails concurrent calls from other sessions with "This browser has been closed." Only a final `close()` marks the client closed; a call that lands mid-restart waits for the replacement worker.
- A worker that dies at boot fails the call immediately with its exit code/signal and stderr tail, instead of after the start timeout with no reason.
- A worker that hangs at boot is killed at the start timeout instead of staying attached as the live worker. `BETTERWRIGHT_WORKER_START_TIMEOUT_MS` tunes the timeout for slow hosts.
- The worker's stdin has an error listener, so a write racing its exit cannot crash the host with an uncaught EPIPE; spawn failures are reported as `BrowserError`.
- `withBrowser` validates its arguments before constructing a client, and keeps the callback's error when `close()` fails too.
- A vault whose `redact()` returns a non-envelope fails closed like a throwing `redact()`.

### Changed
- Provider REST calls (create/list/get/stop, and provider launches) time out after 30 s and report network failures by cause.

### Docs
- `docs/sdk.md` gains an "Errors, timeouts, and the worker" section; `docs/getting-started.md` documents the slow-host timeout.

`npm run release:check` passes locally (989 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoCxUaNZkH8dAPWdnJzBqa