### PR TITLE
release: 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-09-02
+
+### Added
+
+- **Cookie Sync.** The host SDK and `betterwright cookies` CLI can discover
+  mainstream Chromium, Firefox-family, and Safari profiles and copy scoped
+  cookies into local BetterChromium profiles on Windows, macOS, and Linux.
+  Remote Chromium providers and explicit CDP endpoints are supported with
+  exact per-call destination consent. Chromium partition, source-scheme, and
+  source-port scope is preserved; unsupported Firefox isolation is skipped.
+  Target quota preflight and readback verification prevent silent eviction and
+  false success counts.
+
+### Security
+
+- Cookie values stay off command arguments and the profile-daemon socket.
+  Raw Cookie and Set-Cookie header access and browser-context cookie mutation
+  are absent from model snippets, while known synced values
+  are redacted from result envelopes across profile restarts.
+
 ## [2.0.1] - 2026-09-01
 
 A stability release for the SDK. A worker restart no longer surfaces as a
@@ -1327,7 +1347,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/BetterWright/betterwright/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/BetterWright/betterwright/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/BetterWright/betterwright/compare/v1.11.0...v2.0.0
 [1.11.0]: https://github.com/BetterWright/betterwright/compare/v1.10.3...v1.11.0

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ step from what it sees, in a browser that must still be there next turn:
 | [**Agent snapshots**](docs/browser-api.md#reading-the-page) | The token-efficiency core: compressed tree, `[ref=eN]` actions, diff and interactive-only modes, password redaction |
 | [**Built-in agent loop**](docs/agent.md) | `betterwright exec` / the interactive console / `runAgentTask()` — model-first selection across Claude, Codex, Grok, OpenRouter, Ollama, vLLM, and any OpenAI-compatible endpoint |
 | [**Credential vault**](docs/credentials.md) | AES-256-GCM outside the profile; PSL site matching, selector-free login detection, metadata-only account choice |
+| [**Cookie Sync**](docs/cookie-sync.md) | Merge selected cookies from local Chrome, Edge, Brave, Firefox, Safari, and other desktop browsers into BetterChromium or an explicitly approved cloud browser |
 | [**Live view & handoff**](docs/live-view.md) | Watch and coach the agent live; token + optional password gated; `handoff` pauses for human hands and resumes on Done |
 | [**Network policy**](docs/network-policy.md) | Every navigation, subresource, WebSocket, and raw TCP connection checked; metadata endpoints always blocked |
 | [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
@@ -337,7 +338,7 @@ server reads too. See
 | [The built-in agent](docs/agent.md) | [CAPTCHA helpers](docs/captcha.md) | [Chromium fork](docs/chromium-fork.md) |
 | [JavaScript API](docs/javascript.md) | [Network policy](docs/network-policy.md) | [Headed / headless](docs/attach-mode.md) |
 | [Browser API (snippet globals)](docs/browser-api.md) | [BetterChromium](docs/chromium-fork.md) | [Browser providers](docs/browser-providers.md) |
-| [CAPTCHA recipes](docs/browser-recipes.md) | | Benchmarks: [Online-Mind2Web, 92.7% self-judged](benchmarks/online-mind2web/REPORT.md) · [agent head-to-head](benchmarks/exec-headtohead/REPORT.md) |
+| [CAPTCHA recipes](docs/browser-recipes.md) | [Cookie Sync](docs/cookie-sync.md) | Benchmarks: [Online-Mind2Web, 92.7% self-judged](benchmarks/online-mind2web/REPORT.md) · [agent head-to-head](benchmarks/exec-headtohead/REPORT.md) |
 
 The Online-Mind2Web figure is 278/300 on the pinned 2025-11-23 snapshot, scored
 by BetterWright's own strict multimodal judge — **not** an official

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,33 @@ threat model and the controls that enforce it are documented in
 Please read those sections before deploying BetterWright somewhere it can be
 driven by untrusted input.
 
+## Cookie Sync is a trusted transfer
+
+Cookie Sync reads authentication cookies from another local browser profile.
+It is exposed only through the host SDK and CLI, never as a model tool. Values
+do not enter configuration, command arguments, or the profile daemon socket,
+and the sync result contains metadata and counts only. Raw request/response
+header access is absent from model snippets. Synced bearer-like
+values and serialized short cookie pairs are redacted from later result
+envelopes, including after a local profile restart. Unsupported browser
+isolation is skipped rather than widened, and sync refuses an ephemeral
+destination profile.
+
+This output redaction is defense in depth, not a confidentiality boundary
+against hostile model code. A page can read its own non-HttpOnly cookies, and
+model-authored page code can transform a value before returning it, just as it
+can transform a password already filled into that page's DOM. Scope Cookie
+Sync to the origins and destination profile the task needs.
+
+Remote sync requires consent naming the exact provider or CDP host before
+extraction or provider session creation. The cookie then travels over the
+encrypted CDP WebSocket, but the provider necessarily receives it in its
+browser process and can observe subsequent authenticated traffic. Windows
+Chrome App-Bound recovery is a separate opt-in because it uses unprivileged
+process injection; BetterWright never enables the reader's elevated fallback.
+See [docs/cookie-sync.md](docs/cookie-sync.md) for the platform matrix and
+operational limits.
+
 ## The shell is a trusted channel
 
 `betterwright vault show --reveal`, `betterwright vault copy`, and

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.0.1
+generated_by: betterwright@2.1.0
 ---
 
 # BetterWright browser

--- a/bin/betterwright.ts
+++ b/bin/betterwright.ts
@@ -9,6 +9,7 @@
 //   betterwright configure        choose the browser backend (cloud provider,
 //                                 CDP endpoint, own binary, or the managed fork)
 //   betterwright boxes            start, list, and stop cloud browser boxes
+//   betterwright cookies          sync local browser cookies into a profile
 //   betterwright run <file|-|-c>  execute a Playwright snippet in the
 //                                 persistent session (tabs/state survive calls)
 //   betterwright repl             run blank-line-separated snippets from stdin
@@ -49,7 +50,12 @@ import { formatAgentUsage } from "../src/agent-usage.js";
 import { chromiumNeedsSoftwareGpu } from "../src/browser-runtime.js";
 import { configuredBrowserBackend } from "../src/chromium-fork.js";
 import { installChromiumFork } from "../src/chromium-fork-install.js";
-import { collectValues, firstPositional, flagValue } from "../src/cli-flags.js";
+import {
+  collectValues,
+  firstPositional,
+  flagValue,
+  positionalArgs,
+} from "../src/cli-flags.js";
 import { helpFor, MAIN_USAGE, wantsHelp } from "../src/cli-help.js";
 import {
   createInteractiveBrowserLifecycle,
@@ -616,6 +622,125 @@ async function cmdRun(arg, flags) {
     return result.ok ? 0 : 1;
   } finally {
     await acquired.cleanup({ closeSession: flags.has("--close") });
+  }
+}
+
+function cookieFlagValue(tokens, flag) {
+  const value = flagValue(tokens, flag);
+  if (value === undefined) return undefined;
+  const text = String(value).trim();
+  if (!text || text.startsWith("-")) {
+    throw new TypeError(`${flag} requires a value.`);
+  }
+  return text;
+}
+
+function cookieFlagValues(tokens, flag) {
+  const values = collectValues(tokens, flag).map((value) => String(value).trim());
+  if (values.some((value) => !value || value.startsWith("-"))) {
+    throw new TypeError(`${flag} requires a value each time it is used.`);
+  }
+  return values;
+}
+
+async function cmdCookies(tokens, flags) {
+  const [action, browser, ...extra] = positionalArgs(tokens);
+  const json = flags.has("--json");
+  const printFailure = (error) => {
+    const result = { ok: false, error: String(error) };
+    if (json) console.log(JSON.stringify(result, null, 2));
+    else console.error(result.error);
+    return 1;
+  };
+  try {
+    const {
+      listCookieSourceBrowsers,
+      listCookieSourceProfiles,
+    } = await import("../src/cookie-sync.js");
+    const { cookieSyncConsentTarget } = await import("../src/browser-providers.js");
+    if (action === "browsers") {
+      if (browser || extra.length) return printFailure("cookies browsers takes no positional arguments.");
+      const browsers = await listCookieSourceBrowsers();
+      if (json) console.log(JSON.stringify({ ok: true, browsers }, null, 2));
+      else if (!browsers.length) console.log("No supported browser families are registered on this host.");
+      else for (const item of browsers) console.log(`${item.id}\t${item.name}\t${item.engine}`);
+      return 0;
+    }
+    if (action === "profiles") {
+      if (!browser || extra.length) {
+        return printFailure("Usage: betterwright cookies profiles <browser> [--json]");
+      }
+      const profiles = await listCookieSourceProfiles(browser);
+      if (json) console.log(JSON.stringify({ ok: true, browser, profiles }, null, 2));
+      else if (!profiles.length) console.log(`No ${browser} profiles were found.`);
+      else {
+        for (const item of profiles) {
+          console.log(`${item.id}\t${item.name}${item.isDefault ? "\tdefault" : ""}`);
+        }
+      }
+      return 0;
+    }
+    if (action !== "sync" || !browser || extra.length) {
+      return printFailure("Usage: betterwright cookies sync <browser> (--domain <host>... | --all)");
+    }
+
+    const domains = cookieFlagValues(tokens, "--domain");
+    const all = flags.has("--all");
+    if (all === Boolean(domains.length)) {
+      return printFailure("cookies sync requires either --all or one or more --domain values.");
+    }
+    const sourceProfile = cookieFlagValue(tokens, "--source-profile");
+    const cloudConsent = cookieFlagValue(tokens, "--allow-cloud");
+    const source = { browser, profile: sourceProfile || undefined };
+    const options: any = {
+      source,
+      includeSession: flags.has("--include-session"),
+      windowsAppBound: flags.has("--allow-app-bound") ? "injection" : "disabled",
+    };
+    if (domains.length) options.domains = domains;
+    if (cloudConsent) options.cloudConsent = cloudConsent;
+
+    const acquired = await acquireRunBrowser(flags);
+    try {
+      if (!acquired.viaDaemon) {
+        if (options.includeSession) {
+          return printFailure(
+            "Cookie Sync with --include-session requires the session daemon so imported session cookies remain usable. Remove --no-daemon and retry." +
+              (acquired.warning ? ` ${acquired.warning}.` : ""),
+          );
+        }
+        const provider = "provider" in acquired.browser
+          ? acquired.browser.provider
+          : null;
+        const remoteTarget = cookieSyncConsentTarget(provider);
+        if (remoteTarget) {
+          return printFailure(
+            `Cookie Sync to ${remoteTarget} requires the session daemon so the imported browser remains usable. Remove --no-daemon and retry.` +
+              (acquired.warning ? ` ${acquired.warning}.` : ""),
+          );
+        }
+      }
+      const result = await acquired.browser.syncCookies(options);
+      const printable = acquired.warning
+        ? { ...result, runtimeWarnings: [acquired.warning] }
+        : result;
+      if (json) console.log(JSON.stringify(printable, null, 2));
+      else if (result.ok) {
+        console.log(
+          `Synced ${result.synced} cookie${result.synced === 1 ? "" : "s"} from ${browser} into ${result.target}.`,
+        );
+        if (result.skipped) console.log(`Skipped ${result.skipped} cookie rows.`);
+        for (const warning of result.warnings || []) {
+          console.log(`  ${warning.code}: ${warning.count}`);
+        }
+        if (acquired.warning) process.stderr.write(`  ! ${acquired.warning}\n`);
+      } else console.error(result.error || "Cookie Sync failed.");
+      return result.ok ? 0 : 1;
+    } finally {
+      await acquired.cleanup();
+    }
+  } catch (error) {
+    return printFailure(error?.message || "Cookie Sync failed.");
   }
 }
 
@@ -2051,6 +2176,8 @@ async function main() {
       const { runBoxesCommand } = await import("../src/boxes-cli.js");
       return runBoxesCommand(rest);
     }
+    case "cookies":
+      return cmdCookies(rest, flags);
     case "vault": {
       const { runVaultCommand } = await import("../src/vault-cli.js");
       return runVaultCommand(rest);

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ whole path works by loading a real page.
 | Page | What it covers |
 | --- | --- |
 | [Credential vault](credentials.md) | Encrypted storage, site matching, selector-free login, generated-password commits, and `betterwright vault` for reading your own saved passwords back |
+| [Cookie Sync](cookie-sync.md) | Copy selected local browser cookies into BetterChromium or an explicitly approved cloud browser |
 | [Live view & handoff](live-view.md) | Watch/coach/take over in a browser tab; hosting presets, password gate, security model |
 | [CAPTCHA helpers](captcha.md) | Local checkbox/Turnstile/slider/motion/drag-fit solving; numbered-crop vision loop for image grids |
 | [Network policy](network-policy.md) | What the browser may reach; the unliftable metadata floor |

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -561,7 +561,14 @@ it escape the policy or read the host. These are absent by design and return
   properties, and CDP sessions stay inside the worker. Attach-mode endpoints
   are trusted host configuration and are not exposed as snippet globals.
 - **Context mutation** — `context.newPage`, `context.cookies`,
-  `context.storageState`, `context.close`, `context.tracing`. Use `openPage`.
+  `context.storageState`, `context.addCookies`, `context.clearCookies`,
+  `context.setStorageState`, `context.close`, `context.tracing`. Use `openPage`;
+  trusted host code can import an identity with
+  [Cookie Sync](cookie-sync.md).
+- **Raw network credentials** — full and name-addressed request/response header
+  methods are absent. Playwright's filtered `headers()` remains available, as
+  do request/response timing, status, URL, resource type, and request-body
+  inspection.
 - **`page.screenshot`** — use the `screenshot()` helper so captures are tracked
   as artifacts.
 - **Filesystem reach** — `setInputFiles`, `FileChooser.setFiles`,

--- a/docs/browser-providers.md
+++ b/docs/browser-providers.md
@@ -191,6 +191,12 @@ Provider credentials (the API key, and any credentials embedded in the CDP
 URL) are registered with the worker's redaction set at launch, so they appear
 as `[redacted]` in every result envelope, event, and artifact path.
 
+[Cookie Sync](cookie-sync.md) can merge local browser cookies into any of the
+remote contexts above. It requires exact per-call consent because the provider
+can read the resulting authenticated browser state. BetterWright sends the
+cookies through CDP after connection, not through provider REST or session
+configuration APIs.
+
 ## `sessionOptions`
 
 For REST-minting launches (Kernel, Browserbase, Anchor, Hyperbrowser) and for

--- a/docs/cookie-sync.md
+++ b/docs/cookie-sync.md
@@ -1,0 +1,197 @@
+# Cookie Sync
+
+Cookie Sync copies cookies from a local desktop browser into a BetterWright
+browser profile. It is a trusted host operation, not a model tool. The source
+profile stays unchanged, and running the same sync again replaces the same
+cookie identities.
+
+## Sync from the CLI
+
+List the browser families supported on this operating system, then inspect the
+profiles found for one family:
+
+```bash
+betterwright cookies browsers
+betterwright cookies profiles chrome
+```
+
+Sync only the sites needed for the task:
+
+```bash
+betterwright cookies sync chrome \
+  --source-profile "Profile 1" \
+  --domain github.com \
+  --domain npmjs.com \
+  --profile work
+```
+
+`--domain` includes cookies on the named host, its subdomains, and parent
+domains whose cookies apply to that host. Repeat it for more sites. Use
+`--all` instead only when the entire source identity belongs in the target.
+The CLI requires one of these scopes so an omitted flag cannot copy every
+site by accident.
+
+Persistent cookies are included by default. `--include-session` also reads
+Firefox-family session stores. Chromium-family session cookies that exist
+only in a running browser process cannot be recovered from its profile, so
+that flag is a no-op for Chromium sources.
+
+The selected BetterWright `--profile` is the destination. Sync fails rather
+than writing into the temporary profile used after a local profile-lock
+collision. Close the other BetterWright process or use its profile daemon and
+retry.
+
+Remote CLI sync and local CLI sync with `--include-session` require the session
+daemon. A one-shot `--no-daemon` browser would disconnect or end a remote
+session, and it would discard local session cookies when the command closed.
+The CLI refuses those combinations instead of reporting unusable state as a
+successful sync.
+
+Add `--json` for a result containing counts, warning codes, source metadata,
+and the target identity. Cookie names and values are never returned. The
+`synced` count is verified against the target store rather than assumed from a
+successful CDP call.
+
+Before writing, BetterWright reads the target cookie jar and refuses a batch
+whose projected occupancy crosses conservative Chromium limits. This avoids
+triggering Chromium's per-site or global eviction. After writing, it verifies
+both the imported identities and the pre-existing identities. A valid row that
+the target still declines is reported as `target_not_stored`; unexpected loss
+of a pre-existing identity fails the operation loudly.
+
+## JavaScript API
+
+```ts
+import { BetterWright, listCookieSourceProfiles } from "betterwright";
+
+const profiles = await listCookieSourceProfiles("firefox");
+const browser = new BetterWright({ profile: "work" });
+
+const result = await browser.syncCookies({
+  source: { browser: "firefox", profile: profiles[0]?.id },
+  domains: ["github.com"],
+  includeSession: true,
+});
+
+await browser.close();
+```
+
+Omitting `domains` in the API means all compatible cookies. The explicit
+`--all` requirement applies to the CLI because shell mistakes are easier to
+make.
+
+## Source support
+
+BetterWright uses the exact-pinned optional `rookie-cookies` native reader.
+It discovers profiles in their normal operating-system locations and uses the
+host key store where that browser requires it.
+
+| Source family | Windows | macOS | Linux |
+| --- | --- | --- | --- |
+| Chrome, Edge, Brave, Chromium, Opera, Vivaldi and other registered Chromium browsers | Yes | Yes | Yes |
+| Firefox, LibreWolf, Zen and other registered Gecko browsers | Yes | Yes | Yes |
+| Safari | No | Yes | No |
+
+`betterwright cookies browsers` is the source of truth for the current host.
+Registration does not mean the browser is installed; `cookies profiles`
+performs discovery. The shipped native targets are Windows x64, macOS x64 and
+arm64, and glibc Linux x64 and arm64. Windows ARM64 and musl Linux currently
+fail with a feature-local unavailable error instead of weakening extraction.
+
+macOS may ask for Keychain access. Safari profile files can require Full Disk
+Access. Linux Chromium decryption depends on the desktop Secret Service or
+KWallet configuration used by that browser.
+
+### Windows App-Bound cookies
+
+Chrome-family App-Bound recovery is disabled by default. Current Chrome can
+therefore report skipped `v20` rows until the caller opts in:
+
+```bash
+betterwright cookies sync chrome --domain example.com --allow-app-bound
+```
+
+The opt-in permits unprivileged reflective injection into a newly spawned
+browser process. Endpoint security software can flag this technique. The
+reader's elevated SYSTEM-impersonation fallback is never reachable through
+BetterWright. If process injection is unacceptable on the host, leave the
+flag off and sign in again for the skipped sites.
+
+### Isolation and expiry
+
+Chromium CHIPS cookies retain their top-level-site partition and cross-site
+ancestor bit. Origin-bound Chromium cookies also retain their source scheme
+and port. Firefox containers, private-browsing cookies, Firefox partition forms
+that Chromium cannot represent, malformed rows, and expired rows are skipped.
+BetterWright never turns an isolated cookie into an unpartitioned cookie
+because that would widen where the credential can be sent.
+
+Some sites use device-bound session credentials in addition to cookies. Those
+private keys are not copied, so a site can still require authentication after
+a successful sync.
+
+## Cloud browsers
+
+Cookie injection is available for every BetterWright remote target because
+all supported providers converge on a Chromium CDP connection and its default
+Playwright `BrowserContext`:
+
+- Browser Use
+- Kernel
+- Browserbase
+- Steel
+- Anchor
+- Hyperbrowser
+- Browserless
+- Bright Data
+- Oxylabs
+- custom CDP endpoints
+
+BetterWright uses CDP `Network.setCookies` after connecting so CHIPS and
+origin-bound scope survive the transfer. Cookie
+values do not enter provider REST request bodies, session options, command
+arguments, configuration files, the daemon socket, logs, or result envelopes.
+They do cross the encrypted CDP WebSocket in plaintext at the browser endpoint.
+The provider runs that browser and can inspect its memory, storage, recordings,
+and network traffic. End-to-end encryption from the provider is not possible
+because its Chromium process needs the cookie value to send authenticated
+requests.
+
+For that reason, each remote sync must name the exact resolved destination:
+
+```bash
+betterwright cookies sync chrome \
+  --domain github.com \
+  --browser browserbase \
+  --allow-cloud provider:browserbase
+```
+
+For raw or custom CDP endpoints, consent is `cdp:<host>` or
+`cdp:<host>:<port>`. A refused call prints the required target. BetterWright
+checks it before local extraction and before a named provider can create a
+billed session, then checks it again in the worker before connecting. Consent
+is an argument to that one call and is never stored as a preference.
+
+Sync persists for the life of the remote browser context. Provider-owned
+profiles can persist it longer only when the caller separately configured that
+provider feature. Cookie Sync does not call provider-specific profile save
+APIs and does not promise cross-session persistence.
+
+## Trust boundary
+
+The profile daemon receives only source browser, profile, scope, and consent
+options. Extraction runs inside the daemon and the cookie batch travels only
+to its worker over child-process stdin. Browser-context cookie reads and
+mutations, including `cookies`, `storageState`, `addCookies`, and
+`clearCookies`, are absent from model-authored snippets. Full and
+name-addressed request/response header methods are absent as well; Playwright's
+filtered `headers()` remains available.
+
+Cookie Sync transfers browser authority. A page can still read non-HttpOnly
+cookies for its own origin through `document.cookie`, and model code driving
+that page can act with the imported session. BetterWright redacts known raw
+bearer-like values and serialized short cookie pairs from result envelopes,
+including after restart, but model code can transform page-readable data. The
+sandbox is defense in depth, not a confidentiality boundary. HttpOnly cookies
+retain their normal browser protection. Scope the sync to the sites and target
+profile the task actually needs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "betterwright",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "betterwright",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "1.61.1",
@@ -27,7 +27,8 @@
         "node": ">=22.18.0"
       },
       "optionalDependencies": {
-        "patchright-core": "1.61.1"
+        "patchright-core": "1.61.1",
+        "rookie-cookies": "0.6.0"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.30.0",
@@ -1900,6 +1901,109 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rookie-cookies": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rookie-cookies/-/rookie-cookies-0.6.0.tgz",
+      "integrity": "sha512-QFNmmGEK6zujgjopRynAA8Q+YHAIgd5RELNEYLHd7K/VYwFm29mNCgMAs4A/GnmgPN+wE4Dc28C/Lj5x1m7z9A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "rookie-cookies-darwin-arm64": "0.6.0",
+        "rookie-cookies-darwin-x64": "0.6.0",
+        "rookie-cookies-linux-arm64-gnu": "0.6.0",
+        "rookie-cookies-linux-x64-gnu": "0.6.0",
+        "rookie-cookies-win32-x64-msvc": "0.6.0"
+      }
+    },
+    "node_modules/rookie-cookies-darwin-arm64": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rookie-cookies-darwin-arm64/-/rookie-cookies-darwin-arm64-0.6.0.tgz",
+      "integrity": "sha512-bZhUA5e3EGGWL7obpMKyFpw+SBauRD/umix9EPL25i2Gdvk1iSkqHEEVpAr2wUAoEnCeBAWlbFdd3pJ+6SGMBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/rookie-cookies-darwin-x64": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rookie-cookies-darwin-x64/-/rookie-cookies-darwin-x64-0.6.0.tgz",
+      "integrity": "sha512-FPhjqYAG0JXZ+cCshvvOOgZt/qLnMD5iqb6ufYcwanjgFT95Qf+AJ3P5ArhmChcNrTCsVr8lS8PQSSI0m/IDxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/rookie-cookies-linux-arm64-gnu": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rookie-cookies-linux-arm64-gnu/-/rookie-cookies-linux-arm64-gnu-0.6.0.tgz",
+      "integrity": "sha512-+N6jkh5SZren9dmG0xRzjk6GIu0yyIqmD7VHl2v2fQJFi5kAntyziNI6wAqsj0H6T+S7ebf7OGB2gqh+zt/zHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/rookie-cookies-linux-x64-gnu": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rookie-cookies-linux-x64-gnu/-/rookie-cookies-linux-x64-gnu-0.6.0.tgz",
+      "integrity": "sha512-uUGfZNuNWQ6+2SipFsTTGLanOVVJiSHQlH7VtlR52qbN36+j3hdtUz1FxLLUqUPx6ljRsCnNwQSgalf6KJvtiA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/rookie-cookies-win32-x64-msvc": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rookie-cookies-win32-x64-msvc/-/rookie-cookies-win32-x64-msvc-0.6.0.tgz",
+      "integrity": "sha512-mHi3vHJS3bb6QNX3zHIMLWyNhaQ9lo6SQ9H6ZKEwaQaB/4vGHpiclCy+5H35iy2sc2UPJHvyrnHsPvQRZ5mVxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/router": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -163,6 +163,7 @@
     "typescript": "^7.0.2"
   },
   "optionalDependencies": {
-    "patchright-core": "1.61.1"
+    "patchright-core": "1.61.1",
+    "rookie-cookies": "0.6.0"
   }
 }

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -44,6 +44,36 @@ if (patchright !== pkg.dependencies["playwright-core"]) {
 if (lockRoot.optionalDependencies?.["patchright-core"] !== patchright) {
   failures.push("package-lock.json patchright-core pin does not match package.json");
 }
+// Cookie extraction handles authentication bearer material and ships native
+// binaries. Keep the audited facade and every platform package on one exact
+// version rather than accepting a newly published binary during install.
+const rookieCookies = pkg.optionalDependencies?.["rookie-cookies"];
+if (rookieCookies !== "0.6.0") {
+  failures.push(
+    `rookie-cookies must be pinned to the audited exact version 0.6.0; found ${rookieCookies ?? "nothing"}`,
+  );
+}
+if (lockRoot.optionalDependencies?.["rookie-cookies"] !== rookieCookies) {
+  failures.push("package-lock.json rookie-cookies pin does not match package.json");
+}
+expectMatch(
+  "Cookie Sync runtime reader pin",
+  read("src/cookie-sync.ts"),
+  /COOKIE_READER_VERSION = "([^"]+)"/,
+  rookieCookies,
+);
+for (const name of [
+  "rookie-cookies",
+  "rookie-cookies-darwin-arm64",
+  "rookie-cookies-darwin-x64",
+  "rookie-cookies-linux-arm64-gnu",
+  "rookie-cookies-linux-x64-gnu",
+  "rookie-cookies-win32-x64-msvc",
+]) {
+  if (lock.packages?.[`node_modules/${name}`]?.version !== rookieCookies) {
+    failures.push(`${name} lockfile version must be ${rookieCookies}`);
+  }
+}
 const npmVersion = String(pkg.packageManager || "").match(/^npm@(.+)$/)?.[1];
 if (!npmVersion) failures.push("packageManager must pin an exact npm version");
 else {

--- a/src/browser-providers.ts
+++ b/src/browser-providers.ts
@@ -512,6 +512,23 @@ export function resolveBrowserProvider(provider, { env = process.env } = {}) {
   return { plan: resolveNamedProvider(descriptor, name, provider, env) };
 }
 
+/**
+ * Stable identity a Cookie Sync consent must name. Resolving is deliberately
+ * side-effect free here: deferred providers are not created until the worker
+ * launches, after both the client and worker have checked this value.
+ */
+export function cookieSyncConsentTarget(provider, { env = process.env } = {}) {
+  const resolution = resolveBrowserProvider(provider, { env });
+  const plan = resolution?.plan;
+  if (plan?.kind !== "remote") return null;
+  if (plan.provider !== "cdp") return `provider:${plan.provider}`;
+  try {
+    return `cdp:${new URL(plan.cdpUrl).host.toLowerCase()}`;
+  } catch {
+    throw new TypeError("Cookie Sync could not identify the CDP endpoint.");
+  }
+}
+
 function resolveLocalProvider(executablePath) {
   if (!path.isAbsolute(executablePath)) {
     throw new TypeError("provider.executablePath must be an absolute path.");

--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -38,6 +38,7 @@ export const VALUE_FLAGS = new Set([
   // two parsers should agree rather than depend on that ordering.
   "-c",
   "--allow-host",
+  "--allow-cloud",
   "--api-key-env",
   "--base-url",
   "--block-host",
@@ -49,6 +50,7 @@ export const VALUE_FLAGS = new Set([
   "--disconnect",
   "--category",
   "--delay",
+  "--domain",
   "--effort",
   "--endpoint",
   "--expose",
@@ -69,6 +71,7 @@ export const VALUE_FLAGS = new Set([
   "--session",
   "--session-id",
   "--status",
+  "--source-profile",
   "--key-env",
   "--add",
   "--remove",

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -14,6 +14,7 @@ export const COMMAND_SUMMARIES = [
   ["doctor", "check that everything needed is installed and reachable"],
   ["configure", "choose the browser backend: cloud provider, custom CDP, or managed"],
   ["boxes", "start, list, and stop cloud browser boxes"],
+  ["cookies", "sync local browser cookies into a BetterWright profile"],
   ["run", "run one Playwright snippet in the persistent session"],
   ["repl", "run blank-line-separated snippets from stdin"],
   ["exec", "hand a whole task to BetterWright's own browser agent"],
@@ -158,6 +159,34 @@ Connect a provider first:
 
 Browserless, Bright Data, and Oxylabs have no session lifecycle — they are
 connect-only. Details: docs/browser-providers.md`,
+
+  cookies: `Usage: betterwright cookies browsers [--json]
+       betterwright cookies profiles <browser> [--json]
+       betterwright cookies sync <browser> (--domain <host>... | --all) [options]
+
+Copy cookies from a local browser profile into the selected persistent
+BetterWright profile. Sync merges cookies and can be run again safely.
+
+Options for sync:
+  --domain <host>          sync this domain, its subdomains, and applicable
+                           parent-domain cookies. Repeat for more domains
+  --all                    sync every compatible cookie in the source profile
+  --source-profile <id>    source profile id or name from \`cookies profiles\`
+  --include-session        include Firefox-family session-store cookies
+  --allow-app-bound        on Windows, allow unprivileged browser-process
+                           injection for Chrome App-Bound cookie decryption
+  --profile <name>         target BetterWright identity
+  --browser <name|url>     target cloud provider or CDP endpoint
+  --browser-key <key>      target provider API key
+  --session-id <id>        attach to an existing cloud browser
+  --allow-cloud <target>   exact consent target printed by a refused attempt,
+                           such as provider:browserbase or cdp:host:port
+  --no-daemon              run without the target profile daemon
+  --json                   machine-readable result
+
+Cloud sync sends cookie plaintext through the encrypted CDP connection to the
+provider. It does not enable provider profile persistence. Details:
+docs/cookie-sync.md`,
 
   run: `Usage: betterwright run -c "<javascript>"
        betterwright run <file>

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,14 @@ import {
   configuredDefaultProvider,
   expandProviderChoice,
 } from "./browser-config.js";
+import {
+  cookieSyncConsentTarget,
+} from "./browser-providers.js";
 import { resolveChromiumArgs } from "./chromium-args.js";
+import {
+  extractCookieSync,
+  normalizeCookieSyncOptions,
+} from "./cookie-sync.js";
 import {
   assertRotationPreservesMatchMode,
   MAX_PENDING_CREDENTIAL_ORIGINS,
@@ -324,6 +331,7 @@ export class BetterWright {
   declare _ready: any;
   declare _lastConfig: any;
   declare _queues: Map<any, any>;
+  declare _exclusiveGate: Promise<void>;
   declare _preparing: any;
   declare _stderrTail: any[];
   declare _closed: boolean;
@@ -533,6 +541,7 @@ export class BetterWright {
     // (live view) share the lane below, matching the worker, which also runs
     // them outside its per-session execute queues.
     this._queues = new Map();
+    this._exclusiveGate = Promise.resolve();
     this._preparing = null;
     this._stderrTail = [];
     this._closed = false;
@@ -609,6 +618,10 @@ export class BetterWright {
       ...process.env,
       NODE_NO_WARNINGS: "1",
     };
+    // Playwright's pw:protocol debug scope logs complete CDP payloads. The
+    // worker handles cookies and vault fills, so host DEBUG settings must not
+    // turn its stderr into a secret side channel.
+    delete env.DEBUG;
     const core = resolvePlaywrightCore();
     if (core) env.BETTERWRIGHT_PLAYWRIGHT_CORE_PATH = core;
 
@@ -1076,7 +1089,8 @@ export class BetterWright {
   _enqueue(session, job): Promise<any> {
     const lane = this._lane(session);
     const tail = this._queues.get(lane) || Promise.resolve();
-    const task = tail.then(job);
+    const gate = this._exclusiveGate;
+    const task = Promise.all([tail, gate]).then(job);
     // Keep the chain alive even if one run rejects, and drop the lane once it
     // drains so a long-lived browser does not accumulate one dead promise per
     // session name it has ever seen.
@@ -1089,6 +1103,89 @@ export class BetterWright {
       if (this._queues.get(lane) === chained) this._queues.delete(lane);
     });
     return task;
+  }
+
+  _enqueueExclusive(job): Promise<any> {
+    const priorGate = this._exclusiveGate;
+    const priorQueues = [...this._queues.values()];
+    let release: () => void = () => {};
+    this._exclusiveGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return Promise.all([priorGate, ...priorQueues])
+      .then(job)
+      .finally(release);
+  }
+
+  /**
+   * Copy cookies from a local browser profile into this browser's persistent
+   * context. Extraction and injection stay in trusted host code.
+   */
+  syncCookies(options: any = {}) {
+    return this._enqueueExclusive(() => this._syncCookiesNow(options));
+  }
+
+  async _syncCookiesNow(options) {
+    if (this._closed) {
+      return { ok: false, error: "This browser has been closed." };
+    }
+    let normalized;
+    let consentTarget;
+    try {
+      normalized = normalizeCookieSyncOptions(options);
+      consentTarget = cookieSyncConsentTarget(this.provider);
+      if (consentTarget && normalized.cloudConsent !== consentTarget) {
+        return {
+          ok: false,
+          error:
+            `Cookie Sync to ${consentTarget} requires cloudConsent set to that exact target.`,
+        };
+      }
+    } catch (error) {
+      return { ok: false, error: String(error?.message || error) };
+    }
+
+    let extracted;
+    try {
+      extracted = await this._extractCookieSync(normalized);
+    } catch (error) {
+      return { ok: false, error: String(error?.message || error) };
+    }
+    if (!extracted.cookies.length) {
+      return {
+        ok: true,
+        synced: 0,
+        selected: extracted.selected,
+        skipped: extracted.skipped,
+        source: extracted.source,
+        target: consentTarget || "local",
+        warnings: extracted.warnings,
+      };
+    }
+
+    const config = await this._prepare();
+    const timeoutSeconds = Math.max(
+      Math.ceil(normalized.timeoutMs / 1000),
+      this.defaultTimeout,
+      5,
+    );
+    return this._dispatch(
+      {
+        type: "cookie_sync",
+        config,
+        cookies: extracted.cookies,
+        source: extracted.source,
+        selected: extracted.selected,
+        skipped: extracted.skipped,
+        warnings: extracted.warnings,
+        cloudConsent: normalized.cloudConsent,
+      },
+      timeoutSeconds,
+    );
+  }
+
+  _extractCookieSync(options) {
+    return extractCookieSync(options);
   }
 
   /**

--- a/src/cookie-sync.ts
+++ b/src/cookie-sync.ts
@@ -1,0 +1,721 @@
+import { isIP } from "node:net";
+import { domainToASCII } from "node:url";
+
+import {
+  isBoolean,
+  isCallable,
+  isNumber,
+  isRecord,
+  isString,
+  type UntrustedValue,
+  untrustedField,
+} from "./untrusted-value.js";
+
+export const COOKIE_SYNC_MAX_COOKIES = 10_000;
+export const COOKIE_SYNC_MAX_BYTES = 6 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 120_000;
+const COOKIE_READER_VERSION = "0.6.0";
+
+export interface CookieSyncTargetCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires?: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+  sourceScheme?: "Unset" | "NonSecure" | "Secure";
+  sourcePort?: number;
+  partitionKey?: string;
+  partitionCrossSiteAncestor?: boolean;
+}
+
+export interface NormalizedCookieSyncOptions {
+  source: { browser: string; profile?: string };
+  domains?: string[];
+  includeSession: boolean;
+  windowsAppBound: "disabled" | "injection";
+  cloudConsent?: string;
+  timeoutMs: number;
+}
+
+interface CookieReaderReadOptions {
+  browser: string;
+  profile?: string;
+  includeSession: boolean;
+  timeoutMs: number;
+  appBound: "disabled" | "injection_only";
+}
+
+interface CookieReaderModule {
+  version: () => string;
+  read: (options: CookieReaderReadOptions) => Promise<UntrustedValue>;
+  supportedBrowsers: () => Promise<UntrustedValue>;
+  browserProfiles: (
+    browser: string,
+    options: { timeoutMs: number },
+  ) => Promise<UntrustedValue>;
+}
+
+export interface CookieSyncExtraction {
+  cookies: CookieSyncTargetCookie[];
+  selected: number;
+  skipped: number;
+  warnings: Array<{ code: string; count: number }>;
+  source: { browser: string; profile?: string };
+}
+
+function isCookieReaderModule(value: UntrustedValue): value is CookieReaderModule {
+  return (
+    isRecord(value) &&
+    isCallable(untrustedField(value, "version")) &&
+    isCallable(untrustedField(value, "read")) &&
+    isCallable(untrustedField(value, "supportedBrowsers")) &&
+    isCallable(untrustedField(value, "browserProfiles"))
+  );
+}
+
+async function loadCookieReader(): Promise<CookieReaderModule> {
+  let loaded: UntrustedValue;
+  try {
+    loaded = await import("rookie-cookies");
+  } catch {
+    throw new Error(
+      "Cookie Sync is unavailable on this host. Reinstall BetterWright with optional dependencies enabled.",
+    );
+  }
+  if (!isCookieReaderModule(loaded)) {
+    throw new Error("Cookie Sync could not load its local browser reader.");
+  }
+  const reportedVersion = loaded.version();
+  const version = isString(reportedVersion)
+    ? reportedVersion.trim().split(/\s+/, 1)[0]
+    : "";
+  if (version !== COOKIE_READER_VERSION) {
+    throw new Error("Cookie Sync found an unsupported local browser reader version.");
+  }
+  return loaded;
+}
+
+function cleanText(value: UntrustedValue, limit: number): string {
+  return isString(value) ? value.trim().slice(0, limit) : "";
+}
+
+function hasAsciiControl(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function cleanPublicText(value: UntrustedValue, limit: number): string {
+  if (!isString(value)) return "";
+  let clean = "";
+  for (const character of value.trim()) {
+    const code = character.charCodeAt(0);
+    clean += code <= 0x1f || code === 0x7f ? " " : character;
+  }
+  return clean.replace(/\s+/g, " ").trim().slice(0, limit);
+}
+
+function normalizeFilterDomain(value: UntrustedValue): string {
+  const raw = cleanText(value, 2_048);
+  if (!raw) throw new TypeError("Cookie Sync domains must be non-empty strings.");
+  let host = "";
+  try {
+    const input = raw.includes("://") ? raw : `https://${raw}`;
+    const parsed = new URL(input);
+    if (
+      !["http:", "https:"].includes(parsed.protocol) ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new TypeError("invalid");
+    }
+    host = parsed.hostname;
+  } catch {
+    throw new TypeError(
+      "Cookie Sync domains must be hostnames or bare HTTP(S) origins, without paths or credentials.",
+    );
+  }
+  const ascii = domainToASCII(host.replace(/^\./, "").toLowerCase());
+  if (!ascii || ascii.length > 253 || /\s/.test(ascii) || hasAsciiControl(ascii)) {
+    throw new TypeError("Cookie Sync domains must be valid hostnames.");
+  }
+  return ascii;
+}
+
+export function normalizeCookieSyncOptions(
+  value: UntrustedValue,
+): NormalizedCookieSyncOptions {
+  if (!isRecord(value)) {
+    throw new TypeError("syncCookies options must be an object.");
+  }
+  const sourceValue = untrustedField(value, "source");
+  if (!isRecord(sourceValue)) {
+    throw new TypeError("syncCookies options require source.browser.");
+  }
+  const browser = cleanText(untrustedField(sourceValue, "browser"), 128).toLowerCase();
+  if (!browser || !/^[a-z0-9][a-z0-9._-]*$/.test(browser)) {
+    throw new TypeError("syncCookies source.browser must be a browser id.");
+  }
+  const source: NormalizedCookieSyncOptions["source"] = { browser };
+  const profileValue = untrustedField(sourceValue, "profile");
+  if (profileValue !== undefined) {
+    const profile = cleanText(profileValue, 4_096);
+    if (!profile || hasAsciiControl(profile)) {
+      throw new TypeError("syncCookies source.profile must be non-empty and single-line.");
+    }
+    source.profile = profile;
+  }
+
+  const domainsValue = untrustedField(value, "domains");
+  let domains: string[] | undefined;
+  if (domainsValue !== undefined) {
+    if (!Array.isArray(domainsValue) || !domainsValue.length) {
+      throw new TypeError("syncCookies domains must be a non-empty array when provided.");
+    }
+    domains = [...new Set(domainsValue.map(normalizeFilterDomain))];
+  }
+
+  const includeSessionValue = untrustedField(value, "includeSession");
+  if (includeSessionValue !== undefined && !isBoolean(includeSessionValue)) {
+    throw new TypeError("syncCookies includeSession must be a boolean.");
+  }
+  const appBoundValue = untrustedField(value, "windowsAppBound");
+  const windowsAppBound = appBoundValue === undefined
+    ? "disabled"
+    : cleanText(appBoundValue, 32);
+  if (!new Set(["disabled", "injection"]).has(windowsAppBound)) {
+    throw new TypeError(
+      'syncCookies windowsAppBound must be "disabled" or "injection".',
+    );
+  }
+  const cloudConsentValue = untrustedField(value, "cloudConsent");
+  const cloudConsent = cloudConsentValue === undefined
+    ? undefined
+    : cleanText(cloudConsentValue, 512).toLowerCase();
+  if (cloudConsentValue !== undefined && !cloudConsent) {
+    throw new TypeError("syncCookies cloudConsent must be non-empty when provided.");
+  }
+  if (cloudConsent && hasAsciiControl(cloudConsent)) {
+    throw new TypeError("syncCookies cloudConsent must be a single-line target.");
+  }
+  const timeoutValue = untrustedField(value, "timeoutMs");
+  const timeoutMs = timeoutValue === undefined ? DEFAULT_TIMEOUT_MS : timeoutValue;
+  if (!isNumber(timeoutMs) || !Number.isFinite(timeoutMs) || timeoutMs < 1_000) {
+    throw new TypeError("syncCookies timeoutMs must be a finite number of at least 1000.");
+  }
+  const normalized: NormalizedCookieSyncOptions = {
+    source,
+    includeSession: includeSessionValue === true,
+    windowsAppBound: windowsAppBound === "injection" ? "injection" : "disabled",
+    timeoutMs: Math.min(Math.floor(timeoutMs), MAX_TIMEOUT_MS),
+  };
+  if (domains) normalized.domains = domains;
+  if (cloudConsent) normalized.cloudConsent = cloudConsent;
+  return normalized;
+}
+
+function normalizeCookieDomain(value: UntrustedValue): string | null {
+  if (!isString(value)) return null;
+  const raw = value.trim().toLowerCase();
+  const dotted = raw.startsWith(".");
+  const host = raw.replace(/^\./, "");
+  if (host.startsWith("[") && host.endsWith("]")) {
+    return !dotted && isIP(host.slice(1, -1)) === 6 ? host : null;
+  }
+  const ascii = domainToASCII(host);
+  if (
+    !ascii ||
+    ascii.length > 253 ||
+    ascii.startsWith(".") ||
+    ascii.endsWith(".") ||
+    ascii.includes("..") ||
+    /[\s/:]/.test(ascii) ||
+    hasAsciiControl(ascii)
+  ) return null;
+  return dotted ? `.${ascii}` : ascii;
+}
+
+function firefoxOriginIsolated(value: UntrustedValue): boolean | null {
+  if (value === null || value === undefined) return false;
+  if (!isString(value)) return null;
+  const text = value.trim();
+  if (!text) return false;
+  try {
+    const parsed: UntrustedValue = JSON.parse(text);
+    if (isRecord(parsed) && Object.keys(parsed).length === 0) return false;
+  } catch {
+    // Persistent Firefox rows use a compact non-JSON attribute suffix.
+  }
+  return true;
+}
+
+function chromiumSourceScheme(
+  value: UntrustedValue,
+): CookieSyncTargetCookie["sourceScheme"] | null {
+  if (value === null || value === undefined) return undefined;
+  if (value === 0) return "Unset";
+  if (value === 1) return "NonSecure";
+  if (value === 2) return "Secure";
+  return null;
+}
+
+function chromiumSourcePort(value: UntrustedValue): number | undefined | null {
+  if (value === null || value === undefined) return undefined;
+  if (
+    isNumber(value) &&
+    Number.isInteger(value) &&
+    (value === -1 || (value >= 1 && value <= 65_535))
+  ) return value;
+  return null;
+}
+
+function domainSelected(cookieDomain: string, filters: string[] | undefined): boolean {
+  if (!filters) return true;
+  const includesSubdomains = cookieDomain.startsWith(".");
+  const host = cookieDomain.replace(/^\./, "");
+  return filters.some(
+    (domain) =>
+      host === domain ||
+      host.endsWith(`.${domain}`) ||
+      (includesSubdomains && domain.endsWith(`.${host}`)),
+  );
+}
+
+function sameSite(value: UntrustedValue): CookieSyncTargetCookie["sameSite"] | null {
+  if (value === -1) return undefined;
+  if (value === 0) return "None";
+  if (value === 1) return "Lax";
+  if (value === 2) return "Strict";
+  return null;
+}
+
+function partitionSite(value: UntrustedValue): string | null {
+  if (!isString(value) || !value.trim()) return null;
+  try {
+    const url = new URL(value.trim());
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash
+    ) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+type CookieParseResult =
+  | { kind: "cookie"; cookie: CookieSyncTargetCookie }
+  | { kind: "skip"; code: string };
+
+function parseDetailedCookie(
+  value: UntrustedValue,
+  filters: string[] | undefined,
+  nowSeconds: number,
+): CookieParseResult {
+  if (!isRecord(value)) return { kind: "skip", code: "malformed" };
+  const raw = untrustedField(value, "cookie");
+  const context = untrustedField(value, "context");
+  if (!isRecord(raw) || !isRecord(context)) {
+    return { kind: "skip", code: "malformed" };
+  }
+  const name = untrustedField(raw, "name");
+  const cookieValue = untrustedField(raw, "value");
+  const domain = normalizeCookieDomain(untrustedField(raw, "domain"));
+  const path = untrustedField(raw, "path");
+  const secure = untrustedField(raw, "secure");
+  const httpOnly = untrustedField(raw, "httpOnly");
+  const mappedSameSite = sameSite(untrustedField(raw, "sameSite"));
+  if (
+    !isString(name) ||
+    name.length > 4_096 ||
+    /[=;]/.test(name) ||
+    hasAsciiControl(name) ||
+    !isString(cookieValue) ||
+    Buffer.byteLength(name, "utf8") + Buffer.byteLength(cookieValue, "utf8") > 16_384 ||
+    cookieValue.length > 16_384 ||
+    /;/.test(cookieValue) ||
+    hasAsciiControl(cookieValue) ||
+    !domain ||
+    !isString(path) ||
+    !path.startsWith("/") ||
+    path.length > 4_096 ||
+    hasAsciiControl(path) ||
+    !isBoolean(secure) ||
+    !isBoolean(httpOnly) ||
+    mappedSameSite === null
+  ) return { kind: "skip", code: "malformed" };
+  if (!domainSelected(domain, filters)) return { kind: "skip", code: "domain_filtered" };
+  if (mappedSameSite === "None" && !secure) {
+    return { kind: "skip", code: "malformed" };
+  }
+  if (name.startsWith("__Secure-") && !secure) {
+    return { kind: "skip", code: "malformed" };
+  }
+  if (
+    name.startsWith("__Host-") &&
+    (!secure || path !== "/" || domain.startsWith("."))
+  ) return { kind: "skip", code: "malformed" };
+
+  const expiresValue = untrustedField(raw, "expires");
+  let expires: number | undefined;
+  if (expiresValue !== undefined) {
+    if (!isNumber(expiresValue) || !Number.isFinite(expiresValue)) {
+      return { kind: "skip", code: "malformed" };
+    }
+    if (expiresValue <= nowSeconds) return { kind: "skip", code: "expired" };
+    expires = expiresValue;
+  }
+
+  const originAttributes = untrustedField(context, "originAttributes");
+  const userContextId = untrustedField(context, "userContextId");
+  const privateBrowsingId = untrustedField(context, "privateBrowsingId");
+  const firefoxPartition = untrustedField(context, "partitionKey");
+  if (
+    !(
+      originAttributes === null ||
+      originAttributes === undefined ||
+      isString(originAttributes)
+    ) ||
+    !(
+      userContextId === null ||
+      userContextId === undefined ||
+      (isNumber(userContextId) && Number.isInteger(userContextId) && userContextId >= 0)
+    ) ||
+    !(
+      privateBrowsingId === null ||
+      privateBrowsingId === undefined ||
+      (isNumber(privateBrowsingId) &&
+        Number.isInteger(privateBrowsingId) &&
+        privateBrowsingId >= 0)
+    ) ||
+    !(
+      firefoxPartition === null ||
+      firefoxPartition === undefined ||
+      isString(firefoxPartition)
+    )
+  ) return { kind: "skip", code: "malformed" };
+  const originIsolated = firefoxOriginIsolated(originAttributes);
+  if (originIsolated === null) return { kind: "skip", code: "malformed" };
+  if (
+    originIsolated ||
+    (isNumber(userContextId) && userContextId > 0) ||
+    (isNumber(privateBrowsingId) && privateBrowsingId > 0) ||
+    (isString(firefoxPartition) && firefoxPartition.length > 0)
+  ) return { kind: "skip", code: "unsupported_isolation" };
+
+  const topFrame = untrustedField(context, "topFrameSiteKey");
+  const hasCrossSiteAncestor = untrustedField(context, "hasCrossSiteAncestor");
+  if (
+    hasCrossSiteAncestor !== null &&
+    hasCrossSiteAncestor !== undefined &&
+    !isBoolean(hasCrossSiteAncestor)
+  ) return { kind: "skip", code: "malformed" };
+  let partitionKey: string | undefined;
+  if (topFrame !== null && topFrame !== undefined && topFrame !== "") {
+    const site = partitionSite(topFrame);
+    if (!site || !isBoolean(hasCrossSiteAncestor)) {
+      return { kind: "skip", code: "unsupported_partition" };
+    }
+    partitionKey = site;
+  }
+
+  const sourceScheme = chromiumSourceScheme(untrustedField(context, "sourceScheme"));
+  const sourcePort = chromiumSourcePort(untrustedField(context, "sourcePort"));
+  if (sourceScheme === null || sourcePort === null) {
+    return { kind: "skip", code: "malformed" };
+  }
+
+  const cookie: CookieSyncTargetCookie = {
+    name,
+    value: cookieValue,
+    domain,
+    path,
+    httpOnly,
+    secure,
+  };
+  if (expires !== undefined) cookie.expires = expires;
+  if (mappedSameSite !== undefined) cookie.sameSite = mappedSameSite;
+  if (sourceScheme !== undefined) cookie.sourceScheme = sourceScheme;
+  if (sourcePort !== undefined) cookie.sourcePort = sourcePort;
+  if (partitionKey) {
+    cookie.partitionKey = partitionKey;
+    cookie.partitionCrossSiteAncestor = hasCrossSiteAncestor === true;
+  }
+  return { kind: "cookie", cookie };
+}
+
+function cookieIdentity(cookie: CookieSyncTargetCookie): string {
+  return JSON.stringify([
+    cookie.name,
+    cookie.domain,
+    cookie.path,
+    cookie.partitionKey || "",
+    cookie.partitionCrossSiteAncestor ?? null,
+  ]);
+}
+
+function warningCode(value: UntrustedValue): string {
+  const raw = cleanText(value, 80).toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
+  return raw || "source_warning";
+}
+
+function addWarning(counts: Map<string, number>, code: string, count = 1) {
+  counts.set(code, (counts.get(code) || 0) + Math.max(0, Math.floor(count)));
+}
+
+export function normalizeCookieSnapshot(
+  snapshot: UntrustedValue,
+  options: Pick<NormalizedCookieSyncOptions, "source" | "domains">,
+  { now = Date.now() }: { now?: number } = {},
+): CookieSyncExtraction {
+  const detailed = untrustedField(snapshot, "detailedCookies");
+  if (!Array.isArray(detailed)) {
+    throw new Error("Cookie Sync could not read a valid browser snapshot.");
+  }
+  const warningCounts = new Map<string, number>();
+  const upstreamWarnings = untrustedField(snapshot, "warnings");
+  if (Array.isArray(upstreamWarnings)) {
+    for (const warning of upstreamWarnings) {
+      const countValue = untrustedField(warning, "count");
+      addWarning(
+        warningCounts,
+        warningCode(untrustedField(warning, "code")),
+        isNumber(countValue) && Number.isFinite(countValue) ? countValue : 1,
+      );
+    }
+  }
+
+  const cookies = new Map<string, CookieSyncTargetCookie>();
+  const nowSeconds = now / 1000;
+  let skipped = 0;
+  for (const entry of detailed) {
+    const parsed = parseDetailedCookie(entry, options.domains, nowSeconds);
+    if (parsed.kind === "skip") {
+      skipped += 1;
+      addWarning(warningCounts, parsed.code);
+      continue;
+    }
+    const identity = cookieIdentity(parsed.cookie);
+    if (cookies.has(identity)) addWarning(warningCounts, "duplicate_replaced");
+    cookies.set(identity, parsed.cookie);
+  }
+
+  const selected = cookies.size;
+  if (selected > COOKIE_SYNC_MAX_COOKIES) {
+    throw new Error(
+      `Cookie Sync selected more than ${COOKIE_SYNC_MAX_COOKIES} cookies. Add domain filters and try again.`,
+    );
+  }
+  const output = [...cookies.values()];
+  if (Buffer.byteLength(JSON.stringify(output), "utf8") > COOKIE_SYNC_MAX_BYTES) {
+    throw new Error(
+      "Cookie Sync selected more data than the secure transfer limit. Add domain filters and try again.",
+    );
+  }
+  return {
+    cookies: output,
+    selected,
+    skipped,
+    warnings: [...warningCounts.entries()]
+      .filter(([, count]) => count > 0)
+      .map(([code, count]) => ({ code, count })),
+    source: { ...options.source },
+  };
+}
+
+export async function extractCookieSync(
+  options: NormalizedCookieSyncOptions,
+  load: () => Promise<CookieReaderModule> = loadCookieReader,
+): Promise<CookieSyncExtraction> {
+  let reader: CookieReaderModule;
+  let snapshot: UntrustedValue;
+  reader = await load();
+  const readOptions: CookieReaderReadOptions = {
+    browser: options.source.browser,
+    includeSession: options.includeSession,
+    timeoutMs: options.timeoutMs,
+    appBound: options.windowsAppBound === "injection"
+      ? "injection_only"
+      : "disabled",
+  };
+  if (options.source.profile) readOptions.profile = options.source.profile;
+  try {
+    snapshot = await reader.read(readOptions);
+  } catch {
+    throw new Error(
+      "Cookie Sync could not read the selected local browser profile. Check the browser id, profile, permissions, and platform support.",
+    );
+  }
+  return normalizeCookieSnapshot(snapshot, options);
+}
+
+export async function listCookieSourceBrowsers(
+  load: () => Promise<CookieReaderModule> = loadCookieReader,
+): Promise<Array<{ id: string; name: string; engine: string }>> {
+  const reader = await load();
+  let value: UntrustedValue;
+  try {
+    value = await reader.supportedBrowsers();
+  } catch {
+    throw new Error("Cookie Sync could not list browsers on this host.");
+  }
+  if (!Array.isArray(value)) throw new Error("Cookie Sync returned an invalid browser list.");
+  return value.flatMap((entry) => {
+    const id = cleanPublicText(untrustedField(entry, "id"), 128).toLowerCase();
+    const name = cleanPublicText(untrustedField(entry, "displayName"), 256);
+    const engine = cleanPublicText(untrustedField(entry, "engine"), 64);
+    if (!/^[a-z0-9][a-z0-9._-]*$/.test(id)) return [];
+    return id && name ? [{ id, name, engine }] : [];
+  });
+}
+
+export async function listCookieSourceProfiles(
+  browser: UntrustedValue,
+  { timeoutMs = DEFAULT_TIMEOUT_MS }: { timeoutMs?: number } = {},
+  load: () => Promise<CookieReaderModule> = loadCookieReader,
+): Promise<Array<{ id: string; name: string; isDefault: boolean }>> {
+  const normalized = normalizeCookieSyncOptions({ source: { browser }, timeoutMs });
+  const source = normalized.source;
+  const reader = await load();
+  let value: UntrustedValue;
+  try {
+    value = await reader.browserProfiles(source.browser, {
+      timeoutMs: normalized.timeoutMs,
+    });
+  } catch {
+    throw new Error("Cookie Sync could not list profiles for the selected browser.");
+  }
+  if (!Array.isArray(value)) throw new Error("Cookie Sync returned an invalid profile list.");
+  return value.flatMap((entry) => {
+    const profile = untrustedField(entry, "profile");
+    const id = cleanPublicText(untrustedField(profile, "profileId"), 4_096);
+    const name = cleanPublicText(untrustedField(profile, "displayName"), 512);
+    return id
+      ? [{ id, name: name || id, isDefault: untrustedField(entry, "isDefault") === true }]
+      : [];
+  });
+}
+
+export function validateCookieSyncTargetCookies(
+  value: UntrustedValue,
+): CookieSyncTargetCookie[] {
+  if (!Array.isArray(value) || value.length > COOKIE_SYNC_MAX_COOKIES) {
+    throw new Error("Cookie Sync received an invalid cookie batch.");
+  }
+  let encoded = "";
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw new Error("Cookie Sync received an invalid cookie batch.");
+  }
+  if (Buffer.byteLength(encoded, "utf8") > COOKIE_SYNC_MAX_BYTES) {
+    throw new Error("Cookie Sync received a cookie batch above the transfer limit.");
+  }
+  const parsed: CookieSyncTargetCookie[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      throw new Error("Cookie Sync received a malformed cookie batch.");
+    }
+    const name = untrustedField(entry, "name");
+    const cookieValue = untrustedField(entry, "value");
+    const domain = normalizeCookieDomain(untrustedField(entry, "domain"));
+    const path = untrustedField(entry, "path");
+    const httpOnly = untrustedField(entry, "httpOnly");
+    const secure = untrustedField(entry, "secure");
+    const expiresValue = untrustedField(entry, "expires");
+    const sameSiteValue = untrustedField(entry, "sameSite");
+    const sourceSchemeValue = untrustedField(entry, "sourceScheme");
+    const sourcePortValue = untrustedField(entry, "sourcePort");
+    const partitionKeyValue = untrustedField(entry, "partitionKey");
+    const ancestorValue = untrustedField(entry, "partitionCrossSiteAncestor");
+    if (
+      !isString(name) ||
+      name.length > 4_096 ||
+      /[=;]/.test(name) ||
+      hasAsciiControl(name) ||
+      !isString(cookieValue) ||
+      cookieValue.length > 16_384 ||
+      /;/.test(cookieValue) ||
+      hasAsciiControl(cookieValue) ||
+      Buffer.byteLength(name, "utf8") + Buffer.byteLength(cookieValue, "utf8") > 16_384 ||
+      !domain ||
+      !isString(path) ||
+      !path.startsWith("/") ||
+      path.length > 4_096 ||
+      hasAsciiControl(path) ||
+      !isBoolean(httpOnly) ||
+      !isBoolean(secure) ||
+      (expiresValue !== undefined &&
+        (!isNumber(expiresValue) ||
+          !Number.isFinite(expiresValue))) ||
+      (sameSiteValue !== undefined &&
+        (!isString(sameSiteValue) ||
+          !["Strict", "Lax", "None"].includes(sameSiteValue))) ||
+      (sourceSchemeValue !== undefined &&
+        (!isString(sourceSchemeValue) ||
+          !["Unset", "NonSecure", "Secure"].includes(sourceSchemeValue))) ||
+      (sourcePortValue !== undefined &&
+        (!isNumber(sourcePortValue) ||
+          !Number.isInteger(sourcePortValue) ||
+          (sourcePortValue !== -1 &&
+            (sourcePortValue < 1 || sourcePortValue > 65_535)))) ||
+      (sameSiteValue === "None" && !secure) ||
+      (name.startsWith("__Secure-") && !secure) ||
+      (name.startsWith("__Host-") &&
+        (!secure || path !== "/" || domain.startsWith("."))) ||
+      (partitionKeyValue !== undefined && !partitionSite(partitionKeyValue)) ||
+      (partitionKeyValue === undefined && ancestorValue !== undefined) ||
+      (partitionKeyValue !== undefined && !isBoolean(ancestorValue))
+    ) {
+      throw new Error("Cookie Sync received a malformed cookie batch.");
+    }
+    if (isNumber(expiresValue) && expiresValue <= Date.now() / 1000) continue;
+    const cookie: CookieSyncTargetCookie = {
+      name,
+      value: cookieValue,
+      domain,
+      path,
+      httpOnly,
+      secure,
+    };
+    if (isNumber(expiresValue)) cookie.expires = expiresValue;
+    if (isString(sameSiteValue) && ["Strict", "Lax", "None"].includes(sameSiteValue)) {
+      cookie.sameSite = sameSiteValue === "Strict"
+        ? "Strict"
+        : sameSiteValue === "Lax"
+          ? "Lax"
+          : "None";
+    }
+    if (
+      isString(sourceSchemeValue) &&
+      ["Unset", "NonSecure", "Secure"].includes(sourceSchemeValue)
+    ) {
+      cookie.sourceScheme = sourceSchemeValue === "Unset"
+        ? "Unset"
+        : sourceSchemeValue === "NonSecure"
+          ? "NonSecure"
+          : "Secure";
+    }
+    if (isNumber(sourcePortValue)) cookie.sourcePort = sourcePortValue;
+    const validPartition = partitionSite(partitionKeyValue);
+    if (validPartition) {
+      cookie.partitionKey = validPartition;
+      cookie.partitionCrossSiteAncestor = ancestorValue === true;
+    }
+    parsed.push(cookie);
+  }
+  return parsed;
+}

--- a/src/credential-constants.ts
+++ b/src/credential-constants.ts
@@ -20,44 +20,66 @@ function isContainer(value: UntrustedValue): value is object {
 }
 
 /**
- * Deep-scrub every occurrence of the given secret strings from a value,
- * returning a redacted copy without mutating the input. This is the one
- * redaction algorithm: the worker's envelope redaction and the host vault's
- * `redact()` both delegate here so the two defense layers can never drift.
- * The rules are deliberate and security-relevant:
- * - secrets are replaced longest-first, so a secret that contains another
- *   secret is scrubbed whole instead of leaving a recognizable remainder;
- * - replacement uses split/join, so secrets are matched literally rather
- *   than as regular expressions;
- * - object keys are redacted as well as values, because a secret can leak
- *   through either position;
- * - cycles collapse to "[Circular]" so redaction terminates on any input.
+ * Build one literal matcher for a stable secret set. Bucketing by the first
+ * four code units avoids rescanning every result string once per browser
+ * cookie while keeping arbitrary cookie values out of regular expressions.
  */
-export function redactSecretsDeep(value, secrets) {
-  const ordered = [...secrets]
-    .filter(Boolean)
-    .sort((left, right) => right.length - left.length);
+export function createSecretsRedactor(secrets) {
+  const short = new Map<string, string[]>();
+  const long = new Map<string, string[]>();
+  for (const secret of new Set([...secrets].map(String).filter(Boolean))) {
+    const bucket = secret.length < 4 ? short : long;
+    const key = secret.length < 4 ? secret[0] : secret.slice(0, 4);
+    const values = bucket.get(key) || [];
+    values.push(secret);
+    bucket.set(key, values);
+  }
+  for (const values of [...short.values(), ...long.values()]) {
+    values.sort((left, right) => right.length - left.length);
+  }
+
   const redactText = (input) => {
-    let output = String(input);
-    for (const secret of ordered) {
-      output = output.split(secret).join(REDACTED_PASSWORD_PLACEHOLDER);
+    const text = String(input);
+    let output = "";
+    let copiedThrough = 0;
+    let index = 0;
+    while (index < text.length) {
+      const longCandidates = long.get(text.slice(index, index + 4));
+      const shortCandidates = short.get(text[index]);
+      const match = longCandidates?.find((secret) => text.startsWith(secret, index)) ||
+        shortCandidates?.find((secret) => text.startsWith(secret, index));
+      if (!match) {
+        index += 1;
+        continue;
+      }
+      output += text.slice(copiedThrough, index) + REDACTED_PASSWORD_PLACEHOLDER;
+      index += match.length;
+      copiedThrough = index;
     }
-    return output;
+    return copiedThrough ? output + text.slice(copiedThrough) : text;
   };
-  const seen = new WeakSet();
-  const redactValue = (input) => {
-    if (isString(input)) return redactText(input);
-    if (!isContainer(input)) return input;
-    if (seen.has(input)) return "[Circular]";
-    seen.add(input);
-    if (Array.isArray(input)) return input.map(redactValue);
-    const output: Record<string, UntrustedValue> = {};
-    for (const [key, item] of Object.entries(input)) {
-      output[redactText(key)] = redactValue(item);
-    }
-    return output;
+
+  return (value) => {
+    const seen = new WeakSet();
+    const redactValue = (input) => {
+      if (isString(input)) return redactText(input);
+      if (!isContainer(input)) return input;
+      if (seen.has(input)) return "[Circular]";
+      seen.add(input);
+      if (Array.isArray(input)) return input.map(redactValue);
+      const output: Record<string, UntrustedValue> = {};
+      for (const [key, item] of Object.entries(input)) {
+        output[redactText(key)] = redactValue(item);
+      }
+      return output;
+    };
+    return redactValue(value);
   };
-  return redactValue(value);
+}
+
+/** Deep-scrub literal secret strings without mutating the input. */
+export function redactSecretsDeep(value, secrets) {
+  return createSecretsRedactor(secrets)(value);
 }
 
 export const VAULT_MATCH_MODES = Object.freeze([

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -365,6 +365,15 @@ export function createDaemonBrowser(channel, { session = "default" }: any = {}) 
   return {
     session: pinned,
     run: (code, options?: any) => call("run", [code, options]),
+    syncCookies: (options?: any) =>
+      call(
+        "syncCookies",
+        [options],
+        Math.min(
+          Math.max(Number(options?.timeoutMs) || 30_000, 1_000) + 45_000,
+          180_000,
+        ),
+      ),
     // Live view is host-side only (sealed from run snippets). Exposing these
     // on the daemon proxy lets `betterwright view` attach mid-session to the
     // same browser tabs that `run`/`exec` already use.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -458,6 +458,7 @@ const SESSION_OPTION_METHODS = new Set([
   "waitForAsk",
 ]);
 const PLAIN_METHODS = new Set([
+  "syncCookies",
   "stopLiveView",
   "liveViewStatus",
   "liveViewPostChat",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ export {
 export { detectBotChallenge } from "./challenges.js";
 export { BetterWright, BrowserError } from "./client.js";
 export {
+  listCookieSourceBrowsers,
+  listCookieSourceProfiles,
+} from "./cookie-sync.js";
+export {
   piImageArtifacts,
   piImageContent,
   piPrimaryImageArtifact,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -27,6 +27,10 @@ export {
   validateCredentialMatchMode,
 } from "./client.js";
 export {
+  listCookieSourceBrowsers,
+  listCookieSourceProfiles,
+} from "./cookie-sync.js";
+export {
   METADATA_ADDRESSES,
   METADATA_HOSTNAMES,
   NetworkPolicy,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2048,7 +2048,13 @@ async function ensureBrowser(config, { requirePersistentProfile = false } = {}) 
       return browserContext;
     }
   }
-  if (launchPromise) return launchPromise;
+  if (launchPromise) {
+    const context = await launchPromise;
+    if (requirePersistentProfile && profileMode !== "persistent") {
+      throw persistentCookieSyncTargetError();
+    }
+    return context;
+  }
   launchConfig = { ...config };
   launchPromise = (async () => {
     mkdirPrivate(launchConfig.artifactsDir);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2035,6 +2035,13 @@ async function ensureBrowser(config, { requirePersistentProfile = false } = {}) 
     throw new Error('publicSearchPolicy must be "block" or "allow".');
   }
   config = { ...config, publicSearchPolicy };
+  if (launchPromise) {
+    const context = await launchPromise;
+    if (requirePersistentProfile && profileMode !== "persistent") {
+      throw persistentCookieSyncTargetError();
+    }
+    return context;
+  }
   if (browserContext) {
     if (requirePersistentProfile && profileMode !== "persistent") {
       await closeDownloadGuard();
@@ -2047,13 +2054,6 @@ async function ensureBrowser(config, { requirePersistentProfile = false } = {}) 
       launchConfig = { ...launchConfig, ...config };
       return browserContext;
     }
-  }
-  if (launchPromise) {
-    const context = await launchPromise;
-    if (requirePersistentProfile && profileMode !== "persistent") {
-      throw persistentCookieSyncTargetError();
-    }
-    return context;
   }
   launchConfig = { ...config };
   launchPromise = (async () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14,7 +14,9 @@ import path from "node:path";
 import readline from "node:readline";
 import { types as utilTypes } from "node:util";
 import vm from "node:vm";
+import { getDomain } from "tldts";
 import {
+  cookieSyncConsentTarget,
   redactProviderSecrets,
   resolveBrowserProvider,
 } from "./browser-providers.js";
@@ -74,11 +76,12 @@ import {
   selectManagedBrowserBackend,
 } from "./chromium-fork.js";
 import { compileCode } from "./compile-code.js";
+import { validateCookieSyncTargetCookies } from "./cookie-sync.js";
 import {
   assertRotationPreservesMatchMode,
+  createSecretsRedactor,
   MAX_PENDING_CREDENTIAL_ORIGINS,
   pendingCredentialRecovery,
-  redactSecretsDeep,
   validateCredentialMatchMode,
 } from "./credential-constants.js";
 import {
@@ -207,6 +210,14 @@ const DEFAULT_SCREENSHOT_TIMEOUT_MS = 15_000;
 const CAPTCHA_SCREENSHOT_TIMEOUT_MS = 8_000;
 const SAFE_SYNC_VM_TIMEOUT_MS = 1_000;
 const MAX_ACTIVE_SECRETS = 200;
+const MAX_ACTIVE_COOKIE_SECRETS = 20_000;
+const MAX_ACTIVE_COOKIE_SECRET_BYTES = 64 * 1024 * 1024;
+const MAX_COOKIE_REDACTION_IDENTITIES = 100_000;
+// Stay below Chromium's eviction triggers. The lower steady-state ceilings
+// leave room for an idle page to set cookies between preflight and commit.
+const COOKIE_SYNC_UNPARTITIONED_TOTAL_LIMIT = 3_000;
+const COOKIE_SYNC_DOMAIN_LIMIT = 150;
+const COOKIE_SYNC_PARTITION_BYTES_LIMIT = 10_240;
 
 // Guards for values that cross the vm/page bridges, alongside the shared ones
 // in untrusted-value.ts. The shared isRecord excludes arrays, which the call
@@ -242,6 +253,12 @@ let profileLock = null;
 let profileLockHeartbeat = null;
 let profileMode = "persistent";
 let profileWarning = "";
+let cookieSyncActive = false;
+
+interface CookieSyncResultSource {
+  browser: string;
+  profile?: string;
+}
 // Non-empty when caller-supplied Chromium switches were dropped as duplicates
 // of BetterWright's own, so the caller is told rather than left wondering why
 // a switch had no effect.
@@ -380,7 +397,12 @@ const pageIds = new WeakMap();
 const facadeToRaw = new WeakMap();
 const pendingRpc = new Map();
 const activeSecrets = new Set();
+const cookieSecrets = new Set();
+const syncedCookieIdentities = new Set();
+let redactKnownSecrets: ReturnType<typeof createSecretsRedactor> | null = null;
 let redactionCapacityExceeded = false;
+let cookieRedactionCapacityExceeded = false;
+let cookieSecretBytes = 0;
 
 // Last time model-driven code touched a page or origin, used by the vault
 // capture engine to tell model-typed logins (always saved silently) apart
@@ -402,6 +424,98 @@ function trackSecret(value) {
   }
   activeSecrets.delete(secret);
   activeSecrets.add(secret);
+  redactKnownSecrets = null;
+}
+
+function cookieRedactionIdentity(cookie) {
+  return crypto.createHash("sha256").update(cookieTargetIdentity(cookie)).digest("hex");
+}
+
+function cookieRedactionValues(cookie) {
+  const name = String(cookie?.name ?? "");
+  const value = String(cookie?.value ?? "");
+  if (!value) return [];
+  // Short preference values such as "0" and "1" are not useful bearer
+  // material and redacting them globally would corrupt ordinary output. The
+  // full name=value pair is still scrubbed from document.cookie strings.
+  return value.length >= 8 ? [value] : [`${name}=${value}`];
+}
+
+function trackCookieSecrets(cookies) {
+  let changed = false;
+  for (const cookie of cookies || []) {
+    for (const secret of cookieRedactionValues(cookie)) {
+      if (cookieSecrets.has(secret)) continue;
+      const bytes = Buffer.byteLength(secret, "utf8");
+      if (
+        cookieSecrets.size >= MAX_ACTIVE_COOKIE_SECRETS ||
+        cookieSecretBytes + bytes > MAX_ACTIVE_COOKIE_SECRET_BYTES
+      ) {
+        cookieRedactionCapacityExceeded = true;
+        const error = new Error(
+          "Cookie Sync redaction capacity was reached; the browser worker must restart.",
+        );
+        error.code = "BW_COOKIE_SYNC_SECRET_CAPACITY";
+        throw error;
+      }
+      cookieSecrets.add(secret);
+      cookieSecretBytes += bytes;
+      changed = true;
+    }
+  }
+  if (changed) redactKnownSecrets = null;
+}
+
+function cookieRedactionRegistryPath(profileDir) {
+  return path.join(profileDir, ".betterwright-cookie-sync-redaction.json");
+}
+
+function loadCookieRedactionRegistry(profileDir) {
+  const file = cookieRedactionRegistryPath(profileDir);
+  if (!fs.existsSync(file)) return;
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    throw new Error("Cookie Sync redaction metadata is unreadable.");
+  }
+  if (
+    parsed?.version !== 1 ||
+    !Array.isArray(parsed.identities) ||
+    parsed.identities.length > MAX_COOKIE_REDACTION_IDENTITIES ||
+    parsed.identities.some((value) =>
+      !isString(value) || !/^[a-f0-9]{64}$/.test(value)
+    )
+  ) throw new Error("Cookie Sync redaction metadata is invalid.");
+  for (const identity of parsed.identities) syncedCookieIdentities.add(identity);
+}
+
+function rememberSyncedCookies(cookies, profileDir) {
+  const nextIdentities = new Set(syncedCookieIdentities);
+  for (const cookie of cookies) {
+    nextIdentities.add(cookieRedactionIdentity(cookie));
+  }
+  if (nextIdentities.size > MAX_COOKIE_REDACTION_IDENTITIES) {
+    throw new Error("Cookie Sync redaction metadata reached its profile limit.");
+  }
+  const file = cookieRedactionRegistryPath(profileDir);
+  const temporary = `${file}.${process.pid}.tmp`;
+  writePrivate(temporary, `${JSON.stringify({
+    version: 1,
+    identities: [...nextIdentities].sort(),
+  })}\n`);
+  fs.renameSync(temporary, file);
+  for (const identity of nextIdentities) syncedCookieIdentities.add(identity);
+}
+
+async function refreshCookieSecrets(context) {
+  if (!syncedCookieIdentities.size) return;
+  const cookies = await context.cookies();
+  trackCookieSecrets(
+    cookies.filter((cookie) =>
+      syncedCookieIdentities.has(cookieRedactionIdentity(cookie))
+    ),
+  );
 }
 
 function trackSecretValues(value, seen = new WeakSet()) {
@@ -434,6 +548,13 @@ function redactionCapacityError() {
 }
 
 function assertRedactionCapacity() {
+  if (cookieRedactionCapacityExceeded) {
+    const error = new Error(
+      "Cookie Sync redaction capacity was reached; the browser worker must restart.",
+    );
+    error.code = "BW_COOKIE_SYNC_SECRET_CAPACITY";
+    throw error;
+  }
   if (redactionCapacityExceeded) throw redactionCapacityError();
 }
 
@@ -450,7 +571,12 @@ function sendRedactionCapacityFailure(message) {
 function secretCapacityRequiresRestart(error) {
   return (
     redactionCapacityExceeded ||
-    ["BW_SECRET_CAPACITY", "VAULT_SECRET_CAPACITY"].includes(error?.code)
+    cookieRedactionCapacityExceeded ||
+    [
+      "BW_SECRET_CAPACITY",
+      "VAULT_SECRET_CAPACITY",
+      "BW_COOKIE_SYNC_SECRET_CAPACITY",
+    ].includes(error?.code)
   );
 }
 const pendingDownloadTasks = new Set();
@@ -702,15 +828,23 @@ async function closeDownloadGuard() {
   }
 }
 
-// Thin wrappers over the shared algorithm in credential-constants.ts, bound
-// to this worker's module-level secret set. redactText additionally coerces
-// null/undefined to "" because worker call sites pass raw error messages.
+// Browser cookie values remain usable by Chromium but never cross a result
+// envelope. The matcher is rebuilt only when a vault or cookie secret is
+// added, rather than once for every string in every result.
+function knownSecretRedactor() {
+  redactKnownSecrets ??= createSecretsRedactor([
+    ...activeSecrets,
+    ...cookieSecrets,
+  ]);
+  return redactKnownSecrets;
+}
+
 function redactText(value) {
-  return redactSecretsDeep(String(value ?? ""), activeSecrets);
+  return knownSecretRedactor()(String(value ?? ""));
 }
 
 function redactDeep(value) {
-  return redactSecretsDeep(value, activeSecrets);
+  return knownSecretRedactor()(value);
 }
 
 function sessionFor(id) {
@@ -1881,7 +2015,15 @@ async function installContextGuard(context) {
   // guard, which authorizes the host and each resolved address before dialing.
 }
 
-async function ensureBrowser(config) {
+function persistentCookieSyncTargetError() {
+  const error = new Error(
+    "Cookie Sync requires the selected BetterWright profile to be persistent. Close its other BetterWright process and try again.",
+  );
+  error.code = "BW_COOKIE_SYNC_EPHEMERAL_TARGET";
+  return error;
+}
+
+async function ensureBrowser(config, { requirePersistentProfile = false } = {}) {
   // BetterChromium is the only bundled browser; everything else is an
   // explicit provider (a caller-supplied local Chromium binary, or a remote
   // CDP endpoint minted by a cloud-browser service).
@@ -1894,8 +2036,17 @@ async function ensureBrowser(config) {
   }
   config = { ...config, publicSearchPolicy };
   if (browserContext) {
-    launchConfig = { ...launchConfig, ...config };
-    return browserContext;
+    if (requirePersistentProfile && profileMode !== "persistent") {
+      await closeDownloadGuard();
+      const ephemeralContext = browserContext;
+      browserContext = null;
+      await ephemeralContext.close();
+      disposeVaultCapture();
+      releaseProfileLock();
+    } else {
+      launchConfig = { ...launchConfig, ...config };
+      return browserContext;
+    }
   }
   if (launchPromise) return launchPromise;
   launchConfig = { ...config };
@@ -1905,12 +2056,6 @@ async function ensureBrowser(config) {
     // Session-minting providers make their REST call here, at launch, so a
     // client that is constructed but never starts never bills a session.
     let providerPlan = providerResolution?.plan || null;
-    if (providerPlan?.create) {
-      providerPlan = await providerPlan.create();
-    }
-    redactProviderSecrets(trackSecret, providerPlan);
-    providerWarnings = providerPlan?.warnings || [];
-
     const remoteCdp = providerPlan?.kind === "remote";
     let forkBinary = null;
     let launchExecutable = null;
@@ -1957,8 +2102,18 @@ async function ensureBrowser(config) {
     startProfileLockHeartbeat();
     profileMode = profileLock.ephemeral ? "ephemeral" : "persistent";
     const browserProfileDir = profileLock.profileDir;
+    if (requirePersistentProfile && profileMode !== "persistent") {
+      throw persistentCookieSyncTargetError();
+    }
     mkdirPrivate(browserProfileDir);
+    loadCookieRedactionRegistry(browserProfileDir);
     profileWarning = profileLock.warning || "";
+    if (providerPlan?.create) {
+      providerPlan = await providerPlan.create();
+    }
+    redactProviderSecrets(trackSecret, providerPlan);
+    providerWarnings = providerPlan?.warnings || [];
+    if (remoteCdp) endRemoteSession = providerPlan?.end || null;
     // The guard proxy only bounds locally launched browsers. A remote CDP
     // browser runs on the provider's side of the WebSocket; its traffic never
     // touches this listener, so it is not even started (see the warnings).
@@ -2071,7 +2226,6 @@ async function ensureBrowser(config) {
       // rejection from connectOverCDP or newContext still releases the metered
       // session. On success the context's "close" handler disarms and consumes
       // this same reference, so the stop never runs twice.
-      endRemoteSession = providerPlan.end || null;
       try {
         const browser = await chromium.connectOverCDP(
           providerPlan.cdpUrl,
@@ -2139,6 +2293,7 @@ async function ensureBrowser(config) {
     });
     await installContextGuard(launchedContext);
     await installDownloadGuard(launchedContext);
+    await refreshCookieSecrets(launchedContext);
     if (launchConfig.credentialCapture !== false) {
       // CDP-level capture: the sensor runs in dedicated isolated worlds and
       // reports logins in-process; model-typed logins save silently, manual
@@ -2190,6 +2345,9 @@ async function ensureBrowser(config) {
     const launched = browserContext;
     browserContext = null;
     await launched?.close().catch(() => {});
+    const end = endRemoteSession;
+    endRemoteSession = null;
+    if (end) await end().catch(() => {});
     disposeVaultCapture();
     releaseProfileLock();
     throw error;
@@ -2255,10 +2413,13 @@ function propertyForbidden(value, property) {
   if (
     kind === "BrowserContext" &&
     [
+      "addCookies",
+      "clearCookies",
       "close",
       "cookies",
       "newPage",
       "pages",
+      "setStorageState",
       "storageState",
       "tracing",
     ].includes(property)
@@ -2269,7 +2430,35 @@ function propertyForbidden(value, property) {
     ["createReadStream", "path", "saveAs"].includes(property)
   )
     return true;
+  if (
+    kind === "Request" &&
+    [
+      "allHeaders",
+      "headerValue",
+      "headersArray",
+    ].includes(property)
+  )
+    return true;
+  if (
+    kind === "Response" &&
+    [
+      "allHeaders",
+      "headerValue",
+      "headerValues",
+      "headersArray",
+    ].includes(property)
+  )
+    return true;
   return false;
+}
+
+function filterModelHeaders(headers) {
+  const filtered = {};
+  for (const [name, value] of Object.entries(headers || {})) {
+    if (["cookie", "set-cookie"].includes(name.toLowerCase())) continue;
+    filtered[name] = value;
+  }
+  return filtered;
 }
 
 function isWithin(candidate, root) {
@@ -2667,6 +2856,14 @@ function wrap(value, realm) {
           result = setContentCompatible(value, prepared[0], prepared[1]);
         } else {
           result = member.apply(value, prepared);
+        }
+        if (
+          ["Request", "Response"].includes(kind) &&
+          property === "headers"
+        ) {
+          result = result && isCallable(untrustedField(result, "then"))
+            ? result.then(filterModelHeaders)
+            : filterModelHeaders(result);
         }
         if (result && isCallable(untrustedField(result, "then"))) {
           return result.then((item) => wrap(item, realm));
@@ -3832,10 +4029,29 @@ async function buildEnvelope(
     ...fields
   },
 ) {
+  try {
+    if (browserContext) await refreshCookieSecrets(browserContext);
+  } catch {
+    return {
+      type: "result",
+      id: message.id,
+      ok: false,
+      error: "Result withheld: Cookie Sync redaction refresh failed.",
+      restartWorker: true,
+      console: [],
+      events: [],
+      artifacts: [],
+      warnings: [],
+      challenges: [],
+      profileMode,
+      pages: [],
+      durationMs: Math.round((performance.now() - started) * 10) / 10,
+    };
+  }
   return {
     type: "result",
     id: message.id,
-    ...fields,
+    ...redactDeep(fields),
     console: redactDeep(consoleMessages),
     events: redactDeep(session.events.slice(firstEvent)),
     artifacts: redactDeep(artifacts),
@@ -3850,7 +4066,7 @@ async function buildEnvelope(
     ]),
     challenges: redactDeep(challenges),
     profileMode,
-    pages: pages ?? (await summarizeSessionPages(session)),
+    pages: redactDeep(pages ?? (await summarizeSessionPages(session))),
     durationMs: Math.round((performance.now() - started) * 10) / 10,
   };
 }
@@ -4069,6 +4285,10 @@ async function performCredentialFill(
 // generateAndFillCredential): wraps performCredentialFill in the usual result
 // envelope. The active redaction net still scrubs the secret from every field.
 async function credentialFill(message) {
+  if (cookieSyncActive) {
+    cookieSyncBusyResult(message);
+    return;
+  }
   const started = performance.now();
   const session = sessionFor(message.sessionId);
   session.awaitingAnswerSince = null;
@@ -4130,6 +4350,10 @@ async function credentialFill(message) {
 // Dedicated trusted host path for finalizing or discarding a staged generated
 // credential after the caller has verified the visible browser outcome.
 async function credentialPending(message) {
+  if (cookieSyncActive) {
+    cookieSyncBusyResult(message);
+    return;
+  }
   const started = performance.now();
   const session = sessionFor(message.sessionId);
   session.awaitingAnswerSince = null;
@@ -7046,7 +7270,332 @@ async function pumpPageEventQueue(session) {
   ]);
 }
 
+function sanitizedCookieSyncWarnings(value) {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 100).flatMap((entry) => {
+    const code = String(untrustedField(entry, "code") || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "_")
+      .slice(0, 80);
+    const rawCount = untrustedField(entry, "count");
+    const count = isNumber(rawCount) && Number.isFinite(rawCount)
+      ? Math.max(0, Math.floor(rawCount))
+      : 0;
+    return code && count ? [{ code, count }] : [];
+  });
+}
+
+function cookieSyncBusyResult(message) {
+  sendResult({
+    type: "result",
+    id: message.id,
+    ok: false,
+    error: "Cookie Sync cannot run while browser work is active. Try again after the current call finishes.",
+  });
+}
+
+function cookiePartition(cookie) {
+  const value = cookie?.partitionKey;
+  if (isString(value)) {
+    return {
+      topLevelSite: value,
+      hasCrossSiteAncestor: cookie?.partitionCrossSiteAncestor === true,
+    };
+  }
+  if (!isObjectValue(value)) return null;
+  const topLevelSite = untrustedField(value, "topLevelSite");
+  if (!isString(topLevelSite) || !topLevelSite) return null;
+  return {
+    topLevelSite,
+    hasCrossSiteAncestor: untrustedField(value, "hasCrossSiteAncestor") === true,
+  };
+}
+
+function cookieTargetIdentity(cookie) {
+  const partition = cookiePartition(cookie);
+  return JSON.stringify([
+    String(cookie?.name || ""),
+    String(cookie?.domain || "").toLowerCase(),
+    String(cookie?.path || "/"),
+    partition?.topLevelSite || "",
+    partition?.hasCrossSiteAncestor ?? null,
+  ]);
+}
+
+function cookieQuotaDomain(cookie) {
+  const host = String(cookie?.domain || "")
+    .toLowerCase()
+    .replace(/^\./, "")
+    .replace(/^\[|\]$/g, "");
+  return getDomain(host, {
+    allowPrivateDomains: true,
+    extractHostname: false,
+  }) || host;
+}
+
+function cookieQuotaGroup(cookie) {
+  const partition = cookiePartition(cookie);
+  return partition
+    ? JSON.stringify([
+        partition.topLevelSite,
+        partition.hasCrossSiteAncestor,
+        cookieQuotaDomain(cookie),
+      ])
+    : cookieQuotaDomain(cookie);
+}
+
+function cookieQuotaStats(cookies) {
+  const unpartitioned = new Map();
+  const partitioned = new Map();
+  let unpartitionedTotal = 0;
+  for (const cookie of cookies) {
+    const partition = cookiePartition(cookie);
+    const group = cookieQuotaGroup(cookie);
+    if (!partition) {
+      unpartitionedTotal += 1;
+      unpartitioned.set(group, (unpartitioned.get(group) || 0) + 1);
+      continue;
+    }
+    const current = partitioned.get(group) || { count: 0, bytes: 0 };
+    current.count += 1;
+    current.bytes += Buffer.byteLength(
+      `${String(cookie?.name || "")}${String(cookie?.value || "")}`,
+      "utf8",
+    );
+    partitioned.set(group, current);
+  }
+  return { unpartitionedTotal, unpartitioned, partitioned };
+}
+
+function assertCookieSyncCapacity(beforeCookies, cookies) {
+  const beforeByIdentity = new Map(
+    beforeCookies.map((cookie) => [cookieTargetIdentity(cookie), cookie]),
+  );
+  const projectedByIdentity = new Map(beforeByIdentity);
+  for (const cookie of cookies) {
+    projectedByIdentity.set(cookieTargetIdentity(cookie), cookie);
+  }
+  const before = cookieQuotaStats(beforeByIdentity.values());
+  const projected = cookieQuotaStats(projectedByIdentity.values());
+  if (
+    projected.unpartitionedTotal > COOKIE_SYNC_UNPARTITIONED_TOTAL_LIMIT &&
+    projected.unpartitionedTotal > before.unpartitionedTotal
+  ) {
+    const error = new Error("Cookie Sync would exceed the target cookie capacity.");
+    error.code = "BW_COOKIE_SYNC_TARGET_CAPACITY";
+    throw error;
+  }
+  const touchedGroups = new Set(cookies.map(cookieQuotaGroup));
+  for (const group of touchedGroups) {
+    const beforeCount = before.unpartitioned.get(group) || 0;
+    const projectedCount = projected.unpartitioned.get(group) || 0;
+    if (
+      projectedCount > COOKIE_SYNC_DOMAIN_LIMIT &&
+      projectedCount > beforeCount
+    ) {
+      const error = new Error("Cookie Sync would exceed the target cookie capacity.");
+      error.code = "BW_COOKIE_SYNC_TARGET_CAPACITY";
+      throw error;
+    }
+    const beforePartition = before.partitioned.get(group) || { count: 0, bytes: 0 };
+    const projectedPartition = projected.partitioned.get(group) || { count: 0, bytes: 0 };
+    if (
+      (projectedPartition.count > COOKIE_SYNC_DOMAIN_LIMIT &&
+        projectedPartition.count > beforePartition.count) ||
+      (projectedPartition.bytes > COOKIE_SYNC_PARTITION_BYTES_LIMIT &&
+        projectedPartition.bytes > beforePartition.bytes)
+    ) {
+      const error = new Error("Cookie Sync would exceed the target cookie capacity.");
+      error.code = "BW_COOKIE_SYNC_TARGET_CAPACITY";
+      throw error;
+    }
+  }
+  return beforeByIdentity;
+}
+
+function cdpCookieParams(cookie) {
+  const { partitionKey, partitionCrossSiteAncestor, ...plain } = cookie;
+  return partitionKey
+    ? {
+        ...plain,
+        partitionKey: {
+          topLevelSite: partitionKey,
+          hasCrossSiteAncestor: partitionCrossSiteAncestor === true,
+        },
+      }
+    : plain;
+}
+
+async function setCookieSyncCookies(cookies, afterPreflight) {
+  const page = browserContext.pages()[0] || await browserContext.newPage();
+  const session = await browserContext.newCDPSession(page);
+  try {
+    // Network.getAllCookies is deprecated in favor of Storage.getCookies, but
+    // the latter needs a browserContextId. A page CDP session does not expose
+    // that id, and omitting it reads the default store instead of a remote
+    // provider's non-default context. BetterChromium is pinned and this call is
+    // covered against that exact build.
+    const beforeResult = await session.send("Network.getAllCookies");
+    if (!Array.isArray(beforeResult?.cookies)) {
+      throw new Error("Cookie Sync could not inspect the target cookie store.");
+    }
+    const beforeByIdentity = assertCookieSyncCapacity(beforeResult.cookies, cookies);
+    afterPreflight();
+    await session.send("Network.setCookies", {
+      cookies: cookies.map(cdpCookieParams),
+    });
+    const afterResult = await session.send("Network.getAllCookies");
+    if (!Array.isArray(afterResult?.cookies)) {
+      throw new Error("Cookie Sync could not verify the target cookie store.");
+    }
+    const afterByIdentity = new Map(
+      afterResult.cookies.map((cookie) => [cookieTargetIdentity(cookie), cookie]),
+    );
+    const importedIdentities = new Set(cookies.map(cookieTargetIdentity));
+    const evicted = [...beforeByIdentity.keys()].filter((identity) =>
+      !importedIdentities.has(identity) && !afterByIdentity.has(identity)
+    ).length;
+    if (evicted) {
+      const error = new Error(
+        "Cookie Sync detected that Chromium removed pre-existing target cookies.",
+      );
+      error.code = "BW_COOKIE_SYNC_TARGET_EVICTION";
+      throw error;
+    }
+    const stored = cookies.filter((cookie) => {
+      const candidate = afterByIdentity.get(cookieTargetIdentity(cookie));
+      return isObjectValue(candidate) &&
+        untrustedField(candidate, "value") === cookie.value;
+    });
+    return { stored, missing: cookies.length - stored.length };
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+async function cookieSync(message) {
+  if (cookieSyncActive || activeExecutionCounts.size) {
+    cookieSyncBusyResult(message);
+    return;
+  }
+  cookieSyncActive = true;
+  try {
+    let target;
+    try {
+      target = cookieSyncConsentTarget(message.config?.provider);
+    } catch {
+      sendResult({
+        type: "result",
+        id: message.id,
+        ok: false,
+        error: "Cookie Sync could not validate the configured browser target.",
+      });
+      return;
+    }
+    if (target && String(message.cloudConsent || "").toLowerCase() !== target) {
+      sendResult({
+        type: "result",
+        id: message.id,
+        ok: false,
+        error: `Cookie Sync to ${target} requires consent for that exact target.`,
+      });
+      return;
+    }
+
+    let cookies;
+    try {
+      cookies = validateCookieSyncTargetCookies(message.cookies);
+    } catch {
+      sendResult({
+        type: "result",
+        id: message.id,
+        ok: false,
+        error: "Cookie Sync received an invalid cookie batch.",
+      });
+      return;
+    }
+
+    try {
+      await ensureBrowser(message.config, { requirePersistentProfile: true });
+    } catch (error) {
+      sendResult({
+        type: "result",
+        id: message.id,
+        ok: false,
+        error: error?.code === "BW_COOKIE_SYNC_EPHEMERAL_TARGET"
+          ? error.message
+          : "Cookie Sync could not open the target browser.",
+      });
+      return;
+    }
+
+    let storedCookies;
+    let missingCookies = 0;
+    try {
+      const stored = await setCookieSyncCookies(cookies, () => {
+        rememberSyncedCookies(cookies, launchConfig.profileDir);
+        trackCookieSecrets(cookies);
+      });
+      storedCookies = stored.stored;
+      missingCookies = stored.missing;
+    } catch (error) {
+      const capacity = error?.code === "BW_COOKIE_SYNC_SECRET_CAPACITY";
+      const targetCapacity = error?.code === "BW_COOKIE_SYNC_TARGET_CAPACITY";
+      const targetEviction = error?.code === "BW_COOKIE_SYNC_TARGET_EVICTION";
+      sendResult({
+        type: "result",
+        id: message.id,
+        ok: false,
+        error: capacity
+          ? "Cookie Sync redaction capacity was reached; the browser worker was restarted."
+          : targetCapacity
+            ? "Cookie Sync would exceed the target cookie capacity. Narrow the source domains and try again."
+            : targetEviction
+              ? "Cookie Sync stopped because Chromium removed pre-existing target cookies. The target profile may have changed."
+              : "Cookie Sync could not add the selected cookies to the target browser.",
+        restartWorker: capacity,
+      });
+      return;
+    }
+
+    const selected = isNumber(message.selected) && Number.isFinite(message.selected)
+      ? Math.max(0, Math.floor(message.selected))
+      : cookies.length;
+    const skipped = isNumber(message.skipped) && Number.isFinite(message.skipped)
+      ? Math.max(0, Math.floor(message.skipped))
+      : 0;
+    const source: CookieSyncResultSource = { browser: "" };
+    if (isObjectValue(message.source)) {
+      source.browser = String(untrustedField(message.source, "browser") || "").slice(0, 128);
+      if (isString(untrustedField(message.source, "profile"))) {
+        source.profile = "selected";
+      }
+    }
+    sendResult({
+      type: "result",
+      id: message.id,
+      ok: true,
+      synced: storedCookies.length,
+      selected,
+      skipped,
+      source,
+      target: target || "local",
+      warnings: [
+        ...sanitizedCookieSyncWarnings(message.warnings),
+        ...(missingCookies ? [{ code: "target_not_stored", count: missingCookies }] : []),
+      ],
+      profileMode,
+    });
+  } finally {
+    cookieSyncActive = false;
+  }
+}
+
 async function execute(message) {
+  if (cookieSyncActive) {
+    cookieSyncBusyResult(message);
+    return;
+  }
   const started = performance.now();
   const session = sessionFor(message.sessionId);
   session.awaitingAnswerSince = null;
@@ -7178,6 +7727,7 @@ async function execute(message) {
       message.config.outputLimit || DEFAULT_OUTPUT_LIMIT,
     );
     if (serialized.length > outputLimit) {
+      await refreshCookieSecrets(browserContext);
       const spillPath = makeArtifactPath(
         session,
         "browser-output.json",
@@ -7634,6 +8184,9 @@ input.on("line", (line) => {
   }
   if (message.type === "credential_pending") {
     void enqueueForSession(message.sessionId, () => credentialPending(message));
+  }
+  if (message.type === "cookie_sync") {
+    void cookieSync(message);
   }
   // Session teardown rides that session's queue so pages never close under an
   // in-flight execute on the same session.

--- a/tests/node/browser-providers.test.ts
+++ b/tests/node/browser-providers.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import test from "node:test";
 
 import {
+  BROWSER_PROVIDER_NAMES,
   browserProviderInfo,
+  cookieSyncConsentTarget,
   describeCdpUrl,
   listProviderSessions,
   PROVIDER_HTTP_TIMEOUT_MS,
@@ -16,6 +18,27 @@ import { makeTempDir } from "./helpers/temp-dir.js";
 test("no provider means the managed BetterChromium fork", () => {
   assert.equal(resolveBrowserProvider(null, { env: {} }), null);
   assert.equal(resolveBrowserProvider(undefined, { env: {} }), null);
+});
+
+test("Cookie Sync consent identities cover every named provider and raw CDP", () => {
+  for (const name of BROWSER_PROVIDER_NAMES) {
+    const apiKey = ["brightdata", "oxylabs"].includes(name)
+      ? "user:password"
+      : "test-key";
+    assert.equal(
+      cookieSyncConsentTarget({ provider: name, apiKey }, { env: {} }),
+      `provider:${name}`,
+      name,
+    );
+  }
+  assert.equal(
+    cookieSyncConsentTarget(
+      { cdpUrl: "wss://user:secret@Cloud.Example:8443/devtools?token=x" },
+      { env: {} },
+    ),
+    "cdp:cloud.example:8443",
+  );
+  assert.equal(cookieSyncConsentTarget(null, { env: {} }), null);
 });
 
 test("BETTERWRIGHT_CDP_URL is the host-level CDP shorthand", () => {

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -2492,6 +2492,9 @@ test("model code cannot reach CDP or Playwright private channels", opts, async (
         contextCdp: typeof context.newCDPSession,
         pageChannel: typeof page._channel,
         contextBrowser: typeof context.browser,
+        contextAddCookies: typeof context.addCookies,
+        contextClearCookies: typeof context.clearCookies,
+        contextSetStorageState: typeof context.setStorageState,
       };
     `);
     assert.equal(result.ok, true, result.error);
@@ -2500,6 +2503,9 @@ test("model code cannot reach CDP or Playwright private channels", opts, async (
       contextCdp: "undefined",
       pageChannel: "undefined",
       contextBrowser: "undefined",
+      contextAddCookies: "undefined",
+      contextClearCookies: "undefined",
+      contextSetStorageState: "undefined",
     });
   } finally {
     await bw.close();
@@ -2860,6 +2866,220 @@ test("cookies are per profile, and survive a restart of the same profile", opts,
   } finally {
     await Promise.all([social.close(), review.close()]);
     await server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("Cookie Sync installs an HttpOnly cookie and persists it across restart", opts, async () => {
+  const sentinel = `cookie-sync-${Date.now()}`;
+  const rotatedPrefix = `cookie-rotated-${Date.now()}`;
+  const rotatedValues: string[] = [];
+  const server = await listen((request, response) => {
+    const authenticated = String(request.headers.cookie || "")
+      .split(/;\s*/)
+      .includes(`bw_sync=${sentinel}`);
+    let setCookie: string[] | undefined;
+    if (request.url === "/") {
+      const rotated = `${rotatedPrefix}-${rotatedValues.length + 1}`;
+      rotatedValues.push(rotated);
+      setCookie = [
+        `bw_response=${sentinel}; HttpOnly; Path=/`,
+        `bw_public=${rotated}; Path=/`,
+      ];
+    }
+    if (setCookie) {
+      response.writeHead(200, {
+        "content-type": "text/plain",
+        "set-cookie": setCookie,
+      });
+    } else {
+      response.writeHead(200, { "content-type": "text/plain" });
+    }
+    response.end(authenticated ? "authenticated" : "signed out");
+  });
+  const home = tempHome();
+  const options = {
+    home,
+    profile: "cookie-sync",
+    headless: true,
+    vault: false,
+    policy: new NetworkPolicy({ allowLoopback: true }),
+  };
+  const browser = new BetterWright(options);
+  browser._extractCookieSync = async () => ({
+    cookies: [{
+      name: "bw_sync",
+      value: sentinel,
+      domain: "127.0.0.1",
+      path: "/",
+      expires: Date.now() / 1000 + 3_600,
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+      sourceScheme: "NonSecure",
+      sourcePort: server.port,
+    }, {
+      name: "bw_public",
+      value: sentinel,
+      domain: "127.0.0.1",
+      path: "/",
+      expires: Date.now() / 1000 + 3_600,
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+      sourceScheme: "NonSecure",
+      sourcePort: server.port,
+    }],
+    selected: 2,
+    skipped: 0,
+    warnings: [],
+    source: { browser: "fixture" },
+  });
+  try {
+    const previousDebug = process.env.DEBUG;
+    process.env.DEBUG = "pw:protocol";
+    let synced;
+    try {
+      synced = await browser.syncCookies({
+        source: { browser: "fixture" },
+        domains: ["127.0.0.1"],
+      });
+    } finally {
+      if (previousDebug === undefined) delete process.env.DEBUG;
+      else process.env.DEBUG = previousDebug;
+    }
+    assert.equal(synced.ok, true, synced.error);
+    assert.equal(synced.synced, 2);
+    assert.equal(JSON.stringify(synced).includes(sentinel), false);
+    assert.equal(browser._stderrTail.some((line) => line.includes(sentinel)), false);
+    const first = await browser.run(
+      `const requestPending = page.waitForRequest(${JSON.stringify(`${server.origin}/`)});
+       const responsePending = page.waitForResponse(${JSON.stringify(`${server.origin}/`)});
+       await page.goto(${JSON.stringify(server.origin)});
+       const request = await requestPending;
+       const response = await responsePending;
+       return {
+         body: await page.locator("body").innerText(),
+         visibleCookie: await page.evaluate(() => document.cookie),
+         requestMethods: ["allHeaders", "headersArray", "headerValue"].map((key) => typeof request[key]),
+         responseMethods: ["allHeaders", "headersArray", "headerValue", "headerValues"].map((key) => typeof response[key]),
+         filteredRequestHeaders: await request.headers(),
+         filteredResponseHeaders: await response.headers(),
+         postDataType: typeof request.postData,
+       }`,
+    );
+    assert.equal(first.ok, true, first.error);
+    assert.equal(first.result.body, "authenticated");
+    assert.equal(JSON.stringify(first).includes(sentinel), false);
+    assert.equal(JSON.stringify(first).includes(rotatedValues.at(-1)), false);
+    assert.match(first.result.visibleCookie, /REDACTED_PASSWORD/);
+    assert.deepEqual(first.result.requestMethods, Array(3).fill("undefined"));
+    assert.deepEqual(first.result.responseMethods, Array(4).fill("undefined"));
+    assert.equal(Object.hasOwn(first.result.filteredRequestHeaders, "cookie"), false);
+    assert.equal(Object.hasOwn(first.result.filteredResponseHeaders, "set-cookie"), false);
+    assert.equal(first.result.postDataType, "function");
+
+    const failed = await browser.run(
+      `await page.goto(${JSON.stringify(server.origin)});
+       throw new Error(await page.evaluate(() => document.cookie));`,
+    );
+    assert.equal(failed.ok, false);
+    assert.equal(JSON.stringify(failed).includes(rotatedValues.at(-1)), false);
+    assert.match(failed.error, /REDACTED_PASSWORD/);
+
+    await browser.close();
+    const again = new BetterWright(options);
+    try {
+      const persisted = await again.run(
+        `await page.goto(${JSON.stringify(server.origin)}); return {
+          body: await page.locator("body").innerText(),
+          visibleCookie: await page.evaluate(() => document.cookie),
+        }`,
+      );
+      assert.equal(persisted.ok, true, persisted.error);
+      assert.equal(persisted.result.body, "authenticated");
+      assert.equal(JSON.stringify(persisted).includes(sentinel), false);
+      assert.equal(JSON.stringify(persisted).includes(rotatedValues.at(-1)), false);
+      assert.match(persisted.result.visibleCookie, /REDACTED_PASSWORD/);
+    } finally {
+      await again.close();
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("Cookie Sync refuses a batch that could evict target cookies", opts, async () => {
+  const sentinel = `cookie-capacity-${Date.now()}`;
+  const home = tempHome();
+  const browser = new BetterWright({
+    home,
+    profile: "cookie-sync-capacity",
+    headless: true,
+    vault: false,
+  });
+  browser._extractCookieSync = async () => ({
+    cookies: Array.from({ length: 151 }, (_, index) => ({
+      name: `cookie_${index}`,
+      value: `${sentinel}_${index}`,
+      domain: `host-${index}.example.test`,
+      path: "/",
+      httpOnly: true,
+      secure: true,
+    })),
+    selected: 151,
+    skipped: 0,
+    warnings: [],
+    source: { browser: "fixture" },
+  });
+  try {
+    const result = await browser.syncCookies({ source: { browser: "fixture" } });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /exceed the target cookie capacity/);
+    assert.equal(JSON.stringify(result).includes(sentinel), false);
+  } finally {
+    await browser.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("Cookie Sync refuses a local ephemeral target profile", opts, async () => {
+  const home = tempHome();
+  const options = { home, profile: "cookie-sync-lock", headless: true, vault: false };
+  const owner = new BetterWright(options);
+  const contender = new BetterWright(options);
+  contender._extractCookieSync = async () => ({
+    cookies: [{
+      name: "session",
+      value: "fixture-secret",
+      domain: "example.test",
+      path: "/",
+      httpOnly: true,
+      secure: true,
+    }],
+    selected: 1,
+    skipped: 0,
+    warnings: [],
+    source: { browser: "fixture" },
+  });
+  try {
+    const started = await owner.run("return true");
+    assert.equal(started.ok, true, started.error);
+    const temporary = await contender.run("return true");
+    assert.equal(temporary.ok, true, temporary.error);
+    assert.equal(temporary.profileMode, "ephemeral");
+    const synced = await contender.syncCookies({ source: { browser: "fixture" } });
+    assert.equal(synced.ok, false);
+    assert.match(synced.error, /requires the selected BetterWright profile to be persistent/);
+    assert.equal(JSON.stringify(synced).includes("fixture-secret"), false);
+    await owner.close();
+    const retried = await contender.syncCookies({ source: { browser: "fixture" } });
+    assert.equal(retried.ok, true, retried.error);
+    assert.equal(retried.profileMode, "persistent");
+  } finally {
+    await Promise.all([owner.close(), contender.close()]);
     fs.rmSync(home, { recursive: true, force: true });
   }
 });

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -3084,6 +3084,66 @@ test("Cookie Sync refuses a local ephemeral target profile", opts, async () => {
   }
 });
 
+test("Cookie Sync cannot reuse an in-flight ephemeral browser launch", opts, async () => {
+  const home = tempHome();
+  const options = { home, profile: "cookie-sync-launch-race", headless: true, vault: false };
+  const owner = new BetterWright(options);
+  const contender = new BetterWright(options);
+  const cookie = {
+    name: "session",
+    value: "fixture-race-secret",
+    domain: "example.test",
+    path: "/",
+    httpOnly: true,
+    secure: true,
+  };
+  try {
+    const started = await owner.run("return true");
+    assert.equal(started.ok, true, started.error);
+    const config = await contender._prepare();
+    const liveView = contender._dispatch(
+      { type: "live_view_start", config, options: {} },
+      30,
+    );
+    const sync = contender._dispatch(
+      {
+        type: "cookie_sync",
+        config,
+        cookies: [cookie],
+        source: { browser: "fixture" },
+        selected: 1,
+        skipped: 0,
+        warnings: [],
+      },
+      30,
+    );
+    const [liveResult, result] = await Promise.all([liveView, sync]);
+    assert.equal(liveResult.ok, true, liveResult.error);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /requires the selected BetterWright profile to be persistent/);
+    assert.equal(JSON.stringify(result).includes(cookie.value), false);
+
+    await owner.close();
+    const retried = await contender._dispatch(
+      {
+        type: "cookie_sync",
+        config,
+        cookies: [cookie],
+        source: { browser: "fixture" },
+        selected: 1,
+        skipped: 0,
+        warnings: [],
+      },
+      30,
+    );
+    assert.equal(retried.ok, true, retried.error);
+    assert.equal(retried.profileMode, "persistent");
+  } finally {
+    await Promise.all([owner.close(), contender.close()]);
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("a second browser on the SAME profile falls back to ephemeral", opts, async () => {
   const home = tempHome();
   const first = new BetterWright({ home, profile: "social", headless: true });

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -3122,6 +3122,9 @@ test("Cookie Sync cannot reuse an in-flight ephemeral browser launch", opts, asy
     assert.equal(result.ok, false);
     assert.match(result.error, /requires the selected BetterWright profile to be persistent/);
     assert.equal(JSON.stringify(result).includes(cookie.value), false);
+    const liveStatus = await contender._dispatch({ type: "live_view_status" }, 30);
+    assert.equal(liveStatus.ok, true, liveStatus.error);
+    assert.equal(liveStatus.running, true);
 
     await owner.close();
     const retried = await contender._dispatch(

--- a/tests/node/cli-flags.test.ts
+++ b/tests/node/cli-flags.test.ts
@@ -116,5 +116,9 @@ test("firstPositional skips value-flag arguments but not assigned or boolean fla
   // The browser choice is a value: `run --browser steel script.js` runs the file.
   assert.equal(firstPositional(["--browser", "steel", "script.js"]), "script.js");
   assert.equal(firstPositional(["--browser", "steel", "--browser-key", "sk-live"]), undefined);
+  assert.equal(
+    firstPositional(["sync", "chrome", "--domain", "example.com", "--source-profile", "Work"]),
+    "sync",
+  );
   assert.equal(firstPositional([]), undefined);
 });

--- a/tests/node/cli-help.test.ts
+++ b/tests/node/cli-help.test.ts
@@ -143,6 +143,71 @@ test("boxes help names REST providers and the connect-only ones", () => {
   assert.match(text, /configure --connect/);
 });
 
+test("Cookie Sync help names its local and cloud security gates", () => {
+  const text = helpFor("cookies");
+  assert.match(text, /cookies browsers/);
+  assert.match(text, /cookies profiles/);
+  assert.match(text, /cookies sync/);
+  assert.match(text, /--allow-app-bound/);
+  assert.match(text, /--allow-cloud <target>/);
+  assert.match(text, /provider:browserbase/);
+});
+
+test("Cookie Sync CLI rejects unsafe selector shapes before opening a browser", () => {
+  const missingScope = runCli(["cookies", "sync", "chrome", "--json"]);
+  assert.equal(missingScope.status, 1);
+  assert.match(missingScope.stdout, /requires either --all or one or more --domain/);
+
+  const swallowedFlag = runCli([
+    "cookies",
+    "sync",
+    "chrome",
+    "--domain",
+    "--all",
+    "--json",
+  ]);
+  assert.equal(swallowedFlag.status, 1);
+  assert.match(swallowedFlag.stdout, /--domain requires a value/);
+
+  const missingProfile = runCli([
+    "cookies",
+    "sync",
+    "chrome",
+    "--all",
+    "--source-profile",
+    "--json",
+  ]);
+  assert.equal(missingProfile.status, 1);
+  assert.match(missingProfile.stdout, /--source-profile requires a value/);
+
+  const oneShotCloud = runCli([
+    "cookies",
+    "sync",
+    "chrome",
+    "--all",
+    "--browser",
+    "wss://cloud.example.test/devtools/browser/fixture",
+    "--allow-cloud",
+    "cdp:cloud.example.test",
+    "--no-daemon",
+    "--json",
+  ]);
+  assert.equal(oneShotCloud.status, 1);
+  assert.match(oneShotCloud.stdout, /requires the session daemon/);
+
+  const oneShotSession = runCli([
+    "cookies",
+    "sync",
+    "firefox",
+    "--all",
+    "--include-session",
+    "--no-daemon",
+    "--json",
+  ]);
+  assert.equal(oneShotSession.status, 1);
+  assert.match(oneShotSession.stdout, /session cookies remain usable/);
+});
+
 test("wantsHelp only matches flag forms, so task text is never swallowed", () => {
   assert.equal(wantsHelp(["--help"]), true);
   assert.equal(wantsHelp(["-h"]), true);

--- a/tests/node/client.test.ts
+++ b/tests/node/client.test.ts
@@ -161,6 +161,224 @@ test("provider options reach the worker config verbatim", async () => {
   }
 });
 
+test("Cookie Sync rejects cloud targets before extraction or session creation", async () => {
+  const browser = new BetterWright({
+    provider: { provider: "browserbase", apiKey: "bb_test" },
+    vault: false,
+  });
+  let extracted = 0;
+  let prepared = 0;
+  browser._extractCookieSync = async () => {
+    extracted += 1;
+    throw new Error("must not run");
+  };
+  browser._prepare = async () => {
+    prepared += 1;
+    throw new Error("must not run");
+  };
+  try {
+    const missing = await browser.syncCookies({ source: { browser: "chrome" } });
+    assert.equal(missing.ok, false);
+    assert.match(missing.error, /provider:browserbase/);
+    const mismatched = await browser.syncCookies({
+      source: { browser: "chrome" },
+      cloudConsent: "provider:kernel",
+    });
+    assert.equal(mismatched.ok, false);
+    assert.match(mismatched.error, /provider:browserbase/);
+    assert.equal(extracted, 0);
+    assert.equal(prepared, 0);
+  } finally {
+    await browser.close();
+  }
+});
+
+test("Cookie Sync resolves named-provider credentials from the environment during preflight", async () => {
+  const previous = process.env.BROWSERBASE_API_KEY;
+  process.env.BROWSERBASE_API_KEY = "bb_environment_test";
+  const browser = new BetterWright({
+    provider: { provider: "browserbase" },
+    vault: false,
+  });
+  browser._extractCookieSync = async () => {
+    throw new Error("extraction must not run before consent");
+  };
+  try {
+    const result = await browser.syncCookies({ source: { browser: "chrome" } });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /provider:browserbase/);
+    assert.doesNotMatch(result.error, /needs an API key/);
+  } finally {
+    await browser.close();
+    if (previous === undefined) delete process.env.BROWSERBASE_API_KEY;
+    else process.env.BROWSERBASE_API_KEY = previous;
+  }
+});
+
+test("Cookie Sync does not extract after the client is closed", async () => {
+  const browser = new BetterWright({ vault: false });
+  let extracted = false;
+  browser._extractCookieSync = async () => {
+    extracted = true;
+    return { cookies: [] };
+  };
+  await browser.close();
+  const result = await browser.syncCookies({ source: { browser: "chrome" } });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /closed/);
+  assert.equal(extracted, false);
+});
+
+test("Cookie Sync binds raw CDP consent to the endpoint host and sends cookies only to the worker", async () => {
+  const browser = new BetterWright({
+    provider: { cdpUrl: "wss://user:pass@cloud.example.test:8443/devtools?token=secret" },
+    vault: false,
+  });
+  let dispatched;
+  browser._extractCookieSync = async () => ({
+    cookies: [{
+      name: "session",
+      value: "COOKIE_SECRET_SENTINEL",
+      domain: "example.test",
+      path: "/",
+      secure: true,
+      httpOnly: true,
+    }],
+    selected: 1,
+    skipped: 0,
+    warnings: [],
+    source: { browser: "chrome" },
+  });
+  browser._prepare = async () => ({ provider: browser.provider });
+  browser._dispatch = async (message) => {
+    dispatched = message;
+    return { ok: true, synced: 1 };
+  };
+  try {
+    const result = await browser.syncCookies({
+      source: { browser: "chrome" },
+      cloudConsent: "cdp:cloud.example.test:8443",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(dispatched.cloudConsent, "cdp:cloud.example.test:8443");
+    assert.equal(dispatched.cookies[0].value, "COOKIE_SECRET_SENTINEL");
+    assert.equal(JSON.stringify(dispatched.config).includes("COOKIE_SECRET_SENTINEL"), false);
+  } finally {
+    await browser.close();
+  }
+});
+
+test("Cookie Sync exclusively waits for older calls and blocks newer calls", async () => {
+  const browser = new BetterWright({ vault: false });
+  const events: string[] = [];
+  let finishRun: () => void = () => {};
+  let finishSync: () => void = () => {};
+  let runCount = 0;
+  browser._runNow = async () => {
+    runCount += 1;
+    if (runCount > 1) {
+      events.push("new-run");
+      return { ok: true };
+    }
+    events.push("old-run-start");
+    await new Promise<void>((resolve) => {
+      finishRun = resolve;
+    });
+    events.push("old-run-end");
+    return { ok: true };
+  };
+  browser._syncCookiesNow = async () => {
+    events.push("sync-start");
+    await new Promise<void>((resolve) => {
+      finishSync = resolve;
+    });
+    events.push("sync-end");
+    return { ok: true, synced: 0 };
+  };
+  try {
+    const oldRun = browser.run("old");
+    const sync = browser.syncCookies({ source: { browser: "chrome" } });
+    const newRun = browser.run("new", { session: "other" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(events, ["old-run-start"]);
+    finishRun();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(events, ["old-run-start", "old-run-end", "sync-start"]);
+    finishSync();
+    await Promise.all([oldRun, sync, newRun]);
+    assert.deepEqual(events, [
+      "old-run-start",
+      "old-run-end",
+      "sync-start",
+      "sync-end",
+      "new-run",
+    ]);
+  } finally {
+    finishRun();
+    finishSync();
+    await browser.close();
+  }
+});
+
+test("the worker rechecks Cookie Sync consent before opening a remote CDP target", async () => {
+  const browser = new BetterWright({
+    provider: { cdpUrl: "ws://127.0.0.1:9/devtools/browser/unreachable" },
+    vault: false,
+  });
+  try {
+    const config = await browser._prepare();
+    const result = await browser._dispatch(
+      {
+        type: "cookie_sync",
+        config,
+        cookies: [{
+          name: "session",
+          value: "COOKIE_SECRET_SENTINEL",
+          domain: "example.test",
+          path: "/",
+          secure: true,
+          httpOnly: true,
+        }],
+        cloudConsent: "cdp:somewhere-else.test",
+      },
+      5,
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.error, /cdp:127\.0\.0\.1:9/);
+    assert.doesNotMatch(result.error, /ECONNREFUSED|unreachable|COOKIE_SECRET_SENTINEL/);
+  } finally {
+    await browser.close();
+  }
+});
+
+test("the worker rejects malformed Cookie Sync payloads without echoing values", async () => {
+  const browser = new BetterWright({ vault: false });
+  const sentinel = "COOKIE_SECRET_SENTINEL";
+  try {
+    const config = await browser._prepare();
+    const result = await browser._dispatch(
+      {
+        type: "cookie_sync",
+        config,
+        cookies: [{
+          name: "session",
+          value: `${sentinel}\n`,
+          domain: "example.test",
+          path: "/",
+          secure: true,
+          httpOnly: true,
+        }],
+      },
+      5,
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.error, /invalid cookie batch/);
+    assert.equal(JSON.stringify(result).includes(sentinel), false);
+  } finally {
+    await browser.close();
+  }
+});
+
 test("chromiumArgs reach the worker config and only security-sensitive switches fail", async () => {
   const defaults = new BetterWright();
   const tuned = new BetterWright({

--- a/tests/node/cookie-sync.test.ts
+++ b/tests/node/cookie-sync.test.ts
@@ -1,0 +1,361 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  COOKIE_SYNC_MAX_COOKIES,
+  extractCookieSync,
+  listCookieSourceBrowsers,
+  listCookieSourceProfiles,
+  normalizeCookieSnapshot,
+  normalizeCookieSyncOptions,
+  validateCookieSyncTargetCookies,
+} from "../../dist/src/cookie-sync.js";
+
+function detailed(cookie: any = {}, context: any = {}) {
+  return {
+    cookie: {
+      domain: ".example.com",
+      path: "/",
+      secure: true,
+      name: "session",
+      value: "opaque-token",
+      httpOnly: true,
+      sameSite: 1,
+      ...cookie,
+    },
+    context: {
+      topFrameSiteKey: null,
+      hasCrossSiteAncestor: null,
+      sourceScheme: null,
+      sourcePort: null,
+      isPersistent: true,
+      originAttributes: null,
+      userContextId: null,
+      partitionKey: null,
+      privateBrowsingId: null,
+      ...context,
+    },
+  };
+}
+
+function reader(snapshot: any, calls: any[] = []) {
+  return {
+    version: () => "0.6.0",
+    read: async (options) => {
+      calls.push(options);
+      return snapshot;
+    },
+    supportedBrowsers: async () => [],
+    browserProfiles: async () => [],
+  };
+}
+
+test("Cookie Sync normalizes source, domains, timeout, and secure defaults", () => {
+  const options = normalizeCookieSyncOptions({
+    source: { browser: " Chrome " },
+    domains: ["HTTPS://Bücher.example", "xn--bcher-kva.example"],
+    timeoutMs: 999_999,
+  });
+  assert.deepEqual(options, {
+    source: { browser: "chrome" },
+    domains: ["xn--bcher-kva.example"],
+    includeSession: false,
+    windowsAppBound: "disabled",
+    timeoutMs: 120_000,
+  });
+  assert.throws(
+    () => normalizeCookieSyncOptions({ source: { browser: "chrome" }, domains: [] }),
+    /non-empty array/,
+  );
+  assert.throws(
+    () => normalizeCookieSyncOptions({ source: { browser: "chrome" }, domains: ["x.test/path"] }),
+    /without paths/,
+  );
+  assert.throws(
+    () => normalizeCookieSyncOptions({ source: { browser: "chrome" }, domains: ["ftp://x.test"] }),
+    /without paths/,
+  );
+  assert.throws(
+    () => normalizeCookieSyncOptions({ source: { browser: "chrome" }, windowsAppBound: "elevated" }),
+    /disabled.*injection/,
+  );
+});
+
+test("Cookie Sync keeps applicable parent cookies and faithful Chromium partitions", () => {
+  const snapshot = {
+    detailedCookies: [
+      detailed({ name: "parent", domain: ".example.com", sameSite: 0 }),
+      detailed({ name: "host-only-parent", domain: "example.com" }),
+      detailed(
+        { name: "partitioned", domain: "app.example.com", sameSite: 2 },
+        { topFrameSiteKey: "https://top.example", hasCrossSiteAncestor: false },
+      ),
+      detailed({ name: "other", domain: ".unrelated.test" }),
+    ],
+    warnings: [],
+  };
+  const result = normalizeCookieSnapshot(
+    snapshot,
+    { source: { browser: "chrome" }, domains: ["app.example.com"] },
+    { now: Date.UTC(2026, 0, 1) },
+  );
+  assert.deepEqual(
+    result.cookies.map(({ name, sameSite, partitionKey, partitionCrossSiteAncestor }) => ({
+      name,
+      sameSite,
+      partitionKey,
+      partitionCrossSiteAncestor,
+    })),
+    [
+      {
+        name: "parent",
+        sameSite: "None",
+        partitionKey: undefined,
+        partitionCrossSiteAncestor: undefined,
+      },
+      {
+        name: "partitioned",
+        sameSite: "Strict",
+        partitionKey: "https://top.example",
+        partitionCrossSiteAncestor: false,
+      },
+    ],
+  );
+  assert.equal(result.skipped, 2);
+  assert.deepEqual(result.warnings, [{ code: "domain_filtered", count: 2 }]);
+});
+
+test("Cookie Sync keeps IPv6 hosts and origin metadata on the winning target identity", () => {
+  const result = normalizeCookieSnapshot(
+    {
+      detailedCookies: [
+        detailed(
+          { name: "local", domain: "[::1]", secure: false },
+          { sourceScheme: 1, sourcePort: 8_080 },
+        ),
+        detailed(
+          { name: "scoped", value: "port-a" },
+          { sourceScheme: 2, sourcePort: 443 },
+        ),
+        detailed(
+          { name: "scoped", value: "port-b" },
+          { sourceScheme: 2, sourcePort: 8_443 },
+        ),
+      ],
+      warnings: [],
+    },
+    { source: { browser: "chrome" }, domains: ["[::1]", "example.com"] },
+  );
+  assert.equal(result.cookies.length, 2);
+  assert.deepEqual(result.cookies[0], {
+    name: "local",
+    value: "opaque-token",
+    domain: "[::1]",
+    path: "/",
+    httpOnly: true,
+    secure: false,
+    sameSite: "Lax",
+    sourceScheme: "NonSecure",
+    sourcePort: 8_080,
+  });
+  assert.deepEqual(
+    result.cookies.slice(1).map(({ value, sourceScheme, sourcePort }) => ({
+      value,
+      sourceScheme,
+      sourcePort,
+    })),
+    [
+      { value: "port-b", sourceScheme: "Secure", sourcePort: 8_443 },
+    ],
+  );
+  assert.deepEqual(result.warnings, [{ code: "duplicate_replaced", count: 1 }]);
+});
+
+test("Cookie Sync drops expired, malformed, private, container, and Firefox-partitioned rows", () => {
+  const now = Date.UTC(2026, 0, 1);
+  const snapshot = {
+    detailedCookies: [
+      detailed({ name: "default-session" }, { originAttributes: "{}" }),
+      detailed({ name: "expired", expires: now / 1000 - 1 }),
+      detailed({ name: "bad-samesite", sameSite: 9 }),
+      detailed({ name: "private" }, { privateBrowsingId: 1 }),
+      detailed({ name: "container" }, { userContextId: 2, originAttributes: "^userContextId=2" }),
+      detailed({ name: "firefox-partition" }, { partitionKey: "(https,example.com)" }),
+      detailed({ name: "untyped-container" }, { userContextId: "2" }),
+    ],
+    warnings: [{ code: "locked row", count: 3, message: "must not be returned" }],
+  };
+  const result = normalizeCookieSnapshot(
+    snapshot,
+    { source: { browser: "firefox" } },
+    { now },
+  );
+  assert.deepEqual(result.cookies.map(({ name }) => name), ["default-session"]);
+  assert.equal(result.skipped, 6);
+  assert.deepEqual(result.warnings, [
+    { code: "locked_row", count: 3 },
+    { code: "expired", count: 1 },
+    { code: "malformed", count: 2 },
+    { code: "unsupported_isolation", count: 3 },
+  ]);
+});
+
+test("Cookie Sync replaces duplicate target identities and preserves separate CHIPS identities", () => {
+  const result = normalizeCookieSnapshot(
+    {
+      detailedCookies: [
+        detailed({ value: "old" }),
+        detailed({ value: "new" }),
+        detailed(
+          { value: "partitioned" },
+          { topFrameSiteKey: "https://top.example", hasCrossSiteAncestor: true },
+        ),
+      ],
+      warnings: [],
+    },
+    { source: { browser: "chrome" } },
+  );
+  assert.equal(result.cookies.length, 2);
+  assert.equal(result.cookies[0].value, "new");
+  assert.equal(result.cookies[1].partitionCrossSiteAncestor, true);
+  assert.deepEqual(result.warnings, [{ code: "duplicate_replaced", count: 1 }]);
+});
+
+test("Cookie Sync never enables elevated App-Bound recovery", async () => {
+  const calls: any[] = [];
+  const snapshot = { detailedCookies: [], warnings: [] };
+  await extractCookieSync(
+    normalizeCookieSyncOptions({ source: { browser: "chrome" } }),
+    async () => reader(snapshot, calls),
+  );
+  await extractCookieSync(
+    normalizeCookieSyncOptions({
+      source: { browser: "chrome" },
+      windowsAppBound: "injection",
+    }),
+    async () => reader(snapshot, calls),
+  );
+  assert.deepEqual(calls.map((call) => call.appBound), ["disabled", "injection_only"]);
+  assert.equal(calls.some((call) => call.appBound === "allow_elevated_fallback"), false);
+});
+
+test("Cookie Sync accepts the pinned reader's build-suffixed version", async () => {
+  const fake = reader({ detailedCookies: [], warnings: [] });
+  fake.version = () => "0.6.0 (verified-build)";
+  assert.deepEqual(await listCookieSourceBrowsers(async () => fake), []);
+});
+
+test("Cookie Sync discovery preserves unavailable-reader guidance", async () => {
+  const unavailable = async () => {
+    throw new Error(
+      "Cookie Sync is unavailable on this host. Reinstall BetterWright with optional dependencies enabled.",
+    );
+  };
+  await assert.rejects(
+    () => listCookieSourceBrowsers(unavailable),
+    /Reinstall BetterWright with optional dependencies enabled/,
+  );
+  await assert.rejects(
+    () => listCookieSourceProfiles("chrome", {}, unavailable),
+    /Reinstall BetterWright with optional dependencies enabled/,
+  );
+});
+
+test("Cookie Sync replaces source failures without echoing source secrets", async () => {
+  const sentinel = "COOKIE_SECRET_SENTINEL";
+  const broken = reader({});
+  broken.read = async () => {
+    throw new Error(`native failure included ${sentinel}`);
+  };
+  await assert.rejects(
+    () =>
+      extractCookieSync(
+        normalizeCookieSyncOptions({ source: { browser: "chrome" } }),
+        async () => broken,
+      ),
+    (error: any) => !error.message.includes(sentinel) && /could not read/.test(error.message),
+  );
+});
+
+test("Cookie Sync enforces count and encoded-size limits", () => {
+  const tooMany = Array.from({ length: COOKIE_SYNC_MAX_COOKIES + 1 }, (_, index) =>
+    detailed({ name: `c${index}`, value: "x" }),
+  );
+  assert.throws(
+    () => normalizeCookieSnapshot(
+      { detailedCookies: tooMany, warnings: [] },
+      { source: { browser: "chrome" } },
+    ),
+    /more than 10000 cookies/,
+  );
+
+  const tooLarge = Array.from({ length: 950 }, (_, index) =>
+    detailed({ name: `large${index}`, value: "x".repeat(7_000) }),
+  );
+  assert.throws(
+    () => normalizeCookieSnapshot(
+      { detailedCookies: tooLarge, warnings: [] },
+      { source: { browser: "chrome" } },
+    ),
+    /secure transfer limit/,
+  );
+});
+
+test("worker-side Cookie Sync validation accepts the wire shape and rejects secret-bearing corruption", () => {
+  const cookie = normalizeCookieSnapshot(
+    {
+      detailedCookies: [detailed(
+        { expires: Date.now() / 1000 + 60 },
+        { topFrameSiteKey: "https://top.example", hasCrossSiteAncestor: true },
+      )],
+      warnings: [],
+    },
+    { source: { browser: "chrome" } },
+  ).cookies[0];
+  assert.deepEqual(validateCookieSyncTargetCookies([cookie]), [cookie]);
+  assert.throws(
+    () => validateCookieSyncTargetCookies([{ ...cookie, value: "bad\nvalue" }]),
+    /malformed cookie batch/,
+  );
+  assert.deepEqual(
+    validateCookieSyncTargetCookies([{ ...cookie, expires: Date.now() / 1000 - 1 }]),
+    [],
+  );
+});
+
+test("source browser and profile discovery returns only bounded public metadata", async () => {
+  const fake = {
+    version: () => "0.6.0",
+    read: async () => ({ detailedCookies: [], warnings: [] }),
+    supportedBrowsers: async () => [
+      { id: "chrome", displayName: "Google Chrome", engine: "chromium", secret: "drop" },
+      { id: "", displayName: "bad", engine: "x" },
+    ],
+    browserProfiles: async () => [
+      {
+        profile: {
+          profileId: "profile-1",
+          displayName: "Work",
+          path: "/private/source/path",
+        },
+        isDefault: true,
+        sources: [{ path: "/private/cookies" }],
+      },
+    ],
+  };
+  assert.deepEqual(await listCookieSourceBrowsers(async () => fake), [
+    { id: "chrome", name: "Google Chrome", engine: "chromium" },
+  ]);
+  assert.deepEqual(
+    await listCookieSourceProfiles("chrome", {}, async () => fake),
+    [{ id: "profile-1", name: "Work", isDefault: true }],
+  );
+});
+
+test("the pinned native reader loads and advertises the mainstream browser families", async () => {
+  const browsers = await listCookieSourceBrowsers();
+  const ids = new Set(browsers.map((browser) => browser.id));
+  assert.equal(ids.has("chrome"), true);
+  assert.equal(ids.has("firefox"), true);
+  assert.equal(ids.has("safari"), process.platform === "darwin");
+});

--- a/tests/node/credential-constants.test.ts
+++ b/tests/node/credential-constants.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  createSecretsRedactor,
   REDACTED_PASSWORD_PLACEHOLDER,
   redactSecretsDeep,
 } from "../../dist/src/credential-constants.js";
@@ -25,6 +26,15 @@ test("redactSecretsDeep scrubs strings, keys, and nested values without mutating
   assert.equal(output[`key-${REDACTED_PASSWORD_PLACEHOLDER}`][1], 42);
   assert.equal(output[`key-${REDACTED_PASSWORD_PLACEHOLDER}`][2], null);
   assert.equal(input.message, "the password is hunter2!", "input must not be mutated");
+});
+
+test("a compiled redactor handles cookie pairs without corrupting short ordinary text", () => {
+  const redact = createSecretsRedactor(["preference=1", "long-cookie-secret"]);
+  assert.equal(redact("Example 1"), "Example 1");
+  assert.equal(
+    redact("preference=1; session=long-cookie-secret"),
+    `${REDACTED_PASSWORD_PLACEHOLDER}; session=${REDACTED_PASSWORD_PLACEHOLDER}`,
+  );
 });
 
 test("redactSecretsDeep replaces longest secrets first and terminates on cycles", () => {

--- a/tests/node/daemon.test.ts
+++ b/tests/node/daemon.test.ts
@@ -29,6 +29,10 @@ function stubBrowser() {
       calls.push(["run", code, options]);
       return { ok: true, result: `ran:${code}`, session: options.session };
     },
+    syncCookies: async (options) => {
+      calls.push(["syncCookies", options]);
+      return { ok: true, synced: 4, target: "local" };
+    },
     closeSession: async (session) => {
       calls.push(["closeSession", session]);
       return { ok: true, closed: true, pagesClosed: 2 };
@@ -330,6 +334,27 @@ test("createDaemonBrowser proxies run and survives daemon death with an envelope
     const dead = await proxy.run("3+3", {});
     assert.equal(dead.ok, false);
     assert.match(dead.error, /session daemon/);
+    await proxy.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test("Cookie Sync crosses the daemon socket as source options, not cookie plaintext", async () => {
+  const { home, browser, cleanup } = await startTestDaemon();
+  try {
+    const outcome = await connectSessionDaemon({ home, spawnIfNeeded: false });
+    const proxy = createDaemonBrowser(outcome.channel, { session: "cookies" });
+    const options = {
+      source: { browser: "chrome", profile: "Work" },
+      domains: ["example.com"],
+      windowsAppBound: "disabled",
+    };
+    const result = await proxy.syncCookies(options);
+    assert.equal(result.ok, true);
+    assert.equal(result.synced, 4);
+    assert.deepEqual(browser.calls.at(-1), ["syncCookies", options]);
+    assert.equal(JSON.stringify(browser.calls.at(-1)).includes('"cookies"'), false);
     await proxy.close();
   } finally {
     await cleanup();

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -5,12 +5,16 @@ import {
   BrowserError,
   CAPTCHA_SOLVE_STATUSES,
   CAPTCHA_STAGES,
+  type CookieSyncOptions,
+  type CookieSyncResult,
   classifyChallengeStage,
   detectBotChallenge,
   type GenerateAndFillCredentialOptions,
   type Guardrails,
   LocalCredentialVault,
   type LocalCredentialVaultOptions,
+  listCookieSourceBrowsers,
+  listCookieSourceProfiles,
   METADATA_ADDRESSES,
   METADATA_HOSTNAMES,
   NetworkPolicy,
@@ -55,6 +59,8 @@ import {
   describeCdpUrl,
   getProviderSession,
   listProviderSessions,
+  listCookieSourceBrowsers as listSdkCookieSourceBrowsers,
+  listCookieSourceProfiles as listSdkCookieSourceProfiles,
   type ProviderBox,
   type ProviderLifecycleKind,
   REST_BROWSER_PROVIDER_NAMES,
@@ -88,6 +94,16 @@ const browser = new BetterWright(options);
 const vaultOptions: LocalCredentialVaultOptions = { home: "/tmp/betterwright-types" };
 const localVault = new LocalCredentialVault(vaultOptions);
 const browserWithoutVault = new BetterWright({ vault: false });
+const cookieSyncOptions: CookieSyncOptions = {
+  source: { browser: "chrome", profile: "Work" },
+  domains: ["example.com"],
+  includeSession: false,
+  windowsAppBound: "disabled",
+};
+const cookieSync: Promise<CookieSyncResult> = browser.syncCookies(cookieSyncOptions);
+const cookieBrowsers = listCookieSourceBrowsers();
+const cookieProfiles = listCookieSourceProfiles("chrome", { timeoutMs: 10_000 });
+void [cookieSync, cookieBrowsers, cookieProfiles];
 const run: Promise<RunResult<{ title: string }>> = browser.run<{ title: string }>(
   "return { title: await page.title() }",
   { session: "docs", note: "Reading the page" },
@@ -192,6 +208,8 @@ const kernelStopped: Promise<{ provider: string; id: string }> = stopProviderSes
   "s1",
   { apiKey: "k" },
 );
+const sdkCookieBrowsers = listSdkCookieSourceBrowsers();
+const sdkCookieProfiles = listSdkCookieSourceProfiles("firefox");
 const maskedCdp: string = describeCdpUrl("wss://host?apiKey=SECRET");
 void [
   restLifecycle,
@@ -200,6 +218,8 @@ void [
   kernelList,
   kernelShown,
   kernelStopped,
+  sdkCookieBrowsers,
+  sdkCookieProfiles,
   maskedCdp,
   BROWSER_PROVIDER_NAMES,
   REST_BROWSER_PROVIDER_NAMES,

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,6 +1,8 @@
 import type {
   AskResult,
   BetterWrightOptions,
+  CookieSyncOptions,
+  CookieSyncResult,
   CredentialFillResult,
   FillCredentialOptions,
   GenerateAndFillCredentialOptions,
@@ -67,6 +69,8 @@ export class BetterWright {
   liveView: Omit<LiveViewOptions, "expose"> & { expose?: string };
 
   run<T = unknown>(code: string, options?: RunOptions): Promise<RunResult<T>>;
+  /** Merge local browser cookies into this browser's persistent context. */
+  syncCookies(options: CookieSyncOptions): Promise<CookieSyncResult>;
   /**
    * Close one session's pages and forget its state (tabs, `state`, cursor)
    * without touching the browser, the profile, or other sessions.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,6 +53,13 @@ export {
 } from "./captcha-solver.js";
 export { detectBotChallenge } from "./challenges.js";
 export { BetterWright, BrowserError } from "./client.js";
+export function listCookieSourceBrowsers(): Promise<
+  import("./public.js").CookieSourceBrowser[]
+>;
+export function listCookieSourceProfiles(
+  browser: string,
+  options?: { timeoutMs?: number },
+): Promise<import("./public.js").CookieSourceProfile[]>;
 export { METADATA_ADDRESSES, METADATA_HOSTNAMES, NetworkPolicy } from "./policy.js";
 export {
   piImageArtifacts,

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -64,6 +64,57 @@ export type BrowserProviderOptions =
   | CdpEndpointProvider
   | CloudBrowserProvider;
 
+export interface CookieSyncSource {
+  /** Browser id from `listCookieSourceBrowsers()`, such as `chrome` or `firefox`. */
+  browser: string;
+  /** Profile id or name from `listCookieSourceProfiles()`. */
+  profile?: string;
+}
+
+export interface CookieSyncOptions {
+  source: CookieSyncSource;
+  /** Cookie-domain scopes. Omit to sync every compatible cookie. */
+  domains?: string[];
+  /** Include Firefox-family session-store cookies. Defaults to false. */
+  includeSession?: boolean;
+  /** Windows Chrome App-Bound recovery through unprivileged process injection. Defaults to disabled. */
+  windowsAppBound?: "disabled" | "injection";
+  /** Exact remote target consent, for example `provider:browserbase`. */
+  cloudConsent?: string;
+  /** Local extraction timeout in milliseconds. Defaults to 30000. */
+  timeoutMs?: number;
+}
+
+export interface CookieSyncWarning {
+  code: string;
+  count: number;
+}
+
+export type CookieSyncResult =
+  | {
+      ok: true;
+      synced: number;
+      selected: number;
+      skipped: number;
+      source: { browser: string; profile?: string };
+      target: string;
+      warnings?: CookieSyncWarning[];
+      profileMode?: "persistent" | "ephemeral";
+    }
+  | { ok: false; error: string };
+
+export interface CookieSourceBrowser {
+  id: string;
+  name: string;
+  engine: string;
+}
+
+export interface CookieSourceProfile {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
 export interface BetterWrightOptions {
   home?: string;  /**
    * Named persistent browser profile inside the home: a separate identity,

--- a/types/sdk.d.ts
+++ b/types/sdk.d.ts
@@ -8,6 +8,13 @@ import type { UntrustedValue } from "./untrusted-value.js";
 
 export { resolveModel, resolveModelSelection, runAgentTask } from "./agent.js";
 export { BetterWright, BrowserError, validateCredentialMatchMode } from "./client.js";
+export function listCookieSourceBrowsers(): Promise<
+  import("./public.js").CookieSourceBrowser[]
+>;
+export function listCookieSourceProfiles(
+  browser: string,
+  options?: { timeoutMs?: number },
+): Promise<import("./public.js").CookieSourceProfile[]>;
 export { METADATA_ADDRESSES, METADATA_HOSTNAMES, NetworkPolicy } from "./policy.js";
 export { agentSystemPrompt } from "./prompt.js";
 export {


### PR DESCRIPTION
## Summary

- add secure, cross-platform Cookie Sync for local Chromium, Firefox-family, and Safari profiles
- support persistent local BetterChromium profiles and explicitly consented cloud CDP targets
- preserve representable cookie isolation, preflight Chromium quotas, and redact synced values from model-visible output
- bump BetterWright to 2.1.0 and publish the release notes

## Verification

- `npm ci`
- `NPM_CONFIG_USERCONFIG=/dev/null npm run release:check`
- `node --test --test-name-pattern="Cookie Sync" tests/node/browser.test.js`
- package CLI reports `2.1.0`

After merge, `v2.1.0` will be tagged from `main` and the GitHub Release will trigger npm Trusted Publishing.