### PR TITLE
chore: pause Dependabot bun updates until lockfile v2 works

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,21 @@ updates:
   # full rationale lives in scripts/check-versions.ts). Those bumps must be
   # deliberate, so Dependabot only proposes devDependency updates, and the
   # ignore list restates the pinned three in case the allow scope ever widens.
-  - package-ecosystem: bun
-    directory: /
-    schedule:
-      interval: weekly
-    allow:
-      - dependency-type: development
-    ignore:
-      - dependency-name: playwright-core
-      - dependency-name: tldts
-      - dependency-name: patchright-core
+  #
+  # The bun updater is paused. GitHub's image still ships Bun 1.3.14, which
+  # rejects bun.lock lockfileVersion 2 (Dependabot::DependencyFileNotSupported
+  # on every main push after 2.2.0). Bun 1.4.0 writes v2 by default. Track
+  # dependabot/dependabot-core#16026 and #16071. Restore the block below once
+  # that image can read v2. Do not switch this back to npm: CI installs with
+  # `bun install --frozen-lockfile`, so a package.json-only bump would fail.
+  #
+  # - package-ecosystem: bun
+  #   directory: /
+  #   schedule:
+  #     interval: weekly
+  #   allow:
+  #     - dependency-type: development
+  #   ignore:
+  #     - dependency-name: playwright-core
+  #     - dependency-name: tldts
+  #     - dependency-name: patchright-core


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The 2.2.0 Dependabot check on `main` failed because GitHub's bun updater still ships Bun 1.3.14, which rejects `bun.lock` `lockfileVersion` 2 (`Unsupported bun.lock 'lockfileVersion' 2`). Bun 1.4.0 writes v2. Project CI on that commit was green; only the Dependabot job was red.

Pause the `bun` ecosystem until [dependabot/dependabot-core#16026](https://github.com/dependabot/dependabot-core/issues/16026) / [#16071](https://github.com/dependabot/dependabot-core/pull/16071) ship. Action-pin updates stay on. Do not fall back to `npm`: CI uses `bun install --frozen-lockfile`, so a `package.json`-only bump would fail.

## Checklist

- [x] `bun run release:check` is unrelated to this change (Dependabot YAML only; parsed with Python's PyYAML).
- [x] **Every browser connection still goes through the guard proxy.** No launch, transport, or fetch change.
- [x] **No secret value reaches the model sandbox.** No new output channel.
- [x] **Dependency pins are still mirrored everywhere.** The ignore list for playwright-core, tldts, and patchright-core is kept in the commented restore block.
- [x] **Public API changes update `types/*.d.ts` in this same commit.** No public API change.
- [x] The two branch-protected CI job names, "Worker copies in sync" and "Node tests", are unchanged, and no new action was added.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js` directly.
- [x] User-visible behaviour is unchanged, so `CHANGELOG.md` is not updated.
- [x] Nothing private is being committed.

## How it was verified

- Failed job: [Dependabot Updates run 33724445961](https://github.com/BetterWright/betterwright/actions/runs/33724445961) on `b65ce1c` (`release: 2.2.0`).
- Error: `Unsupported bun.lock 'lockfileVersion' 2 in /bun.lock. The bun version Dependabot runs supports up to 1.`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` — only `github-actions` remains active.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cd01c5c-e641-437a-b690-d937a421247c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cd01c5c-e641-437a-b690-d937a421247c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

