### PR TITLE
test: stabilize recording timing and CLI subprocess checks

### DIFF
--- a/tests/node/cli-help.test.ts
+++ b/tests/node/cli-help.test.ts
@@ -7,7 +7,7 @@
 // exit 0, and without side effects.
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -19,24 +19,52 @@ import { COMMAND_SUMMARIES, helpFor, MAIN_USAGE, wantsHelp } from "../../dist/sr
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const cli = path.join(root, "dist", "bin", "betterwright.js");
 
-function runCli(args, { timeout = 20_000, env = {} } = {}) {
-  return spawnSync(process.execPath, [cli, ...args], {
-    cwd: root,
-    encoding: "utf8",
-    timeout,
-    // No stdin: a command that tries to read it would hang and be killed,
-    // which is exactly the regression this file guards.
-    input: "",
-    env: { ...process.env, ...env },
+function runCli(args, { timeout = 20_000, env = {}, entrypoint = cli } = {}) {
+  return new Promise<{ status: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }>(resolve => {
+    const child = execFile(process.execPath, [entrypoint, ...args], {
+      cwd: root,
+      encoding: "utf8",
+      timeout,
+      killSignal: "SIGKILL",
+      env: { ...process.env, ...env },
+    }, (_error, stdout, stderr) => {
+      resolve({ status: child.exitCode, signal: child.signalCode, stdout, stderr });
+    });
+    // Close stdin so a command that reads it cannot wait for more input.
+    child.stdin?.end();
   });
 }
+
+test("CLI test subprocesses close stdin and preserve nonzero exit output", async t => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-cli-helper-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const entrypoint = path.join(directory, "eof.mjs");
+  fs.writeFileSync(entrypoint, `process.stdin.on("end", () => {
+    process.stdout.write("stdin closed");
+    process.stderr.write("expected failure");
+    process.exitCode = 7;
+  });
+  process.stdin.resume();`);
+  const result = await runCli([], { entrypoint });
+  assert.deepEqual(result, { status: 7, signal: null, stdout: "stdin closed", stderr: "expected failure" });
+});
+
+test("CLI test subprocesses are killed at their deadline", async t => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-cli-helper-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const entrypoint = path.join(directory, "hang.mjs");
+  fs.writeFileSync(entrypoint, "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);");
+  const result = await runCli([], { entrypoint, timeout: 200 });
+  assert.equal(result.status, null);
+  assert.equal(result.signal, "SIGKILL");
+});
 
 // Commands whose help is provided elsewhere but must still be reachable.
 const HELP_COMMANDS = COMMAND_SUMMARIES.map(([name]) => name);
 
 for (const command of HELP_COMMANDS) {
-  test(`\`${command} --help\` explains without acting`, () => {
-    const result = runCli([command, "--help"]);
+  test(`\`${command} --help\` explains without acting`, async () => {
+    const result = await runCli([command, "--help"]);
     assert.equal(result.status, 0, `${command} --help exited ${result.status}: ${result.stderr}`);
     assert.equal(result.signal, null, `${command} --help was killed (it blocked or hung)`);
     assert.match(result.stdout, /Usage: betterwright/, `${command} --help printed no usage`);
@@ -48,18 +76,18 @@ for (const command of HELP_COMMANDS) {
   });
 }
 
-test("-h is accepted wherever --help is", () => {
+test("-h is accepted wherever --help is", async () => {
   for (const command of ["doctor", "run", "vault", "skill"]) {
-    const result = runCli([command, "-h"]);
+    const result = await runCli([command, "-h"]);
     assert.equal(result.status, 0, `${command} -h exited ${result.status}`);
     assert.match(result.stdout, /Usage: betterwright/);
   }
 });
 
-test("`setup --help` does not download a browser", () => {
+test("`setup --help` does not download a browser", async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-help-"));
   try {
-    const result = runCli(["setup", "--help"], { env: { BETTERWRIGHT_HOME: home } });
+    const result = await runCli(["setup", "--help"], { env: { BETTERWRIGHT_HOME: home } });
     assert.equal(result.status, 0);
     assert.doesNotMatch(result.stdout, /Installing the managed/);
     // Nothing at all should have been created in a fresh home.
@@ -69,23 +97,23 @@ test("`setup --help` does not download a browser", () => {
   }
 });
 
-test("`run --help` returns instead of blocking on stdin", () => {
-  const result = runCli(["run", "--help"], { timeout: 10_000 });
+test("`run --help` returns instead of blocking on stdin", async () => {
+  const result = await runCli(["run", "--help"], { timeout: 10_000 });
   assert.equal(result.signal, null, "run --help hung and had to be killed");
   assert.equal(result.status, 0);
   assert.match(result.stdout, /betterwright run -c/);
 });
 
-test("`skill --help` prints help, not the nine-kilobyte skill body", () => {
-  const result = runCli(["skill", "--help"]);
+test("`skill --help` prints help, not the nine-kilobyte skill body", async () => {
+  const result = await runCli(["skill", "--help"]);
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Usage: betterwright skill/);
   assert.doesNotMatch(result.stdout, /# Browser tool: BetterWright/);
   assert.ok(result.stdout.length < 2000, "help should be short");
 });
 
-test("vault help names copy and type as the secret-delivery paths", () => {
-  const result = runCli(["vault", "--help"]);
+test("vault help names copy and type as the secret-delivery paths", async () => {
+  const result = await runCli(["vault", "--help"]);
   assert.equal(result.status, 0);
   assert.match(result.stdout, /copy <id>/);
   assert.match(result.stdout, /type <id>/);
@@ -94,22 +122,22 @@ test("vault help names copy and type as the secret-delivery paths", () => {
   assert.match(result.stdout, /--key-delay/);
 });
 
-test("bare --help and `help <command>` both work", () => {
-  const bare = runCli(["--help"]);
+test("bare --help and `help <command>` both work", async () => {
+  const bare = await runCli(["--help"]);
   assert.equal(bare.status, 0);
   assert.match(bare.stdout, /betterwright init/);
 
-  const routed = runCli(["help", "vault"]);
+  const routed = await runCli(["help", "vault"]);
   assert.equal(routed.status, 0);
   assert.match(routed.stdout, /Usage: betterwright vault/);
 
-  const bareHelp = runCli(["help"]);
+  const bareHelp = await runCli(["help"]);
   assert.equal(bareHelp.status, 0);
   assert.match(bareHelp.stdout, /Usage: betterwright <command>/);
 });
 
-test("an unknown command names itself and lists the real ones", () => {
-  const result = runCli(["frobnicate"]);
+test("an unknown command names itself and lists the real ones", async () => {
+  const result = await runCli(["frobnicate"]);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Unknown command "frobnicate"/);
   assert.match(result.stderr, /betterwright init/);
@@ -153,12 +181,12 @@ test("Cookie Sync help names its local and cloud security gates", () => {
   assert.match(text, /provider:browserbase/);
 });
 
-test("Cookie Sync CLI rejects unsafe selector shapes before opening a browser", () => {
-  const missingScope = runCli(["cookies", "sync", "chrome", "--json"]);
+test("Cookie Sync CLI rejects unsafe selector shapes before opening a browser", async () => {
+  const missingScope = await runCli(["cookies", "sync", "chrome", "--json"]);
   assert.equal(missingScope.status, 1);
   assert.match(missingScope.stdout, /requires either --all or one or more --domain/);
 
-  const swallowedFlag = runCli([
+  const swallowedFlag = await runCli([
     "cookies",
     "sync",
     "chrome",
@@ -169,7 +197,7 @@ test("Cookie Sync CLI rejects unsafe selector shapes before opening a browser", 
   assert.equal(swallowedFlag.status, 1);
   assert.match(swallowedFlag.stdout, /--domain requires a value/);
 
-  const missingProfile = runCli([
+  const missingProfile = await runCli([
     "cookies",
     "sync",
     "chrome",
@@ -180,7 +208,7 @@ test("Cookie Sync CLI rejects unsafe selector shapes before opening a browser", 
   assert.equal(missingProfile.status, 1);
   assert.match(missingProfile.stdout, /--source-profile requires a value/);
 
-  const oneShotCloud = runCli([
+  const oneShotCloud = await runCli([
     "cookies",
     "sync",
     "chrome",
@@ -195,7 +223,7 @@ test("Cookie Sync CLI rejects unsafe selector shapes before opening a browser", 
   assert.equal(oneShotCloud.status, 1);
   assert.match(oneShotCloud.stdout, /requires the session daemon/);
 
-  const oneShotSession = runCli([
+  const oneShotSession = await runCli([
     "cookies",
     "sync",
     "firefox",
@@ -217,10 +245,10 @@ test("wantsHelp only matches flag forms, so task text is never swallowed", () =>
   assert.equal(wantsHelp(["show", "cred_1"]), false);
 });
 
-test("mcp help registers the server with bunx, not npx", () => {
+test("mcp help registers the server with bunx, not npx", async () => {
   assert.match(helpFor("mcp"), /bunx betterwright mcp/);
   assert.doesNotMatch(helpFor("mcp"), /\bnpx betterwright\b/);
-  const result = runCli(["mcp", "--help"]);
+  const result = await runCli(["mcp", "--help"]);
   assert.equal(result.status, 0);
   assert.match(result.stdout, /bunx betterwright mcp/);
 });
@@ -234,27 +262,22 @@ test("the daemon child is the thin CLI router, not a silent cli-main export", ()
   );
 });
 
-test("cli-main.js still dispatches when executed as the main module", () => {
+test("cli-main.js still dispatches when executed as the main module", async () => {
   const cliMain = path.join(root, "dist", "bin", "cli-main.js");
-  const result = spawnSync(process.execPath, [cliMain, "--version"], {
-    cwd: root,
-    encoding: "utf8",
-    timeout: 20_000,
-    input: "",
-  });
+  const result = await runCli(["--version"], { entrypoint: cliMain });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout.trim(), /^\d+\.\d+\.\d+/);
 });
 
-test("record help documents capture limits, artifact paths, and daemon requirements", () => {
-  const result = runCli(["record", "--help"]);
+test("record help documents capture limits, artifact paths, and daemon requirements", async () => {
+  const result = await runCli(["record", "--help"]);
   assert.equal(result.status, 0);
   for (const expected of ["--fps", "--max-duration <s>", "BETTERWRIGHT_FFMPEG_PATH", "filename, not a path", "session daemon"]) {
     assert.ok(result.stdout.includes(expected), `record help is missing ${expected}`);
   }
 });
 
-test("record rejects invalid commands before creating a session", () => {
+test("record rejects invalid commands before creating a session", async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "betterwright-record-errors-"));
   try {
     for (const [args, expected] of [
@@ -271,7 +294,7 @@ test("record rejects invalid commands before creating a session", () => {
       [["record", "unknown"], /Usage: betterwright record/],
       [["record", "start", "one.webm", "two.webm"], /Usage: betterwright record/],
     ] satisfies [string[], RegExp][]) {
-      const result = runCli(args, { env: { BETTERWRIGHT_HOME: home } });
+      const result = await runCli(args, { env: { BETTERWRIGHT_HOME: home } });
       assert.equal(result.status, 1, args.join(" "));
       assert.match(result.stderr, expected);
     }

--- a/tests/node/recording.test.ts
+++ b/tests/node/recording.test.ts
@@ -199,7 +199,7 @@ test("missing FFmpeg returns setup guidance without leaving a partial file", asy
   assert.equal(fs.existsSync(output), false);
 });
 
-test("slow encoder input preserves elapsed duration without retaining every source frame", {
+test("slow encoder input and delayed timers preserve elapsed duration with bounded source frames", {
   skip: !encoderAvailable || process.platform === "win32",
 }, async t => {
   const output = location(t);
@@ -219,12 +219,15 @@ test("slow encoder input preserves elapsed duration without retaining every sour
   cdp.frame(large);
   await delay(30);
   for (let i = 0; i < 20; i++) cdp.frame(large);
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 400);
   await delay(70);
   const result = await recording.stop();
   assert.equal(result.state, "completed", JSON.stringify(result));
-  assert.ok(result.droppedFrames >= 19, JSON.stringify(result));
-  assert.ok(result.outputFrames >= 6 && result.outputFrames < 20, JSON.stringify(result));
-  assert.ok(Math.abs(result.outputFrames / 60 * 1000 - result.durationMs) <= 20);
+  assert.equal(result.capturedFrames, 22);
+  assert.ok(result.droppedFrames >= 19 && result.droppedFrames < result.capturedFrames, JSON.stringify(result));
+  assert.ok(result.durationMs >= 400, JSON.stringify(result));
+  assert.ok(result.outputFrames >= 6, JSON.stringify(result));
+  assert.ok(Math.abs(result.outputFrames / options.fps * 1000 - result.durationMs) <= 1000 / options.fps, JSON.stringify(result));
 });
 
 test("oversized source frames fail before decoding an unbounded payload", encoderOpts, async t => {


### PR DESCRIPTION
## What and why

The slow-encoder test assumed recording always stopped before 20 output frames. In [publish attempt 2](https://github.com/BetterWright/betterwright/actions/runs/33939430597/attempts/2), CI scheduling stretched capture to 342 ms, correctly producing 21 frames at 60 FPS and failing that ceiling.

The test now deliberately blocks timer callbacks for 400 ms without busy-spinning, verifies the source-frame dropping bounds, and compares encoded duration with measured elapsed time to within one frame. Runtime recording behavior is unchanged. [Node documents that timer callbacks have no exact timing guarantee](https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args).

The CLI help/validation tests also switch their subprocess helper from synchronous spawning to asynchronous `execFile`. In [the first PR check](https://github.com/BetterWright/betterwright/actions/runs/33941455714/job/101239584959), `record status demo.webm` stayed inside `spawnSync` until the enclosing 120-second test timeout, despite its 20-second subprocess timeout. The command's validation path returns before browser acquisition. The exact runtime cause remains unproven; [upstream reports involving concurrent synchronous spawning](https://github.com/oven-sh/bun/issues/37849) are supporting context, not a confirmed match.

The async helper keeps the same command arguments, environment, closed stdin, output and exit assertions, and 10/20-second deadlines. It uses SIGKILL at the deadline and adds real subprocess fixtures for EOF, nonzero output and termination. All existing CLI cases remain. [Bun's execFile API](https://bun.com/reference/node/child_process/execFile) supplies the existing dependency option without serializing the whole suite or changing the runner.

## Checklist

- [ ] `bun run release:check` passes locally. Full release checks were not rerun for this isolated test correction; focused checks are listed below and CI will run the broader suite.
- [x] No unit test imports the worker entrypoint directly.
- [x] Only `tests/node/recording.test.ts` and `tests/node/cli-help.test.ts` are committed; no private files or generated artifacts.

Guard, redaction, dependency, public API, workflow and user-documentation checklist items are unrelated: this patch changes only test assertions and their subprocess helper.

## How it was verified

The following local checks cover the recording commit. CLI helper changes were verified by remote CI; local test execution stayed paused during a scored benchmark on this host. `git diff --check` passes for both commits.

- With the deliberate delay and original assertion: reproduced the failure at 508.54 ms, 31 output frames, 22 captured frames and 21 dropped frames.
- `bun test tests/node/recording.test.ts --test-name-pattern 'slow encoder input'`: 1 passed.
- Same focused command with `--coverage`: 1 passed; recording module line coverage 88.05% for this focused case.
- `bun run lint`: passed with existing warnings outside the changed test.
- `bun run typecheck`: passed.
- `tsc --noEmit -p tsconfig.harness.json`: passed.
- `git diff --check`: passed.

Focused tests use the unchanged built runtime from the release checkout. No browser was launched.

Final [CI run](https://github.com/BetterWright/betterwright/actions/runs/33941982994) on `fc7b1197b4278ed2f16d41728791d9a1d7994e70`: all checks passed, including all six platform unit jobs and the full suite (1106 passed, 4 skipped, 0 failed). The formerly stalled recording validation completed in 1.22 seconds, Cookie Sync validation in 0.47 seconds, and the explicit deadline fixture in 0.20 seconds.
