### PR TITLE
chore: add BetterWright sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [BetterWright]


### PR DESCRIPTION
Closes: none.

## What

Add `.github/FUNDING.yml` with `github: [BetterWright]` so the repository can link to BetterWright on GitHub Sponsors. One file, one added line. No runtime code changes.

## Why

The repository had no funding configuration. Sponsorships are now enabled in repository settings, and the Sponsors profile is awaiting GitHub approval. The link can become usable after approval and merge.

## Testing

- Inspected the GitHub diff: only the BetterWright account handle is added, with no private payout information.
- Verified the Sponsors preview shows BetterWright, its introduction, and the monthly tier; GitHub confirmed publication of both monthly and one-time tiers.
- Did not run `bun run release:check`: this is GitHub funding metadata only. Runtime, API, dependency, workflow, and changelog checklist items are unrelated and omitted. The public Sponsor button cannot be verified until the profile is approved and this change is merged.