### PR TITLE
chore: release BetterWright 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-09-09
+
 ### Added
 
 - Optional `betterwright/electron` adapter for a host-owned tab, with scoped
@@ -1462,7 +1464,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/BetterWright/betterwright/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/BetterWright/betterwright/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/BetterWright/betterwright/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/BetterWright/betterwright/compare/v2.1.0...v2.2.0

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.4.0
+generated_by: betterwright@2.5.0
 ---
 
 # BetterWright browser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## What

Prepare BetterWright 2.5.0. Update the package version and generated skill marker, and move the reviewed embedded-browser changes into a dated changelog entry. Only three metadata files change; runtime code and dependencies remain untouched.

## Why

The optional Electron and credential-capture APIs warrant a minor release. PR #168 is merged, including the reviewed PDF, cancellation and reconnect fixes.

## Testing

- Release tag and dependency/version alignment checks pass for `v2.5.0`.
- The unchanged runtime passed 1,143 tests, release checks, native Electron and ASAR reliability/recovery fixtures before merge.
- Fresh 2.5.0 `release:check` passed with 1,053 passes, three opt-in live CAPTCHA skips and zero failures. The 2.5.0 tarball consumer smoke test passed. PR CI is running.

## Checklist

- [x] Fresh `bun run release:check` passes.
- [x] Changelog and shipped version marker match 2.5.0.
- [x] No private files or generated artifacts are included.

Runtime routing, credential handling, dependency pins, public APIs and CI configuration are unchanged, so their change-specific checklist items do not apply to this metadata-only PR.
