### PR TITLE
feat(release): release 2.5.0 with embedded browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-09-09
+
 ### Added
 
 - Optional `betterwright/electron` adapter for a host-owned tab, with scoped
@@ -1462,7 +1464,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/BetterWright/betterwright/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/BetterWright/betterwright/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/BetterWright/betterwright/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/BetterWright/betterwright/compare/v2.1.0...v2.2.0

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.4.0
+generated_by: betterwright@2.5.0
 ---
 
 # BetterWright browser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## What and why

Cut **2.5.0** for the merged embedded-browser work in #168. Version bump, skill stamp, and changelog in one commit, per CONTRIBUTING.md.

## Checklist

- [x] `bun run release:check` passes locally (versions, lint, typecheck, build, unit tests, published declarations, tarball).
- [x] **Every browser connection still goes through the guard proxy.** No new launch path, transport, or fetch bypasses the worker's SOCKS guard.
- [x] **No secret value reaches the model sandbox.** Host vault keys and capture redaction stay on the existing fill-without-returning-values path.
- [x] **Dependency pins are still mirrored everywhere.** `bun run check:versions` is green: betterwright 2.5.0, bun 1.4.0, BetterChromium 151.0.7922.108, playwright-core 1.61.1.
- [x] **Public API changes update `types/*.d.ts` in this same commit.** This commit is version/changelog only; #168 already shipped the handwritten declarations.
- [x] The two branch-protected CI job names, "Worker copies in sync" and "Node tests", are unchanged.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js` directly.
- [x] User-visible behaviour is reflected in `CHANGELOG.md`.
- [x] Nothing private is being committed.

## How it was verified

On merge commit `bac153157e3195692dd1a00d93e3cf5b9862aae8`, then again after the 2.5.0 bump (`1f287f218001405937c5b0363c42ba093056d32f`):

- `bun run lint` / `typecheck` / `test:types` / `check:build` / `check:versions`: pass
- `bun run test:unit`: 1052 pass, 4 skip, 0 fail
- `bun run release:check`: pass, including `betterwright-2.5.0.tgz` (153 files)
- `BETTERWRIGHT_REQUIRE_BROWSER=1 bun run test`: 1142 pass, 4 skip, 0 fail
- Built CLI `--version` / `--help` / `doctor`: version 2.5.0, doctor ready
- PR 168 focused host/capture/prompt/cookie/electron-cdp/client tests: 81 pass, 0 fail

Linux `bun run test:electron` still fails on native clipboard (documented unverified on Linux). Packaged Electron fixture not rerun for that reason.

## After merge

Create tag `v2.5.0` from `main` and publish the GitHub Release so `publish-npm.yml` can run.

Walkthrough logs: `/opt/cursor/artifacts/00-gauntlet-summary.txt`, `/opt/cursor/artifacts/26-release-check.log`, `/opt/cursor/artifacts/30-test-browser.log`, `/opt/cursor/artifacts/31-release-check-2.5.0.log`.