### PR TITLE
Vault master-password controls and 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-09-09
+
+### Added
+
+- Master-password protection for the local vault, with hidden CLI prompts,
+  timed unlocks, cross-process locking, and trusted SDK controls.
+- Separate saved-login settings for agent access, capture, and human autosave.
+  No new MCP password-management tools are exposed.
+
+### Fixed
+
+- Preserve existing credentials and pending logins during master-password setup.
+- Keep autofill origin-scoped and retain secret redaction after locking.
+- Report actionable cookie-import permission and profile-discovery errors.
+
 ## [2.5.0] - 2026-09-09
 
 ### Added
@@ -1464,7 +1479,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.5.1...HEAD
+[2.5.1]: https://github.com/BetterWright/betterwright/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/BetterWright/betterwright/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/BetterWright/betterwright/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/BetterWright/betterwright/compare/v2.2.0...v2.3.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,9 +60,11 @@ Be clear about what this does and does not change:
   and therefore model-authored snippet code can address — cannot route to.
   Snippets still get metadata only.
 - **It does not defend against a hostile shell.** Anyone who can run
-  `betterwright vault` can already read `vault.key` and `vault.enc` as the same
-  OS user. If you give an agent an unrestricted shell tool on a machine with a
-  populated vault, that agent can read the vault, with or without this command.
+  `betterwright vault` can read a legacy `vault.key` and `vault.enc` as the same
+  OS user. Master-password setup removes that plaintext key and wraps it using
+  scrypt (N=131072, r=8, p=1) and AES-256-GCM. This protects a locked vault's
+  files, not a compromised host: an unrestricted shell can modify the runtime
+  or attack a process after its owner unlocks it.
   Scope the agent's shell, run it as a different OS user, or use an external
   vault adapter whose key material lives somewhere the agent cannot reach.
 
@@ -74,6 +76,11 @@ cannot collect a password by mistake. Overriding it takes a deliberate
 `vault type` are exempt because the secret goes to the clipboard or the focused
 window and never to stdout. Every reveal is written to the metadata-only audit
 log (`betterwright vault audit`).
+
+Unlocks expire after 15 minutes by default. A lock changes the persisted unlock
+epoch, so other instances reject cached keys on their next vault access.
+Already-filled pages and active browser sessions are not revoked by a vault
+lock. Their redaction material remains active until those pages close.
 
 ## Reporting a vulnerability
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.5.0
+generated_by: betterwright@2.5.1
 ---
 
 # BetterWright browser

--- a/bin/cli-main.ts
+++ b/bin/cli-main.ts
@@ -2245,7 +2245,22 @@ export async function runCli() {
       return cmdCookies(rest, flags);
     case "vault": {
       const { runVaultCommand } = await import("../src/vault-cli.js");
-      return runVaultCommand(rest);
+      return runVaultCommand(rest, {
+        daemonStatus: async () => {
+          const outcome = await connectSessionDaemon({ cliPath: CLI_PATH,
+            config: daemonConfigFromFlags(flags), spawnIfNeeded: false });
+          if (!outcome.ok) return null;
+          try { return await createDaemonBrowser(outcome.channel).vaultStatus(); }
+          finally { outcome.channel.end(); }
+        },
+        unlockDaemon: async (password: string) => {
+          const acquired = await acquireRunBrowser(flags);
+          try {
+            if (!acquired.viaDaemon) throw new Error("Unlock requires the persistent session daemon; retry without --no-daemon.");
+            return await acquired.browser.unlockVault({ password });
+          } finally { await acquired.cleanup(); }
+        },
+      });
     }
     case "run":
       return cmdRun(positional, flags);
@@ -2332,4 +2347,3 @@ if (invokedAsCliMain()) {
     },
   );
 }
-

--- a/docs/cookie-sync.md
+++ b/docs/cookie-sync.md
@@ -52,6 +52,12 @@ and the target identity. Cookie names and values are never returned. The
 `synced` count is verified against the target store rather than assumed from a
 successful CDP call.
 
+On macOS, a permission-denied result requires Full Disk Access for the app
+running BetterWright. Restart that app after granting access, then retry.
+Profile-discovery failures are reported separately from an empty profile list.
+Neither failure means cookies were imported. The source browser does not need
+to be closed; OS permission and native-reader failures are not bypassed.
+
 Before writing, BetterWright reads the target cookie jar and refuses a batch
 whose projected occupancy crosses conservative Chromium limits. This avoids
 triggering Chromium's per-site or global eviction. After writing, it verifies

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -196,7 +196,51 @@ that redirect or open a popup are covered.
 
 ## Getting a password back (`betterwright vault`)
 
-Everything above is agent-facing: site-scoped, metadata-only, and deliberately
+### Master password and lock state
+
+```bash
+betterwright vault setup                  # hidden password entry and confirmation
+betterwright vault unlock                 # unlock the selected profile's session daemon
+betterwright vault status --json
+betterwright vault lock                   # revoke unlocks across all profiles
+betterwright vault settings
+betterwright vault settings agent-use off
+betterwright vault settings offer-save off
+betterwright vault settings offer-save on
+betterwright vault settings autosave on
+```
+
+Setup wraps the existing data key with a password-derived key, verifies the
+wrapper, and removes `vault.key`. Existing records and pending generated logins
+are preserved. Back up `vault.enc` and `master-key.json` together. There is no
+password reset that recovers a lost master password.
+
+Master passwords are accepted only through hidden terminal input, never CLI
+arguments or environment variables. Owner commands such as `list` and `copy`
+prompt when protected. `unlock` keeps the selected daemon unlocked for 15
+minutes; a daemon restart requires another unlock. Other SDK processes must
+unlock their own vault instance. Locking does not sign out websites or undo a
+fill that already happened, and does not clear secret redaction while pages
+remain open. It prevents subsequent vault access.
+
+Settings persist across restarts. Agent access and automatic login capture are
+independent. `offer-save off` suppresses capture; `autosave on` saves accepted
+human logins without a prompt and requires `offer-save on`. Existing defaults
+remain unchanged: agent use and capture enabled, human autosave disabled.
+Agent-driven accepted logins still save automatically when capture is enabled.
+Autofill remains explicit and origin-scoped; submission requires an explicit
+request. No new MCP vault-management or password-reveal tools are exposed.
+
+Trusted SDK hosts can use `ownerSetupMaster(password)`, `ownerUnlock(password)`,
+`ownerLock()`, `ownerStatus()`, `ownerSettings()`, and `ownerConfigure(settings)`
+on `LocalCredentialVault`. Pass `autoLockMs` at construction to select an
+unlock lifetime from 1 millisecond to 24 hours. Call `dispose()` when done.
+`BetterWright.unlockVault({password})`, `lockVault()`, and `vaultStatus()` control
+its built-in vault without making passwords available to browser snippets.
+Custom host-owned keys continue to use `keyProvider`; master-password setup
+refuses to replace an externally managed key.
+
+The browser credential API is agent-facing: site-scoped, metadata-only, and deliberately
 incapable of returning a secret. That is the right shape for model-authored
 code, and the wrong shape for you — a password the agent generated during a
 signup, or captured from a login you typed, would otherwise be unreachable.
@@ -307,7 +351,7 @@ can still expose them. If that bounded set fills, BetterWright returns a static
 failure and restarts the worker instead of evicting old plaintext while an old
 page is alive.
 
-The default key file protects against plaintext logs, support bundles, casual
+Without master-password setup, the default key file protects against plaintext logs, support bundles, casual
 file inspection, and copying only the ciphertext. It is not a defense against
 malware or another process already able to read files as the same OS user.
 Use an external password manager or secret service when that is in scope for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -52,7 +52,7 @@ import {
   type UntrustedValue,
   untrustedField,
 } from "./untrusted-value.js";
-import { createLocalCredentialVault } from "./vault.js";
+import { createLocalCredentialVault, LocalCredentialVault } from "./vault.js";
 
 const WORKER_PATH = fileURLToPath(new URL("./worker.js", import.meta.url));
 // The lane host-wide calls (live view, worker revival) queue on. A session can
@@ -297,6 +297,7 @@ function stealthDriverAvailable() {
 
 /** A persistent, policy-guarded Playwright browser. */
 export class BetterWright {
+  #ownsVault = false;
   declare home: string;
   declare profile: string | null;
   declare policy: NetworkPolicy;
@@ -479,6 +480,7 @@ export class BetterWright {
         );
     } else {
       this.vault = createLocalCredentialVault({ home: this.home });
+      this.#ownsVault = true;
     }
     this.credentialCapture = this.vault
       ? options.credentialCapture !== false
@@ -942,6 +944,16 @@ export class BetterWright {
         // object, and `cacheable` is an envelope field, not part of the public
         // NetworkDecision the policy produced.
         result = { ...this.policy.check(url, details), cacheable: this._policyCacheable };
+      } else if (message.method === "vault_capture_save") {
+        if (!this.vault || this.hostTarget) throw new Error("Credential capture is unavailable.");
+        result = this.vault.ownerCapture
+          ? await this.vault.ownerCapture(payload.payload, payload.origin)
+          : await this.vault.handleRequest("save", payload.payload, payload.origin);
+      } else if (message.method === "vault_capture_policy") {
+        const protection = await this.vault?.ownerStatus?.();
+        const settings = await this.vault?.ownerSettings?.();
+        result = { offerSave: !protection?.locked && settings?.offerSave !== false,
+          autosave: settings?.autosave === true };
       } else if (message.method === "vault") {
         if (!this.vault)
           throw new Error(
@@ -1185,6 +1197,22 @@ export class BetterWright {
    */
   syncCookies(options: any = {}) {
     return this._enqueueExclusive(() => this._syncCookiesNow(options));
+  }
+
+  /** Owner control only; deliberately absent from the worker's snippet bindings. */
+  async vaultStatus() {
+    if (!this.vault?.ownerStatus) return { available: false };
+    return { available: true, ...await this.vault.ownerStatus() };
+  }
+
+  async unlockVault(options: { password: string }) {
+    if (!this.vault?.ownerUnlock) throw new Error("This vault does not support master-password unlock.");
+    return this.vault.ownerUnlock(options?.password);
+  }
+
+  async lockVault() {
+    if (!this.vault?.ownerLock) throw new Error("This vault does not support locking.");
+    return this.vault.ownerLock();
   }
 
   async _syncCookiesNow(options) {
@@ -1750,7 +1778,10 @@ export class BetterWright {
     // and the next call brings a replacement up; a call from another session
     // that lands in between must wait for that replacement, not be told the
     // browser is gone.
-    if (!restart) this._closed = true;
+    if (!restart) {
+      this._closed = true;
+      if (this.#ownsVault && this.vault instanceof LocalCredentialVault) this.vault.dispose();
+    }
     const child = requestedChild || this._process;
     const closesActiveWorker = !requestedChild || this._process === child;
     if (closesActiveWorker) {

--- a/src/cookie-reader-error.ts
+++ b/src/cookie-reader-error.ts
@@ -16,11 +16,24 @@ export class CookieReaderError extends Error {
   }
 }
 
+function explain(error: CookieReaderError): CookieReaderError {
+  if (error.cookiePermissionDenied) {
+    error.message += process.platform === "darwin"
+      ? " Grant Full Disk Access to the app running BetterWright in System Settings > Privacy & Security, restart that app, then retry."
+      : " Allow the current user to read the source browser profile, then retry.";
+  } else if (error.cookieReaderCode === "discovery_failed") {
+    error.message += " Browser profile discovery failed. Check that the source browser has a profile and the current process can read its directory.";
+  } else if (error.cookieReaderCode === "timed_out") {
+    error.message += " The native reader timed out; retry after any OS permission prompt is resolved.";
+  }
+  return error;
+}
+
 /** Extract only fixed diagnostic fields. Native messages can contain paths or secrets. */
 export async function cookieReaderError(cause, reader, options): Promise<CookieReaderError> {
   const error = new CookieReaderError(cause);
   const report = untrustedField(reader, "report");
-  if (error.cookiePermissionDenied || error.cookieReaderCode !== "source_extraction_failed" || !isCallable(report)) return error;
+  if (error.cookiePermissionDenied || error.cookieReaderCode !== "source_extraction_failed" || !isCallable(report)) return explain(error);
   try {
     const pending = [await report.call(reader, { ...options, select: "legacy_first", timeoutMs: Math.min(options.timeoutMs, 10_000), appBound: "disabled" })];
     for (let visited = 0; pending.length && visited < 100; visited++) {
@@ -38,5 +51,5 @@ export async function cookieReaderError(cause, reader, options): Promise<CookieR
       }
     }
   } catch { /* The fixed original error remains useful without a report. */ }
-  return error;
+  return explain(error);
 }

--- a/src/cookie-sync.ts
+++ b/src/cookie-sync.ts
@@ -594,8 +594,8 @@ export async function listCookieSourceProfiles(
     value = await reader.browserProfiles(source.browser, {
       timeoutMs: normalized.timeoutMs,
     });
-  } catch {
-    throw new Error("Cookie Sync could not list profiles for the selected browser.");
+  } catch (cause) {
+    throw await cookieReaderError(cause, reader, { browser: source.browser, timeoutMs: normalized.timeoutMs });
   }
   if (!Array.isArray(value)) throw new Error("Cookie Sync returned an invalid profile list.");
   return value.flatMap((entry) => {

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -365,6 +365,9 @@ export function createDaemonBrowser(channel, { session = "default" }: any = {}) 
   };
   return {
     session: pinned,
+    vaultStatus: () => call("vaultStatus"),
+    unlockVault: (options: { password: string }) => call("unlockVault", [options]),
+    lockVault: () => call("lockVault"),
     run: (code, options?: any) => call("run", [code, options]),
     syncCookies: (options?: any) =>
       call(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -463,6 +463,9 @@ const SESSION_OPTION_METHODS = new Set([
   "waitForAsk",
 ]);
 const PLAIN_METHODS = new Set([
+  "vaultStatus",
+  "unlockVault",
+  "lockVault",
   "syncCookies",
   "stopLiveView",
   "liveViewStatus",

--- a/src/secret-prompt.ts
+++ b/src/secret-prompt.ts
@@ -1,0 +1,43 @@
+import { StringDecoder } from "node:string_decoder";
+
+/** Read only from a human terminal, without echo, argv, environment, or stdout. */
+export function promptSecret(label: string): Promise<string> {
+  const input = process.stdin;
+  if (!input.isTTY || !process.stderr.isTTY) {
+    throw new Error("A terminal is required for master-password entry. Never put it in arguments or tool input.");
+  }
+  return new Promise((resolve, reject) => {
+    const decoder = new StringDecoder("utf8");
+    let value = "";
+    const wasRaw = input.isRaw;
+    const wasPaused = input.isPaused();
+    const finish = (error?: Error) => {
+      input.removeListener("data", onData);
+      input.removeListener("end", onEnd);
+      input.removeListener("error", onError);
+      input.setRawMode(wasRaw);
+      if (wasPaused) input.pause();
+      process.stderr.write("\n");
+      if (error) reject(error);
+      else resolve(value);
+      value = "";
+    };
+    const onEnd = () => finish(new Error("Password entry cancelled."));
+    const onError = () => finish(new Error("Password entry failed."));
+    const onData = (chunk: Buffer) => {
+      for (const char of decoder.write(chunk)) {
+        if (char === "\r" || char === "\n") { finish(); return; }
+        if (char === "\u0003" || char === "\u0004") { onEnd(); return; }
+        if (char === "\u007f" || char === "\b") value = [...value].slice(0, -1).join("");
+        else if (char >= " ") value += char;
+        if (Buffer.byteLength(value) > 1024) { finish(new Error("Master password is too long.")); return; }
+      }
+    };
+    input.setRawMode(true);
+    input.on("data", onData);
+    input.once("end", onEnd);
+    input.once("error", onError);
+    input.resume();
+    process.stderr.write(label);
+  });
+}

--- a/src/vault-capture.ts
+++ b/src/vault-capture.ts
@@ -231,13 +231,15 @@ export function installVaultCapture(context, deps: any = {}) {
     clearTimeout(capture.timer);
     if (neverOrigins.has(capture.origin)) return;
     if (deps.shouldCapture && !await deps.shouldCapture(capture)) return;
+    const policy = deps.capturePolicy ? await deps.capturePolicy() : { offerSave: true, autosave: false };
+    if (!policy.offerSave) return;
     if (state.disposed) return;
 
     const lastModelAt = deps.lastModelActivity(page, capture.origin);
-    if (
+    if (policy.autosave || (
       Number.isFinite(lastModelAt) &&
       Date.now() - lastModelAt <= timings.modelWindowMs
-    ) {
+    )) {
       // The model just drove this page/origin: signups and logins it types
       // are always saved without a prompt.
       await saveCapture(capture);

--- a/src/vault-cli.ts
+++ b/src/vault-cli.ts
@@ -25,6 +25,7 @@ import { flagValue, positionalArgs } from "./cli-flags.js";
 import { wantsHelp } from "./cli-help.js";
 import { cliPaint, paintedError, paintedLog } from "./cli-theme.js";
 import { defaultHome } from "./home.js";
+import { promptSecret } from "./secret-prompt.js";
 import { createLocalCredentialVault, VAULT_CATEGORIES } from "./vault.js";
 import {
   DEFAULT_KEY_DELAY_MS,
@@ -40,6 +41,11 @@ const REVEAL_ESCAPE_HATCH = "BETTERWRIGHT_VAULT_ALLOW_NON_INTERACTIVE";
 
 export const VAULT_USAGE = `Usage: betterwright vault <command>
 
+  status                                   master-password protection and lock state
+  setup                                    set a master password (hidden terminal prompt)
+  unlock                                   unlock the selected session daemon
+  lock                                     lock this vault across all profiles/processes
+  settings [agent-use|offer-save|autosave on|off]  inspect or change saving preferences
   list [--query <text>] [--category <c>]   saved credentials (metadata only)
   show <id> [--reveal]                     one credential; --reveal prints the password
   get <id>                                 alias for show
@@ -206,8 +212,9 @@ async function confirm(question) {
  */
 export async function runVaultCommand(rest: any[] = [], io: any = {}) {
   const fail = io.error || paintedError(cliPaint({ stream: process.stderr }));
+  const vault = createLocalCredentialVault({ home: io.home || defaultHome() });
   try {
-    return await dispatchVaultCommand(rest, io);
+    return await dispatchVaultCommand(rest, { ...io, vault });
   } catch (error) {
     // A mistyped flag should read like a mistyped flag, not like a crash. The
     // vault's own errors already say what went wrong in a sentence; the codes
@@ -218,11 +225,13 @@ export async function runVaultCommand(rest: any[] = [], io: any = {}) {
     }
     if (error?.code === "VAULT_KEY_MISSING") {
       fail(
-        "vault.key and vault.enc must be kept together — restore the key from your backup, " +
+        "The matching key and vault.enc must be kept together: restore master-key.json for a protected vault, or vault.key for a legacy vault, " +
           "or delete both to start a new vault (the saved passwords are unrecoverable without it).",
       );
     }
     return 1;
+  } finally {
+    vault.dispose();
   }
 }
 
@@ -233,10 +242,67 @@ async function dispatchVaultCommand(rest, io) {
   const json = flags.has("--json");
   const positional = positionalArgs(rest);
   const [subcommand = "list", target] = positional;
-  const vault = createLocalCredentialVault({ home: io.home || defaultHome() });
+  const vault = io.vault;
+  const readPassword = io.readPassword || promptSecret;
 
   if (wantsHelp(rest) || subcommand === "help") {
     log(cliPaint().help(VAULT_USAGE));
+    return 0;
+  }
+
+  if (["status", "setup", "unlock", "lock"].includes(subcommand)) {
+    if (target) throw new Error("This command takes no password arguments. Use the hidden terminal prompt.");
+    let result;
+    if (subcommand === "status") {
+      result = await vault.ownerStatus();
+      const daemon = await io.daemonStatus?.();
+      if (daemon?.available) result = { ...result, locked: daemon.locked };
+    }
+    else if (subcommand === "lock") result = await vault.ownerLock();
+    else {
+      let password = await readPassword("Master password: ");
+      try {
+        if (subcommand === "setup") {
+          let confirmation = await readPassword("Confirm master password: ");
+          const matches = password === confirmation;
+          confirmation = "";
+          if (!matches) throw new Error("Master passwords do not match.");
+          await vault.ownerSetupMaster(password);
+          result = await vault.ownerLock();
+        } else {
+          if (!io.unlockDaemon) throw new Error("Unlock requires a persistent session daemon.");
+          await vault.ownerUnlock(password);
+          result = await io.unlockDaemon(password);
+          if (result?.ok === false) throw new Error(result.error || "Session vault unlock failed.");
+        }
+      } finally { password = ""; }
+    }
+    log(json ? JSON.stringify(result, null, 2) :
+      `Master password: ${result.configured ? "configured" : "not configured"}. Vault: ${result.locked ? "locked" : "unlocked"}.`);
+    return 0;
+  }
+
+  if (!["path", "audit"].includes(subcommand) && (await vault.ownerStatus()).locked) {
+    let password = await readPassword("Master password: ");
+    try { await vault.ownerUnlock(password); } finally { password = ""; }
+  }
+
+  if (subcommand === "settings") {
+    const settings = await vault.ownerSettings();
+    if (target) {
+      const value = positional[2];
+      if (!["on", "off"].includes(value) || positional.length !== 3) {
+        throw new Error("Use vault settings <agent-use|offer-save|autosave> <on|off>.");
+      }
+      if (target === "agent-use") settings.agentUse = value === "on";
+      else if (target === "offer-save") settings.offerSave = value === "on";
+      else if (target === "autosave") settings.autosave = value === "on";
+      else throw new Error("Unknown vault setting. Choose agent-use, offer-save, or autosave.");
+      if (target === "offer-save" && !settings.offerSave) settings.autosave = false;
+      await vault.ownerConfigure(settings);
+    }
+    log(json ? JSON.stringify(settings, null, 2) :
+      `Agent use: ${settings.agentUse ? "on" : "off"}. Offer save: ${settings.offerSave ? "on" : "off"}. Autosave: ${settings.autosave ? "on" : "off"}.`);
     return 0;
   }
 
@@ -247,7 +313,9 @@ async function dispatchVaultCommand(rest, io) {
     }
     log(vault.dir);
     log("  vault.enc    AES-256-GCM record table");
-    log("  vault.key    the key that decrypts it — back this up with vault.enc, or lose both");
+    log("  master-key.json  wrapped key when master-password protection is configured");
+    log("  vault.key    legacy key, removed after master-password setup");
+    log("  back this up: vault.enc together with master-key.json, or vault.key for a legacy vault");
     log("  audit.jsonl  metadata-only activity log");
     return 0;
   }

--- a/src/vault-key-protection.ts
+++ b/src/vault-key-protection.ts
@@ -1,0 +1,86 @@
+import { createCipheriv, createDecipheriv, randomBytes, scrypt } from "node:crypto";
+import { isRecord, isString, type UntrustedValue, untrustedField } from "./untrusted-value.js";
+
+const AAD = Buffer.from("betterwright-vault-master:v1");
+
+export interface MasterKeyEnvelope {
+  version: 1;
+  salt: string;
+  iv: string;
+  tag: string;
+  data: string;
+  epoch: string;
+}
+
+function decode(value: string, length: number): Buffer {
+  const bytes = Buffer.from(value, "base64");
+  if (bytes.length !== length || bytes.toString("base64") !== value) {
+    throw new Error("Invalid master key envelope.");
+  }
+  return bytes;
+}
+
+export function parseMasterKey(contents: Buffer): MasterKeyEnvelope {
+  const value: UntrustedValue = JSON.parse(contents.toString("utf8"));
+  const salt = untrustedField(value, "salt");
+  const iv = untrustedField(value, "iv");
+  const tag = untrustedField(value, "tag");
+  const data = untrustedField(value, "data");
+  const epoch = untrustedField(value, "epoch");
+  if (!isRecord(value) || untrustedField(value, "version") !== 1 ||
+      !isString(salt) || !isString(iv) || !isString(tag) || !isString(data) || !isString(epoch)) {
+    throw new Error("Invalid master key envelope.");
+  }
+  decode(salt, 16);
+  decode(iv, 12);
+  decode(tag, 16);
+  decode(data, 32);
+  decode(epoch, 16);
+  return { version: 1, salt, iv, tag, data, epoch };
+}
+
+function derive(password: string, salt: Buffer): Promise<Buffer> {
+  if (!isString(password) || !password || Buffer.byteLength(password) > 1024) {
+    throw new Error("Invalid master password.");
+  }
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, 32, { N: 131072, r: 8, p: 1, maxmem: 256 * 1024 * 1024 },
+      (error, key) => error ? reject(new Error("Master password verification failed.")) : resolve(key));
+  });
+}
+
+export async function wrapMasterKey(key: Buffer, password: string): Promise<MasterKeyEnvelope> {
+  if (!isString(password) || password.length < 12) {
+    throw new Error("Use at least 12 characters for the master password.");
+  }
+  const salt = randomBytes(16);
+  const derived = await derive(password, salt);
+  try {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", derived, iv);
+    cipher.setAAD(AAD);
+    const data = Buffer.concat([cipher.update(key), cipher.final()]);
+    return { version: 1, salt: salt.toString("base64"), iv: iv.toString("base64"),
+      tag: cipher.getAuthTag().toString("base64"), data: data.toString("base64"),
+      epoch: randomBytes(16).toString("base64") };
+  } finally {
+    derived.fill(0);
+  }
+}
+
+export async function unwrapMasterKey(envelope: MasterKeyEnvelope, password: string): Promise<Buffer> {
+  const derived = await derive(password, decode(envelope.salt, 16));
+  let plaintext: Buffer | undefined;
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", derived, decode(envelope.iv, 12));
+    decipher.setAAD(AAD);
+    decipher.setAuthTag(decode(envelope.tag, 16));
+    plaintext = decipher.update(decode(envelope.data, 32));
+    return Buffer.concat([plaintext, decipher.final()]);
+  } catch {
+    throw new Error("Master password verification failed.");
+  } finally {
+    plaintext?.fill(0);
+    derived.fill(0);
+  }
+}

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -39,6 +39,7 @@ import {
   type UntrustedValue,
   untrustedField,
 } from "./untrusted-value.js";
+import { parseMasterKey, unwrapMasterKey, wrapMasterKey } from "./vault-key-protection.js";
 
 const DIRECTORY_MODE = 0o700;
 const FILE_MODE = 0o600;
@@ -66,6 +67,23 @@ const MUTATION_AUDIT_WARNING = Object.freeze({
   message: "Credential vault mutation succeeded, but its audit entry could not be written.",
 });
 const execFileAsync = promisify(execFile);
+
+export interface VaultSettings {
+  agentUse: boolean;
+  offerSave: boolean;
+  autosave: boolean;
+}
+
+function vaultSettings(value: UntrustedValue): VaultSettings {
+  const agentUse = untrustedField(value, "agentUse");
+  const offerSave = untrustedField(value, "offerSave");
+  const autosave = untrustedField(value, "autosave");
+  if (!isRecord(value) || !isBoolean(agentUse) || !isBoolean(offerSave) || !isBoolean(autosave) ||
+      (autosave && !offerSave)) {
+    throw vaultError("Settings require agentUse, offerSave, and autosave booleans; autosave requires offerSave.", "BAD_INPUT");
+  }
+  return { agentUse, offerSave, autosave };
+}
 
 export const VAULT_CATEGORIES = Object.freeze([
   "login",
@@ -1402,6 +1420,12 @@ interface RevealedSecretMaterial {
  * been active in this process from result envelopes.
  */
 export class LocalCredentialVault {
+  #masterKey: Buffer | null = null;
+  #masterEnvelope: string | null = null;
+  #retryAt = 0;
+  #unlockUntil = 0;
+  #autoLockMs: number;
+  #unlockTimer: ReturnType<typeof setTimeout> | null = null;
   #activeSecrets = new Set();
   #lockAcquiredForTest = null;
   #beforeGeneratePersistForTest = null;
@@ -1421,6 +1445,7 @@ export class LocalCredentialVault {
 
   constructor(options: any = {}) {
     const resolved = normalizeOptions(options);
+    this.#autoLockMs = boundedInteger(resolved.autoLockMs, 15 * 60_000, 1, 24 * 60 * 60_000, "autoLockMs");
     if (resolved.keyProvider != null && !isCallable(resolved.keyProvider)) {
       throw new TypeError("keyProvider must be a function.");
     }
@@ -2025,8 +2050,11 @@ export class LocalCredentialVault {
   }
 
   async #dispatch(action, payload, target) {
-    const { key, snapshot } = await loadKeyAndSnapshot(this.paths, this.keyProvider);
+    const { key, snapshot } = await this.#load();
     try {
+      const settings = await this.ownerSettings();
+      if (!settings.agentUse) throw vaultError("Agent use of saved logins is disabled.", "VAULT_AGENT_DISABLED");
+      if (action === "save" && payload?.deferToPending && !settings.offerSave) return { saved: false };
       if (action === "list") return await this.#list(snapshot, payload, target);
       if (action === "list-pending") {
         return await this.#listPending(snapshot, target);
@@ -2109,9 +2137,8 @@ export class LocalCredentialVault {
 
   // --- Owner-only local access ---------------------------------------------
   //
-  // The person who owns these files can already read vault.key, so refusing
-  // them their own saved passwords protects nothing and strands anything the
-  // agent captured or generated. These methods give them a supported way in.
+  // Owners can recover captured and generated passwords here. Legacy vaults
+  // use vault.key; master-protected vaults require an unlocked instance.
   //
   // They are deliberately NOT reachable through `handleRequest`: that method
   // resolves a fixed action list in `#dispatch`, which is the only surface the
@@ -2128,9 +2155,14 @@ export class LocalCredentialVault {
    */
   async #readSnapshot() {
     if (!(await pathExists(this.paths.data))) return null;
-    const { key, snapshot } = await loadKeyAndSnapshot(this.paths, this.keyProvider);
-    key.fill(0);
-    return snapshot;
+    const release = await acquireLock(this.paths, this.lockTimeoutMs, this.staleLockMs);
+    try {
+      const { key, snapshot } = await this.#load();
+      key.fill(0);
+      return snapshot;
+    } finally {
+      await release();
+    }
   }
 
   /**
@@ -2241,7 +2273,7 @@ export class LocalCredentialVault {
         if (!(await pathExists(this.paths.data))) {
           throw vaultError("No credential vault exists yet.", "NOT_FOUND");
         }
-        const { key, snapshot } = await loadKeyAndSnapshot(this.paths, this.keyProvider);
+        const { key, snapshot } = await this.#load();
         try {
           const index = snapshot.records.findIndex((candidate) => candidate.id === wanted);
           const pendingIndex =
@@ -2299,6 +2331,174 @@ export class LocalCredentialVault {
       }
     }
     return { entries: entries.slice(-count).reverse() };
+  }
+
+  get #protectionPath() { return path.join(this.dir, "master-key.json"); }
+
+  async ownerSettings(): Promise<VaultSettings> {
+    try {
+      return vaultSettings(JSON.parse((await readBoundedFile(
+        path.join(this.dir, "settings.json"), 4096, "Vault settings",
+      )).toString("utf8")));
+    } catch (error) {
+      if (isMissing(error)) return { agentUse: true, offerSave: true, autosave: false };
+      throw error;
+    }
+  }
+
+  async ownerConfigure(input: VaultSettings): Promise<VaultSettings> {
+    const settings = vaultSettings(input);
+    return this.#ownerTransaction(async () => {
+      const { key } = await this.#load();
+      key.fill(0);
+      await atomicWrite(path.join(this.dir, "settings.json"), Buffer.from(JSON.stringify(settings)));
+      return settings;
+    });
+  }
+
+  /** Trusted capture sensor only; agent preferences do not disable the owner's saving. */
+  async ownerCapture(payload, origin: string) {
+    const target = normalizeHttpOrigin(origin);
+    return this.#ownerTransaction(async () => {
+      if (!(await this.ownerSettings()).offerSave) return { saved: false };
+      const { key, snapshot } = await this.#load();
+      try { return await this.#save(snapshot, key, { ...payload, deferToPending: true }, target); }
+      finally { key.fill(0); }
+    });
+  }
+
+  #rememberKey(key: Buffer, identity: string) {
+    this.dispose();
+    this.#masterKey = Buffer.from(key);
+    this.#masterEnvelope = identity;
+    this.#unlockUntil = Date.now() + this.#autoLockMs;
+    this.#unlockTimer = setTimeout(() => this.dispose(), this.#autoLockMs);
+    this.#unlockTimer.unref?.();
+  }
+
+  async #protection() {
+    try {
+      const bytes = await readBoundedFile(this.#protectionPath, 4096, "Master key envelope");
+      return { envelope: parseMasterKey(bytes), identity: bytes.toString("utf8") };
+    } catch (error) {
+      if (isMissing(error)) return null;
+      throw vaultError("Master key protection could not be read.", "VAULT_KEY_INVALID");
+    }
+  }
+
+  async #load() {
+    const protection = await this.#protection();
+    if (!protection) {
+      // Never fall back to a legacy key after this instance observed protection.
+      if (this.#masterEnvelope) throw vaultError("Master key protection is missing.", "VAULT_KEY_MISSING");
+      return loadKeyAndSnapshot(this.paths, this.keyProvider);
+    }
+    if (!this.#masterKey || Date.now() >= this.#unlockUntil || protection.identity !== this.#masterEnvelope) {
+      this.#masterKey?.fill(0);
+      this.#masterKey = null;
+      throw vaultError("Vault is locked. Unlock it from a trusted host or `betterwright vault unlock`.", "VAULT_LOCKED");
+    }
+    const activeKey = Buffer.from(this.#masterKey);
+    try { return await loadKeyAndSnapshot(this.paths, async () => Buffer.from(activeKey)); }
+    finally { activeKey.fill(0); }
+  }
+
+  async #ownerTransaction<T>(operation: () => Promise<T>): Promise<T> {
+    return serialize(this.dir, async () => {
+      await ensurePrivateDirectory(this.dir);
+      const release = await acquireLock(this.paths, this.lockTimeoutMs, this.staleLockMs);
+      try {
+        await release.assertOwned();
+        return await operation();
+      } finally {
+        await release();
+      }
+    });
+  }
+
+  /** Metadata only; does not create a vault or attempt to unlock it. */
+  async ownerStatus() {
+    return serialize(this.dir, async () => {
+      const protection = await this.#protection();
+      return { configured: Boolean(protection),
+        locked: Boolean(protection && (!this.#masterKey || Date.now() >= this.#unlockUntil || protection.identity !== this.#masterEnvelope)),
+        osProtected: false, exists: await pathExists(this.paths.data) };
+    });
+  }
+
+  /** Wrap the existing data key, verify it, then remove the legacy plaintext key. */
+  async ownerSetupMaster(password: string) {
+    if (!isString(password) || password.length < 12 || Buffer.byteLength(password) > 1024) {
+      throw vaultError("Use a master password of at least 12 characters and at most 1024 bytes.", "BAD_INPUT");
+    }
+    return this.#ownerTransaction(async () => {
+      if (this.keyProvider) throw vaultError("The host owns this vault key.", "VAULT_EXTERNAL_KEY");
+      if (await this.#protection()) throw vaultError("A master password is already configured.", "BAD_INPUT");
+      const { key } = await this.#load();
+      try {
+        const envelope = await wrapMasterKey(key, password);
+        const verified = await unwrapMasterKey(envelope, password);
+        try {
+          if (!timingSafeEqual(key, verified)) throw vaultError("Key verification failed.", "VAULT_KEY_INVALID");
+        } finally { verified.fill(0); }
+        const identity = JSON.stringify(envelope);
+        await atomicWrite(this.#protectionPath, Buffer.from(identity));
+        this.#rememberKey(key, identity);
+        await rm(this.paths.key, { force: true });
+        await syncDirectory(this.dir);
+        return { configured: true, locked: false, osProtected: false };
+      } finally { key.fill(0); }
+    });
+  }
+
+  async ownerUnlock(password: string) {
+    return this.#ownerTransaction(async () => {
+      if (Date.now() < this.#retryAt) throw vaultError("Try unlocking again shortly.", "VAULT_AUTH_FAILED");
+      const protection = await this.#protection();
+      if (!protection) throw vaultError("Set a master password first.", "BAD_INPUT");
+      let key: Buffer | undefined;
+      try {
+        key = await unwrapMasterKey(protection.envelope, password);
+        // Verify against the actual ciphertext before retiring a migration key.
+        const loaded = await loadKeyAndSnapshot(this.paths, async () => Buffer.from(key));
+        loaded.key.fill(0);
+        const legacy = await regularFileStats(this.paths.key, { missing: true });
+        if (legacy) {
+          const old = await readBoundedFile(this.paths.key, KEY_BYTES, "Legacy vault key");
+          try {
+            if (old.length !== key.length || !timingSafeEqual(old, key)) throw new Error("Key mismatch.");
+          } finally { old.fill(0); }
+          await rm(this.paths.key);
+          await syncDirectory(this.dir);
+        }
+        this.#rememberKey(key, protection.identity);
+        return { configured: true, locked: false, osProtected: false };
+      } catch {
+        this.#retryAt = Date.now() + 1000;
+        throw vaultError("Master password verification failed.", "VAULT_AUTH_FAILED");
+      } finally { key?.fill(0); }
+    });
+  }
+
+  /** Revoke cached unlocks in every process using this vault directory. */
+  async ownerLock() {
+    return this.#ownerTransaction(async () => {
+      const protection = await this.#protection();
+      if (!protection) throw vaultError("Set a master password before locking.", "BAD_INPUT");
+      this.dispose();
+      await atomicWrite(this.#protectionPath, Buffer.from(JSON.stringify({
+        ...protection.envelope, epoch: randomBytes(16).toString("base64"),
+      })));
+      return { configured: true, locked: true, osProtected: false };
+    });
+  }
+
+  /** Clear only key material. Redaction must survive while filled pages exist. */
+  dispose() {
+    if (this.#unlockTimer) clearTimeout(this.#unlockTimer);
+    this.#unlockTimer = null;
+    this.#masterKey?.fill(0);
+    this.#masterKey = null;
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2451,8 +2451,10 @@ async function ensureBrowser(config, { requirePersistentProfile = false } = {}) 
           ? path.dirname(launchConfig.runtimeDir)
           : path.dirname(profileLock.profileDir);
         vaultCapture = installVaultCapture(launchedContext, {
-          vaultCallAtOrigin: (session, origin, action, payload) =>
-            vaultCallAtOrigin(session, origin, action, payload),
+          capturePolicy: () => rpc("vault_capture_policy", {}, null),
+          vaultCallAtOrigin: (session, origin, action, payload) => action === "save"
+            ? rpc("vault_capture_save", { origin, payload }, null)
+            : vaultCallAtOrigin(session, origin, action, payload),
           sessionForPage: (page) =>
             sessionFor(pageToSession.get(page) || "default"),
           trackSecret,

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -7,15 +7,18 @@ import fs from "node:fs";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { test } from "node:test";
 import zlib from "node:zlib";
 import { PlaywrightBlocker } from "@ghostery/adblocker-playwright";
+import { fromPath } from "rookie-cookies";
 import { AD_BLOCK_CACHE_FILE } from "../../dist/src/ad-blocker.js";
-
+import { normalizeCookieSnapshot, normalizeCookieSyncOptions } from "../../dist/src/cookie-sync.js";
 import { doctorReport } from "../../dist/src/doctor.js";
 import { BetterWright, NetworkPolicy, runAgentTask } from "../../dist/src/index.js";
 import { _createMcpHandlersForTest } from "../../dist/src/mcp-server.js";
 import { isBoolean, isCallable, isString } from "../../dist/src/untrusted-value.js";
+import { createLocalCredentialVault } from "../../dist/src/vault.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
 const browserStatus = await doctorReport();
@@ -859,6 +862,77 @@ test("setInputFiles only reads files from the artifact root", opts, async () => 
     }
   } finally {
     await bw.close();
+  }
+});
+
+test("master-protected autofill survives migration, locks, unlocks, and browser restart", opts, async () => {
+  const secret = "synthetic-autofill-secret";
+  const master = "synthetic master password for autofill";
+  let accepted = 0;
+  const server = await listen((request, response) => {
+    response.setHeader("content-type", "text/html");
+    if (request.method === "POST") {
+      let body = "";
+      request.on("data", (chunk) => { body += chunk; });
+      request.on("end", () => {
+        const fields = new URLSearchParams(body);
+        const valid = fields.get("username") === "fixture" && fields.get("password") === secret;
+        if (valid) accepted += 1;
+        response.end(valid ? "<h1>Signed in</h1>" : "<h1>Rejected</h1>");
+      });
+      return;
+    }
+    response.end(`<form method="post"><label>Username<input name="username" autocomplete="username"></label>
+      <label>Password<input name="password" type="password" autocomplete="current-password"></label>
+      <input name="future" type="password" autocomplete="new-password" hidden>
+      <button type="submit">Sign in</button></form>`);
+  });
+  const home = tempHome();
+  const owner = createLocalCredentialVault({ home });
+  const browser = new BetterWright({ home, headless: true, adBlock: false });
+  try {
+    const saved = await owner.handleRequest("save", { username: "fixture", password: secret, matchMode: "exact-origin" }, server.origin);
+    await owner.ownerSetupMaster(master);
+    const opened = await browser.run(`await page.goto(${JSON.stringify(server.origin)}); return true;`);
+    assert.equal(opened.ok, true, opened.error);
+    const locked = await browser.fillCredential({ id: saved.id, submit: true });
+    assert.equal(locked.ok, false);
+    assert.match(locked.error, /locked/i);
+    assert.equal(accepted, 0);
+    await browser.unlockVault({ password: master });
+    const filled = await browser.fillCredential({ id: saved.id, submit: true });
+    assert.equal(filled.ok, true, filled.error);
+    const signedIn = await browser.run("await page.getByRole('heading', {name: 'Signed in'}).waitFor(); return true;");
+    assert.equal(signedIn.ok, true, signedIn.error);
+    assert.equal(accepted, 1);
+    assert.equal(JSON.stringify(filled).includes(secret), false);
+    await owner.ownerLock();
+    assert.equal((await browser.vaultStatus()).locked, true);
+    await browser.unlockVault({ password: master });
+    await browser.run(`await page.goto(${JSON.stringify(server.origin)});`);
+    const handlers = _createMcpHandlersForTest({ browser, downloadPolicy: "deny" });
+    const mcp = await handlers.callTool({ params: { name: "browser_login", arguments: { id: saved.id, submit: true } } });
+    assert.notEqual(mcp.isError, true);
+    const mcpResult = JSON.parse(mcp.content[0].text);
+    assert.equal(mcpResult.ok, true, mcpResult.error);
+    assert.equal(JSON.stringify(mcp).includes(secret), false);
+    await browser.run("await page.getByRole('heading', {name: 'Signed in'}).waitFor();");
+    assert.equal(accepted, 2);
+    await browser.close();
+    const restarted = new BetterWright({ home, headless: true, adBlock: false });
+    try {
+      assert.equal((await restarted.vaultStatus()).locked, true);
+      await restarted.unlockVault({ password: master });
+      await restarted.run(`await page.goto(${JSON.stringify(server.origin)});`);
+      const again = await restarted.fillCredential({ id: saved.id, submit: true });
+      assert.equal(again.ok, true, again.error);
+      await restarted.run("await page.getByRole('heading', {name: 'Signed in'}).waitFor();");
+      assert.equal(accepted, 3);
+    } finally { await restarted.close(); }
+  } finally {
+    owner.dispose();
+    await browser.close();
+    await server.close();
   }
 });
 
@@ -3634,6 +3708,45 @@ test("Cookie Sync installs an HttpOnly cookie and persists it across restart", o
     await server.close();
     fs.rmSync(home, { recursive: true, force: true });
   }
+});
+
+test("native Cookie Sync reads a live SQLite WAL and authenticates after target restart", opts, async () => {
+  const home = tempHome();
+  const cookieFile = path.join(home, "cookies.sqlite");
+  const db = new DatabaseSync(cookieFile);
+  const sentinel = "synthetic-native-cookie";
+  db.exec(`PRAGMA journal_mode=WAL;
+    CREATE TABLE moz_cookies (id INTEGER PRIMARY KEY, originAttributes TEXT NOT NULL DEFAULT '',
+      name TEXT, value TEXT, host TEXT, path TEXT, expiry INTEGER, lastAccessed INTEGER,
+      creationTime INTEGER, isSecure INTEGER, isHttpOnly INTEGER, inBrowserElement INTEGER,
+      sameSite INTEGER, rawSameSite INTEGER, schemeMap INTEGER);`);
+  db.prepare("INSERT INTO moz_cookies VALUES (1, '', 'native_auth', ?, '127.0.0.1', '/', ?, 0, 0, 0, 1, 0, 1, 1, 1)")
+    .run(sentinel, Math.floor(Date.now() / 1000) + 3600);
+  const server = await listen((request, response) => {
+    response.setHeader("content-type", "text/html");
+    response.end(request.headers.cookie?.includes(`native_auth=${sentinel}`) ? "authenticated" : "signed out");
+  });
+  const config = { home, headless: true, adBlock: false, vault: false };
+  const browser = new BetterWright(config);
+  browser._extractCookieSync = async (options) => normalizeCookieSnapshot(
+    await fromPath({ path: cookieFile, timeoutMs: 10000 }), normalizeCookieSyncOptions(options));
+  try {
+    const result = await browser.syncCookies({ source: { browser: "firefox" }, domains: ["127.0.0.1"] });
+    assert.equal(result.ok, true, result.error);
+    assert.equal(result.synced, 1);
+    assert.equal(JSON.stringify(result).includes(sentinel), false);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM moz_cookies").get().count, 1);
+    const first = await browser.run(`await page.goto(${JSON.stringify(server.origin)}); return page.locator('body').innerText();`);
+    assert.equal(first.ok, true, first.error);
+    assert.equal(first.result, "authenticated");
+    await browser.close();
+    const again = new BetterWright(config);
+    try {
+      const result = await again.run(`await page.goto(${JSON.stringify(server.origin)}); return page.locator('body').innerText();`);
+      assert.equal(result.ok, true, result.error);
+      assert.equal(result.result, "authenticated");
+    } finally { await again.close(); }
+  } finally { db.close(); await browser.close(); await server.close(); }
 });
 
 test("Cookie Sync refuses a batch that could evict target cookies", opts, async () => {

--- a/tests/node/cookie-reader-error.test.ts
+++ b/tests/node/cookie-reader-error.test.ts
@@ -8,6 +8,7 @@ test("cookie errors retain actionable codes without native diagnostic text", asy
   assert.equal(error.cookieReaderCode, "source_extraction_failed");
   assert.ok(!JSON.stringify(error).includes("secret-profile"));
   assert.ok(!error.message.includes("secret-profile"));
+  assert.match(error.message, process.platform === "darwin" ? /Full Disk Access/ : /current user/);
 });
 
 test("nested native acquisition reports explain generic extraction errors", async () => {
@@ -19,4 +20,11 @@ test("nested native acquisition reports explain generic extraction errors", asyn
   const unavailable = await cookieReaderError({ rookieCode: "secret-code" }, reader, { timeoutMs: 1000 });
   assert.equal(unavailable.cookieReaderCode, "reader_failed");
   assert.equal(unavailable.cookieReaderStage, undefined);
+});
+
+test("profile discovery errors retain fixed guidance without source paths", async () => {
+  const error = await cookieReaderError({ rookieCode: "discovery_failed", message: "read directory /private/secret-source" }, {}, { timeoutMs: 1000 });
+  assert.equal(error.cookieReaderCode, "discovery_failed");
+  assert.match(error.message, /profile discovery failed/);
+  assert.equal(error.message.includes("secret-source"), false);
 });

--- a/tests/node/vault-capture.test.ts
+++ b/tests/node/vault-capture.test.ts
@@ -129,6 +129,7 @@ async function waitFor(condition, timeoutMs = 2_000) {
 type UntrustedValue = NonNullable<unknown> | null | undefined;
 
 interface HarnessOverrides {
+  capturePolicy?: () => Promise<{ offerSave: boolean; autosave: boolean }>;
   listRecords?: Array<{ username: string }>;
   pendingFails?: boolean;
   pendingRecords?: Array<{ pendingId: string; origin: string; username: string }>;
@@ -142,6 +143,7 @@ function isModelClock(value: number | (() => number) | undefined): value is () =
 }
 
 interface HarnessDeps {
+  capturePolicy?: () => Promise<{ offerSave: boolean; autosave: boolean }>;
   vaultCallAtOrigin: (
     session: UntrustedValue,
     origin: string,
@@ -170,6 +172,7 @@ function makeHarness(overrides: HarnessOverrides = {}) {
   const context = new FakeContext([page]);
   const calls = [];
   const deps: HarnessDeps = {
+    capturePolicy: overrides.capturePolicy,
     vaultCallAtOrigin: async (_session, origin, action, payload) => {
       calls.push({ kind: "vault", origin, action, payload });
       if (action === "list") return { credentials: overrides.listRecords || [] };
@@ -247,6 +250,31 @@ function emitPasswordFormScan(session, present) {
 
 const vaultSaves = (calls) =>
   calls.filter((call) => call.kind === "vault" && call.action === "save");
+
+test("disabled capture policy suppresses prompts and automatic saves", async () => {
+  const harness = makeHarness({ headed: true, modelAt: () => Date.now(),
+    capturePolicy: async () => ({ offerSave: false, autosave: false }) });
+  try {
+    const session = await attached(harness);
+    emitCapture(session);
+    emitNavigation(session, `${ORIGIN}/home`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(vaultSaves(harness.calls).length, 0);
+    assert.equal(session.promptCalls().length, 0);
+  } finally { harness.handle.dispose(); }
+});
+
+test("explicit autosave saves an accepted human login without a prompt", async () => {
+  const harness = makeHarness({ headed: true, modelAt: 0,
+    capturePolicy: async () => ({ offerSave: true, autosave: true }) });
+  try {
+    const session = await attached(harness);
+    emitCapture(session);
+    emitNavigation(session, `${ORIGIN}/home`);
+    assert.equal(await waitFor(() => vaultSaves(harness.calls).length === 1), true);
+    assert.equal(session.promptCalls().length, 0);
+  } finally { harness.handle.dispose(); }
+});
 
 test("model-driven capture is saved silently after navigation", async () => {
   const harness = makeHarness({ headed: false, modelAt: () => Date.now() });

--- a/tests/node/vault-cli-e2e.test.ts
+++ b/tests/node/vault-cli-e2e.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { connectSessionDaemon } from "../../dist/src/daemon-client.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+const cli = path.resolve("dist/bin/betterwright.js");
+
+function command(home: string, args: string[], prompts: Array<[string, string]> = []) {
+  return new Promise<{ code: number; output: string }>((resolve, reject) => {
+    const child = spawn(prompts.length ? "/usr/bin/expect" : process.execPath,
+      prompts.length ? ["-f", "-"] : [cli, ...args],
+      { env: { ...process.env, BETTERWRIGHT_HOME: home, NO_COLOR: "1" }, stdio: ["pipe", "pipe", "pipe"] });
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      const safe = prompts.reduce((text, [, value]) => text.replaceAll(value, "[redacted]"), output);
+      reject(new Error(`CLI ${args[1]} timed out: ${safe}`));
+    }, 30000);
+    const collect = (chunk: Buffer) => {
+      output += chunk.toString();
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    child.on("error", (error) => { clearTimeout(timer); reject(error); });
+    child.on("close", (code) => { clearTimeout(timer); resolve({ code: code ?? 1, output }); });
+    if (prompts.length) {
+      // Synthetic test input goes through a real PTY, never through CLI flags.
+      child.stdin.end([
+        "set timeout 20",
+        `spawn -noecho {${process.execPath}} {${cli}} ${args.map((arg) => `{${arg}}`).join(" ")}`,
+        ...prompts.flatMap(([label, value]) => [
+          `expect {\n-exact {${label}} {}\ntimeout { exit 124 }\neof { exit 125 }\n}`,
+          `send -- ${JSON.stringify(`${value}\r`)}`,
+        ]),
+        "expect {\neof {}\ntimeout { exit 124 }\n}",
+        "exit [lindex [wait] 3]",
+      ].join("\n") + "\n");
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+test("CLI hidden setup and unlock reach the real daemon without echoing the master password", {
+  skip: process.platform !== "darwin" ? "macOS terminal integration" : false,
+  timeout: 60000,
+}, async () => {
+  const home = makeTempDir("vault-cli-e2e-");
+  const password = "synthetic-terminal-master-password";
+  try {
+    const setup = await command(home, ["vault", "setup"], [["Master password:", password], ["Confirm master password:", password]]);
+    assert.equal(setup.code, 0, setup.output);
+    assert.equal(setup.output.includes(password), false, "terminal must not echo password entry");
+    const locked = await command(home, ["vault", "status", "--json"]);
+    assert.equal(JSON.parse(locked.output).locked, true);
+    const unlock = await command(home, ["vault", "unlock"], [["Master password:", password]]);
+    assert.equal(unlock.code, 0, unlock.output);
+    assert.equal(unlock.output.includes(password), false);
+    assert.match(unlock.output, /unlocked/);
+    const status = await command(home, ["vault", "status", "--json"]);
+    assert.equal(JSON.parse(status.output).locked, false);
+    const lock = await command(home, ["vault", "lock", "--json"]);
+    assert.equal(lock.code, 0, lock.output);
+    assert.equal(JSON.parse(lock.output).locked, true);
+    const after = await command(home, ["vault", "status", "--json"]);
+    assert.equal(JSON.parse(after.output).locked, true);
+    const refused = await command(home, ["vault", "unlock"]);
+    assert.equal(refused.code, 1);
+    assert.match(refused.output, /terminal is required/);
+  } finally {
+    const daemon = await connectSessionDaemon({ home, spawnIfNeeded: false, ignoreMismatch: true });
+    if (daemon.ok) {
+      try { await daemon.channel.request({ op: "shutdown" }); }
+      finally { daemon.channel.end(); }
+    }
+  }
+});

--- a/tests/node/vault-master.test.ts
+++ b/tests/node/vault-master.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createLocalCredentialVault } from "../../dist/src/vault.js";
+import { runVaultCommand } from "../../dist/src/vault-cli.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+const password = "synthetic master password for tests";
+const origin = "https://vault.example.test";
+
+test("master protection migrates existing records, survives restart, and revokes other instances", async () => {
+  const home = makeTempDir("vault-master-");
+  const vault = createLocalCredentialVault({ home });
+  const other = createLocalCredentialVault({ home });
+  try {
+    const saved = await vault.handleRequest("save", { username: "fixture", password: "synthetic-login-secret" }, origin);
+    const pending = await vault.handleRequest("generate", { username: "pending" }, origin);
+    const ciphertext = fs.readFileSync(vault.paths.data);
+    await vault.ownerSetupMaster(password);
+    assert.equal(fs.existsSync(vault.paths.key), false);
+    assert.deepEqual(fs.readFileSync(vault.paths.data), ciphertext);
+    assert.equal((await vault.ownerStatus()).locked, false);
+    assert.equal((await other.ownerStatus()).locked, true);
+    await assert.rejects(other.ownerList(), { code: "VAULT_LOCKED" });
+    await other.ownerUnlock(password);
+    assert.equal((await other.ownerList()).credentials.length, 1);
+    assert.equal((await other.ownerList()).pendingCredentials[0].pendingId, pending.pendingId);
+    assert.equal((await other.ownerReveal(saved.id)).secret, "synthetic-login-secret");
+    await vault.ownerLock();
+    await assert.rejects(other.handleRequest("fill", { id: saved.id }, origin), { code: "VAULT_LOCKED" });
+    await assert.rejects(other.ownerReveal(saved.id), { code: "VAULT_LOCKED" });
+    await vault.ownerUnlock(password);
+    await assert.rejects(vault.ownerUnlock("incorrect synthetic password"), { code: "VAULT_AUTH_FAILED" });
+    assert.equal(vault.redact("synthetic-login-secret"), "[REDACTED_PASSWORD]");
+    assert.equal(fs.readFileSync(path.join(vault.dir, "master-key.json"), "utf8").includes(password), false);
+  } finally {
+    vault.dispose(); other.dispose();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("master setup races preserve one key and rejected unlock never replaces ciphertext", async () => {
+  const home = makeTempDir("vault-master-race-");
+  const a = createLocalCredentialVault({ home });
+  const b = createLocalCredentialVault({ home });
+  try {
+    const outcomes = await Promise.allSettled([a.ownerSetupMaster(password), b.ownerSetupMaster(password)]);
+    assert.equal(outcomes.filter((value) => value.status === "fulfilled").length, 1);
+    const before = fs.readFileSync(a.paths.data);
+    await a.ownerLock();
+    await assert.rejects(b.ownerUnlock("wrong synthetic password"), { code: "VAULT_AUTH_FAILED" });
+    assert.deepEqual(fs.readFileSync(a.paths.data), before);
+    for (const action of ["ownerUnlock", "ownerSetupMaster", "ownerReveal", "ownerLock"]) {
+      await assert.rejects(a.handleRequest(action, {}, origin));
+    }
+  } finally {
+    a.dispose(); b.dispose(); fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("CLI setup confirms privately, never prints secrets, and requires a persistent unlock destination", async () => {
+  const home = makeTempDir("vault-master-cli-");
+  const output: string[] = [];
+  const io = { home, log: (text: string) => output.push(text), error: (text: string) => output.push(text),
+    readPassword: async () => password };
+  try {
+    assert.equal(await runVaultCommand(["setup", "--json"], io), 0);
+    assert.equal(await runVaultCommand(["status", "--json"], io), 0);
+    assert.equal(JSON.parse(output.at(-1)).locked, true);
+    assert.equal(await runVaultCommand(["unlock"], io), 1);
+    let received = false;
+    assert.equal(await runVaultCommand(["unlock", "--json"], { ...io,
+      unlockDaemon: async (value: string) => {
+        received = value === password;
+        return { configured: true, locked: false };
+      },
+    }), 0);
+    assert.equal(received, true);
+    assert.equal(output.join("\n").includes(password), false);
+    assert.equal(await runVaultCommand(["setup", "plaintext-argument"], io), 1);
+  } finally { fs.rmSync(home, { recursive: true, force: true }); }
+});
+
+test("unlock expires without removing saved data or redaction material", async () => {
+  const home = makeTempDir("vault-master-expiry-");
+  const vault = createLocalCredentialVault({ home, autoLockMs: 20 });
+  try {
+    await assert.rejects(vault.ownerSetupMaster("short"), { code: "BAD_INPUT" });
+    assert.equal(fs.existsSync(vault.paths.key), false);
+    await vault.handleRequest("save", { username: "fixture", password: "expiry-secret" }, origin);
+    await vault.ownerSetupMaster(password);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal((await vault.ownerStatus()).locked, true);
+    await assert.rejects(vault.ownerList(), { code: "VAULT_LOCKED" });
+    assert.equal(vault.redact("expiry-secret"), "[REDACTED_PASSWORD]");
+    assert.equal(fs.existsSync(vault.paths.data), true);
+  } finally { vault.dispose(); fs.rmSync(home, { recursive: true, force: true }); }
+});
+
+test("saving preferences persist, fail closed, and keep owner capture independent of agent access", async () => {
+  const home = makeTempDir("vault-settings-");
+  const vault = createLocalCredentialVault({ home });
+  try {
+    await assert.rejects(vault.ownerConfigure({ agentUse: true, offerSave: false, autosave: true }));
+    await vault.ownerConfigure({ agentUse: false, offerSave: true, autosave: false });
+    await assert.rejects(vault.handleRequest("list", {}, origin), { code: "VAULT_AGENT_DISABLED" });
+    await vault.ownerCapture({ username: "owner", password: "captured-synthetic" }, origin);
+    assert.equal((await vault.ownerList()).credentials.length, 1);
+    await vault.ownerConfigure({ agentUse: true, offerSave: false, autosave: false });
+    const other = createLocalCredentialVault({ home });
+    assert.equal((await other.ownerSettings()).offerSave, false);
+    assert.deepEqual(await other.ownerCapture({ username: "disabled", password: "not-saved" }, origin), { saved: false });
+    assert.equal((await other.ownerList()).credentials.length, 1);
+    other.dispose();
+    const output: string[] = [];
+    const io = { home, log: (text: string) => output.push(text), error: (text: string) => output.push(text) };
+    assert.equal(await runVaultCommand(["settings", "offer-save", "on", "--json"], io), 0);
+    assert.equal(JSON.parse(output.at(-1)).offerSave, true);
+    assert.equal(await runVaultCommand(["settings", "autosave", "on", "--json"], io), 0);
+    assert.equal(JSON.parse(output.at(-1)).autosave, true);
+  } finally { vault.dispose(); fs.rmSync(home, { recursive: true, force: true }); }
+});

--- a/tests/types/package.test.ts
+++ b/tests/types/package.test.ts
@@ -291,6 +291,15 @@ void [
 // The owner-only vault surface behind `betterwright vault`. These must never be
 // reachable from model code; they exist for a trusted host acting for the user.
 const ownedVault = createLocalCredentialVault({ home: "/tmp/betterwright-types" });
+void ownedVault.ownerStatus();
+void ownedVault.ownerSetupMaster("synthetic master password");
+void ownedVault.ownerUnlock("synthetic master password");
+void ownedVault.ownerLock();
+void ownedVault.ownerConfigure({ agentUse: true, offerSave: true, autosave: false });
+void ownedVault.ownerSettings();
+void new BetterWright().unlockVault({ password: "synthetic master password" });
+// @ts-expect-error Owner operations cannot be routed through model credentials.
+void ownedVault.handleRequest("ownerUnlock", {}, "https://example.com");
 const ownerListed: Promise<VaultOwnerListResult> = ownedVault.ownerList({
   query: "github",
   category: "login",

--- a/types/capture.d.ts
+++ b/types/capture.d.ts
@@ -13,6 +13,7 @@ export interface CaptureOptions {
   shouldCapture?(capture: { page: Page; origin: string; username: string; password: string }): boolean | Promise<boolean>;
   /** Host-native save UI receives metadata, never a password. */
   requestSave?(request: { page: Page; origin: string; username: string; mode: "save" | "update" }): Promise<"save" | "dismiss" | "never">;
+  capturePolicy?(): Promise<{ offerSave: boolean; autosave: boolean }>;
   onReady?(): void;
   onError?(error: Error): void;
   prefsPath?: string;

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -72,6 +72,10 @@ export class BetterWright {
   run<T = unknown>(code: string, options?: RunOptions): Promise<RunResult<T>>;
   /** Merge local browser cookies into this browser's persistent context. */
   syncCookies(options: CookieSyncOptions): Promise<CookieSyncResult>;
+  vaultStatus(): Promise<{ available: boolean; configured?: boolean; locked?: boolean; osProtected?: boolean; exists?: boolean }>;
+  /** Trusted host only. Never expose password input to a model tool. */
+  unlockVault(options: { password: string }): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
+  lockVault(): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
   /**
    * Close one session's pages and forget its state (tabs, `state`, cursor)
    * without touching the browser, the profile, or other sessions.

--- a/types/vault.d.ts
+++ b/types/vault.d.ts
@@ -10,6 +10,12 @@ export type VaultCategory =
 
 export type VaultMatchMode = "base-domain" | "host" | "exact-origin" | "never";
 
+export interface VaultSettings {
+  agentUse: boolean;
+  offerSave: boolean;
+  autosave: boolean;
+}
+
 /**
  * A JSON value as accepted for credential `fields`: the vault clones and
  * bounds every stored field, so nothing beyond plain JSON survives a save.
@@ -23,6 +29,8 @@ export type VaultJsonValue =
   | { [key: string]: VaultJsonValue };
 
 export interface LocalCredentialVaultOptions {
+  /** Master-password unlock lifetime in milliseconds, 1..86400000. Default 15 minutes. */
+  autoLockMs?: number;
   /** Host-owned encryption key. Return fresh 32-byte storage; the vault zeroes it. */
   keyProvider?: () => Promise<Uint8Array>;
   /** Exact vault directory. Takes precedence over `home`. */
@@ -133,6 +141,18 @@ export class LocalCredentialVault {
   readonly pendingTtlMs: number;
   readonly lockTimeoutMs: number;
   readonly staleLockMs: number;
+
+  ownerStatus(): Promise<{ configured: boolean; locked: boolean; osProtected: boolean; exists: boolean }>;
+  /** Trusted host only. Never pass a master password through model-authored code. */
+  ownerSetupMaster(password: string): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
+  ownerUnlock(password: string): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
+  /** Revokes cached unlocks in every process sharing this directory. */
+  ownerLock(): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
+  dispose(): void;
+  ownerSettings(): Promise<VaultSettings>;
+  ownerConfigure(settings: VaultSettings): Promise<VaultSettings>;
+  /** Trusted capture sensor only; never expose this method to a model. */
+  ownerCapture(payload: Record<string, UntrustedValue>, origin: string): Promise<UntrustedValue>;
 
   handleRequest(
     action:


### PR DESCRIPTION
## Changes
- Add master-password setup, timed unlock, cross-process lock, and trusted CLI/SDK controls.
- Separate agent access, capture, and autosave settings without adding MCP password-management tools.
- Preserve origin-scoped autofill and improve cookie-import diagnostics.
- Bump to 2.5.1 with release notes.

## Verification
- Previous release checks passed: 1,062 tests, zero failures; rerunning against the version bump.
- Terminal prompt, master-protected autofill, and native SQLite cookie-import E2E passed.
- Live Chrome cookie import authenticated Gmail and survived a full browser-daemon restart. No messages opened or sent.
- Native Safari reads passed; no Edge profiles found.
