### PR TITLE
chore: release BetterWright 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.5.2] - 2026-09-09
+
+### Fixed
+
+- Refresh the JavaScript API reference with default-on ad blocking, Electron
+  hosting requirements, and trusted vault status, unlock, lock, and saved-login
+  settings. Clarify daemon versus SDK unlock lifetimes and locking limits.
+
 ## [2.5.1] - 2026-09-09
 
 ### Added
@@ -1479,7 +1487,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.5.1...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.5.2...HEAD
+[2.5.2]: https://github.com/BetterWright/betterwright/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/BetterWright/betterwright/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/BetterWright/betterwright/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/BetterWright/betterwright/compare/v2.3.0...v2.4.0

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.5.1
+generated_by: betterwright@2.5.2
 ---
 
 # BetterWright browser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Release the JavaScript reference corrections shipped in #173 as a documentation-only patch. Bump package and shipped skill versions to 2.5.2 and record the changes and comparison links in the changelog. No runtime behavior or dependency changes.

Validated the exact release candidate with frozen dependency installation, `release:check` (including package smoke), required managed-browser and recording E2E (1,152 passes, five platform/live-service skips, zero failures), native Electron reliability/recovery, packaged ASAR reliability/recovery, and `git diff --check`. Native tests ran on Linux under Xvfb.

After merge, tag the main commit as `v2.5.2` and publish a GitHub Release to trigger npm Trusted Publishing.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M226G5S8H2CAZJ423HDSASV0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->