### PR TITLE
test: stop model-selection CLI subprocesses from hanging spawnSync

### DIFF
--- a/tests/node/model-selection-cli.test.ts
+++ b/tests/node/model-selection-cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -13,55 +13,70 @@ import {
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const cli = path.join(root, "dist", "bin", "betterwright.js");
 
-function runCli(args, envOverrides = {}) {
-  const env = { ...process.env, ...envOverrides };
-  for (const [name, value] of Object.entries(envOverrides)) {
-    if (value === undefined) delete env[name];
-  }
-  return spawnSync(process.execPath, [cli, ...args], {
-    cwd: root,
-    env,
-    encoding: "utf8",
+// Async execFile, closed stdin, SIGKILL at a deadline. spawnSync can sit
+// until the 120s bun test timeout under parallel workers (see #164 and
+// oven-sh/bun#37849), which is what failed Worker copies in sync on 2.5.2.
+function runCli(args, envOverrides = {}, timeout = 20_000) {
+  return new Promise<{ status: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }>((resolve) => {
+    const env = { ...process.env, ...envOverrides };
+    for (const [name, value] of Object.entries(envOverrides)) {
+      if (value === undefined) delete env[name];
+    }
+    const child = execFile(process.execPath, [cli, ...args], {
+      cwd: root,
+      encoding: "utf8",
+      timeout,
+      killSignal: "SIGKILL",
+      env,
+    }, (_error, stdout, stderr) => {
+      resolve({ status: child.exitCode, signal: child.signalCode, stdout, stderr });
+    });
+    child.stdin?.end();
   });
 }
 
-test("models command lists actual native model ids without a provider flag", () => {
-  const result = runCli(["models"], {
+function assertCliExited(result, status, label) {
+  assert.equal(result.signal, null, `${label} hung and had to be killed`);
+  assert.equal(result.status, status, `${label} exited ${result.status}: ${result.stderr}`);
+}
+
+test("models command lists actual native model ids without a provider flag", async () => {
+  const result = await runCli(["models"], {
     BETTERWRIGHT_MODEL_BASE_URL: undefined,
     OPENROUTER_API_KEY: undefined,
   });
 
-  assert.equal(result.status, 0);
+  assertCliExited(result, 0, "models");
   assert.match(result.stdout, /claude-opus-4-8/);
   assert.match(result.stdout, /gpt-/);
   assert.match(result.stdout, /grok-/);
   assert.doesNotMatch(result.stdout, /^(?:claude|codex|grok)$/m);
 });
 
-test("model command help is specific and successful", () => {
-  const models = runCli(["models", "--help"]);
-  const exec = runCli(["exec", "--help"]);
+test("model command help is specific and successful", async () => {
+  const models = await runCli(["models", "--help"]);
+  const exec = await runCli(["exec", "--help"]);
 
-  assert.equal(models.status, 0);
+  assertCliExited(models, 0, "models --help");
   assert.match(models.stdout, /betterwright models/);
   assert.match(models.stdout, /openrouter \| ollama \| vllm/);
   assert.doesNotMatch(models.stdout, /--provider/);
-  assert.equal(exec.status, 0);
+  assertCliExited(exec, 0, "exec --help");
   assert.match(exec.stdout, /betterwright exec.*--base-url/s);
   assert.match(exec.stdout, /single quotes.*\$4000/s);
   assert.match(exec.stdout, /betterwright exec --stdin/);
   assert.doesNotMatch(exec.stdout, /--provider|--model-id/);
 });
 
-test("exec rejects ambiguous task argument plus stdin mode", () => {
-  const result = runCli(["exec", "find options under $4000", "--stdin"]);
+test("exec rejects ambiguous task argument plus stdin mode", async () => {
+  const result = await runCli(["exec", "find options under $4000", "--stdin"]);
 
-  assert.equal(result.status, 1);
+  assertCliExited(result, 1, "exec task plus --stdin");
   assert.match(result.stderr, /either a task argument or --stdin/);
 });
 
-test("removed provider flag points users to the model-first syntax", () => {
-  const result = runCli(
+test("removed provider flag points users to the model-first syntax", async () => {
+  const result = await runCli(
     [
       "exec",
       "--provider",
@@ -76,12 +91,12 @@ test("removed provider flag points users to the model-first syntax", () => {
     },
   );
 
-  assert.equal(result.status, 1);
+  assertCliExited(result, 1, "removed --provider");
   assert.match(result.stderr, /--provider was removed.*--model ollama\/qwen3:8b/s);
 });
 
-test("OpenRouter CLI points to the expected key without exposing key flags", () => {
-  const result = runCli(
+test("OpenRouter CLI points to the expected key without exposing key flags", async () => {
+  const result = await runCli(
     [
       "exec",
       "inspect example.com",
@@ -90,26 +105,26 @@ test("OpenRouter CLI points to the expected key without exposing key flags", () 
     { OPENROUTER_API_KEY: undefined },
   );
 
-  assert.equal(result.status, 1);
+  assertCliExited(result, 1, "openrouter without key");
   assert.match(result.stderr, /OpenRouter needs an API key.*OPENROUTER_API_KEY/s);
 });
 
-test("model-id flag is folded into the primary model selector", () => {
-  const result = runCli([
+test("model-id flag is folded into the primary model selector", async () => {
+  const result = await runCli([
     "exec",
     "inspect example.com",
     "--model-id",
     "gpt-5.6-sol",
   ]);
 
-  assert.equal(result.status, 1);
+  assertCliExited(result, 1, "folded --model-id");
   assert.match(result.stderr, /--model-id was merged into --model/);
 });
 
-test("models rejects an unknown source with agent.ts's shared error message", () => {
-  const result = runCli(["models", "bogus"]);
+test("models rejects an unknown source with agent.ts's shared error message", async () => {
+  const result = await runCli(["models", "bogus"]);
 
-  assert.equal(result.status, 1);
+  assertCliExited(result, 1, "models bogus");
   // The CLI used to keep its own copy of this message ("...or a custom
   // --base-url.") that had drifted from the one --model parsing emits; both
   // now come from endpointSourceName.
@@ -119,15 +134,15 @@ test("models rejects an unknown source with agent.ts's shared error message", ()
   );
 });
 
-test("models normalizes source spellings the same way --model parsing does", () => {
+test("models normalizes source spellings the same way --model parsing does", async () => {
   // endpointSourceName strips [-_ ], so `cus_tom` selects the custom source
   // (which then fails fast for want of a --base-url, keeping the test
   // offline) instead of being rejected as an unknown source.
-  const result = runCli(["models", "cus_tom"], {
+  const result = await runCli(["models", "cus_tom"], {
     BETTERWRIGHT_MODEL_BASE_URL: undefined,
   });
 
-  assert.equal(result.status, 1);
+  assertCliExited(result, 1, "models cus_tom");
   assert.match(result.stderr, /custom: unavailable .*--base-url/s);
   assert.match(result.stderr, /No available models found\./);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`Worker copies in sync` failed on `main` at `a57d843` (2.5.2). Six `model-selection-cli` cases sat in `spawnSync` until the 120s bun test timeout (`null !== 0`, then `killed 1 dangling process`). The same hang class was already fixed for help/validation in #164.

Switch this file to the same async `execFile` helper: close stdin, SIGKILL at 20s, and fail if the child was killed. Runtime CLI behavior is unchanged.

## Checklist

- [x] Focused `bun test tests/node/model-selection-cli.test.ts` is the verification for this test-only change; full `release:check` is unrelated to the runtime.
- [x] **Every browser connection still goes through the guard proxy.** No launch, transport, or fetch change.
- [x] **No secret value reaches the model sandbox.** No new output channel.
- [x] **Dependency pins are still mirrored everywhere.** No pin change.
- [x] **Public API changes update `types/*.d.ts` in this same commit.** No public API change.
- [x] The two branch-protected CI job names, "Worker copies in sync" and "Node tests", are unchanged, and no new action was added.
- [x] No unit test imports `src/worker.ts` or `dist/src/worker.js` directly.
- [x] User-visible behaviour is unchanged, so `CHANGELOG.md` is not updated.
- [x] Nothing private is being committed.

## How it was verified

- Failed job: [CI run 34313090887](https://github.com/BetterWright/betterwright/actions/runs/34313090887) on `a57d843`, `Worker copies in sync` / `bun run test:unit` (coverage).
- Failed cases: `model command help is specific and successful`, `exec rejects ambiguous task argument plus stdin mode`, `removed provider flag…`, `model-id flag…`, `models rejects an unknown source…`, `models normalizes source spellings…`.
- Other jobs on that commit (Node tests, all cross-platform unit cells) were green.
- Local: `BETTERWRIGHT_COVERAGE=1 bun test tests/node/model-selection-cli.test.ts` after this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cd01c5c-e641-437a-b690-d937a421247c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cd01c5c-e641-437a-b690-d937a421247c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

