### PR TITLE
fix: align 2.6.0 docs, CLI help, and SDK declarations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,11 @@ line only if it is genuinely unrelated to your change, and say so.
 
 - [ ] `bun run release:check` passes locally (versions, lint, typecheck, build,
       unit tests, published declarations, tarball).
-- [ ] **Every browser connection still goes through the guard proxy.** No new
-      launch path, transport, or fetch bypasses the worker's SOCKS guard
-      (`src/guard-proxy.ts`) — the network floor is the security boundary.
+- [ ] **Locally launched browsers and Electron attachments stay on the guard
+      proxy.** No local launch or Electron transport bypasses the worker's
+      SOCKS guard (`src/guard-proxy.ts`). Ordinary remote CDP/provider browsers
+      remain the explicit exception; their warnings and documentation must
+      not claim the local transport boundary applies.
 - [ ] **No secret value reaches the model sandbox.** New output channels,
       result envelopes, log lines, and MCP/agent tool results go through
       redaction; the vault still fills without returning values to snippet code.
@@ -41,7 +43,7 @@ line only if it is genuinely unrelated to your change, and say so.
 
 <!--
 Beyond release:check. Name the commands you ran — for example the managed
-browser suite (`BETTERWRIGHT_REQUIRE_BROWSER=1 BETTERWRIGHT_CHROMIUM_ROOT=off
-bun run test`), a `betterwright doctor` before/after, or the platform you tested on
-if the change is platform-specific.
+browser suite (`BETTERWRIGHT_REQUIRE_BROWSER=1 bun run test` after installing
+the managed browser), a `betterwright doctor` before/after, or the platform you
+tested on if the change is platform-specific.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ because they are enforced by code, not convention.
 
 ## Commands
 
-- `bun run lint` — biome lint rules. The formatter is off deliberately (see
+- `bun run lint` — Biome and Oxlint rules. The formatter is off deliberately (see
   biome.jsonc); match the hand style recorded in .editorconfig.
 - `bun run typecheck` — TypeScript 7 checks, without emitting, the runtime and
   CLI (`tsconfig.json`), the build tooling (`tsconfig.tools.json`), and the
@@ -41,11 +41,14 @@ because they are enforced by code, not convention.
 
 ## Invariants
 
-- **Every browser connection stays on the guard proxy.** Chromium is pointed
-  at the worker's SOCKS guard (`src/guard-proxy.ts`) on the command line so
-  even traffic that bypasses Playwright routing is policy-checked. The network
-  floor is the security boundary (SECURITY.md) — never add a launch path or
-  transport that skips it.
+- **Locally launched browsers and Electron attachments stay on the guard
+  proxy.** Chromium launch flags and Electron session proxy settings point at
+  the worker's SOCKS guard (`src/guard-proxy.ts`), so traffic that bypasses
+  Playwright routing is still policy-checked. Never add a local launch or
+  Electron transport that skips it. Ordinary remote CDP/provider browsers are
+  the explicit exception: their traffic is outside this guard, and launch
+  warnings and documentation must preserve that limitation. See SECURITY.md
+  and docs/browser-providers.md for the boundary.
 - **Secrets never enter the model sandbox.** The vault fills credentials via
   trusted input without returning values to model code, and handled secrets
   are redacted from every result envelope. Any new output channel must go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Align setup, security, browser, SDK, and agent documentation with current
+  network-policy defaults, remote-browser limits, session lifetimes, result
+  bounds, cancellation, live-view access, and conditional skill loading.
+- Correct the semantic UI batch example and MCP CLI help inventory, and
+  distinguish historical Chromium patch measurements from current launch
+  defaults.
+- Accept synchronous callbacks in the `withBrowser` declarations and include
+  the existing large-output spill wrapper in successful `RunResult` types.
+- Refresh vulnerable transitive dependencies in the development lockfile
+  without changing the pinned browser or runtime dependencies.
+
 ## [2.6.0] - 2026-09-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,10 @@ bun run release:check
 ```
 
 For the complete managed-browser integration suite, install the runtime and run
-`BETTERWRIGHT_REQUIRE_BROWSER=1 BETTERWRIGHT_CHROMIUM_ROOT=off bun run test`.
+`BETTERWRIGHT_REQUIRE_BROWSER=1 bun run test`. Leave
+`BETTERWRIGHT_CHROMIUM_PATH` / `BETTERWRIGHT_CHROMIUM_ROOT` unset to use the
+managed installation, or point them at a real artifact; `off` is no longer
+supported.
 The policy, vault, prompt, and challenge suites run anywhere.
 
 One note on running the suite locally: **do not run the tests as root.**

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ machine, and proves it works by loading a real page. One command, no choices to
 make up front.
 
 **Compressed snapshots** instead of raw HTML or a full accessibility dump ·
-read-only tasks finish in **one model turn** · persistent sessions so you
-don't re-pay login and navigation cost every step.
+simple non-checkout read-only tasks can finish in **one model turn** ·
+persistent sessions so you don't re-pay login and navigation cost every step.
 
 ---
 
@@ -67,7 +67,8 @@ betterwright skill >> ~/.codex/AGENTS.md   # Codex reads an instructions file
 # and the npm package (node_modules/betterwright/SKILL.md); copy it wherever
 # your agent reads skills, or print it with `betterwright skill`.
 
-# MCP (stdio server: browser, browser_login, browser_download, browser_handoff, browser_doctor)
+# MCP (stdio server: browser, browser_batch, browser_download, browser_record,
+# browser_handoff, browser_doctor; browser_login when the vault is enabled)
 bun add -g betterwright @modelcontextprotocol/sdk
 claude mcp add betterwright -- bunx betterwright mcp
 betterwright mcp --check           # why does my client show no tools?
@@ -208,9 +209,9 @@ BetterWright's whole observation stack is built around that problem:
 | --- | --- |
 | **Compressed agent snapshots** | Playwright's `mode: "ai"` accessibility tree with everything an agent cannot act on pruned out — `/url` property lines, refs on non-actionable roles, bare `generic` wrappers, duplicated text, names past 100 characters — leaving `[ref=eN]` markers the model acts on directly instead of re-deriving selectors |
 | **Diff mode** | After an action, return **only what changed** — not the page again |
-| **Interactive-only filter** | Drop static text nodes; keep what the agent can click, fill, or read |
+| **Interactive-only filter** | Keep actionable elements, live status/alert text, and short item/table context; omit unrelated prose |
 | **Scoped truncation** | Hints about *where* to look next instead of a silently clipped wall |
-| **Single-call finish** | Read-only tasks complete in **one model turn** — the code returns `{finalAnswer}` and the loop ends, no confirmation round-trip |
+| **Single-call finish** | Simple non-checkout read-only tasks can complete in **one model turn** with `{finalAnswer}`; [checkout tasks receive additional completion checks](docs/agent.md) |
 | **Persistent session** | One long-lived browser: no re-login, no re-navigation, no re-paying the token cost of getting back to where you were |
 | **Sub-agent delegation** | `betterwright exec` keeps the entire browsing transcript out of your main agent's context — a whole task costs it one tool call |
 
@@ -243,7 +244,7 @@ step from what it sees, in a browser that must still be there next turn:
 | **Observations** | Raw accessibility tree or DIY HTML | Compressed, diffable, redacted snapshots priced for a context window |
 | **Session** | Browser per script | One persistent managed browser — logins survive turns, days, restarts |
 | **Trust** | Full API access | Model code runs sandboxed: no file, process, or network-routing APIs |
-| **Network** | Any URL | Every request policy-checked (DNS-rebinding-proof); cloud metadata endpoints always blocked |
+| **Network** | Any URL | Guarded local and Electron browsers get policy checks and a DNS-rebinding-resistant metadata floor; [remote CDP browsers lack that transport boundary](docs/browser-providers.md#what-changes-with-a-remote-browser) |
 | **Secrets** | Passwords in the script | AES-256-GCM vault; forms are detected and filled without the secret ever entering the conversation |
 | **Evidence** | Assertions | `screenshot({kind: 'proof'})` — tagged artifacts the agent cites as proof of work |
 | **CAPTCHAs** | Out of scope | Local `captcha.solve()` — checkbox, Turnstile, slider; vision handoff for image grids |
@@ -260,14 +261,14 @@ step from what it sees, in a browser that must still be there next turn:
 | [**Cookie Sync**](docs/cookie-sync.md) | Merge selected cookies from local Chrome, Edge, Brave, Firefox, Safari, and other desktop browsers into BetterChromium or an explicitly approved cloud browser |
 | [**Live view & handoff**](docs/live-view.md) | Watch and coach the agent live; token + optional password gated; `handoff` pauses for human hands and resumes on Done |
 | [**Recording**](docs/recording.md) | Record the current tab to MP4 (or WebM) at up to 60 FPS through the CLI, snippet helpers, or MCP |
-| [**Network policy**](docs/network-policy.md) | Every navigation, subresource, WebSocket, and raw TCP connection checked; metadata endpoints always blocked |
+| [**Network policy**](docs/network-policy.md) | Guarded local and Electron browsers check navigations, subresources, WebSockets, and TCP connections; remote CDP browsers retain supported routing checks, not the transport floor |
 | [**CAPTCHA helpers**](docs/captcha.md) | Local solving for checkbox/Turnstile/slider; image grids hand off to the agent's own vision with tile crops |
 | [**Human-shaped input**](docs/browser-api.md#human-shaped-interactions) | Curved pointer movement, paced typing, eased wheel — no extra dependency |
 | [**WebMCP page tools**](docs/browser-api.md#page-published-webmcp-tools) | Discover and invoke typed first-party page capabilities; fresh frame-aware lookup, bounded input/output, explicit autosubmit opt-in, and automatic timeout cancellation |
-| [**Launch identity**](docs/launch-identity.md) | Coherent native identity: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; the two public reCAPTCHA v3 score-detector demos in the stealth report return a server-verified 0.9 headed and headless |
+| [**Launch identity**](docs/launch-identity.md) | Coherent native identity: build-specific viewport, locale, timezone, optional geo-matched egress. No page-world shims; recorded runs of two public reCAPTCHA v3 score-detector demos returned a server-verified 0.9 headed and headless, not a guarantee for other runs or sites |
 | [**BetterChromium**](docs/chromium-fork.md) | Default browser on supported macOS arm64, Linux x64, and Windows x64 hosts: per-profile-stable canvas/audio farbling, no OS masquerade (Linux runs as Linux). Bring your own executable, CDP endpoint, or cloud browser via the [provider option](docs/browser-providers.md) |
 | [**Browser providers**](docs/browser-providers.md) | Managed fork by default; attach a local executable, a raw CDP endpoint, or a named cloud browser. `configure --connect` saves API keys; `betterwright boxes` starts/lists/stops sessions on the six SDK-backed providers |
-| [**Skill packs**](docs/skills.md) | Per-site and per-password-manager guidance the driving agent reads on demand — your own or the built-in loop — surfaced automatically when an open page matches |
+| [**Skill packs**](docs/skills.md) | External agents read pack bodies on demand from URL-match hints; the built-in loop injects task-keyword matches before browsing, while later URL matches surface metadata hints |
 | [**Download approval**](docs/browser-api.md) | Denied by default; a trusted host approves one download run at a time |
 | [**Operator guidance**](docs/agent-prompt.md) | `betterwright skill` / `agentSystemPrompt()` — decisive action on authorized tasks, with optional confirmation/spending guardrails |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,14 @@ BetterWright hands a browser to automated, sometimes model-authored, code. Its
 threat model and the controls that enforce it are documented in
 [docs/architecture.md](docs/architecture.md#security-model). In short:
 
-- **The network floor** (metadata endpoints and private networks blocked at the
-  resolver, transport proxy, and policy layers) is the real boundary and fails
-  closed.
+- **The network floor** is the real boundary for locally launched browsers and
+  guarded Electron attachments and fails closed. Cloud metadata is always
+  blocked there; private networks and loopback are allowed by default. Set both
+  `allowPrivateNetwork: false` and `allowLoopback: false` to block those too.
+  Ordinary remote CDP/provider browsers are outside the local transport guard:
+  supported Playwright routing checks still apply, but the transport and
+  DNS-rebinding guarantees do not. See [provider boundaries](docs/browser-providers.md#what-changes-with-a-remote-browser)
+  and [Electron network safety](docs/electron-host.md#ownership-and-network-safety).
 - **The sandbox** removes the escape-hatch APIs from model code as defense in
   depth. It is not, and does not claim to be, a `node:vm` security boundary.
 - **The credential vault** encrypts records at rest, URL-gates login lookup,

--- a/SETUP.md
+++ b/SETUP.md
@@ -139,9 +139,11 @@ betterwright repl < steps.txt
 
 Semantics the skill already explains to the agent:
 
-- Logins, cookies, and the browser profile persist across **every** invocation.
-  Open tabs and the in-memory `state` object persist only within one `repl`
-  session; each `run` starts on a fresh tab.
+- The profile preserves cookies and logins. By default, `run`, `repl`, and
+  `exec` share a daemon that preserves tabs and the in-memory `state` object
+  for the same named session. Closing the session, its idle TTL, or a worker
+  restart ends that live state. `--no-daemon` and a warned one-shot fallback
+  do not preserve tabs between invocations. See [sessions](docs/sessions.md).
 - Longer snippets come from a file (`betterwright run snippet.js`) or stdin
   (`betterwright run -`).
 - Screenshots land in the JSON `artifacts` list as file paths; the agent opens
@@ -166,7 +168,7 @@ For a published package:
 
 ```bash
 pi install npm:betterwright
-npx -y betterwright setup
+bunx betterwright setup
 pi
 ```
 
@@ -206,9 +208,11 @@ keep download approval and network policy under trusted host control. Then do
 ## §3 — MCP client
 
 If the host is an MCP client and you prefer a first-class tool over the CLI,
-BetterWright ships an MCP server that exposes `browser`, `browser_download`,
-`browser_handoff`, and `browser_doctor`, plus `browser_login` when the
-credential vault is enabled. `browser_download` is the autonomous download
+BetterWright ships an MCP server that exposes `browser`, `browser_batch`,
+`browser_download`, `browser_record`, `browser_handoff`, and `browser_doctor`,
+plus `browser_login` when the credential vault is enabled. `browser_batch`
+runs [guarded UI batches](docs/browser-api.md); `browser_record` controls
+[local video recording](docs/recording.md). `browser_download` is the autonomous download
 tool: calling it grants that one run permission to save a remote file. The
 `browser` tool cannot download. Set `BETTERWRIGHT_DOWNLOAD_POLICY=deny` to disable
 downloads, or `allow` if the `browser` tool should be able to save files too.
@@ -372,10 +376,12 @@ using an alternate source or requesting human help.
 
 ## §6 — Safeguards (configure to taste)
 
-By default BetterWright blocks only cloud-metadata endpoints; the public
-internet, private networks, and loopback are all reachable so an agent can
-drive local dev servers and intranet hosts out of the box. Tighten it
-deliberately. Two independent layers:
+By default, network policy allows the public internet, private networks, and
+loopback while blocking cloud-metadata endpoints. The transport-level metadata
+floor and DNS-rebinding protection apply to locally launched browsers and
+guarded Electron attachments, not ordinary remote CDP/provider browsers; see
+[provider boundaries](docs/browser-providers.md#what-changes-with-a-remote-browser).
+Tighten private-network access deliberately. Two independent layers:
 
 **Network — what the browser can reach** (CLI flags, `NetworkPolicy` options,
 or the MCP env vars):
@@ -384,7 +390,7 @@ or the MCP env vars):
 | --- | --- | --- |
 | Block the private network | `--block-private-network` / `allowPrivateNetwork: false` | `BETTERWRIGHT_BLOCK_PRIVATE_NETWORK=1` |
 | Block loopback too | `--block-loopback` / `allowLoopback: false` | `BETTERWRIGHT_BLOCK_LOOPBACK=1` |
-| Restrict to specific sites | `--allow-host example.com` / `allowHosts: ["example.com"]` | `BETTERWRIGHT_ALLOW_HOSTS=example.com` |
+| Allow an otherwise-blocked host | `--allow-host staging.internal` / `allowHosts: ["staging.internal"]` | `BETTERWRIGHT_ALLOW_HOSTS=staging.internal` |
 | Block specific sites | `--block-host ads.example.com` / `blockHosts: [...]` | `BETTERWRIGHT_BLOCK_HOSTS=ads.example.com` |
 | `browser_download` may save files; the `browser` tool may not | `downloadPolicy: "ask"` (default) | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
 | Allow downloads from any run | `downloadPolicy: "allow"` | `BETTERWRIGHT_DOWNLOAD_POLICY=allow` |
@@ -400,7 +406,12 @@ shared, so a credential saved once fills in any profile. Omit it for the single
 default profile. Use `--session <name>` instead for parallel work as the *same*
 identity. See [docs/sessions.md](docs/sessions.md#sessions-vs-profiles).
 
-Cloud metadata endpoints can never be allowlisted. See
+`allowHosts` adds exceptions; it does not restrict access to other public sites.
+There is no exclusive CLI site-allowlist flag. Hosts needing that restriction
+must supply a custom policy that denies nonmatching destinations, including
+resolved-literal transport checks.
+
+Cloud metadata endpoints can never be allowlisted in `NetworkPolicy`. See
 [docs/network-policy.md](docs/network-policy.md).
 
 **Behavior — how bold the agent is** (`Guardrails`, prompt-level). The default

--- a/bun.lock
+++ b/bun.lock
@@ -236,7 +236,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -260,7 +260,7 @@
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
-    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
+    "hono": ["hono@4.13.5", "", {}, "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -332,7 +332,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 

--- a/docs/agent-prompt.md
+++ b/docs/agent-prompt.md
@@ -24,14 +24,17 @@ With no guardrails, the guidance tells the model to:
   stalling, or adding "are you sure?" friction to ordinary steps.
 - **Work autonomously** — inspect, act, recover, use multiple tabs, and keep a
   running `note`.
-- **Read by escalation and never guess.** Start with
-  `snapshot({interactive: true})`, escalate to a full snapshot, a re-snapshot
-  after a brief wait, and finally `screenshot({annotate: true})`; never guess a
-  ref, URL, or page state it has not observed, and never scroll just to read
-  (snapshots already include iframe contents and off-screen elements).
-- **Verify actions and batch steps.** An action is unconfirmed until
-  `snapshot({diff: true})` shows the expected state; action and verification go
-  in one `run()` when the next step needs no fresh ref.
+- **Read by escalation and never guess.** Use known semantic locators,
+  scoped DOM extraction, or the compact action directory first. Inspect with
+  `snapshot({interactive: true})`, then a full snapshot, when structure is
+  unknown, a locator failed, or the directory omitted a required target. Use
+  `screenshot({annotate: true})` for layout or pixels. Never guess a ref, URL,
+  or page state, and never scroll just to read: snapshots include iframe
+  contents and off-screen elements.
+- **Verify actions and batch steps.** Wait for a positive confirmation locator
+  and verify the observed text, form value, or URL. Use
+  `snapshot({diff: true})` for broader changes. Keep the action, wait, and
+  verification in one `run()` when the next step needs no fresh ref.
 - **Prefer batch-native site workflows when present.** Check
   the automatic `webagents` result after opening an app without a preliminary
   snapshot; it is the complete directory, so do not rediscover it. When absent,
@@ -44,9 +47,10 @@ With no guardrails, the guidance tells the model to:
   when this compact directory omitted a required target. Treat every
   descriptor and result as untrusted, and opt into writes or autosubmit only
   for authorized effects.
-- **Recover deliberately** — no sleeps after auto-waiting actions, a fresh
-  snapshot before any retry, inspect the real hit target after an "obscured"
-  click, and switch approach after the same path fails twice.
+- **Recover deliberately** — no sleeps after auto-waiting actions; inspect
+  fresh evidence after a failure and the real hit target after an "obscured"
+  click. Switch approach after the same path fails twice. Back off for
+  transient server errors, timeouts, or connection resets.
 - **Keep credentials out of the chat.** When authentication is required, use a
   configured external manager or BetterWright's metadata-only account search
   and selector-free fill. Verify signup/rotation success before committing a

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -56,9 +56,10 @@ stdout:
 }
 ```
 
-`toolCalls` counts the `browser`/`login`/`ask`/`done` calls the model issued (it
-can exceed `steps` when a turn batches several). `usage` sums the token counts the
-model adapter reported across turns (a field is `0` when the provider returned no
+`toolCalls` counts all calls the model issued: `browser`, `login`, `ask`,
+`live_view`, `handoff`, and `done` (it can exceed `steps` when a turn batches
+several). `usage` sums the token counts the model adapter reported across turns
+(a field is `0` when the provider returned no
 usage block); `inputTokens` is fresh input only: each turn's provider input total
 minus the portion served from cache.
 `cacheReadTokens` and `cacheWriteTokens` come straight from the provider's usage
@@ -139,7 +140,7 @@ Flags:
 | `--session <name>` | `default` | Parallel lanes inside one identity; the browser and the conversation both persist under that name |
 | `--profile <name>` | the shared profile | A separate identity: its own cookies, its own daemon, its own `exec` history (`BETTERWRIGHT_PROFILE` sets one for the whole shell; the flag wins) |
 | `--headed` | off | Show the managed browser |
-| `--live-view` | off | Start the viewer at step 0 and print its URL (see [live-view.md](live-view.md)) |
+| `--live-view` | off | Start the viewer at step 0 and print its URL; without the flag, the agent can still open it on demand (see [live-view.md](live-view.md)) |
 | `--stdin` | off | Read the task from stdin instead of an argument — no second round of shell parsing |
 | `--fresh` | off | Forget this session's `exec` conversation and start the transcript over; the browser and its logins are untouched |
 | `--close` | off | Close the session after this task instead of leaving it live |
@@ -216,8 +217,14 @@ choice with no reasonable default, or a task ambiguous enough that guessing risk
 the wrong thing — it asks you a question (offering short concrete options when the
 answer is a choice) and waits for your typed reply before continuing. It still
 acts on its own for ordinary reversible steps; it does not ask permission to
-proceed. `betterwright exec` has no user watching, so it runs without the `ask`
-tool and never stalls on a question.
+proceed.
+
+`betterwright exec` has no terminal question handler, but it can still offer
+`ask`, `live_view`, and `handoff` through an on-demand live viewer. When the
+model asks a question, the CLI prints the viewer URL and the run can wait for
+an answer in its chat. `--live-view` starts that viewer immediately; omitting
+the flag does not disable it. Programmatic callers that must not wait for a
+human should omit `askUser` and set `liveView: false`.
 
 ## Choosing a model
 
@@ -429,7 +436,7 @@ CLI behavior:
 import { runAgentTask } from "betterwright/agent";
 
 const result = await runAgentTask({
-  task: "log in to example.com and download this month's invoice",
+  task: "log in to example.com and report this month's invoice total",
   model: "claude-opus-5",         // actual model id, or your own model object
   maxDurationMs: 30 * 60 * 1000,   // configurable; there is no fixed step cap
   maxTranscriptChars: 1_000_000,   // bound accumulated model/tool context
@@ -443,7 +450,14 @@ console.log(result.toolCalls, result.usage, result.durationMs);
 
 Pass an **`askUser`** handler to let the loop ask the human mid-task — this is
 how the interactive console wires the `ask` tool. Given a handler, `runAgentTask`
-exposes an `ask` tool to the model; without one it runs fully autonomously.
+exposes an `ask` tool to the model and sends questions to that handler. Without
+one, the loop can instead ask through live-view chat when `liveView` is not
+`false`, the browser supports live view, and an `onStep` callback can surface
+its URL. `live_view` and `handoff` use the same availability gate, with either
+`askUser` or `onStep` providing a human-facing surface. Pass `liveView: true`
+or a live-view options object to start the viewer at the beginning; otherwise
+it starts on demand. To disable human-input tools, omit `askUser` and pass
+`liveView: false`.
 
 ```js
 const result = await runAgentTask({
@@ -470,8 +484,26 @@ await browser.close();
 The loop exposes a selector-free `login` tool backed by the same URL-matched
 worker fill as MCP/Pi's `browser_login`. Generated signup/rotation passwords
 remain pending until a later browser step verifies success and commits them, so
-failed forms do not leave stale saved items. Pass `vault: false` to disable the
-tool or a custom adapter to replace the local store.
+failed forms do not leave stale saved items. For a browser the loop creates,
+pass `vault: false` to disable the tool or a custom adapter to replace the local
+store. When passing an existing browser, configure its vault on that browser;
+the task's `vault` option is ignored.
+
+The loop's default browser uses `downloadPolicy: "ask"`, and its `browser` tool
+does not set trusted per-run download approval. A task asking for a download
+does not bypass that gate. Use a trusted host's approval-gated download path,
+or, after obtaining the user's approval for the task's downloads, pass a
+browser configured with `downloadPolicy: "allow"`. See
+[download approval](javascript.md#download-approval).
+
+Pass `signal: controller.signal` to interrupt a task. Model requests receive
+cancellation, and the result retains the transcript with `reason: "interrupted"`.
+For an externally supplied browser, interruption stops waiting for an in-flight
+browser call but does not cancel that call: it can finish or reach its worker
+timeout. The loop closes a browser it created itself during cleanup. Do not
+assume an interrupted task rolled back a page action; inspect the state before
+resuming. This differs from calling the client's
+[`run(code, { signal })`](javascript.md#cancellation) directly.
 
 ## Bring your own model or agent
 
@@ -516,7 +548,8 @@ remains available when you need full control of the request shape.
 
 Each turn: the model sees the task, the operator guidance from
 [`agentSystemPrompt`](agent-prompt.md), and the tools (`browser`, `done`,
-`login` when a vault is present, and `ask` when an `askUser` handler is present).
+`login` when a vault is present, `ask` when a question handler or live-view
+channel is available, and `live_view`/`handoff` when live view is available).
 It calls `browser` with async Playwright
 JavaScript; BetterWright runs it and feeds back a compact JSON observation
 (`ok`, `result`, `console`, `pages`, `challenges`, `skills`, `warnings`,
@@ -526,7 +559,11 @@ paths surfaced; the last `proof` screenshot is returned on the result.
 
 A `browser` call can also end the task in the *same* turn: when the model's
 code returns `{ finalAnswer: "…" }` (from an `ok` run), the harness records
-that as the answer and finishes without spending another model round-trip. The
-preamble teaches the model to use this single-call shape for read-only tasks —
+that as its candidate answer. For tasks outside checkout verification it can
+finish without spending another model round-trip. The preamble teaches the
+model to use this single-call shape for read-only tasks —
 navigate, extract, compute, capture proof, and return `finalAnswer` in one
-call — which makes a simple lookup cost one model turn instead of two.
+call — which can make a simple lookup cost one model turn instead of two.
+Tasks matching `checkout-verification` still run the bounded independent
+completion check described above, even for read-only checkout analysis. A
+`finalAnswer` does not bypass those checks or guarantee one-turn completion.

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -18,11 +18,16 @@ await bw.run(`
 - A single trailing **expression** is returned automatically:
   `bw.run("return page.title()")` and `bw.run("page.title()")` are equivalent.
 - A multi-statement block must use `return`.
-- The value is serialized to JSON. Playwright handles (`Page`, `Locator`) are
-  summarized rather than serialized whole — a `Page` becomes
+- The value becomes a bounded JSON-safe summary. Playwright handles (`Page`,
+  `Locator`) are summarized rather than serialized whole — a `Page` becomes
   `{type: "Page", pageId, url, title, closed}`.
-- Large results are spilled to an artifact file and replaced with a
-  `{truncated: true, preview, fullOutputPath}` summary.
+- Arrays, Maps, Sets, and object properties are limited to the first 200
+  entries; nested containers beyond depth eight become `"[Max depth]"`.
+  These reductions do not themselves add a `truncated` marker. Aggregate
+  inside the snippet or return explicit bounded chunks when completeness matters.
+- If the summarized result still exceeds the output-size limit, it is spilled
+  to a file and replaced with `{truncated: true, preview, fullOutputPath}`.
+  That file contains the bounded summary, not the original unbounded value.
 
 ## Pages
 
@@ -38,6 +43,15 @@ await bw.run(`
 Pages persist across `run()` calls within the same session, so an agent can
 open a tab in one step and act on it in the next. Popups and
 `target=_blank` links are adopted automatically and appear in `pages`.
+
+By default, idle headless pages are parked after a short delay between calls:
+their timers, animation frames, and animation timelines pause, then resume
+before the next execution. Pass `parkBackgroundPages: false` to the client
+or set `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0` when the application must keep
+progressing in the background. Headed sessions, sessions with a live view,
+and actively recording pages are not parked. Worker restarts discard the
+session's in-memory state and live page handles; see
+[timeouts and the worker](sdk.md#errors-timeouts-and-the-worker).
 
 ```js
 // Work two tabs at once
@@ -105,7 +119,7 @@ halves the size of a real page's tree without losing anything actionable.
 | `selector` | — | Scope the snapshot to a CSS selector, e.g. `{selector: '#main'}`. |
 | `depth` | — | Limit tree depth. |
 | `urls` | `false` | Keep `- /url:` property lines on links. |
-| `maxChars` | `10000` | Size limit, capped at 20000. An over-limit snapshot returns an error with the actual size and scoping hints instead of a silently cut-off tree. |
+| `maxChars` | `10000` | Size limit, capped at 20000. An over-limit snapshot returns a diagnostic string with the actual size and scoping hints instead of a cut-off tree. It does not throw or make the run envelope fail. |
 | `timeout` | `10000` | Milliseconds. |
 
 Interactive snapshots retain short text beside list/table controls, table column
@@ -298,13 +312,15 @@ await human.scroll(650); // negative values scroll upward
 `human.click(target, options?)` and `human.type(target, text, options?)` accept a
 selector, Locator, ElementHandle, or `{x, y, width, height}` bounds. Typing clears
 the field by default; pass `{clear: false}` to append, or set `minDelay` and
-`maxDelay`. After typing, `human.type` reads the field back. Success requires the
-requested text to be inserted in full, so a prefix, an unchanged field, or
-an overlapping partial append is not a hit.
+`maxDelay`. For readable element targets, `human.type` reads the field back.
+Success requires the requested text to be inserted in full, so a prefix, an
+unchanged field, or an overlapping partial append is not a hit.
 If that check fails — typical of Draft.js and other rich-text editors that
 swallow synthetic key events — it restores the original value when appending,
 retries with `insertText`, and throws if the field still did not accept the
-text.
+text. Bounds-only targets cannot be read back, so they do not get this
+verification or retry. Prefer a selector, Locator, or ElementHandle; verify
+coordinate-based typing independently.
 `human.scroll(deltaY, options?)` accepts `steps`, while the object
 form also accepts `deltaX`.
 
@@ -449,7 +465,7 @@ return controls.batch({
   operations: [
     {id: 'query', action: 'fill', target: {label: 'Search'}, value: 'keyboard'},
     {id: 'submit', action: 'click', target: {role: 'button', name: 'Search', exact: true}},
-    {id: 'verify', action: 'read', target: {role: 'heading', name: 'Results'}},
+    {id: 'verify', action: 'read', target: {role: 'heading', name: 'Results'}, value: 'Results'},
   ],
   allowWrites: true,
 });

--- a/docs/chromium-fork-patches.md
+++ b/docs/chromium-fork-patches.md
@@ -6,17 +6,18 @@ changes and why it lives in the browser source rather than in the JS layer.
 Install, discovery, and the runtime options are in
 [chromium-fork.md](chromium-fork.md).
 
-`src/fork-identity.ts` masks the user agent, UA-CH, `navigator.platform`, and
-screen geometry through launch flags and CDP emulation. The surfaces below are
-reachable only from Chromium source, so the binary stays coherent where CDP
-cannot follow: service workers and other non-page contexts, WebGL, canvas
-readback, audio rendering, and font enumeration.
+The current launcher uses `src/launch-identity.ts` and defaults to the host's
+real operating system. It does not install the former `src/fork-identity.ts`
+CDP masking layer or configure a macOS font collection on Linux. Native patch
+behavior still covers non-page contexts, WebGL, canvas readback, and audio.
 
-Every patch is gated on `--fingerprint-platform=macos`, the flag the launcher
-passes, and per-profile variation is keyed to `--fingerprint=<seed>`. The masked
-values are the ones genuine Google Chrome 151.0.7922.108 reports on Apple
-silicon under macOS 26.6 — the same table `src/fork-identity.ts` applies from
-the launch side, so both layers describe one machine rather than two.
+The aggregate [Chromium patch](../patches/chromium-151/chromium-betterchromium-151.patch)
+retains optional macOS-mask hunks gated on `--fingerprint-platform=macos`.
+Their reference values below came from Google Chrome 151.0.7922.108 on Apple
+silicon under macOS 26.6; they are not the default Linux identity. Other hunks
+apply to Linux or to fingerprint seeds independently of that mask. Per-profile
+variation is keyed to `--fingerprint=<seed>`. The font and performance
+measurements below are historical build evidence, not current-release results.
 
 ## 1. Platform identity at the source
 
@@ -155,50 +156,58 @@ A real display stack completes the picture: under a window manager and panel
 that publish `_NET_WORKAREA`, `screen.availHeight < screen.height`, so
 `noTaskbar` reads false as it would on a physical desktop.
 
-## 8. Fonts
+## 8. Historical macOS-metric font setup
 
-Font metrics are the strongest Linux-to-macOS tell, and nothing in the JS layer
-can fake them:
+The earlier Linux-to-macOS masking experiment also used a local macOS-metric
+font collection. This is not part of the current launcher or the public
+artifact:
 
 - `research/assemble-mac-fonts.sh`, run on macOS, copies 36 mac-metric fonts
   (Helvetica and Helvetica Neue, the Arial and Times New Roman sets, Courier
   New, Georgia, Verdana, Trebuchet, Menlo, Monaco, SFNS, Palatino, Futura,
   Avenir Next, Apple Color Emoji, …) into `artifacts/linux-x64/fonts/ttf`.
   Apple-licensed fonts are not redistributed in the public artifact.
-- The worker writes an absolute-path `fonts.conf` into the profile runtime
-  directory and launches the fork with `FONTCONFIG_FILE` pointing at it
-  (`prepareForkFontsConfig` in `src/fork-identity.ts`, gated on the macOS mask).
+- The former worker wrote an absolute-path `fonts.conf` into the profile
+  runtime directory and set `FONTCONFIG_FILE` through `prepareForkFontsConfig`
+  in the removed `src/fork-identity.ts`. Current launches do not do this.
 
-With that set in place, `fc-list` enumerates 470 faces and `measureText` widths
-differ per family (Helvetica Neue 291, Menlo 247, Georgia 307, Palatino 307,
-Avenir Next 304) instead of collapsing onto a single fallback.
+With that set in place, the recorded experiment enumerated 470 faces with
+`fc-list`, and `measureText` widths differed per family (Helvetica Neue 291,
+Menlo 247, Georgia 307, Palatino 307, Avenir Next 304) instead of collapsing
+onto a single fallback. These are measurements of that local font set.
 
 ## 9. Linux font-data file sharing
 
-[`patches/chromium-151/font-data-file-sharing.patch`](../patches/chromium-151/font-data-file-sharing.patch)
-applies from the Chromium source root. It was validated against Chromium
+The FontDataService hunks now live in
+[`patches/chromium-151/chromium-betterchromium-151.patch`](../patches/chromium-151/chromium-betterchromium-151.patch),
+which applies from the Chromium source root; there is no separate Chromium 151
+font-data patch file. The earlier standalone change was validated against Chromium
 `e69b30bba288603e514cffb4c79c359cac68e923` and Skia
 `bee4c917220040e147f14964635ff92ce6c5a3f6`.
 
-Upstream, `getResourceName()` is unimplemented on Linux and ChromeOS, so
-`FontDataService` always falls back to copying a complete font into an anonymous
-shared memory region. The patch lets Skia's FontConfig-backed typefaces expose
-their backing file identity, so the service can hand renderers a read-only font
-file handle instead. TTC indices, variation coordinates, synthetic styles, the
-fallback for typefaces that are not file-backed, and renderer-side per-file
-mapping are all unchanged. The patch also promotes the service's unit tests to a
-standalone `font_data_service_unittests` target and moves the Linux
-expectations from the memory-region fallback to the file-handle path, while the
-explicit memory-fallback tests keep asserting valid shared regions.
+The aggregate removes the service's assertion that Linux/ChromeOS typefaces
+cannot expose a resource path. When Skia supplies a backing-file identity,
+`FontDataService` can hand renderers a read-only file handle rather than copying
+the complete font into an anonymous shared memory region. TTC indices,
+variation coordinates, synthetic styles, the memory fallback, and renderer-side
+per-file mapping are unchanged. The aggregate also adds a standalone
+`font_data_service_unittests` target and changes Linux test expectations to
+the file-handle path while retaining explicit memory-fallback tests.
 
-This matters most with the bundled mac-metric collection above, where the old
-fallback held large font mappings alongside deleted `/tmp/.org.chromium.*`
-copies.
+The earlier standalone patch also implemented the backing-file identity in
+Skia's FontConfig typefaces. Those Skia hunks are not in the current Chromium
+151 aggregate; applying its service-side changes alone does not establish that
+Skia supplies the path.
+
+The recorded memory benefit was greatest with the historical local mac-metric
+collection above, where the old fallback held large font mappings alongside
+deleted `/tmp/.org.chromium.*` copies. That collection is not bundled publicly.
 
 ## 10. Linux renderer soft limit
 
-[`patches/chromium-151/renderer-process-soft-limit.patch`](../patches/chromium-151/renderer-process-soft-limit.patch)
-applies from the Chromium source root and makes four the Linux fork's default
+The renderer-limit hunk in
+[`patches/chromium-151/chromium-betterchromium-151.patch`](../patches/chromium-151/chromium-betterchromium-151.patch)
+makes four the Linux binary's native default
 **soft** renderer-process limit, keeping `--renderer-process-limit` as an
 explicit override. Chromium's memory-derived default allows dozens of renderers
 in a small sandbox, duplicating substantial same-site V8 and Blink state without
@@ -221,12 +230,19 @@ fate. Chromium's own
 `SitePerProcessBrowserTest.MainFrameProcessReuseWhenOverLimit` and
 `SubframeProcessReuseWhenOverLimit` cover that invariant.
 
-On the compiled Linux artifact, summed Chromium PSS fell 29.62%, 29.81%,
-25.96%, and 28.50% at 1, 5, 10, and 20 same-site tabs against the PGO control.
+In the recorded four-renderer compiled-artifact comparison, summed Chromium PSS
+fell 29.62%, 29.81%, 25.96%, and 28.50% at 1, 5, 10, and 20 same-site tabs
+against the PGO control.
 Concurrent deterministic throughput moved between +0.55% and +1.42%, and live
-CPU-seconds per 1,000 operations improved between 1.55% and 8.67%. On a host
-where same-site renderer parallelism matters more than memory, raise the limit
-with `BETTERWRIGHT_CHROMIUM_ARGS=--renderer-process-limit=N`.
+CPU-seconds per 1,000 operations improved between 1.55% and 8.67%. These are
+historical measurements, not measurements of the current managed launch.
+
+BetterWright now passes `--renderer-process-limit=2` from
+`src/browser-runtime.ts`, overriding that native default. Caller switches that
+collide with a managed switch are ignored with a warning, so
+`BETTERWRIGHT_CHROMIUM_ARGS=--renderer-process-limit=N` cannot raise the limit
+for a managed launch. The current two-renderer limit remains soft: site
+isolation can still require additional processes.
 
 ## 11. Build flags
 
@@ -235,15 +251,15 @@ with `BETTERWRIGHT_CHROMIUM_ARGS=--renderer-process-limit=N`.
 
 ## Coherence with egress
 
-The patch set makes the binary self-consistent; it cannot make the *session*
-consistent. A headless Linux fork behind residential egress returns a real
-Google SERP for a query a genuine Mac passes only once timezone and locale match
-the egress IP (`timezone: "Asia/Singapore"` and `locale: "en-US"` for a
-Singapore exit, or `geoip: true` with an upstream proxy). A UTC timezone paired
-with a residential exit in another region is a coherence break on its own,
-whatever the rest of the surfaces report.
+The patch set cannot guarantee session acceptance. In the earlier recorded
+egress experiment, the headless Linux fork returned a Google SERP only after
+timezone and locale matched the exit IP (`timezone: "Asia/Singapore"` and
+`locale: "en-US"` for that Singapore exit). This is historical evidence, not a
+current search workflow or an acceptance guarantee. Configure geography for
+the actual exit, or use `geoip: true` with an upstream proxy; no region is the
+default for every session.
 
-`research/stealth-report.js` inspects a built artifact — roughly 30 local surface
+`research/stealth-report.ts` inspects a built artifact — roughly 30 local surface
 checks against stock-Chrome behavior, plus the live score endpoints described in
 [launch-identity.md](launch-identity.md#verification):
 

--- a/docs/chromium-fork.md
+++ b/docs/chromium-fork.md
@@ -115,10 +115,12 @@ WebGL fallback, and the missing-device warning appears in run results and
 worker's local SOCKS guard.
 
 **Profiles are not interchangeable across Chromium majors.** A profile upgraded
-by a newer Chromium cannot be opened by an older one; BetterWright preserves
-the newer profile and opens the older browser in a stable nested compatibility
-profile. Sign-ins in the original profile are not copied, but new
-compatibility sign-ins persist across restarts.
+by a newer Chromium cannot be opened by an older one. Managed launch refuses
+that downgrade rather than creating a compatibility profile automatically.
+Preserve the old profile and select a fresh named `--profile` or a separate
+`BETTERWRIGHT_HOME`, or move aside only the profile directory named in the error
+and sign in again. Browser sign-ins are not copied; vault credentials remain
+outside the browser profile and survive moving it.
 
 **Match timezone/locale to egress** (or enable `geoip` with `upstreamProxy`).
 Nothing in the fork hard-codes Singapore or any other region — pin whatever

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -170,8 +170,11 @@ stays populated without any agent code calling `save`:
   login, an in-page banner asks "Save password?" with **Save**, **Not now**,
   and **Never for this site**. Choosing an existing username's account offers
   "Update saved password?" instead. "Never" is remembered per origin in
-  `$BETTERWRIGHT_HOME/browser/save-prompt.json` (owner-only). In headless
-  sessions there is nobody to ask, so user-driven captures are dropped.
+  `$BETTERWRIGHT_HOME/browser/save-prompt.json` (owner-only). With the default
+  human-autosave-off setting, headless sessions have no save prompt and drop
+  user-driven captures. Enabling both `offer-save` and `autosave` saves accepted
+  human logins silently, including headless handoffs; see
+  [master password and lock state](#master-password-and-lock-state).
 
 Capture is implemented by a worker-injected sensor running in a dedicated CDP
 isolated world per frame (`src/vault-sensor.ts` + `src/vault-capture.ts`),

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -12,6 +12,7 @@ CommonJS.
 ```js
 new BetterWright({
   home,             // state dir; default $BETTERWRIGHT_HOME or ~/.betterwright
+  profile,          // optional named identity; sessions within it share cookies
   policy,           // a NetworkPolicy; default: safe policy
   vault,            // optional { handleRequest(action, payload, origin), redact? }
   browser: "chromium-fork", // the managed BetterChromium fork (the default)
@@ -24,6 +25,7 @@ new BetterWright({
   defaultTimeout: 30,   // per-snippet seconds, min 5
   downloadPolicy: "ask", // "ask" (default), "allow", or "deny"
   stealthRuntimeFix: false, // isolated-world driver; evades main-world detection
+  parkBackgroundPages: true, // pause idle headless pages between calls
 });
 ```
 
@@ -47,6 +49,13 @@ the filter lists, and blocking disables service workers in new contexts without
 weakening network policy. See [ad blocking](ad-blocking.md) for caching and
 restart requirements.
 
+Idle headless pages are parked after a short delay between calls by default.
+Timers, animation frames, and animation timelines pause while parked and resume
+before the next execution. Set `parkBackgroundPages: false` or
+`BETTERWRIGHT_PARK_BACKGROUND_PAGES=0` if the application must keep progressing
+between calls. Headed sessions, sessions with a live view, and actively recording
+pages are not parked.
+
 To control a host-owned Electron tab instead of launching a managed browser,
 pass a `hostTarget` created by `betterwright/electron`. The adapter keeps the
 tab on the network guard and leaves its lifetime with the host. See
@@ -69,14 +78,36 @@ Install the optional dependency (`npm install patchright-core`) to use it;
 
 | Method | Description |
 | --- | --- |
-| `run(code, { session, note, timeout, approvedDownloads }) => Promise<envelope>` | Execute one snippet. Calls are queued and run one at a time. |
+| `run(code, { session, note, timeout, approvedDownloads, signal }) => Promise<envelope>` | Execute one snippet. Calls within a session are queued; different sessions may execute concurrently. |
 | `close() => Promise<void>` | Shut the worker down. Idempotent. |
+| `closeSession(session?) => Promise<{ ok, closed, pagesClosed, error? }>` | Close one session's pages and forget its state without closing other sessions or the browser. |
+| `syncCookies(options) => Promise<CookieSyncResult>` | Import cookies from a local browser into this identity. See [Cookie Sync](cookie-sync.md). |
+| `startLiveView(options?) => Promise<LiveViewStatus>` | Start or reuse a live viewer; returns its URL and status. See [live view](live-view.md). |
+| `stopLiveView()`, `liveViewStatus() => Promise<LiveViewStatus>` | Stop the viewer or read its status. |
+| `waitForHandoff(options?) => Promise<HandoffResult>` | Wait for a human to finish or cancel a live-view handoff. |
+| `waitForAsk(options?) => Promise<AskResult>` | Wait for a human's answer in live-view chat. |
+| `liveViewPostChat(options?) => Promise<{ ok, message?, error? }>` | Post a chat message to the live viewer. |
+| `liveViewDrainChat() => Promise<LiveViewDrainChatResult>` | Read and drain pending human chat messages. |
 | `vaultStatus() => Promise<status>` | Read vault availability and protection state without unlocking it. |
 | `unlockVault({ password }) => Promise<status>` | Unlock this browser's vault instance from a trusted host. Never expose the password to model code. |
 | `lockVault() => Promise<status>` | Revoke cached unlocks across processes sharing the master-protected vault directory. |
 | `policy` | The active `NetworkPolicy`. |
 
-There is no context-manager sugar in JS — call `close()` in a `finally`.
+Call `close()` in a `finally`, or use `withBrowser` from
+[`betterwright/sdk`](sdk.md) to own that lifetime for you.
+
+### Cancellation
+
+Pass an `AbortSignal` as `run(code, { signal })`. If the signal is already
+aborted before dispatch, the snippet does not execute. Aborting dispatched
+work stops and drains the worker; other in-flight sessions in that worker
+also stop. The client remains reusable, but the managed browser context and
+in-memory session state are lost, as on a [timeout](sdk.md#errors-timeouts-and-the-worker).
+
+Cancellation failures carry an `errorCode`, normally `BW_ABORTED`. A
+dispatched operation reports `effectMayHaveCommitted: true`: cancellation
+cannot undo a submission, payment, or other effect already performed by the
+page. Verify application state before replaying an interrupted operation.
 
 ### Download approval
 
@@ -104,8 +135,10 @@ it from inside the sandbox.
 | Field | Description |
 | --- | --- |
 | `ok` | Whether the snippet completed. |
-| `result` | The snippet's return value. |
+| `result` | The bounded summary of the snippet's return value, or a spill-file descriptor. See [return values](browser-api.md#return-values). |
 | `error` | Error message when `ok` is `false`. |
+| `errorCode` | Optional machine-readable error code, such as `BW_ABORTED` for cancellation. |
+| `effectMayHaveCommitted` | Cancellation cannot undo page effects; `true` means dispatched work may already have performed them. |
 | `console` | Captured snippet `console.*` calls. Page-side logs use `page.on("console")`. |
 | `events` | Page lifecycle events. |
 | `artifacts` | `[{ kind, path, media, size? }]`. |
@@ -113,7 +146,27 @@ it from inside the sandbox.
 | `challenges` | Visible CAPTCHA/bot checks with page, provider, URL, and routing advice. |
 | `warnings` | Non-fatal notices. |
 | `webagents` | One-time compact action directory when the active origin supports WebAgents. |
+| `ui` | Optional compact semantic action directory or bounded failure evidence. |
+| `skills` | Optional metadata hints for skill packs matching an open page. |
+| `profileMode` | Whether the browser is using a persistent or ephemeral profile. |
+| `pendingCredential` | Secret-free recovery metadata for an interrupted generated credential. |
+| `envelopeTruncated` | Present when the envelope was reduced to fit transport limits. |
 | `durationMs` | Time spent in the worker. |
+
+In TypeScript, a successful `run<T>()` envelope has `result: T | SpilledRunOutput`,
+not unconditionally `T`. `SpilledRunOutput` is exported as a type from both
+`betterwright` and `betterwright/sdk`. After checking `ok`, narrow the result
+before using it; for a string result:
+
+```ts
+const output = await bw.run<string>("return page.title()");
+if (!output.ok) throw new BrowserError(output.error);
+if (typeof output.result === "string") {
+  console.log(output.result);
+} else {
+  console.log(output.result.preview, output.result.fullOutputPath);
+}
+```
 
 ```js
 const bw = new BetterWright();
@@ -304,12 +357,21 @@ does not need to implement any of this.
 ## Sessions
 
 Pass `{ session: "name" }` to `run()`. Each session is an isolated set of pages
-and `state`; snippets in the same session share tabs across calls.
+and `state`; snippets in the same session share tabs across calls. Calls are
+ordered within each session, while separate sessions may run concurrently.
+Sessions share the browser's cookie jar and identity: they are separate work
+lanes, not separate logins.
 
 ```js
 await bw.run("await page.goto('https://a.example')", { session: "a" });
 await bw.run("await page.goto('https://b.example')", { session: "b" });
 ```
+
+Use `new BetterWright({ profile: "work" })` for a separate persistent browser
+identity. Profiles have separate cookie jars, but share the home directory's
+vault, artifacts, and browser cache. See [sessions and profiles](sessions.md).
+Call `bw.closeSession("a")` to discard only that session's pages and state;
+`bw.close()` shuts down the client and all its sessions.
 
 ## `agentSystemPrompt`
 

--- a/docs/launch-identity.md
+++ b/docs/launch-identity.md
@@ -38,20 +38,25 @@ plugins, hardware, automation markers, and client hints.
 | Platform | `--fingerprint-platform=<host>` — the real host OS |
 | GPU, plugins, hardware | Fork source-level fingerprint patches |
 | JavaScript APIs | Left native; no replacement getters or functions |
-| Service workers | Allowed natively; traffic still crosses the policy guard |
+| Service workers | Blocked in new contexts while default-on ad blocking is enabled; allowed when it is disabled. Existing remote contexts have [coverage limits](ad-blocking.md#filtering) |
 
-Forcing page-world values made a synthetic probe look perfect once, but live
-reCAPTCHA checks stalled. Leaving the APIs native restored server-verified
-`0.9` in both true-headless and headed modes.
+In the recorded identity comparison, forcing page-world values made a synthetic
+probe look perfect, but live reCAPTCHA checks stalled. Leaving the APIs native
+restored server-verified `0.9` in both true-headless and headed modes. These
+were demo observations, not an acceptance guarantee for future runs or sites.
 
 ## Launch modes
 
-- **Headless** (default): a real `--headless` fork process with a realistic
+- **Headless** (CLI default): a real `--headless` fork process with a realistic
   desktop viewport. This is not an off-screen headed substitute.
 - **Headed** (`--headed`): a normal visible browser window.
 - **Headed-invisible** (`headedInvisible: true` / `--headed-invisible`): a
   headed window parked off-screen for workflows that explicitly need native
   window compositing.
+
+The JavaScript SDK instead defaults to `headless: "auto"`: headed when a
+display is available, headless otherwise. Pass `true` or `false` to pin it.
+See [display detection](attach-mode.md#choosing-the-display-mode).
 
 ## Egress proxy
 
@@ -72,7 +77,7 @@ const browser = new BetterWright({
 
 ## Verification
 
-Compile the harness first with `bun run build`.
+Build the runtime and type-check the harness first with `bun run build:harness`.
 
 ```bash
 bun research/stealth-report.ts
@@ -81,7 +86,9 @@ bun research/stealth-report.ts --live --site recaptcha-v3-score
 ```
 
 The local fixture checks roughly 30 browser surfaces against stock-Chrome
-behavior. Live acceptance uses server-verified score endpoints:
+behavior. The table records earlier runs against server-verified score
+endpoints; it is not a verification of the current release or a promise that
+another session will receive the same scores:
 
 | Check | True headless | Headed |
 | --- | --- | --- |
@@ -89,11 +96,11 @@ behavior. Live acceptance uses server-verified score endpoints:
 | `antcpt.com/score_detector` | 0.9 | 0.9 |
 | `democaptcha.com` | 0.9 | 0.9 |
 
-`recaptcha-demo.appspot.com` is not an acceptance gate. Its widget currently
-reports that the site exceeded its Enterprise free quota, so an unresolved
-request there does not establish browser detection.
+`recaptcha-demo.appspot.com` was not an acceptance gate in those runs. Its widget
+reported that the site exceeded its Enterprise free quota, so an unresolved
+request there did not establish browser detection.
 
-Interactive CAPTCHA issuance is a separate gate. In the current public-demo
+Interactive CAPTCHA issuance is a separate gate. In those recorded public-demo
 runs, Turnstile remained at `processing` without a token in both modes, while
 reCAPTCHA v2 escalated to an image grid that requires vision. The report prints
 `tokenIssued` explicitly so those outcomes cannot be mistaken for a pass.

--- a/docs/live-view.md
+++ b/docs/live-view.md
@@ -90,12 +90,14 @@ you'd do in normal Chrome chrome, you can do to the streamed session:
 
 Every control is gated exactly like mouse/keyboard input: available when the
 view is interactive or a handoff is active, refused server-side on watch-only
-views. Viewer-driven navigation flows through the SOCKS policy proxy and every
-other guard, the same as agent navigation.
+views. Viewer-driven navigation uses the same guards as agent navigation.
 
-Human browser input goes through every existing guard: the SOCKS policy proxy,
-download limits, and credential capture treat takeover navigation exactly like
-model-driven navigation. **Takeover does not bypass network policy.** Chat is
+Human browser input goes through the existing guards: download limits and
+credential capture treat takeover navigation like model-driven navigation.
+Locally launched browsers and guarded Electron attachments also retain the
+SOCKS policy proxy; ordinary remote CDP browsers have the same
+[transport limitations](browser-providers.md#what-changes-with-a-remote-browser)
+during takeover as during agent use. **Takeover does not bypass network policy.** Chat is
 allowed even in watch-only mode (watch-only only blocks mouse/keyboard into the
 page).
 
@@ -190,17 +192,21 @@ Unlike cloud debug URLs, the self-hosted viewer is authenticated by default:
   SHA-256 digest; the session is a random 192-bit id in an `HttpOnly;
   SameSite=Strict` cookie valid 12 hours; failed logins lock the source
   address out after 10 attempts per 15 minutes; sessions die with the server.
-  The page is plain http — rely on the network layer (LAN, tailnet, or an
-  https tunnel) for transport privacy, which every preset provides.
+  The page and WebSocket use plain HTTP/WS. The `lan` preset provides
+  reachability, not encryption: the token, password, and browser stream travel
+  unencrypted on that network. Use Tailscale or an HTTPS tunnel when transport
+  confidentiality is required.
 - **Server-side watch-only.** `--watch-only` (or `interactive: false`) is
   enforced in the worker; the browser-side toggle is a convenience, never an
   authority. Handoffs force interactive on for their duration only.
 - **Origin check + headers.** WebSocket upgrades with a mismatched `Origin`
   are dropped; the page is served with `Cache-Control: no-store`,
   `Referrer-Policy: no-referrer`, and `X-Frame-Options: DENY`.
-- **Sealed from the model.** Nothing live-view-related exists in the code
-  sandbox. The model can *request* a handoff; it cannot start servers, read
-  the token, or synthesize input.
+- **Sealed from snippet code.** Live-view controls and tokens are absent from
+  snippet globals. Trusted host tools such as `live_view` and `browser_handoff`
+  can start the viewer and intentionally return its token-bearing URL to the
+  model for relay to the user. That URL can therefore enter model context;
+  treat tool outputs and transcripts containing it as sensitive.
 
 ## Options
 
@@ -246,10 +252,15 @@ Unlike cloud debug URLs, the self-hosted viewer is authenticated by default:
   auto-handled by the worker). If a step needs a file picker, use the
   download/upload APIs instead.
 - Credentials you type manually during a handoff are treated as *manual*
-  logins by the capture engine: in headless sessions the save prompt cannot
-  render, so they are not captured into the vault. The characters you type are
-  visible as pixels in your own viewer stream (and nowhere else — frames never
-  enter the model transcript).
+  logins by the capture engine. With the default human-autosave-off setting,
+  headless sessions cannot show the save prompt and do not save these logins.
+  Enabling both `vault settings offer-save on` and `vault settings autosave on`
+  allows accepted human logins to save silently, including headless handoffs;
+  see [credential settings](credentials.md#master-password-and-lock-state).
+  The viewer stream is not automatically attached to model results. Ordinary
+  screenshot and DOM-reading capabilities remain available, subject to their
+  usual redaction limits; the stream does not make page pixels or data private
+  from those capabilities.
 - One page streams full-res at a time. When more than one tab is open, the
   tab strip shows a live low-res thumbnail of every tab (refreshed every few
   seconds, re-sent only when it changes); click a card to switch the main

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -1,12 +1,18 @@
 # Network policy
 
-![The policy blocks private and metadata addresses while public traffic flows through](https://raw.githubusercontent.com/BetterWright/betterwright/main/docs/assets/network-policy.png)
+![A hardened policy blocks private and metadata addresses while public traffic flows through](https://raw.githubusercontent.com/BetterWright/betterwright/main/docs/assets/network-policy.png)
 
-Every request the browser makes is authorized before it goes out — page
-navigations, subresources (scripts, images, XHR/fetch), WebSocket upgrades, and
+For locally launched browsers and guarded Electron attachments, every browser
+request is authorized before it goes out — page navigations, subresources
+(scripts, images, XHR/fetch), WebSocket upgrades, and
 the raw TCP connections the worker's transport makes on the browser's behalf.
 The worker sends each one to the client as a `guard` request; the client answers
 it with a `NetworkPolicy`.
+
+Ordinary remote CDP/provider browsers do not use the local transport guard.
+Playwright routing still checks requests where the attached browser supports
+it, but the transport-level metadata floor and DNS-rebinding protection do not
+apply. See [browser providers](browser-providers.md#what-changes-with-a-remote-browser).
 
 ## The default posture
 
@@ -52,14 +58,20 @@ new BetterWright({ policy });
 
 | Option | Effect |
 | --- | --- |
-| `allowLoopback` | Permit `127.0.0.1` / `localhost` (for local dev servers). Does **not** open the wider private network. Default `true`; set `false` to block. |
+| `allowLoopback` | Permit `127.0.0.1` / `localhost` (for local dev servers). Does **not** open the wider private network. Default `true`; set both this and `allowPrivateNetwork` to `false` to block loopback. |
 | `allowPrivateNetwork` | Permit RFC 1918, link-local, and `*.internal`/`*.local` hosts. Implies loopback. Default `true`; set `false` to block. |
-| `allowHosts` | Always allow these hosts. An entry matches a host exactly or as a parent domain (`example.com` also matches `sub.example.com`); add `:port` to pin a port. |
-| `blockHosts` | Always block these hosts, evaluated before allowlists. |
+| `allowHosts` | Allow these hosts in the built-in decision, unless metadata or `blockHosts` denies them. An entry matches a host exactly or as a parent domain (`example.com` also matches `sub.example.com`); add `:port` to pin a port. A custom hook can override ordinary decisions. |
+| `blockHosts` | Block these hosts in the built-in decision, before allowlists. A custom hook may override this denial, but never the metadata floor. |
 | `custom` | A hook, `custom(url, details)`, returning a decision or `null`, evaluated last. |
 
-Evaluation order is: scheme check → `blockHosts` → `allowHosts` → metadata
-floor → private-network rules → `custom`.
+`allowHosts` adds exceptions to the normal policy; it is not an exclusive site
+allowlist. Other public sites remain allowed. Restricting browsing to specific
+destinations requires a trusted custom policy, including handling the
+resolved-literal transport checks described below.
+
+Evaluation order is: scheme check → metadata floor → `blockHosts` →
+`allowHosts` → private-network rules → `custom`. A custom allow is checked
+against the metadata floor again.
 
 ### The custom hook
 
@@ -119,16 +131,18 @@ that can make an HTTP request from the box. A prompt-injected page trying to
 read those is one of the sharpest risks in agent browsing. So the block is not
 just a policy default — it is enforced at two independent layers:
 
-1. **The transport guard.** All traffic is forced through the worker's own
-   loopback SOCKS proxy (Chromium cannot bypass it, even for localhost). The
-   proxy validates the connect target *and* re-validates every IP the hostname
+1. **The transport guard.** Locally launched browsers and guarded Electron
+   attachments force traffic through the worker's own loopback SOCKS proxy,
+   including localhost. The proxy validates the connect target *and*
+   re-validates every IP the hostname
    resolved to, so a hostname that passes cannot be swapped for a metadata
    address by DNS rebinding.
 2. **The policy.** `NetworkPolicy` refuses metadata hosts and refuses to honor
    an `allowHosts` entry or a `custom` allow that names one.
 
-Either layer stops the common case; together they close the redirect and
-rebinding variants too.
+For those guarded browsers, either layer stops the common case; together they
+close the redirect and rebinding variants too. An ordinary remote CDP
+attachment has no local transport guard, so it does not gain that guarantee.
 
 ## Failure is closed
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -29,6 +29,9 @@ const title = await withBrowser({ headless: false }, async (bw) => {
 
   const result = await bw.run<string>("return page.title()");
   if (!result.ok) throw new BrowserError(result.error);
+  if (typeof result.result !== "string") {
+    throw new BrowserError(`Title output was truncated; inspect ${result.result.fullOutputPath}`);
+  }
 
   await bw.run("return screenshot({ kind: 'proof', name: 'example-home' })");
   return result.result;
@@ -40,7 +43,8 @@ console.log(title);
 `withBrowser` constructs a `BetterWright`, awaits your function, and closes the
 client in a `finally`, so the worker process and the browser are released even
 when the function throws. It resolves with whatever your function returned.
-Pass the callback alone, `withBrowser(fn)`, to take the default options.
+The callback may be synchronous or asynchronous. Pass the callback alone,
+`withBrowser(fn)`, to take the default options.
 
 The string each `run()` call takes is Playwright code, executed inside the
 worker sandbox where `page`, `snapshot`, `screenshot`, `human`, and
@@ -57,6 +61,9 @@ Browser client:
 | `BetterWright` | The client itself: `run()`, sessions, live view, downloads, credential filling. Full reference in [javascript.md](javascript.md). |
 | `BrowserError` | The error type to throw when a result envelope comes back with `ok: false`. |
 | `validateCredentialMatchMode(value)` | Returns the value when it is one of the four credential URL scopes, and throws a `TypeError` otherwise. |
+| `listCookieSourceBrowsers()` | List local browser sources supported by Cookie Sync. |
+| `listCookieSourceProfiles(browser, options?)` | List profiles for one Cookie Sync source. See [Cookie Sync](cookie-sync.md). |
+| `agentSystemPrompt(guardrails?)` | Operator guidance and optional behavioral limits for an external agent. See [agent-prompt.md](agent-prompt.md). |
 
 Network policy:
 
@@ -128,13 +135,21 @@ an exception.
   timeout, 15 s by default. Set `BETTERWRIGHT_WORKER_START_TIMEOUT_MS` higher
   on a cold disk or a small ARM board; the hung process is killed either way.
 
-**Timeouts restart the worker, not the browser.** Each call takes a `timeout`
-in seconds (default `defaultTimeout`, 30). When it expires the worker is
-restarted, the call resolves `{ ok: false, error: "Execution timed out …" }`,
-and the next call spawns a replacement. Calls from other sessions that land
-during that restart wait for the replacement; they are not told the browser
-has been closed, because it has not. The browser profile, cookies, and
-logins are on disk and survive every restart.
+**Timeouts restart the worker and its managed browser context, not the client.**
+Each call takes a `timeout` in seconds (default `defaultTimeout`, 30; minimum 5).
+On expiry the call resolves `{ ok: false, error }` and the worker is torn down.
+The usual worker error is `Playwright code timed out after …ms`; the client's
+fallback watchdog reports `Execution timed out after …s`. Do not match only one
+literal error message.
+
+The `BetterWright` client remains reusable: calls arriving during teardown wait
+for the replacement worker. Live page handles and in-memory session `state` are
+lost, while the persistent profile's on-disk cookies and logins remain available
+to the replacement browser. Externally owned browser targets have their own
+lifetime rules; the host-owned Electron tab is not destroyed by a worker restart.
+After an interrupted action, inspect application state before deciding whether
+it is safe to replay it. See [cancellation](javascript.md#cancellation) for the
+related `run(code, { signal })` contract.
 
 **Provider API calls are bounded.** A cloud-provider launch and every
 `createProviderSession` / `listProviderSessions` / `getProviderSession` /
@@ -149,5 +164,5 @@ non-object options bag is a `TypeError` before any client exists.
 
 ## Runnable example
 
-[examples/typescript/sdk.ts](../examples/typescript/sdk.ts) is the code above as
-a file you can run with `node examples/typescript/sdk.ts`.
+[examples/typescript/sdk.ts](../examples/typescript/sdk.ts) demonstrates the same
+workflow as a file you can run with `node examples/typescript/sdk.ts`.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -66,10 +66,12 @@ betterwright close --all     # stops every profile's daemon
 `BETTERWRIGHT_PROFILE=social` sets the identity for a whole shell (and is the
 only way to set it for the MCP server); `--profile` beats it. Both run at once
 and both stay signed in, because each profile locks its own directory under
-`$BETTERWRIGHT_HOME/browser/profiles/`. Two runs of the *same*
-profile still serialize: the second gets an isolated, signed-out ephemeral
-profile, exactly as two runs of the default profile do. Omitting `--profile`
-keeps the single default profile and the daemon it already had. The vault is
+`$BETTERWRIGHT_HOME/browser/profiles/`. Ordinary CLI calls for the same profile
+share its daemon: different sessions run concurrently, and calls within one
+session serialize. If independent browser workers compete for the same profile
+directory instead, the second gets an isolated, signed-out ephemeral profile.
+Omitting `--profile` keeps the single default profile and the daemon it already
+had. The vault is
 shared, so a credential saved once fills in any profile.
 
 ## Stopping a run
@@ -117,10 +119,12 @@ use — same `0600` socket, same same-user-only rule. Without this the daemon
 died on `listen` and every command silently fell back to a private,
 non-persistent browser. Sessions
 are **collaboration scopes, not a security boundary**: any client that can open
-the socket can drive any session. What *is* a boundary is the worker process —
-model-authored snippets run there, not in the daemon, and never see Node's
-`process`, module loader, filesystem, or the route APIs that enforce the
-network policy. See [architecture.md](architecture.md).
+the socket can drive any session. The separate worker provides lifecycle and
+fault isolation from the daemon. Its snippet globals omit Node's `process`,
+module loader, filesystem, and routing APIs, but those facades and `node:vm`
+are defense in depth, not a security boundary against adversarial JavaScript.
+The relied-upon controls are at the browser and network layers, with the
+remote-provider limitations described in [architecture.md](architecture.md).
 
 ## Diagnosing
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -3,15 +3,17 @@
 Whoever drives the browser needs more than the mechanics of the browser. One
 static operator prompt can teach a model to observe, act, and verify, but it
 cannot carry the specifics of every site and password manager without bloating
-every request. Skill packs solve that — small Markdown files read **on demand**,
-only when a page or task makes them relevant.
+every request. Skill packs are small Markdown files loaded selectively when
+a page or task makes them relevant.
 
 They serve both shapes BetterWright is used in. **Integrated**, a host agent
 (Claude Code, Codex, a Pi package, any MCP client) reads a pack as a plain file
 with the file tool it already has. **Standalone**, BetterWright's own agent loop
 — `betterwright exec`, the interactive console, `runAgentTask()` — reads the
-same packs from the same directories. One set of files, one format, either
-driver.
+same packs from the same directories when their keywords match the task.
+External hosts can read packs on demand; the built-in loop currently loads
+matching bodies only at task start. One set of files and one format serve
+either driver, with different loading paths.
 
 ## What a pack looks like
 
@@ -45,9 +47,9 @@ agent pulls detail in only when it needs it.
 
 ## How an agent finds them
 
-Every run result — and every observation the built-in loop feeds its model —
-carries a `skills` array listing packs whose `autoInject.url` patterns match any
-open page:
+When packs' `autoInject.url` patterns match an open page in the session, run
+results include a `skills` array of metadata hints. The built-in loop forwards
+these hints in its observations. When no packs match, the field is omitted:
 
 ```json
 {
@@ -59,15 +61,17 @@ open page:
 }
 ```
 
-The operator prompt — the same text `betterwright skill` prints and the built-in
-loop runs on — tells whoever is driving to read the named `path` (with its own
-file tool, or `betterwright skills show <name>`) before improvising site-specific
-behavior, and to read the `credential-manager` pack before any login, signup,
-or checkout.
+The browser guidance tells whoever is driving to read relevant packs before
+improvising site-specific behavior, and to read `credential-manager` before
+login, signup, or checkout. An external host can read the named `path` with its
+file tool or run `betterwright skills show <name>`.
 
-The built-in loop has one extra path in: a pack whose `autoInject.keywords`
-match the task text is loaded into that run's system prompt before the first
-step, so guidance the task plainly needs costs no round-trip to fetch.
+The built-in loop instead loads packs whose `autoInject.keywords` match the
+task text into the system prompt before the first step, so guidance the task
+plainly needs costs no round-trip to fetch. It has no file, shell, or skill-read
+tool: a URL hint encountered later does not load that pack's body on demand.
+For standalone use, give a relevant pack task keywords rather than relying
+only on URL matching.
 
 ## Packaged and user packs
 
@@ -78,6 +82,11 @@ Packaged packs ship in the npm package's `skills/`:
 - `1password`, `bitwarden` — provider packs encoding the inline-menu detection
   heuristics, extension popup URLs, and unlock-then-reload flows.
 - `github` — a lean site pack (canonical URLs, working style, shortcuts).
+- `browser-console` — bounded console/error history for matching debugging
+  tasks, without replaying a failed action just to attach listeners.
+- `checkout-verification` — cart quantities and fresh transaction outcomes.
+  Matching tasks also receive the built-in loop's bounded independent
+  [completion check](agent.md), including read-only checkout analysis.
 - `full-stack-e2e-review` — a host playbook for end-to-end product review.
   `betterwright skill --install` writes it next to the browser skill. Hosts
   keep only its name and description in context; the body loads when the user

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -358,7 +358,11 @@ results hint at packs matching the open page; this is how you read one yourself.
   mcp: `Usage: betterwright mcp [--check] [--ad-block | --no-ad-block]
 
 Serve BetterWright over the Model Context Protocol on stdio. Exposes browser,
-browser_login, browser_download, browser_handoff, and browser_doctor.
+browser_batch, browser_download, browser_record, browser_handoff, and
+browser_doctor, plus browser_login when the credential vault is enabled.
+
+browser_batch runs guarded UI batches (docs/browser-api.md).
+browser_record controls local video recording (docs/recording.md).
 
   --check   verify the server can start, then exit — use this to debug a
             client that shows no BetterWright tools

--- a/tests/node/cli-help-inventory.test.ts
+++ b/tests/node/cli-help-inventory.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { helpFor } from "../../dist/src/cli-help.js";
+
+test("MCP help lists batching, recording, and conditional credential tools", () => {
+  const help = helpFor("mcp");
+  for (const name of [
+    "browser",
+    "browser_batch",
+    "browser_download",
+    "browser_record",
+    "browser_handoff",
+    "browser_doctor",
+    "browser_login",
+  ]) {
+    assert.match(help, new RegExp(`\\b${name}\\b`));
+  }
+  assert.match(help, /browser_login when the credential vault is enabled/);
+  assert.match(help, /browser_batch runs guarded UI batches/);
+  assert.match(help, /browser_record controls local video recording/);
+});

--- a/tests/types/sdk-callbacks.test.ts
+++ b/tests/types/sdk-callbacks.test.ts
@@ -1,0 +1,35 @@
+import { type BetterWrightOptions, withBrowser } from "betterwright/sdk";
+
+const options: BetterWrightOptions = { headless: true, vault: false };
+
+const syncDefault: Promise<string> = withBrowser((browser) => browser.home);
+const syncOptions: Promise<number> = withBrowser(options, (browser) => browser.defaultTimeout);
+const asyncDefault: Promise<string> = withBrowser(async (browser) => browser.home);
+const asyncOptions: Promise<number> = withBrowser(options, async (browser) => browser.defaultTimeout);
+
+const thenable: PromiseLike<number> = Promise.resolve(42);
+const thenableDefault: Promise<number> = withBrowser(() => thenable);
+const thenableOptions: Promise<number> = withBrowser(options, () => thenable);
+
+const mixedDefault: Promise<string> = withBrowser((browser) =>
+  browser.headless ? browser.home : Promise.resolve(browser.home),
+);
+const mixedOptions: Promise<string> = withBrowser(options, (browser) =>
+  browser.headless ? browser.home : Promise.resolve(browser.home),
+);
+
+const voidDefault: Promise<void> = withBrowser(() => {});
+const voidOptions: Promise<void> = withBrowser(options, () => {});
+
+void [
+  syncDefault,
+  syncOptions,
+  asyncDefault,
+  asyncOptions,
+  thenableDefault,
+  thenableOptions,
+  mixedDefault,
+  mixedOptions,
+  voidDefault,
+  voidOptions,
+];

--- a/tests/types/spill-result.test.ts
+++ b/tests/types/spill-result.test.ts
@@ -1,0 +1,21 @@
+import type { RunResult, SpilledRunOutput } from "betterwright";
+import type { SpilledRunOutput as SdkSpilledRunOutput } from "betterwright/sdk";
+
+const spilled: SpilledRunOutput = {
+  truncated: true,
+  preview: "A bounded preview",
+  fullOutputPath: "/tmp/browser-output.json",
+};
+const sdkSpilled: SdkSpilledRunOutput = spilled;
+const result: RunResult<string> = { ok: true, result: spilled };
+
+function readText(output: RunResult<{ text: string }>): string {
+  if (!output.ok) return output.error;
+  if (!("truncated" in output.result)) return output.result.text;
+  const truncated: true = output.result.truncated;
+  const path: string = output.result.fullOutputPath;
+  void [truncated, path];
+  return output.result.preview;
+}
+
+void [sdkSpilled, result, readText({ ok: true, result: spilled })];

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": false,
     "types": []
   },
-  "include": ["package.test.ts"]
+  "include": ["package.test.ts", "sdk-callbacks.test.ts", "spill-result.test.ts"]
 }

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -99,9 +99,11 @@ export interface RunAgentTaskOptions {
   /** Override or disable the built-in vault. Ignored when an external browser is passed. */
   vault?: CredentialVault | false | null;
   /**
-   * Stop the run early: the in-flight model call or browser step is aborted,
-   * the loop returns a partial result with `reason: "interrupted"`, and the
-   * transcript is preserved so the session can pick up where it left off.
+   * Stop the run early and preserve the transcript with `reason: "interrupted"`.
+   * Model requests receive cancellation. An externally supplied browser's
+   * in-flight step is not aborted and may still finish or reach its worker
+   * timeout. A browser created by this loop is closed during cleanup.
+   * Interruption does not roll back page effects; verify state before replaying.
    */
   signal?: AbortSignal;
   onStep?: (event: AgentStepEvent) => void;
@@ -113,8 +115,9 @@ export interface RunAgentTaskOptions {
   /**
    * When provided, the loop exposes an `ask` tool so the model can put a
    * question to the user mid-task; the returned string is fed back as the
-   * answer. Omit it (the `exec` default) to run fully autonomously with no
-   * `ask` tool.
+   * answer. Without it, the loop can still ask through live-view chat when
+   * live view is available and `onStep` can surface the URL. Omit this handler
+   * and set `liveView: false` to disable human-input tools.
    */
   askUser?: (question: {
     question: string;

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -51,9 +51,15 @@ export interface ResultEnvelopeBase {
   pendingCredential?: PendingCredentialRecovery;
 }
 
+export interface SpilledRunOutput {
+  truncated: true;
+  preview: string;
+  fullOutputPath: string;
+}
+
 export interface SuccessfulRunResult<T = unknown> extends ResultEnvelopeBase {
   ok: true;
-  result: T;
+  result: T | SpilledRunOutput;
   error?: never;
 }
 

--- a/types/public.d.ts
+++ b/types/public.d.ts
@@ -245,14 +245,14 @@ export interface BetterWrightOptions {
    * A headless Chromium target never becomes hidden — `document.visibilityState`
    * stays `"visible"` for the life of the page — so every open page keeps its
    * frame loop running at the host refresh rate whether or not anything is
-   * driving it. Parking disables page script and pauses animation timelines
-   * once a session's last execution unwinds, and restores both before the next
-   * one begins, so the quiet window is exactly the model's thinking time.
+   * driving it. After a short idle delay, parking freezes the native page
+   * lifecycle and pauses animation timelines. Pending timers and animation-frame
+   * registrations are preserved and resume before the next execution.
    *
-   * Never applies in headed mode or while a live view is streaming. The one
-   * behavior change: a page animated by a `requestAnimationFrame` chain does
-   * not resume that chain after being parked (CSS/Web Animations do). Also
-   * settable per host with `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0`.
+   * Never applies in headed mode or while a live view is running; active
+   * recording pages are also exempt. Set false when an application must keep
+   * progressing between calls. Also settable per host with
+   * `BETTERWRIGHT_PARK_BACKGROUND_PAGES=0`.
    */
   parkBackgroundPages?: boolean;
   /**

--- a/types/sdk.d.ts
+++ b/types/sdk.d.ts
@@ -92,6 +92,6 @@ export function stopProviderSession(
  */
 export function withBrowser<T>(
   options: BetterWrightOptions,
-  fn: (bw: BetterWright) => Promise<T>,
+  fn: (bw: BetterWright) => T | PromiseLike<T>,
 ): Promise<T>;
-export function withBrowser<T>(fn: (bw: BetterWright) => Promise<T>): Promise<T>;
+export function withBrowser<T>(fn: (bw: BetterWright) => T | PromiseLike<T>): Promise<T>;


### PR DESCRIPTION
## Security and operational accuracy

Reconcile the setup and security guides with the implementation: `allowHosts` adds exceptions rather than an exclusive allowlist; private networks and loopback are allowed by default; the transport guard applies to local launches and guarded Electron attachments, not ordinary remote CDP/provider browsers. Clarify VM defense-in-depth, unencrypted LAN Live View, capability URLs in host/model outputs, and human-capture autosave settings.

Correct daemon/session persistence, managed-browser timeout lifetimes, SDK-versus-CLI display defaults, service-worker blocking, profile downgrade refusal, and contributor browser-test commands. Repair Chromium patch links and distinguish retained native patches and historical measurements from current managed launch behavior.

## API and agent references

Fix the runnable UI batch example, document collection/depth bounds before output spilling, per-session concurrency, cancellation and potentially committed effects, background page parking, and host integration methods. Align agent guidance with on-demand human questions, trusted download approval, task-keyword skill loading, and checkout completion checks—even for read-only checkout tasks.

Update MCP help to include batching and recording, with credential login conditional on the vault. Accept synchronous and thenable `withBrowser` callbacks in the declarations; successful `RunResult<T>` now includes the existing `SpilledRunOutput` shape, so concrete-result consumers must narrow before assuming `T`. Add CLI-help inventory and public declaration regression coverage. Browser/agent runtime behavior and package version are unchanged.

## Dependency hygiene

Update only vulnerable transitive `fast-uri`, `hono`, and `qs` lock entries within their existing ranges. Direct dependencies and the pinned browser/runtime versions are unchanged; `bun audit` reports no findings.

## Validation

- Final `bun run release:check`: lint, implementation/tooling/example typechecks, version/build/export checks, **1,097 passing tests**, five platform/optional skips, public declarations, and package smoke all pass.
- All **99 managed-browser/recording integration tests** pass; browser runtime code is unchanged by this PR.
- Real-browser probes execute the corrected documentation batch and verify the 200-entry collection bound, spill descriptor, and reusable-client/lost-live-state timeout behavior.
- Maintained Markdown local file targets and `git diff --check` pass.

The companion website update will vendor these guides at this PR's exact source commit. No merge, deployment, release tag, or package publication is included.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M25G8C0FHS7MHTQ0PTTYEARX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->