### PR TITLE
Reduce navigation waits and agent observation overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+### Changed
+
+- Default sandbox navigation to `domcontentloaded` so slow subresources do not
+  hold up agent actions. Explicit load modes and timeouts remain supported;
+  wait on the relevant locator before reading dynamic page or frame state.
+- Limit automatic UI discovery to 2,400 JSON characters and omit it when a
+  snippet returns the full `betterwright-ui/1` directory itself.
+  `controls.directory()` retains the full discovery limits and option lists.
+- Print compact JSON for piped `betterwright run` output without dropping any
+  fields. Terminal output stays indented; `--pretty` also indents piped output.
+
+### Added
+
+- Per-call `automaticUI: false` / `run --no-auto-ui` for agents returning scoped
+  page observations. It omits successful automatic UI catalogs while preserving
+  on-demand discovery, first-party workflows, failure evidence, and warnings.
+
 ### Fixed
 
 - Align setup, security, browser, SDK, and agent documentation with current

--- a/benchmarks/navigation-context/README.md
+++ b/benchmarks/navigation-context/README.md
@@ -1,0 +1,51 @@
+# Navigation and observation overhead
+
+This local benchmark compares two built BetterWright packages with identical
+browser binaries, default options, and unchanged native skills. It checks result
+parity on article extraction, form submission, table filtering, delayed content,
+and explicit control discovery. There are no task-specific runtime or prompt
+changes.
+
+```sh
+export BETTERWRIGHT_CHROMIUM_PATH=/path/to/BetterChromium
+bun benchmarks/navigation-context/run.ts \
+  --baseline /path/to/built/baseline \
+  --candidate /path/to/built/candidate \
+  --output results.json
+```
+
+Each workload has one warmup pair and ten measured pairs, alternating which
+build goes first. Browser startup is excluded. Unique URL paths cause the same
+automatic-discovery opportunity in each sample. The script asserts identical
+returned results, including the full explicit control directory.
+
+`pipedEnvelopeChars` applies each build's CLI JSON formatting to its SDK result:
+baseline indented, candidate compact. This is a serialization measurement, not
+a CLI latency measurement or a token count. The browser integration suite also
+executes the CLI in both compact and `--pretty` modes and checks JSON parity.
+
+## Recorded result
+
+[results.json](results.json) records ten samples per workload/build on macOS
+arm64, together with source/build identifiers and the browser/fixture hashes.
+
+| Workload | Baseline median ms | Candidate median ms | Baseline piped characters | Candidate piped characters |
+| --- | ---: | ---: | ---: | ---: |
+| Article extraction | 48.7 | 47.4 | 8,855 | 2,740 |
+| Form submission | 368.7 | 372.6 | 1,864 | 973 |
+| Table filtering | 66.6 | 72.5 | 1,471 | 744 |
+| Delayed content | 850.3 | 225.7 | 318 | 236 |
+| Explicit directory | 50.9 | 46.7 | 3,056 | 837 |
+
+All 100 measured executions passed result parity. Piped observations were
+25.8–72.6% smaller. The delayed-content fixture has an explicit 800 ms decorative
+image delay and renders its required output after 120 ms; both builds wait for
+that output. The candidate avoids waiting for the image. The other fixtures
+have no delayed resources. Small ordinary-page timing differences include
+regressions and do not establish a general action-latency improvement.
+
+The default automatic directory is a bounded discovery hint. The full directory
+remains available on demand; truncating discovery can require another model
+turn on some pages. These measurements establish smaller observations and less
+waiting for irrelevant subresources, not a universal reduction in model cost or
+end-to-end completion time. No paid model requests are made by this script.

--- a/benchmarks/navigation-context/README.md
+++ b/benchmarks/navigation-context/README.md
@@ -47,14 +47,16 @@ executes the CLI in both compact and `--pretty` modes and checks JSON parity.
 
 [results.json](results.json) records ten samples per workload/build on macOS
 arm64, together with source/build identifiers and the browser/fixture hashes.
+The measured baseline is `8a87ae6e44341204803c84085bf72b706a0e92fc`; the measured candidate is
+`07141956b22f781cbe8f359828a1ae59926c38f3`. The source/build inputs in subsequent report-only commits must remain identical.
 
 | Workload | Baseline median ms | Candidate median ms | Baseline piped characters | Candidate piped characters |
 | --- | ---: | ---: | ---: | ---: |
-| Article extraction | 48.7 | 47.4 | 8,855 | 2,740 |
-| Form submission | 368.7 | 372.6 | 1,864 | 973 |
-| Table filtering | 66.6 | 72.5 | 1,471 | 744 |
-| Delayed content | 850.3 | 225.7 | 318 | 236 |
-| Explicit directory | 50.9 | 46.7 | 3,056 | 837 |
+| Article extraction | 46.4 | 46.8 | 8,855 | 2,740 |
+| Form submission | 392.3 | 357.9 | 1,864 | 973 |
+| Table filtering | 83.5 | 84.2 | 1,471 | 744 |
+| Delayed content | 859.0 | 239.4 | 318 | 236 |
+| Explicit directory | 54.2 | 48.0 | 3,056 | 837 |
 
 All 100 measured executions passed result parity. Piped observations were
 25.8–72.6% smaller. The delayed-content fixture has an explicit 800 ms decorative

--- a/benchmarks/navigation-context/README.md
+++ b/benchmarks/navigation-context/README.md
@@ -1,6 +1,6 @@
 # Navigation and observation overhead
 
-This local benchmark compares two built BetterWright packages with identical
+This local benchmark builds and compares two BetterWright source checkouts with identical
 browser binaries, default options, and unchanged native skills. It checks result
 parity on article extraction, form submission, table filtering, delayed content,
 and explicit control discovery. There are no task-specific runtime or prompt
@@ -9,10 +9,29 @@ changes.
 ```sh
 export BETTERWRIGHT_CHROMIUM_PATH=/path/to/BetterChromium
 bun benchmarks/navigation-context/run.ts \
-  --baseline /path/to/built/baseline \
-  --candidate /path/to/built/candidate \
+  --baseline /path/to/baseline-checkout \
+  --candidate /path/to/candidate-checkout \
   --output results.json
 ```
+
+Install each checkout's locked dependencies first. Source and build inputs must
+be committed and clean, including staged, untracked, and ignored files under
+the recorded source paths. The harness rebuilds each checkout before importing
+its runtime, then records:
+
+- Immutable baseline and candidate commit IDs.
+- SHA-256 of the committed baseline-to-variant diff over `src`, `bin`, and
+  `types`, including newly added files.
+- SHA-256 of Git tree entries for all recorded source/build inputs, plus a
+  fingerprint of every generated file in `dist/`.
+- Browser and benchmark-code hashes.
+
+The harness checks these inputs and outputs again after measurement. Publishing
+`results.json` necessarily creates a later commit than the measured candidate;
+a report-only commit is valid when its recorded source tree and runtime diff
+are unchanged. The candidate commit identifies the code measured, not the
+later commit containing the result file. The provenance regression tests cover
+this distinction and reject subsequent runtime changes.
 
 Each workload has one warmup pair and ten measured pairs, alternating which
 build goes first. Browser startup is excluded. Unique URL paths cause the same

--- a/benchmarks/navigation-context/fixtures.ts
+++ b/benchmarks/navigation-context/fixtures.ts
@@ -1,0 +1,53 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+const departments = ["Engineering", "Operations", "Design"];
+const inventory = Array.from({ length: 24 }, (_, i) => ({
+  name: `Device ${String(i + 1).padStart(2, "0")}`,
+  department: departments[i % departments.length],
+  available: i % 4 !== 0,
+  count: i + 2,
+}));
+
+const navigation = `<nav>${Array.from({ length: 40 }, (_, i) => `<a href="/article/${i}">Reference section ${i + 1}</a>`).join(" ")}</nav>`;
+const pages = {
+  article: `<h1>Service handbook</h1><main><h2>Retention policy</h2><p>Standard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours.</p></main>${navigation}`,
+  form: `<h1>Notification preferences</h1><form><label>Display name <input name="displayName" required></label><label>Department <select name="department">${departments.map((name) => `<option>${name}</option>`).join("")}</select></label><label><input name="digest" type="checkbox">Weekly digest</label><button>Save preferences</button></form><output role="status"></output><script>document.querySelector('form').onsubmit = event => {event.preventDefault(); const values = Object.fromEntries(new FormData(event.target)); setTimeout(() => {document.querySelector('output').textContent = 'Saved: ' + JSON.stringify(values)}, 120)};</script>`,
+  table: `<h1>Equipment inventory</h1><label>Department <select id="department"><option>All</option>${departments.map((name) => `<option>${name}</option>`).join("")}</select></label><label><input id="available" type="checkbox">Available only</label><table><thead><tr><th>Device</th><th>Department</th><th>Available</th><th>Count</th></tr></thead><tbody></tbody></table><script>const rows = ${JSON.stringify(inventory)}; function render() {document.querySelector('tbody').innerHTML = rows.filter(row => (department.value === 'All' || row.department === department.value) && (!available.checked || row.available)).map(row => '<tr><td>' + row.name + '</td><td>' + row.department + '</td><td>' + (row.available ? 'Yes' : 'No') + '</td><td>' + row.count + '</td></tr>').join('')} department.onchange = render; available.onchange = render; render();</script>`,
+  deferred: '<h1>Loading report</h1><output role="status"></output><img src="/slow-image" alt="Decorative image"><script>setTimeout(() => {document.querySelector("output").textContent = "Report ready: 24 records"}, 120)</script>',
+};
+
+// Delayed resources occur in one explicit scenario only; ordinary fixtures
+// have no artificial network delay. No external site or account is involved.
+export async function startFixtures() {
+  const server = http.createServer((request, response) => {
+    const route = request.url?.split("/")[1];
+    if (route === "slow-image") {
+      setTimeout(() => { response.writeHead(204).end(); }, 800);
+      return;
+    }
+    const content = pages[route];
+    if (!content) { response.writeHead(404).end("Missing"); return; }
+    response.setHeader("Content-Type", "text/html; charset=utf-8");
+    response.setHeader("Cache-Control", "no-store");
+    response.end(`<!doctype html><html><head><title>${route}</title></head><body>${content}</body></html>`);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  // SAFETY: listen succeeded on a TCP host/port, so the address is AddressInfo.
+  const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  return {
+    origin,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+      server.closeAllConnections();
+    }),
+  };
+}
+
+export const workloads = {
+  article: { code: "return await page.locator('main').innerText()", expected: "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours." },
+  form: { code: "await page.getByLabel('Display name').fill('Taylor'); await page.getByLabel('Department').selectOption('Operations'); await page.getByLabel('Weekly digest').check(); await page.getByRole('button', {name:'Save preferences'}).click(); await page.getByRole('status').filter({hasText:'Saved:'}).waitFor(); return await page.getByRole('status').innerText()", expected: 'Saved: {"displayName":"Taylor","department":"Operations","digest":"on"}' },
+  table: { code: "await page.getByLabel('Department').selectOption('Operations'); await page.getByLabel('Available only').check(); return await page.locator('tbody tr').allTextContents()", expected: inventory.filter((row) => row.department === "Operations" && row.available).map((row) => `${row.name}${row.department}Yes${row.count}`) },
+  deferred: { code: "await page.getByRole('status').filter({hasText:'Report ready:'}).waitFor(); return await page.getByRole('status').innerText()", expected: "Report ready: 24 records" },
+  directory: { route: "form", code: "return await controls.directory()", expected: null },
+};

--- a/benchmarks/navigation-context/provenance.ts
+++ b/benchmarks/navigation-context/provenance.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const RUNTIME_PATHS = ["src", "bin", "types"];
+export const SOURCE_PATHS = [...RUNTIME_PATHS, "scripts", "package.json", "bun.lock", ".bun-version", "tsconfig.json", "tsconfig.tools.json", "SKILL.md"];
+export const sha256 = (value: string | Buffer) => createHash("sha256").update(value).digest("hex");
+
+export function sourceIdentity(root: string, baselineHead?: string) {
+  const git = (args: string[]) => execFileSync("git", args, { cwd: root });
+  const head = git(["rev-parse", "HEAD"]).toString().trim();
+  const baseline = baselineHead ?? head;
+  assert.match(baseline, /^[a-f0-9]{40}$/i, "The baseline must be an immutable commit ID");
+  git(["cat-file", "-e", `${baseline}^{commit}`]);
+  const dirty = git(["status", "--porcelain", "--untracked-files=all", "--ignored=matching", "--", ...SOURCE_PATHS]).toString().trim();
+  assert.equal(dirty, "", `Commit or remove changed source/build inputs before benchmarking:\n${dirty}`);
+  return {
+    head,
+    baselineHead: baseline,
+    // Tree entries include every committed input, including added files. This
+    // stays stable when a later commit only publishes benchmark measurements.
+    sourceTreeSha256: sha256(git(["ls-tree", "-r", "-z", head, "--", ...SOURCE_PATHS])),
+    diffSha256: sha256(git(["diff", "--no-ext-diff", "--no-textconv", "--no-color", "--binary", baseline, head, "--", ...RUNTIME_PATHS])),
+  };
+}
+
+export type SourceIdentity = ReturnType<typeof sourceIdentity>;
+
+export function assertSameSource(recorded: SourceIdentity, current: SourceIdentity) {
+  assert.equal(current.baselineHead, recorded.baselineHead, "The declared baseline changed");
+  assert.equal(current.sourceTreeSha256, recorded.sourceTreeSha256, "Source/build inputs differ from the measured revision");
+  assert.equal(current.diffSha256, recorded.diffSha256, "The committed runtime difference changed");
+}
+
+export async function directoryIdentity(root: string) {
+  const files: Array<[string, string]> = [];
+  async function visit(relative: string) {
+    for (const entry of (await readdir(path.join(root, relative), { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
+      const name = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) await visit(name);
+      else {
+        assert.ok(entry.isFile(), `Expected a regular build artifact: ${name}`);
+        files.push([name, sha256(await readFile(path.join(root, name)))]);
+      }
+    }
+  }
+  await visit("");
+  return { sha256: sha256(JSON.stringify(files)), fileCount: files.length };
+}

--- a/benchmarks/navigation-context/results.json
+++ b/benchmarks/navigation-context/results.json
@@ -1,6 +1,7 @@
 {
-  "startedAt": "2026-09-10T22:08:35.862Z",
-  "finishedAt": "2026-09-10T22:09:02.691Z",
+  "schemaVersion": 2,
+  "startedAt": "2026-09-10T22:44:25.402Z",
+  "finishedAt": "2026-09-10T22:44:56.781Z",
   "host": {
     "platform": "darwin",
     "arch": "arm64",
@@ -8,6 +9,7 @@
     "bun": "1.4.0"
   },
   "browserSha256": "0c942f4891ea6bf8c83fe9ff278b1a032c40033aa769ae69f7fd83021f98fb24",
+  "harnessSha256": "5390cb080c154c3d7640094f5c0403873ed5a57734fa95753a43fcd953c364f3",
   "fixtureSha256": "c11e0642e8d6fddc2e28f433c780dc737faeabd77782a80baaca930d8d51699f",
   "config": {
     "repetitions": 10,
@@ -15,17 +17,47 @@
     "defaultOptions": true,
     "pipedSerializationSimulated": true,
     "deferredResourceMs": 800,
-    "promptsUnchanged": true
+    "promptsUnchanged": true,
+    "rebuildBeforeMeasurement": true,
+    "sourcePaths": [
+      "src",
+      "bin",
+      "types",
+      "scripts",
+      "package.json",
+      "bun.lock",
+      ".bun-version",
+      "tsconfig.json",
+      "tsconfig.tools.json",
+      "SKILL.md"
+    ],
+    "runtimeDiffPaths": [
+      "src",
+      "bin",
+      "types"
+    ]
   },
   "identities": {
     "baseline": {
       "head": "8a87ae6e44341204803c84085bf72b706a0e92fc",
+      "baselineHead": "8a87ae6e44341204803c84085bf72b706a0e92fc",
+      "sourceTreeSha256": "7504c99d96dd1fcde5446d41482afec88c9778dd175c3c49d28cf3e2d881c5cc",
       "diffSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "build": {
+        "sha256": "c81e40b0e5386288ff0db6052b0b6ade2f1f59efd840311b4bd1a635346037db",
+        "fileCount": 90
+      },
       "workerSha256": "a21568aaa52d1802f410ee9c4d00404739f94cff3e388e9487d5e7eea881504c"
     },
     "candidate": {
-      "head": "8a87ae6e44341204803c84085bf72b706a0e92fc",
-      "diffSha256": "b79885f073368b58b5115fdf29c9cf4e17bb7711c8ede3f3a16c61219d48bcfa",
+      "head": "07141956b22f781cbe8f359828a1ae59926c38f3",
+      "baselineHead": "8a87ae6e44341204803c84085bf72b706a0e92fc",
+      "sourceTreeSha256": "cb6359a5a7fafd3f1a4208faf32dab03e16b776039cad04b7371be6c9c1af7b4",
+      "diffSha256": "586f74b7378c91f542429cbee098acb8215209864e33fbd082a481fc3c18ce54",
+      "build": {
+        "sha256": "7f25256b58540720c371e2f0945f1a99923ea1c98098c9fa6c6d1f023c4ed75e",
+        "fileCount": 92
+      },
       "workerSha256": "35793c9ae2aa11ce03e8f596b8d5bb2085d7891e13be23f0dfee67df5bccfa2a"
     }
   },
@@ -36,13 +68,13 @@
   "summary": {
     "article": {
       "baseline": {
-        "medianMs": 48.67964599999959,
+        "medianMs": 46.377958500001114,
         "medianPipedChars": 8855,
         "medianCompactChars": 4331,
         "resultParity": true
       },
       "candidate": {
-        "medianMs": 47.40264600000046,
+        "medianMs": 46.79027150000002,
         "medianPipedChars": 2740,
         "medianCompactChars": 2740,
         "resultParity": true
@@ -50,13 +82,13 @@
     },
     "form": {
       "baseline": {
-        "medianMs": 368.7468955000004,
+        "medianMs": 392.3491040000008,
         "medianPipedChars": 1864,
         "medianCompactChars": 1022,
         "resultParity": true
       },
       "candidate": {
-        "medianMs": 372.60058350000054,
+        "medianMs": 357.88062549999813,
         "medianPipedChars": 973,
         "medianCompactChars": 973,
         "resultParity": true
@@ -64,13 +96,13 @@
     },
     "table": {
       "baseline": {
-        "medianMs": 66.55741649999982,
+        "medianMs": 83.531645999999,
         "medianPipedChars": 1471,
         "medianCompactChars": 813,
         "resultParity": true
       },
       "candidate": {
-        "medianMs": 72.50202100000024,
+        "medianMs": 84.23379199999908,
         "medianPipedChars": 744,
         "medianCompactChars": 744,
         "resultParity": true
@@ -78,13 +110,13 @@
     },
     "deferred": {
       "baseline": {
-        "medianMs": 850.3196875000003,
+        "medianMs": 859.0160210000004,
         "medianPipedChars": 318,
         "medianCompactChars": 236,
         "resultParity": true
       },
       "candidate": {
-        "medianMs": 225.68189600000187,
+        "medianMs": 239.41918749999877,
         "medianPipedChars": 236,
         "medianCompactChars": 236,
         "resultParity": true
@@ -92,13 +124,13 @@
     },
     "directory": {
       "baseline": {
-        "medianMs": 50.91279149999991,
+        "medianMs": 54.24360449999949,
         "medianPipedChars": 3056,
         "medianCompactChars": 1478,
         "resultParity": true
       },
       "candidate": {
-        "medianMs": 46.69135449999976,
+        "medianMs": 47.99243750000005,
         "medianPipedChars": 837,
         "medianCompactChars": 837,
         "resultParity": true
@@ -110,7 +142,7 @@
       "variant": "baseline",
       "workload": "article",
       "repetition": 0,
-      "elapsedMs": 47.80904199999986,
+      "elapsedMs": 47.13641699999971,
       "compactEnvelopeChars": 4331,
       "pipedEnvelopeChars": 8855,
       "automaticUIChars": 3971,
@@ -120,7 +152,7 @@
       "variant": "candidate",
       "workload": "article",
       "repetition": 0,
-      "elapsedMs": 53.67433299999993,
+      "elapsedMs": 44.04512500000055,
       "compactEnvelopeChars": 2740,
       "pipedEnvelopeChars": 2740,
       "automaticUIChars": 2380,
@@ -130,7 +162,7 @@
       "variant": "baseline",
       "workload": "form",
       "repetition": 0,
-      "elapsedMs": 380.1554580000002,
+      "elapsedMs": 363.5135829999999,
       "compactEnvelopeChars": 1022,
       "pipedEnvelopeChars": 1864,
       "automaticUIChars": 733,
@@ -140,7 +172,7 @@
       "variant": "candidate",
       "workload": "form",
       "repetition": 0,
-      "elapsedMs": 373.0427500000005,
+      "elapsedMs": 270.56287500000053,
       "compactEnvelopeChars": 973,
       "pipedEnvelopeChars": 973,
       "automaticUIChars": 684,
@@ -150,7 +182,7 @@
       "variant": "baseline",
       "workload": "table",
       "repetition": 0,
-      "elapsedMs": 86.6155830000007,
+      "elapsedMs": 90.58216699999957,
       "compactEnvelopeChars": 813,
       "pipedEnvelopeChars": 1471,
       "automaticUIChars": 446,
@@ -167,7 +199,7 @@
       "variant": "candidate",
       "workload": "table",
       "repetition": 0,
-      "elapsedMs": 71.70924999999988,
+      "elapsedMs": 66.13850000000002,
       "compactEnvelopeChars": 744,
       "pipedEnvelopeChars": 744,
       "automaticUIChars": 377,
@@ -184,7 +216,7 @@
       "variant": "baseline",
       "workload": "deferred",
       "repetition": 0,
-      "elapsedMs": 847.941417,
+      "elapsedMs": 859.2935830000006,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 318,
       "automaticUIChars": 0,
@@ -194,7 +226,7 @@
       "variant": "candidate",
       "workload": "deferred",
       "repetition": 0,
-      "elapsedMs": 233.09020800000053,
+      "elapsedMs": 243.72329200000058,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 236,
       "automaticUIChars": 0,
@@ -204,7 +236,7 @@
       "variant": "baseline",
       "workload": "directory",
       "repetition": 0,
-      "elapsedMs": 50.71437499999956,
+      "elapsedMs": 72.22249999999985,
       "compactEnvelopeChars": 1478,
       "pipedEnvelopeChars": 3056,
       "automaticUIChars": 635,
@@ -290,7 +322,7 @@
       "variant": "candidate",
       "workload": "directory",
       "repetition": 0,
-      "elapsedMs": 45.38995799999975,
+      "elapsedMs": 48.07099999999991,
       "compactEnvelopeChars": 837,
       "pipedEnvelopeChars": 837,
       "automaticUIChars": 0,
@@ -376,7 +408,7 @@
       "variant": "candidate",
       "workload": "article",
       "repetition": 1,
-      "elapsedMs": 45.58191699999952,
+      "elapsedMs": 45.96129199999996,
       "compactEnvelopeChars": 2740,
       "pipedEnvelopeChars": 2740,
       "automaticUIChars": 2380,
@@ -386,7 +418,7 @@
       "variant": "baseline",
       "workload": "article",
       "repetition": 1,
-      "elapsedMs": 50.022375000000466,
+      "elapsedMs": 45.940333000000464,
       "compactEnvelopeChars": 4331,
       "pipedEnvelopeChars": 8855,
       "automaticUIChars": 3971,
@@ -396,7 +428,7 @@
       "variant": "candidate",
       "workload": "form",
       "repetition": 1,
-      "elapsedMs": 367.77141699999993,
+      "elapsedMs": 361.58791700000074,
       "compactEnvelopeChars": 973,
       "pipedEnvelopeChars": 973,
       "automaticUIChars": 684,
@@ -406,7 +438,7 @@
       "variant": "baseline",
       "workload": "form",
       "repetition": 1,
-      "elapsedMs": 364.1736659999997,
+      "elapsedMs": 369.884,
       "compactEnvelopeChars": 1022,
       "pipedEnvelopeChars": 1864,
       "automaticUIChars": 733,
@@ -416,290 +448,7 @@
       "variant": "candidate",
       "workload": "table",
       "repetition": 1,
-      "elapsedMs": 70.21179100000063,
-      "compactEnvelopeChars": 744,
-      "pipedEnvelopeChars": 744,
-      "automaticUIChars": 377,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "baseline",
-      "workload": "table",
-      "repetition": 1,
-      "elapsedMs": 65.86937500000022,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
-      "automaticUIChars": 446,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "candidate",
-      "workload": "deferred",
-      "repetition": 1,
-      "elapsedMs": 222.38458300000093,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 236,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "baseline",
-      "workload": "deferred",
-      "repetition": 1,
-      "elapsedMs": 849.1908329999987,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 318,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "candidate",
-      "workload": "directory",
-      "repetition": 1,
-      "elapsedMs": 46.5044999999991,
-      "compactEnvelopeChars": 837,
-      "pipedEnvelopeChars": 837,
-      "automaticUIChars": 0,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "baseline",
-      "workload": "directory",
-      "repetition": 1,
-      "elapsedMs": 48.944250000000466,
-      "compactEnvelopeChars": 1478,
-      "pipedEnvelopeChars": 3056,
-      "automaticUIChars": 635,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "baseline",
-      "workload": "article",
-      "repetition": 2,
-      "elapsedMs": 46.88441700000112,
-      "compactEnvelopeChars": 4331,
-      "pipedEnvelopeChars": 8855,
-      "automaticUIChars": 3971,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "candidate",
-      "workload": "article",
-      "repetition": 2,
-      "elapsedMs": 50.59970799999974,
-      "compactEnvelopeChars": 2740,
-      "pipedEnvelopeChars": 2740,
-      "automaticUIChars": 2380,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "baseline",
-      "workload": "form",
-      "repetition": 2,
-      "elapsedMs": 364.6087919999991,
-      "compactEnvelopeChars": 1022,
-      "pipedEnvelopeChars": 1864,
-      "automaticUIChars": 733,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "candidate",
-      "workload": "form",
-      "repetition": 2,
-      "elapsedMs": 378.2791669999988,
-      "compactEnvelopeChars": 971,
-      "pipedEnvelopeChars": 971,
-      "automaticUIChars": 684,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "baseline",
-      "workload": "table",
-      "repetition": 2,
-      "elapsedMs": 68.19279099999949,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
-      "automaticUIChars": 446,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "candidate",
-      "workload": "table",
-      "repetition": 2,
-      "elapsedMs": 73.2947920000006,
+      "elapsedMs": 86.3361670000013,
       "compactEnvelopeChars": 742,
       "pipedEnvelopeChars": 742,
       "automaticUIChars": 377,
@@ -714,9 +463,292 @@
     },
     {
       "variant": "baseline",
+      "workload": "table",
+      "repetition": 1,
+      "elapsedMs": 71.71187500000087,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 1,
+      "elapsedMs": 241.71016699999927,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 1,
+      "elapsedMs": 877.0549169999995,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 1,
+      "elapsedMs": 50.14954200000102,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 1,
+      "elapsedMs": 44.65912500000013,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 2,
+      "elapsedMs": 47.88891599999988,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 2,
+      "elapsedMs": 48.18870900000002,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 2,
+      "elapsedMs": 888.0389160000013,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 2,
+      "elapsedMs": 742.5012920000008,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 2,
+      "elapsedMs": 174.92100000000028,
+      "compactEnvelopeChars": 814,
+      "pipedEnvelopeChars": 1472,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 2,
+      "elapsedMs": 189.40733399999954,
+      "compactEnvelopeChars": 745,
+      "pipedEnvelopeChars": 745,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
       "workload": "deferred",
       "repetition": 2,
-      "elapsedMs": 850.7257499999996,
+      "elapsedMs": 848.3243340000008,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 318,
       "automaticUIChars": 0,
@@ -726,7 +758,7 @@
       "variant": "candidate",
       "workload": "deferred",
       "repetition": 2,
-      "elapsedMs": 222.8227910000005,
+      "elapsedMs": 226.83287500000006,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 236,
       "automaticUIChars": 0,
@@ -736,7 +768,7 @@
       "variant": "baseline",
       "workload": "directory",
       "repetition": 2,
-      "elapsedMs": 50.55341700000099,
+      "elapsedMs": 60.75129100000049,
       "compactEnvelopeChars": 1478,
       "pipedEnvelopeChars": 3056,
       "automaticUIChars": 635,
@@ -822,7 +854,7 @@
       "variant": "candidate",
       "workload": "directory",
       "repetition": 2,
-      "elapsedMs": 48.167208999999275,
+      "elapsedMs": 47.91387500000019,
       "compactEnvelopeChars": 837,
       "pipedEnvelopeChars": 837,
       "automaticUIChars": 0,
@@ -908,9 +940,9 @@
       "variant": "candidate",
       "workload": "article",
       "repetition": 3,
-      "elapsedMs": 47.2450000000008,
-      "compactEnvelopeChars": 2738,
-      "pipedEnvelopeChars": 2738,
+      "elapsedMs": 48.649083000000246,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
       "automaticUIChars": 2380,
       "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
     },
@@ -918,7 +950,7 @@
       "variant": "baseline",
       "workload": "article",
       "repetition": 3,
-      "elapsedMs": 48.8693749999984,
+      "elapsedMs": 46.07337499999994,
       "compactEnvelopeChars": 4331,
       "pipedEnvelopeChars": 8855,
       "automaticUIChars": 3971,
@@ -928,9 +960,9 @@
       "variant": "candidate",
       "workload": "form",
       "repetition": 3,
-      "elapsedMs": 387.6250830000008,
-      "compactEnvelopeChars": 973,
-      "pipedEnvelopeChars": 973,
+      "elapsedMs": 330.22799999999916,
+      "compactEnvelopeChars": 971,
+      "pipedEnvelopeChars": 971,
       "automaticUIChars": 684,
       "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
     },
@@ -938,7 +970,7 @@
       "variant": "baseline",
       "workload": "form",
       "repetition": 3,
-      "elapsedMs": 366.73391600000105,
+      "elapsedMs": 405.0528750000012,
       "compactEnvelopeChars": 1022,
       "pipedEnvelopeChars": 1864,
       "automaticUIChars": 733,
@@ -948,7 +980,7 @@
       "variant": "candidate",
       "workload": "table",
       "repetition": 3,
-      "elapsedMs": 99.77087500000016,
+      "elapsedMs": 97.1142920000002,
       "compactEnvelopeChars": 744,
       "pipedEnvelopeChars": 744,
       "automaticUIChars": 377,
@@ -965,7 +997,7 @@
       "variant": "baseline",
       "workload": "table",
       "repetition": 3,
-      "elapsedMs": 73.41279199999917,
+      "elapsedMs": 72.1049579999999,
       "compactEnvelopeChars": 813,
       "pipedEnvelopeChars": 1471,
       "automaticUIChars": 446,
@@ -982,7 +1014,7 @@
       "variant": "candidate",
       "workload": "deferred",
       "repetition": 3,
-      "elapsedMs": 225.0044170000001,
+      "elapsedMs": 230.33470800000032,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 236,
       "automaticUIChars": 0,
@@ -992,7 +1024,7 @@
       "variant": "baseline",
       "workload": "deferred",
       "repetition": 3,
-      "elapsedMs": 850.5811250000006,
+      "elapsedMs": 859.3077499999999,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 318,
       "automaticUIChars": 0,
@@ -1002,7 +1034,7 @@
       "variant": "candidate",
       "workload": "directory",
       "repetition": 3,
-      "elapsedMs": 46.878209000000425,
+      "elapsedMs": 53.20804099999987,
       "compactEnvelopeChars": 837,
       "pipedEnvelopeChars": 837,
       "automaticUIChars": 0,
@@ -1088,7 +1120,7 @@
       "variant": "baseline",
       "workload": "directory",
       "repetition": 3,
-      "elapsedMs": 51.93183300000055,
+      "elapsedMs": 45.432333000000654,
       "compactEnvelopeChars": 1478,
       "pipedEnvelopeChars": 3056,
       "automaticUIChars": 635,
@@ -1174,7 +1206,7 @@
       "variant": "baseline",
       "workload": "article",
       "repetition": 4,
-      "elapsedMs": 46.81291699999929,
+      "elapsedMs": 48.06287499999962,
       "compactEnvelopeChars": 4331,
       "pipedEnvelopeChars": 8855,
       "automaticUIChars": 3971,
@@ -1184,1071 +1216,7 @@
       "variant": "candidate",
       "workload": "article",
       "repetition": 4,
-      "elapsedMs": 46.895541999998386,
-      "compactEnvelopeChars": 2740,
-      "pipedEnvelopeChars": 2740,
-      "automaticUIChars": 2380,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "baseline",
-      "workload": "form",
-      "repetition": 4,
-      "elapsedMs": 370.75987499999974,
-      "compactEnvelopeChars": 1022,
-      "pipedEnvelopeChars": 1864,
-      "automaticUIChars": 733,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "candidate",
-      "workload": "form",
-      "repetition": 4,
-      "elapsedMs": 383.8160829999997,
-      "compactEnvelopeChars": 973,
-      "pipedEnvelopeChars": 973,
-      "automaticUIChars": 684,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "baseline",
-      "workload": "table",
-      "repetition": 4,
-      "elapsedMs": 66.1763749999991,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
-      "automaticUIChars": 446,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "candidate",
-      "workload": "table",
-      "repetition": 4,
-      "elapsedMs": 82.32941600000049,
-      "compactEnvelopeChars": 744,
-      "pipedEnvelopeChars": 744,
-      "automaticUIChars": 377,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "baseline",
-      "workload": "deferred",
-      "repetition": 4,
-      "elapsedMs": 850.05825,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 318,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "candidate",
-      "workload": "deferred",
-      "repetition": 4,
-      "elapsedMs": 226.83550000000105,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 236,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "baseline",
-      "workload": "directory",
-      "repetition": 4,
-      "elapsedMs": 51.11120800000026,
-      "compactEnvelopeChars": 1478,
-      "pipedEnvelopeChars": 3056,
-      "automaticUIChars": 635,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "candidate",
-      "workload": "directory",
-      "repetition": 4,
-      "elapsedMs": 44.40162500000042,
-      "compactEnvelopeChars": 837,
-      "pipedEnvelopeChars": 837,
-      "automaticUIChars": 0,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "candidate",
-      "workload": "article",
-      "repetition": 5,
-      "elapsedMs": 48.66479199999958,
-      "compactEnvelopeChars": 2740,
-      "pipedEnvelopeChars": 2740,
-      "automaticUIChars": 2380,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "baseline",
-      "workload": "article",
-      "repetition": 5,
-      "elapsedMs": 48.48991700000079,
-      "compactEnvelopeChars": 4331,
-      "pipedEnvelopeChars": 8855,
-      "automaticUIChars": 3971,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "candidate",
-      "workload": "form",
-      "repetition": 5,
-      "elapsedMs": 372.15841700000055,
-      "compactEnvelopeChars": 973,
-      "pipedEnvelopeChars": 973,
-      "automaticUIChars": 684,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "baseline",
-      "workload": "form",
-      "repetition": 5,
-      "elapsedMs": 372.7737080000006,
-      "compactEnvelopeChars": 1022,
-      "pipedEnvelopeChars": 1864,
-      "automaticUIChars": 733,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "candidate",
-      "workload": "table",
-      "repetition": 5,
-      "elapsedMs": 68.03395900000032,
-      "compactEnvelopeChars": 744,
-      "pipedEnvelopeChars": 744,
-      "automaticUIChars": 377,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "baseline",
-      "workload": "table",
-      "repetition": 5,
-      "elapsedMs": 58.37216699999772,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
-      "automaticUIChars": 446,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "candidate",
-      "workload": "deferred",
-      "repetition": 5,
-      "elapsedMs": 221.75124999999753,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 236,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "baseline",
-      "workload": "deferred",
-      "repetition": 5,
-      "elapsedMs": 849.0656249999993,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 318,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "candidate",
-      "workload": "directory",
-      "repetition": 5,
-      "elapsedMs": 55.256790999999794,
-      "compactEnvelopeChars": 837,
-      "pipedEnvelopeChars": 837,
-      "automaticUIChars": 0,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "baseline",
-      "workload": "directory",
-      "repetition": 5,
-      "elapsedMs": 52.808249999998225,
-      "compactEnvelopeChars": 1478,
-      "pipedEnvelopeChars": 3056,
-      "automaticUIChars": 635,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "baseline",
-      "workload": "article",
-      "repetition": 6,
-      "elapsedMs": 44.98004200000287,
-      "compactEnvelopeChars": 4331,
-      "pipedEnvelopeChars": 8855,
-      "automaticUIChars": 3971,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "candidate",
-      "workload": "article",
-      "repetition": 6,
-      "elapsedMs": 48.39650000000256,
-      "compactEnvelopeChars": 2740,
-      "pipedEnvelopeChars": 2740,
-      "automaticUIChars": 2380,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "baseline",
-      "workload": "form",
-      "repetition": 6,
-      "elapsedMs": 373.7307919999985,
-      "compactEnvelopeChars": 1022,
-      "pipedEnvelopeChars": 1864,
-      "automaticUIChars": 733,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "candidate",
-      "workload": "form",
-      "repetition": 6,
-      "elapsedMs": 371.7917500000003,
-      "compactEnvelopeChars": 973,
-      "pipedEnvelopeChars": 973,
-      "automaticUIChars": 684,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "baseline",
-      "workload": "table",
-      "repetition": 6,
-      "elapsedMs": 64.28512499999852,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
-      "automaticUIChars": 446,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "candidate",
-      "workload": "table",
-      "repetition": 6,
-      "elapsedMs": 76.04875000000175,
-      "compactEnvelopeChars": 744,
-      "pipedEnvelopeChars": 744,
-      "automaticUIChars": 377,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "baseline",
-      "workload": "deferred",
-      "repetition": 6,
-      "elapsedMs": 850.8112919999985,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 318,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "candidate",
-      "workload": "deferred",
-      "repetition": 6,
-      "elapsedMs": 227.30199999999968,
-      "compactEnvelopeChars": 234,
-      "pipedEnvelopeChars": 234,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "baseline",
-      "workload": "directory",
-      "repetition": 6,
-      "elapsedMs": 56.3236250000009,
-      "compactEnvelopeChars": 1476,
-      "pipedEnvelopeChars": 3054,
-      "automaticUIChars": 635,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "candidate",
-      "workload": "directory",
-      "repetition": 6,
-      "elapsedMs": 45.65983300000153,
-      "compactEnvelopeChars": 837,
-      "pipedEnvelopeChars": 837,
-      "automaticUIChars": 0,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "candidate",
-      "workload": "article",
-      "repetition": 7,
-      "elapsedMs": 47.52758400000312,
-      "compactEnvelopeChars": 2740,
-      "pipedEnvelopeChars": 2740,
-      "automaticUIChars": 2380,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "baseline",
-      "workload": "article",
-      "repetition": 7,
-      "elapsedMs": 49.80279200000223,
-      "compactEnvelopeChars": 4331,
-      "pipedEnvelopeChars": 8855,
-      "automaticUIChars": 3971,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "candidate",
-      "workload": "form",
-      "repetition": 7,
-      "elapsedMs": 363.9832920000008,
-      "compactEnvelopeChars": 973,
-      "pipedEnvelopeChars": 973,
-      "automaticUIChars": 684,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "baseline",
-      "workload": "form",
-      "repetition": 7,
-      "elapsedMs": 363.58033299999806,
-      "compactEnvelopeChars": 1022,
-      "pipedEnvelopeChars": 1864,
-      "automaticUIChars": 733,
-      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
-    },
-    {
-      "variant": "candidate",
-      "workload": "table",
-      "repetition": 7,
-      "elapsedMs": 71.21179100000154,
-      "compactEnvelopeChars": 744,
-      "pipedEnvelopeChars": 744,
-      "automaticUIChars": 377,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "baseline",
-      "workload": "table",
-      "repetition": 7,
-      "elapsedMs": 64.3761250000025,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
-      "automaticUIChars": 446,
-      "result": [
-        "Device 02OperationsYes3",
-        "Device 08OperationsYes9",
-        "Device 11OperationsYes12",
-        "Device 14OperationsYes15",
-        "Device 20OperationsYes21",
-        "Device 23OperationsYes24"
-      ]
-    },
-    {
-      "variant": "candidate",
-      "workload": "deferred",
-      "repetition": 7,
-      "elapsedMs": 225.2502080000013,
-      "compactEnvelopeChars": 234,
-      "pipedEnvelopeChars": 234,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "baseline",
-      "workload": "deferred",
-      "repetition": 7,
-      "elapsedMs": 852.746916,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 318,
-      "automaticUIChars": 0,
-      "result": "Report ready: 24 records"
-    },
-    {
-      "variant": "candidate",
-      "workload": "directory",
-      "repetition": 7,
-      "elapsedMs": 47.37837500000023,
-      "compactEnvelopeChars": 837,
-      "pipedEnvelopeChars": 837,
-      "automaticUIChars": 0,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "baseline",
-      "workload": "directory",
-      "repetition": 7,
-      "elapsedMs": 51.25483299999905,
-      "compactEnvelopeChars": 1476,
-      "pipedEnvelopeChars": 3054,
-      "automaticUIChars": 635,
-      "result": {
-        "protocol": "betterwright-ui/1",
-        "tool": "browser_batch",
-        "controls": [
-          {
-            "target": {
-              "label": "Display name",
-              "exact": true
-            },
-            "actions": [
-              "fill",
-              "read"
-            ]
-          },
-          {
-            "target": {
-              "role": "combobox",
-              "name": "Department",
-              "exact": true
-            },
-            "actions": [
-              "select",
-              "read"
-            ],
-            "value": "Engineering",
-            "options": [
-              [
-                "Engineering",
-                "Engineering",
-                true
-              ],
-              [
-                "Operations",
-                "Operations",
-                false
-              ],
-              [
-                "Design",
-                "Design",
-                false
-              ]
-            ]
-          },
-          {
-            "target": {
-              "label": "Weekly digest",
-              "exact": true
-            },
-            "actions": [
-              "check",
-              "read"
-            ],
-            "value": "on",
-            "checked": false
-          },
-          {
-            "target": {
-              "role": "button",
-              "name": "Save preferences",
-              "exact": true
-            },
-            "actions": [
-              "click",
-              "read"
-            ]
-          }
-        ],
-        "evidence": [
-          {
-            "target": {
-              "role": "status"
-            },
-            "text": ""
-          }
-        ],
-        "truncated": false
-      }
-    },
-    {
-      "variant": "baseline",
-      "workload": "article",
-      "repetition": 8,
-      "elapsedMs": 56.83770799999911,
-      "compactEnvelopeChars": 4331,
-      "pipedEnvelopeChars": 8855,
-      "automaticUIChars": 3971,
-      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
-    },
-    {
-      "variant": "candidate",
-      "workload": "article",
-      "repetition": 8,
-      "elapsedMs": 47.2777079999978,
+      "elapsedMs": 47.33270899999843,
       "compactEnvelopeChars": 2738,
       "pipedEnvelopeChars": 2738,
       "automaticUIChars": 2380,
@@ -2257,8 +1225,8 @@
     {
       "variant": "baseline",
       "workload": "form",
-      "repetition": 8,
-      "elapsedMs": 382.06383300000016,
+      "repetition": 4,
+      "elapsedMs": 264.7199999999975,
       "compactEnvelopeChars": 1022,
       "pipedEnvelopeChars": 1864,
       "automaticUIChars": 733,
@@ -2267,8 +1235,8 @@
     {
       "variant": "candidate",
       "workload": "form",
-      "repetition": 8,
-      "elapsedMs": 264.46887499999866,
+      "repetition": 4,
+      "elapsedMs": 279.22291699999914,
       "compactEnvelopeChars": 973,
       "pipedEnvelopeChars": 973,
       "automaticUIChars": 684,
@@ -2277,8 +1245,540 @@
     {
       "variant": "baseline",
       "workload": "table",
-      "repetition": 8,
-      "elapsedMs": 69.5391660000023,
+      "repetition": 4,
+      "elapsedMs": 68.3049170000013,
+      "compactEnvelopeChars": 811,
+      "pipedEnvelopeChars": 1469,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 4,
+      "elapsedMs": 58.40679099999761,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 4,
+      "elapsedMs": 855.5740829999995,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 4,
+      "elapsedMs": 258.70279200000004,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 4,
+      "elapsedMs": 60.62158400000044,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 4,
+      "elapsedMs": 42.3035830000008,
+      "compactEnvelopeChars": 835,
+      "pipedEnvelopeChars": 835,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 5,
+      "elapsedMs": 44.83233299999847,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 5,
+      "elapsedMs": 45.61191599999802,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 5,
+      "elapsedMs": 355.02879199999734,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 5,
+      "elapsedMs": 391.54475000000093,
+      "compactEnvelopeChars": 1020,
+      "pipedEnvelopeChars": 1862,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 5,
+      "elapsedMs": 139.6762920000001,
+      "compactEnvelopeChars": 745,
+      "pipedEnvelopeChars": 745,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 5,
+      "elapsedMs": 76.48112499999843,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 5,
+      "elapsedMs": 255.83083400000032,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 5,
+      "elapsedMs": 858.7384590000001,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 5,
+      "elapsedMs": 45.40412500000093,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 5,
+      "elapsedMs": 47.865624999998545,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 6,
+      "elapsedMs": 43.47745800000121,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 6,
+      "elapsedMs": 46.2478340000016,
+      "compactEnvelopeChars": 2738,
+      "pipedEnvelopeChars": 2738,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 6,
+      "elapsedMs": 497.3110839999972,
+      "compactEnvelopeChars": 1020,
+      "pipedEnvelopeChars": 1862,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 6,
+      "elapsedMs": 393.3859999999986,
+      "compactEnvelopeChars": 971,
+      "pipedEnvelopeChars": 971,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 6,
+      "elapsedMs": 93.84270900000047,
       "compactEnvelopeChars": 813,
       "pipedEnvelopeChars": 1471,
       "automaticUIChars": 446,
@@ -2294,8 +1794,540 @@
     {
       "variant": "candidate",
       "workload": "table",
+      "repetition": 6,
+      "elapsedMs": 82.13141699999687,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 6,
+      "elapsedMs": 857.0584579999995,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 6,
+      "elapsedMs": 237.12820799999827,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 6,
+      "elapsedMs": 65.3059170000015,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 6,
+      "elapsedMs": 45.122041999999055,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 7,
+      "elapsedMs": 43.480124999998225,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 7,
+      "elapsedMs": 46.682542000002286,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 7,
+      "elapsedMs": 360.7324589999989,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 7,
+      "elapsedMs": 393.1534580000007,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 7,
+      "elapsedMs": 75.87225000000035,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 7,
+      "elapsedMs": 69.23174999999901,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 7,
+      "elapsedMs": 225.49687500000073,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 7,
+      "elapsedMs": 870.1082080000015,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 7,
+      "elapsedMs": 57.79504100000122,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 7,
+      "elapsedMs": 44.97075000000041,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
       "repetition": 8,
-      "elapsedMs": 73.9353749999973,
+      "elapsedMs": 45.873084000002564,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 8,
+      "elapsedMs": 48.47070800000074,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 8,
+      "elapsedMs": 365.40016599999944,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 8,
+      "elapsedMs": 385.9108750000014,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 8,
+      "elapsedMs": 103.96812499999942,
+      "compactEnvelopeChars": 814,
+      "pipedEnvelopeChars": 1472,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 8,
+      "elapsedMs": 69.63087500000256,
       "compactEnvelopeChars": 744,
       "pipedEnvelopeChars": 744,
       "automaticUIChars": 377,
@@ -2312,9 +2344,9 @@
       "variant": "baseline",
       "workload": "deferred",
       "repetition": 8,
-      "elapsedMs": 849.5917499999996,
-      "compactEnvelopeChars": 236,
-      "pipedEnvelopeChars": 318,
+      "elapsedMs": 1924.4412920000032,
+      "compactEnvelopeChars": 237,
+      "pipedEnvelopeChars": 319,
       "automaticUIChars": 0,
       "result": "Report ready: 24 records"
     },
@@ -2322,7 +2354,7 @@
       "variant": "candidate",
       "workload": "deferred",
       "repetition": 8,
-      "elapsedMs": 259.5966249999983,
+      "elapsedMs": 393.2467089999991,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 236,
       "automaticUIChars": 0,
@@ -2332,7 +2364,7 @@
       "variant": "baseline",
       "workload": "directory",
       "repetition": 8,
-      "elapsedMs": 48.740874999999505,
+      "elapsedMs": 63.616375000001426,
       "compactEnvelopeChars": 1478,
       "pipedEnvelopeChars": 3056,
       "automaticUIChars": 635,
@@ -2418,7 +2450,7 @@
       "variant": "candidate",
       "workload": "directory",
       "repetition": 8,
-      "elapsedMs": 44.32404200000019,
+      "elapsedMs": 45.85133300000234,
       "compactEnvelopeChars": 837,
       "pipedEnvelopeChars": 837,
       "automaticUIChars": 0,
@@ -2504,9 +2536,9 @@
       "variant": "candidate",
       "workload": "article",
       "repetition": 9,
-      "elapsedMs": 47.16679199999999,
-      "compactEnvelopeChars": 2738,
-      "pipedEnvelopeChars": 2738,
+      "elapsedMs": 47.49304200000188,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
       "automaticUIChars": 2380,
       "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
     },
@@ -2514,7 +2546,7 @@
       "variant": "baseline",
       "workload": "article",
       "repetition": 9,
-      "elapsedMs": 50.76841599999898,
+      "elapsedMs": 47.23829200000182,
       "compactEnvelopeChars": 4331,
       "pipedEnvelopeChars": 8855,
       "automaticUIChars": 3971,
@@ -2524,7 +2556,7 @@
       "variant": "candidate",
       "workload": "form",
       "repetition": 9,
-      "elapsedMs": 380.66425000000163,
+      "elapsedMs": 338.03391700000066,
       "compactEnvelopeChars": 973,
       "pipedEnvelopeChars": 973,
       "automaticUIChars": 684,
@@ -2534,7 +2566,7 @@
       "variant": "baseline",
       "workload": "form",
       "repetition": 9,
-      "elapsedMs": 364.52829100000235,
+      "elapsedMs": 418.6958339999983,
       "compactEnvelopeChars": 1022,
       "pipedEnvelopeChars": 1864,
       "automaticUIChars": 733,
@@ -2544,9 +2576,9 @@
       "variant": "candidate",
       "workload": "table",
       "repetition": 9,
-      "elapsedMs": 67.63141699999687,
-      "compactEnvelopeChars": 744,
-      "pipedEnvelopeChars": 744,
+      "elapsedMs": 308.86391699999876,
+      "compactEnvelopeChars": 745,
+      "pipedEnvelopeChars": 745,
       "automaticUIChars": 377,
       "result": [
         "Device 02OperationsYes3",
@@ -2561,9 +2593,9 @@
       "variant": "baseline",
       "workload": "table",
       "repetition": 9,
-      "elapsedMs": 66.93845800000054,
-      "compactEnvelopeChars": 813,
-      "pipedEnvelopeChars": 1471,
+      "elapsedMs": 120.8996670000015,
+      "compactEnvelopeChars": 814,
+      "pipedEnvelopeChars": 1472,
       "automaticUIChars": 446,
       "result": [
         "Device 02OperationsYes3",
@@ -2578,7 +2610,7 @@
       "variant": "candidate",
       "workload": "deferred",
       "repetition": 9,
-      "elapsedMs": 226.11358400000245,
+      "elapsedMs": 229.0723340000004,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 236,
       "automaticUIChars": 0,
@@ -2588,7 +2620,7 @@
       "variant": "baseline",
       "workload": "deferred",
       "repetition": 9,
-      "elapsedMs": 853.9733750000014,
+      "elapsedMs": 856.997292,
       "compactEnvelopeChars": 236,
       "pipedEnvelopeChars": 318,
       "automaticUIChars": 0,
@@ -2598,7 +2630,7 @@
       "variant": "candidate",
       "workload": "directory",
       "repetition": 9,
-      "elapsedMs": 48.556791999999405,
+      "elapsedMs": 49.31450000000041,
       "compactEnvelopeChars": 837,
       "pipedEnvelopeChars": 837,
       "automaticUIChars": 0,
@@ -2684,7 +2716,7 @@
       "variant": "baseline",
       "workload": "directory",
       "repetition": 9,
-      "elapsedMs": 45.993624999999156,
+      "elapsedMs": 43.81850000000122,
       "compactEnvelopeChars": 1478,
       "pipedEnvelopeChars": 3056,
       "automaticUIChars": 635,

--- a/benchmarks/navigation-context/results.json
+++ b/benchmarks/navigation-context/results.json
@@ -1,0 +1,2770 @@
+{
+  "startedAt": "2026-09-10T22:08:35.862Z",
+  "finishedAt": "2026-09-10T22:09:02.691Z",
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpu": "Apple M4 Max",
+    "bun": "1.4.0"
+  },
+  "browserSha256": "0c942f4891ea6bf8c83fe9ff278b1a032c40033aa769ae69f7fd83021f98fb24",
+  "fixtureSha256": "c11e0642e8d6fddc2e28f433c780dc737faeabd77782a80baaca930d8d51699f",
+  "config": {
+    "repetitions": 10,
+    "warmupPairs": 1,
+    "defaultOptions": true,
+    "pipedSerializationSimulated": true,
+    "deferredResourceMs": 800,
+    "promptsUnchanged": true
+  },
+  "identities": {
+    "baseline": {
+      "head": "8a87ae6e44341204803c84085bf72b706a0e92fc",
+      "diffSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "workerSha256": "a21568aaa52d1802f410ee9c4d00404739f94cff3e388e9487d5e7eea881504c"
+    },
+    "candidate": {
+      "head": "8a87ae6e44341204803c84085bf72b706a0e92fc",
+      "diffSha256": "b79885f073368b58b5115fdf29c9cf4e17bb7711c8ede3f3a16c61219d48bcfa",
+      "workerSha256": "35793c9ae2aa11ce03e8f596b8d5bb2085d7891e13be23f0dfee67df5bccfa2a"
+    }
+  },
+  "promptHashes": {
+    "baseline": "147212b84f3feaf02745355260e9b9a045375e3ae7196aa8efe9328bb80c42e2",
+    "candidate": "147212b84f3feaf02745355260e9b9a045375e3ae7196aa8efe9328bb80c42e2"
+  },
+  "summary": {
+    "article": {
+      "baseline": {
+        "medianMs": 48.67964599999959,
+        "medianPipedChars": 8855,
+        "medianCompactChars": 4331,
+        "resultParity": true
+      },
+      "candidate": {
+        "medianMs": 47.40264600000046,
+        "medianPipedChars": 2740,
+        "medianCompactChars": 2740,
+        "resultParity": true
+      }
+    },
+    "form": {
+      "baseline": {
+        "medianMs": 368.7468955000004,
+        "medianPipedChars": 1864,
+        "medianCompactChars": 1022,
+        "resultParity": true
+      },
+      "candidate": {
+        "medianMs": 372.60058350000054,
+        "medianPipedChars": 973,
+        "medianCompactChars": 973,
+        "resultParity": true
+      }
+    },
+    "table": {
+      "baseline": {
+        "medianMs": 66.55741649999982,
+        "medianPipedChars": 1471,
+        "medianCompactChars": 813,
+        "resultParity": true
+      },
+      "candidate": {
+        "medianMs": 72.50202100000024,
+        "medianPipedChars": 744,
+        "medianCompactChars": 744,
+        "resultParity": true
+      }
+    },
+    "deferred": {
+      "baseline": {
+        "medianMs": 850.3196875000003,
+        "medianPipedChars": 318,
+        "medianCompactChars": 236,
+        "resultParity": true
+      },
+      "candidate": {
+        "medianMs": 225.68189600000187,
+        "medianPipedChars": 236,
+        "medianCompactChars": 236,
+        "resultParity": true
+      }
+    },
+    "directory": {
+      "baseline": {
+        "medianMs": 50.91279149999991,
+        "medianPipedChars": 3056,
+        "medianCompactChars": 1478,
+        "resultParity": true
+      },
+      "candidate": {
+        "medianMs": 46.69135449999976,
+        "medianPipedChars": 837,
+        "medianCompactChars": 837,
+        "resultParity": true
+      }
+    }
+  },
+  "samples": [
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 0,
+      "elapsedMs": 47.80904199999986,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 0,
+      "elapsedMs": 53.67433299999993,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 0,
+      "elapsedMs": 380.1554580000002,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 0,
+      "elapsedMs": 373.0427500000005,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 0,
+      "elapsedMs": 86.6155830000007,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 0,
+      "elapsedMs": 71.70924999999988,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 0,
+      "elapsedMs": 847.941417,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 0,
+      "elapsedMs": 233.09020800000053,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 0,
+      "elapsedMs": 50.71437499999956,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 0,
+      "elapsedMs": 45.38995799999975,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 1,
+      "elapsedMs": 45.58191699999952,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 1,
+      "elapsedMs": 50.022375000000466,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 1,
+      "elapsedMs": 367.77141699999993,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 1,
+      "elapsedMs": 364.1736659999997,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 1,
+      "elapsedMs": 70.21179100000063,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 1,
+      "elapsedMs": 65.86937500000022,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 1,
+      "elapsedMs": 222.38458300000093,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 1,
+      "elapsedMs": 849.1908329999987,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 1,
+      "elapsedMs": 46.5044999999991,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 1,
+      "elapsedMs": 48.944250000000466,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 2,
+      "elapsedMs": 46.88441700000112,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 2,
+      "elapsedMs": 50.59970799999974,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 2,
+      "elapsedMs": 364.6087919999991,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 2,
+      "elapsedMs": 378.2791669999988,
+      "compactEnvelopeChars": 971,
+      "pipedEnvelopeChars": 971,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 2,
+      "elapsedMs": 68.19279099999949,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 2,
+      "elapsedMs": 73.2947920000006,
+      "compactEnvelopeChars": 742,
+      "pipedEnvelopeChars": 742,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 2,
+      "elapsedMs": 850.7257499999996,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 2,
+      "elapsedMs": 222.8227910000005,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 2,
+      "elapsedMs": 50.55341700000099,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 2,
+      "elapsedMs": 48.167208999999275,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 3,
+      "elapsedMs": 47.2450000000008,
+      "compactEnvelopeChars": 2738,
+      "pipedEnvelopeChars": 2738,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 3,
+      "elapsedMs": 48.8693749999984,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 3,
+      "elapsedMs": 387.6250830000008,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 3,
+      "elapsedMs": 366.73391600000105,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 3,
+      "elapsedMs": 99.77087500000016,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 3,
+      "elapsedMs": 73.41279199999917,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 3,
+      "elapsedMs": 225.0044170000001,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 3,
+      "elapsedMs": 850.5811250000006,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 3,
+      "elapsedMs": 46.878209000000425,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 3,
+      "elapsedMs": 51.93183300000055,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 4,
+      "elapsedMs": 46.81291699999929,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 4,
+      "elapsedMs": 46.895541999998386,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 4,
+      "elapsedMs": 370.75987499999974,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 4,
+      "elapsedMs": 383.8160829999997,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 4,
+      "elapsedMs": 66.1763749999991,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 4,
+      "elapsedMs": 82.32941600000049,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 4,
+      "elapsedMs": 850.05825,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 4,
+      "elapsedMs": 226.83550000000105,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 4,
+      "elapsedMs": 51.11120800000026,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 4,
+      "elapsedMs": 44.40162500000042,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 5,
+      "elapsedMs": 48.66479199999958,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 5,
+      "elapsedMs": 48.48991700000079,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 5,
+      "elapsedMs": 372.15841700000055,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 5,
+      "elapsedMs": 372.7737080000006,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 5,
+      "elapsedMs": 68.03395900000032,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 5,
+      "elapsedMs": 58.37216699999772,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 5,
+      "elapsedMs": 221.75124999999753,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 5,
+      "elapsedMs": 849.0656249999993,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 5,
+      "elapsedMs": 55.256790999999794,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 5,
+      "elapsedMs": 52.808249999998225,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 6,
+      "elapsedMs": 44.98004200000287,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 6,
+      "elapsedMs": 48.39650000000256,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 6,
+      "elapsedMs": 373.7307919999985,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 6,
+      "elapsedMs": 371.7917500000003,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 6,
+      "elapsedMs": 64.28512499999852,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 6,
+      "elapsedMs": 76.04875000000175,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 6,
+      "elapsedMs": 850.8112919999985,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 6,
+      "elapsedMs": 227.30199999999968,
+      "compactEnvelopeChars": 234,
+      "pipedEnvelopeChars": 234,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 6,
+      "elapsedMs": 56.3236250000009,
+      "compactEnvelopeChars": 1476,
+      "pipedEnvelopeChars": 3054,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 6,
+      "elapsedMs": 45.65983300000153,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 7,
+      "elapsedMs": 47.52758400000312,
+      "compactEnvelopeChars": 2740,
+      "pipedEnvelopeChars": 2740,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 7,
+      "elapsedMs": 49.80279200000223,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 7,
+      "elapsedMs": 363.9832920000008,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 7,
+      "elapsedMs": 363.58033299999806,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 7,
+      "elapsedMs": 71.21179100000154,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 7,
+      "elapsedMs": 64.3761250000025,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 7,
+      "elapsedMs": 225.2502080000013,
+      "compactEnvelopeChars": 234,
+      "pipedEnvelopeChars": 234,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 7,
+      "elapsedMs": 852.746916,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 7,
+      "elapsedMs": 47.37837500000023,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 7,
+      "elapsedMs": 51.25483299999905,
+      "compactEnvelopeChars": 1476,
+      "pipedEnvelopeChars": 3054,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 8,
+      "elapsedMs": 56.83770799999911,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 8,
+      "elapsedMs": 47.2777079999978,
+      "compactEnvelopeChars": 2738,
+      "pipedEnvelopeChars": 2738,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 8,
+      "elapsedMs": 382.06383300000016,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 8,
+      "elapsedMs": 264.46887499999866,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 8,
+      "elapsedMs": 69.5391660000023,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 8,
+      "elapsedMs": 73.9353749999973,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 8,
+      "elapsedMs": 849.5917499999996,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 8,
+      "elapsedMs": 259.5966249999983,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 8,
+      "elapsedMs": 48.740874999999505,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 8,
+      "elapsedMs": 44.32404200000019,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "candidate",
+      "workload": "article",
+      "repetition": 9,
+      "elapsedMs": 47.16679199999999,
+      "compactEnvelopeChars": 2738,
+      "pipedEnvelopeChars": 2738,
+      "automaticUIChars": 2380,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "baseline",
+      "workload": "article",
+      "repetition": 9,
+      "elapsedMs": 50.76841599999898,
+      "compactEnvelopeChars": 4331,
+      "pipedEnvelopeChars": 8855,
+      "automaticUIChars": 3971,
+      "result": "Retention policy\n\nStandard records are retained for 45 days. Archived records are retained for 180 days. Export requests finish within 12 hours."
+    },
+    {
+      "variant": "candidate",
+      "workload": "form",
+      "repetition": 9,
+      "elapsedMs": 380.66425000000163,
+      "compactEnvelopeChars": 973,
+      "pipedEnvelopeChars": 973,
+      "automaticUIChars": 684,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "baseline",
+      "workload": "form",
+      "repetition": 9,
+      "elapsedMs": 364.52829100000235,
+      "compactEnvelopeChars": 1022,
+      "pipedEnvelopeChars": 1864,
+      "automaticUIChars": 733,
+      "result": "Saved: {\"displayName\":\"Taylor\",\"department\":\"Operations\",\"digest\":\"on\"}"
+    },
+    {
+      "variant": "candidate",
+      "workload": "table",
+      "repetition": 9,
+      "elapsedMs": 67.63141699999687,
+      "compactEnvelopeChars": 744,
+      "pipedEnvelopeChars": 744,
+      "automaticUIChars": 377,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "baseline",
+      "workload": "table",
+      "repetition": 9,
+      "elapsedMs": 66.93845800000054,
+      "compactEnvelopeChars": 813,
+      "pipedEnvelopeChars": 1471,
+      "automaticUIChars": 446,
+      "result": [
+        "Device 02OperationsYes3",
+        "Device 08OperationsYes9",
+        "Device 11OperationsYes12",
+        "Device 14OperationsYes15",
+        "Device 20OperationsYes21",
+        "Device 23OperationsYes24"
+      ]
+    },
+    {
+      "variant": "candidate",
+      "workload": "deferred",
+      "repetition": 9,
+      "elapsedMs": 226.11358400000245,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 236,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "baseline",
+      "workload": "deferred",
+      "repetition": 9,
+      "elapsedMs": 853.9733750000014,
+      "compactEnvelopeChars": 236,
+      "pipedEnvelopeChars": 318,
+      "automaticUIChars": 0,
+      "result": "Report ready: 24 records"
+    },
+    {
+      "variant": "candidate",
+      "workload": "directory",
+      "repetition": 9,
+      "elapsedMs": 48.556791999999405,
+      "compactEnvelopeChars": 837,
+      "pipedEnvelopeChars": 837,
+      "automaticUIChars": 0,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    },
+    {
+      "variant": "baseline",
+      "workload": "directory",
+      "repetition": 9,
+      "elapsedMs": 45.993624999999156,
+      "compactEnvelopeChars": 1478,
+      "pipedEnvelopeChars": 3056,
+      "automaticUIChars": 635,
+      "result": {
+        "protocol": "betterwright-ui/1",
+        "tool": "browser_batch",
+        "controls": [
+          {
+            "target": {
+              "label": "Display name",
+              "exact": true
+            },
+            "actions": [
+              "fill",
+              "read"
+            ]
+          },
+          {
+            "target": {
+              "role": "combobox",
+              "name": "Department",
+              "exact": true
+            },
+            "actions": [
+              "select",
+              "read"
+            ],
+            "value": "Engineering",
+            "options": [
+              [
+                "Engineering",
+                "Engineering",
+                true
+              ],
+              [
+                "Operations",
+                "Operations",
+                false
+              ],
+              [
+                "Design",
+                "Design",
+                false
+              ]
+            ]
+          },
+          {
+            "target": {
+              "label": "Weekly digest",
+              "exact": true
+            },
+            "actions": [
+              "check",
+              "read"
+            ],
+            "value": "on",
+            "checked": false
+          },
+          {
+            "target": {
+              "role": "button",
+              "name": "Save preferences",
+              "exact": true
+            },
+            "actions": [
+              "click",
+              "read"
+            ]
+          }
+        ],
+        "evidence": [
+          {
+            "target": {
+              "role": "status"
+            },
+            "text": ""
+          }
+        ],
+        "truncated": false
+      }
+    }
+  ]
+}

--- a/benchmarks/navigation-context/run.ts
+++ b/benchmarks/navigation-context/run.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import type { UntrustedValue } from "../../src/untrusted-value.js";
+import { startFixtures, workloads } from "./fixtures.js";
+
+const { values } = parseArgs({ options: {
+  baseline: { type: "string" }, candidate: { type: "string" }, output: { type: "string" },
+} });
+assert.ok(values.baseline && values.candidate && values.output, "Pass --baseline, --candidate (built packages), and --output");
+assert.ok(process.env.BETTERWRIGHT_CHROMIUM_PATH, "Set BETTERWRIGHT_CHROMIUM_PATH to the shared browser executable");
+const roots = { baseline: path.resolve(values.baseline), candidate: path.resolve(values.candidate) };
+const fixture = await startFixtures();
+const browsers: Record<string, { run(code: string): Promise<any>; close(): Promise<void> }> = {};
+const homes: string[] = [];
+const samples = [];
+const repetitions = 10;
+const sha256 = (text: string | Buffer) => createHash("sha256").update(text).digest("hex");
+const promptHashes: Record<string, string> = {};
+const identities = {};
+const startedAt = new Date().toISOString();
+
+try {
+  for (const [variant, root] of Object.entries(roots)) {
+    promptHashes[variant] = sha256(await readFile(path.join(root, "SKILL.md")));
+    identities[variant] = {
+      head: execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
+      diffSha256: sha256(execFileSync("git", ["diff", "--", "src", "bin", "types"], { cwd: root })),
+      workerSha256: sha256(await readFile(path.join(root, "dist/src/worker.js"))),
+    };
+    const { BetterWright } = await import(pathToFileURL(path.join(root, "dist/src/index.js")).href);
+    const home = await mkdtemp(path.join(os.tmpdir(), "bw-navigation-context-"));
+    homes.push(home);
+    browsers[variant] = new BetterWright({ home, headless: true, vault: false });
+    const warmup = await browsers[variant].run("return 'ready'");
+    assert.equal(warmup.ok, true, warmup.error);
+  }
+  assert.equal(promptHashes.baseline, promptHashes.candidate, "Native skill must be unchanged");
+  for (let repetition = -1; repetition < repetitions; repetition++) {
+    // Alternate which build runs first. The first pair is an unrecorded warmup.
+    const order = repetition % 2 === 0 ? ["baseline", "candidate"] : ["candidate", "baseline"];
+    for (const [workload, spec] of Object.entries(workloads)) {
+      const results: Record<string, UntrustedValue> = {};
+      for (const variant of order) {
+        const route = "route" in spec ? spec.route : workload;
+        // Unique pathnames re-arm automatic discovery equally for every sample.
+        const url = `${fixture.origin}/${route}/${workload}/${repetition}`;
+        const start = performance.now();
+        const result = await browsers[variant].run(`await page.goto(${JSON.stringify(url)}); ${spec.code}`);
+        const elapsedMs = performance.now() - start;
+        assert.equal(result.ok, true, `${variant}/${workload}: ${result.error}`);
+        if (spec.expected !== null) assert.deepEqual(result.result, spec.expected, workload);
+        results[variant] = result.result;
+        // cmdRun's actual pipe serialization: pretty on the baseline, compact
+        // on the candidate. The CLI integration test verifies these formats.
+        const pipe = JSON.stringify(result, null, variant === "baseline" ? 2 : undefined);
+        if (repetition >= 0) samples.push({
+          variant, workload, repetition, elapsedMs,
+          compactEnvelopeChars: JSON.stringify(result).length,
+          pipedEnvelopeChars: pipe.length,
+          automaticUIChars: result.ui ? JSON.stringify(result.ui).length : 0,
+          result: result.result,
+        });
+      }
+      assert.deepEqual(results.candidate, results.baseline, `${workload} result parity`);
+    }
+  }
+} finally {
+  for (const browser of Object.values(browsers)) await browser.close();
+  await fixture.close();
+  for (const home of homes) await rm(home, { recursive: true, force: true });
+}
+
+const median = (values: number[]) => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return (sorted[Math.floor((sorted.length - 1) / 2)] + sorted[Math.floor(sorted.length / 2)]) / 2;
+};
+const summary = Object.fromEntries(Object.keys(workloads).map((workload) => [workload,
+  Object.fromEntries(Object.keys(roots).map((variant) => {
+    const selected = samples.filter((sample) => sample.workload === workload && sample.variant === variant);
+    return [variant, {
+      medianMs: median(selected.map((sample) => sample.elapsedMs)),
+      medianPipedChars: median(selected.map((sample) => sample.pipedEnvelopeChars)),
+      medianCompactChars: median(selected.map((sample) => sample.compactEnvelopeChars)),
+      resultParity: true,
+    }];
+  })),
+]));
+await writeFile(values.output, `${JSON.stringify({
+  startedAt, finishedAt: new Date().toISOString(),
+  host: { platform: process.platform, arch: process.arch, cpu: os.cpus()[0]?.model, bun: process.versions.bun },
+  browserSha256: sha256(await readFile(process.env.BETTERWRIGHT_CHROMIUM_PATH)),
+  fixtureSha256: sha256(await readFile(new URL("fixtures.ts", import.meta.url))),
+  config: { repetitions, warmupPairs: 1, defaultOptions: true, pipedSerializationSimulated: true, deferredResourceMs: 800, promptsUnchanged: true },
+  identities, promptHashes, summary, samples,
+}, null, 2)}\n`);
+console.log(JSON.stringify(summary, null, 2));

--- a/benchmarks/navigation-context/run.ts
+++ b/benchmarks/navigation-context/run.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,29 +7,39 @@ import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 import type { UntrustedValue } from "../../src/untrusted-value.js";
 import { startFixtures, workloads } from "./fixtures.js";
+import { assertSameSource, directoryIdentity, RUNTIME_PATHS, SOURCE_PATHS, sha256, sourceIdentity } from "./provenance.js";
 
 const { values } = parseArgs({ options: {
   baseline: { type: "string" }, candidate: { type: "string" }, output: { type: "string" },
 } });
-assert.ok(values.baseline && values.candidate && values.output, "Pass --baseline, --candidate (built packages), and --output");
+assert.ok(values.baseline && values.candidate && values.output, "Pass --baseline, --candidate (clean source checkouts with dependencies installed), and --output");
 assert.ok(process.env.BETTERWRIGHT_CHROMIUM_PATH, "Set BETTERWRIGHT_CHROMIUM_PATH to the shared browser executable");
 const roots = { baseline: path.resolve(values.baseline), candidate: path.resolve(values.candidate) };
-const fixture = await startFixtures();
 const browsers: Record<string, { run(code: string): Promise<any>; close(): Promise<void> }> = {};
 const homes: string[] = [];
 const samples = [];
 const repetitions = 10;
-const sha256 = (text: string | Buffer) => createHash("sha256").update(text).digest("hex");
 const promptHashes: Record<string, string> = {};
-const identities = {};
+type BuildIdentity = ReturnType<typeof sourceIdentity> & { build: Awaited<ReturnType<typeof directoryIdentity>>; workerSha256: string };
+const identities: Record<string, BuildIdentity> = {};
+const baselineHead = sourceIdentity(roots.baseline).head;
+const browserSha256 = sha256(await readFile(process.env.BETTERWRIGHT_CHROMIUM_PATH));
+const harnessHash = async () => sha256(JSON.stringify(await Promise.all(["run.ts", "provenance.ts", "fixtures.ts"].map(async (name) => [name, sha256(await readFile(new URL(name, import.meta.url)))]))));
+const harnessSha256 = await harnessHash();
 const startedAt = new Date().toISOString();
+const fixture = await startFixtures();
 
 try {
   for (const [variant, root] of Object.entries(roots)) {
     promptHashes[variant] = sha256(await readFile(path.join(root, "SKILL.md")));
+    const source = sourceIdentity(root, baselineHead);
+    // Rebuild before importing either runtime; a clean checkout alone cannot
+    // prove that an existing dist/ was produced from that checkout.
+    execFileSync(process.execPath, ["run", "build"], { cwd: root, stdio: "pipe" });
+    assert.deepEqual(sourceIdentity(root, baselineHead), source, "Build changed source inputs");
     identities[variant] = {
-      head: execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
-      diffSha256: sha256(execFileSync("git", ["diff", "--", "src", "bin", "types"], { cwd: root })),
+      ...source,
+      build: await directoryIdentity(path.join(root, "dist")),
       workerSha256: sha256(await readFile(path.join(root, "dist/src/worker.js"))),
     };
     const { BetterWright } = await import(pathToFileURL(path.join(root, "dist/src/index.js")).href);
@@ -76,6 +85,15 @@ try {
   for (const home of homes) await rm(home, { recursive: true, force: true });
 }
 
+for (const [variant, root] of Object.entries(roots)) {
+  const current = sourceIdentity(root, baselineHead);
+  assert.equal(current.head, identities[variant].head, "Source revision changed during measurement");
+  assertSameSource(identities[variant], current);
+  assert.deepEqual(await directoryIdentity(path.join(root, "dist")), identities[variant].build, "Build artifacts changed during measurement");
+}
+assert.equal(await harnessHash(), harnessSha256, "Benchmark code changed during measurement");
+assert.equal(sha256(await readFile(process.env.BETTERWRIGHT_CHROMIUM_PATH)), browserSha256, "Browser changed during measurement");
+
 const median = (values: number[]) => {
   const sorted = [...values].sort((a, b) => a - b);
   return (sorted[Math.floor((sorted.length - 1) / 2)] + sorted[Math.floor(sorted.length / 2)]) / 2;
@@ -92,11 +110,12 @@ const summary = Object.fromEntries(Object.keys(workloads).map((workload) => [wor
   })),
 ]));
 await writeFile(values.output, `${JSON.stringify({
+  schemaVersion: 2,
   startedAt, finishedAt: new Date().toISOString(),
   host: { platform: process.platform, arch: process.arch, cpu: os.cpus()[0]?.model, bun: process.versions.bun },
-  browserSha256: sha256(await readFile(process.env.BETTERWRIGHT_CHROMIUM_PATH)),
+  browserSha256, harnessSha256,
   fixtureSha256: sha256(await readFile(new URL("fixtures.ts", import.meta.url))),
-  config: { repetitions, warmupPairs: 1, defaultOptions: true, pipedSerializationSimulated: true, deferredResourceMs: 800, promptsUnchanged: true },
+  config: { repetitions, warmupPairs: 1, defaultOptions: true, pipedSerializationSimulated: true, deferredResourceMs: 800, promptsUnchanged: true, rebuildBeforeMeasurement: true, sourcePaths: SOURCE_PATHS, runtimeDiffPaths: RUNTIME_PATHS },
   identities, promptHashes, summary, samples,
 }, null, 2)}\n`);
 console.log(JSON.stringify(summary, null, 2));

--- a/bin/cli-main.ts
+++ b/bin/cli-main.ts
@@ -603,7 +603,7 @@ async function acquireRunBrowser(flags) {
   };
 }
 
-type CliRunOptions = { session: string; approvedDownloads?: boolean };
+type CliRunOptions = { session: string; approvedDownloads?: boolean; automaticUI?: boolean };
 
 async function cmdRun(arg, flags) {
   const code = await readSnippet(arg);
@@ -616,11 +616,15 @@ async function cmdRun(arg, flags) {
       session: acquired.session,
     };
     if (flags.has("--approve-downloads")) runOptions.approvedDownloads = true;
+    if (flags.has("--no-auto-ui")) runOptions.automaticUI = false;
     const result = await acquired.browser.run(code, runOptions);
     if (acquired.viaDaemon) result.session = acquired.session;
     if (acquired.warning)
       result.warnings = [...(result.warnings || []), acquired.warning];
-    console.log(JSON.stringify(result, null, 2));
+    // Agent hosts usually pipe stdout and send it back to a model. Preserve
+    // every field without charging for indentation on every browser turn.
+    const pretty = flags.has("--pretty") || process.stdout.isTTY;
+    console.log(JSON.stringify(result, null, pretty ? 2 : undefined));
     return result.ok ? 0 : 1;
   } finally {
     await acquired.cleanup({ closeSession: flags.has("--close") });

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -29,6 +29,10 @@ await bw.run(`
   to a file and replaced with `{truncated: true, preview, fullOutputPath}`.
   That file contains the bounded summary, not the original unbounded value.
 
+`betterwright run` prints compact JSON when stdout is piped, preserving every
+field while avoiding repeated indentation in agent observations. Terminal output
+is indented by default; pass `--pretty` to retain indentation in a pipe or file.
+
 ## Pages
 
 | Global | Description |
@@ -43,6 +47,14 @@ await bw.run(`
 Pages persist across `run()` calls within the same session, so an agent can
 open a tab in one step and act on it in the next. Popups and
 `target=_blank` links are adopted automatically and appear in `pages`.
+
+Sandbox navigation (`page.goto`, `frame.goto`, `page.reload`, `page.goBack`,
+`page.goForward`, and `openPage(url)`) defaults to `waitUntil: 'domcontentloaded'`.
+Unlike Playwright's `load` default, this does not wait for every image or other
+subresource. Wait for the relevant locator before reading dynamic results.
+Explicit `waitUntil` and `timeout` options are preserved; use
+`{waitUntil: 'load'}` when the task requires all load-event resources.
+`waitForLoadState()` and `setContent()` retain their Playwright behavior.
 
 By default, idle headless pages are parked after a short delay between calls:
 their timers, animation frames, and animation timelines pause, then resume
@@ -131,6 +143,28 @@ before verifying a representation you have not observed.
 The automatic UI directory also carries visible item context, cart/output
 summaries, and target handles for empty live-status regions. These are read
 targets, not a prediction of the eventual result text.
+
+On sites without WebAgents, the automatic fallback is offered once per origin
+and pathname. Structured extractions, short acknowledgements, and summarized
+Playwright handles still receive discovery context; an extracted object does
+not establish that the caller has enough actionable state. When the snippet
+returns a `betterwright-ui/1` directory itself, the automatic duplicate is
+omitted. First-party WebAgents discovery is unchanged.
+
+The automatic directory is limited to 2,400 JSON characters before envelope
+redaction. It includes up to two evidence entries, omits select-option lists,
+and drops whole controls to fit; exact target strings are never shortened.
+`truncated: true` signals omitted data. Call `controls.directory()` for the
+full discovery limits and option lists, or use a scoped snapshot. Returning
+that directory does not append another automatic copy. Failure evidence uses
+the separate limits below.
+
+Agents returning their own scoped observations can use
+`bw.run(code, {automaticUI: false})` or `betterwright run --no-auto-ui` to omit
+the automatic UI catalog on that successful call. This does not consume its
+one-time announcement: a later default call can still receive it. On-demand
+`controls.directory()`/`snapshot()`, WebAgents discovery, challenge reporting,
+failure evidence, and redaction continue to operate normally.
 
 On an ordinary snippet failure, a live page may return a partial `ui.evidence`
 directory: at most four 300-character excerpts, collected within a 200ms budget.
@@ -444,7 +478,7 @@ plain JSON; frames with nothing to report are omitted.
 | --- | --- |
 | `overlays.dismiss()` | Close obstructing cookie-consent and promotional overlays — for cookie banners it prefers a reject/essential-only button and falls back to accept; promos get close/no-thanks. Only layers whose text matches consent or promo patterns are considered, so a task-critical dialog is never dismissed. Returns `{dismissed: [{kind, label}]}` — `kind` is `"cookie"` or `"promotion"`, `label` is the clicked control's label. |
 | `controls.inspect()` | Report the exact state of every form control — inputs, selects, textareas, and ARIA checkbox/combobox/listbox/radio/slider/spinbutton/switch roles. Returns `{frames: [{url, controls}]}`; each control carries `type`, `label`, `value` (`[redacted]` for passwords), `checked`, `selected`/`pressed`/`ariaChecked`, `min`/`max`/`step`, `disabled`, `visible`, and `options` for selects. Use it to prove a required filter or facet is actually active rather than inferring that from the results. |
-| `controls.directory()` | Return the token-small semantic action directory BetterWright automatically attaches as `result.ui` after first navigation on a site without a first-party workflow. Controls include a copyable target, supported actions, current value/options, duplicate context, and frame scope; `evidence` contains visible status/result summaries. |
+| `controls.directory()` | Return the full semantic action directory, independent of the smaller automatic `result.ui` budget. Controls include a copyable target, supported actions, current value/options, duplicate context, and frame scope; `evidence` contains visible status/result summaries. |
 | `controls.batch()` | Execute one guarded semantic UI transaction on a site without a first-party batch protocol. Targets use ARIA ref, role/name, label, text, placeholder, test id, or CSS; an optional unique frame name/URL fragment scopes an iframe. Interactions auto-wait and ambiguous targets fail closed. |
 | `media.inspect()` | Report every `<video>` and `<audio>` element with its playback state. Returns `{frames: [{url, media}]}`; each item carries `kind`, `title` (aria-label, title attribute, or nearby caption/heading), `source`, `paused`, `ended`, `currentTime`, `duration`, `readyState`, `visible`, plus the frame's `documentTitle` and visible `headings`. Use it to match what is actually playing against the requested item before claiming playback. |
 

--- a/src/automatic-ui.ts
+++ b/src/automatic-ui.ts
@@ -1,0 +1,42 @@
+import type { inspectActionDirectory } from "./page-inspect.js";
+import { type UntrustedValue, untrustedField } from "./untrusted-value.js";
+
+export const AUTOMATIC_UI_MAX_CHARS = 2_400;
+
+// Suppress only a known duplicate, not arbitrary caller data: an extracted
+// object may contain empty fields and still need actionable discovery context.
+export function hasReturnedUIDirectory(result: UntrustedValue): boolean {
+  return untrustedField(result, "protocol") === "betterwright-ui/1" &&
+    Array.isArray(untrustedField(result, "controls"));
+}
+
+type ActionDirectory = Awaited<ReturnType<typeof inspectActionDirectory>>;
+
+export function compactAutomaticUI(directory: ActionDirectory) {
+  const compact: ActionDirectory & { hint: string } = {
+    protocol: directory.protocol,
+    tool: directory.tool,
+    controls: [],
+    evidence: [],
+    truncated: directory.truncated,
+    hint: "Call controls.directory() for the full directory.",
+  };
+  const fits = () => JSON.stringify(compact).length <= AUTOMATIC_UI_MAX_CHARS;
+  // Reserve some space for observed state before the control list. Never cut a
+  // target string: shortened labels and frame selectors are not valid handles.
+  for (const entry of directory.evidence.slice(0, 2)) {
+    compact.evidence.push(entry);
+    if (!fits()) compact.evidence.pop();
+  }
+  if (compact.evidence.length < directory.evidence.length) compact.truncated = true;
+  for (const entry of directory.controls) {
+    const { options, ...control } = entry;
+    if (options) compact.truncated = true;
+    compact.controls.push(control);
+    if (!fits()) {
+      compact.controls.pop();
+      compact.truncated = true;
+    }
+  }
+  return compact;
+}

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -236,6 +236,8 @@ Options:
   --no-ad-block           disable blocking, overriding the environment
   --headed               show the browser window
   --close                close the session after this call
+  --pretty               indent JSON even when stdout is piped (terminals indent by default)
+  --no-auto-ui           omit automatic UI catalogs on successful calls; discovery remains on demand
   --approve-downloads    allow downloads for this one run
   --no-daemon            do not use the background session daemon
   --stealth              isolated-world driver (needs patchright-core)

--- a/src/client.ts
+++ b/src/client.ts
@@ -1142,7 +1142,7 @@ export class BetterWright {
   /**
    * Execute one Playwright snippet and resolve with a result object.
    * @param {string} code asynchronous Playwright JavaScript
-   * @param {object} [options] { session, note, timeout, approvedDownloads }
+   * @param {object} [options] { session, note, timeout, approvedDownloads, automaticUI }
    */
   run(code, options: any = {}) {
     if (this.hostTarget) return this._enqueueExclusive(() => {
@@ -1403,6 +1403,8 @@ export class BetterWright {
     if (options.signal?.aborted) return { ok: false, error: "Browser operation aborted.", errorCode: "BW_ABORTED", effectMayHaveCommitted: false };
     if (!isString(code) || !code.trim())
       return { ok: false, error: "code must be a non-empty string" };
+    if (options.automaticUI !== undefined && !isBoolean(options.automaticUI))
+      return { ok: false, error: "automaticUI must be a boolean" };
     const timeoutSeconds = Math.max(Number(options.timeout) || this.defaultTimeout, 5);
     const config = await this._prepare();
     return this._dispatch(
@@ -1411,6 +1413,7 @@ export class BetterWright {
         sessionId: String(options.session || "default"),
         code,
         approvedDownloads: options.approvedDownloads === true,
+        automaticUI: options.automaticUI !== false,
         timeoutMs: timeoutSeconds * 1000,
         config,
       },

--- a/src/navigation-defaults.ts
+++ b/src/navigation-defaults.ts
@@ -1,0 +1,16 @@
+import { isRecord } from "./untrusted-value.js";
+
+// Agent navigation needs a usable document, not every third-party subresource.
+// Keep explicit Playwright options (including invalid ones) for Playwright to validate.
+export function navigationOptions(options?: any): any {
+  if (options !== undefined && !isRecord(options) && !Array.isArray(options)) return options;
+  return { ...options, waitUntil: options?.waitUntil === undefined ? "domcontentloaded" : options.waitUntil };
+}
+
+export function applyNavigationDefaults(kind: string, method: string, args: any[]): void {
+  if ((kind === "Page" || kind === "Frame") && method === "goto") {
+    args[1] = navigationOptions(args[1]);
+  } else if (kind === "Page" && ["reload", "goBack", "goForward"].includes(method)) {
+    args[0] = navigationOptions(args[0]);
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17,6 +17,7 @@ import vm from "node:vm";
 import type { Page } from "playwright-core";
 import { getDomain } from "tldts";
 import type { RecordingStatus } from "../types/recording.js";
+import { compactAutomaticUI, hasReturnedUIDirectory } from "./automatic-ui.js";
 import {
   cookieSyncConsentTarget,
   redactProviderSecrets,
@@ -116,6 +117,7 @@ import {
 import { buildLaunchIdentityPlan, resolveGeoIdentity } from "./launch-identity.js";
 import { createLiveViewServer } from "./live-view.js";
 import { liveViewHtml, liveViewLoginHtml } from "./live-view-html.js";
+import { applyNavigationDefaults, navigationOptions } from "./navigation-defaults.js";
 import {
   createSnippetPageEvents,
   isSnippetPageEventMethod,
@@ -3007,6 +3009,7 @@ function wrap(value, realm) {
         const kind = objectKind(value);
         validateMethodArguments(property, prepared);
         validateMethodPaths(kind, property, prepared);
+        applyNavigationDefaults(kind, property, prepared);
         let result;
         if (kind === "Page" && property === "close") {
           result = stopPageRecording(value).then(() => member.apply(value, prepared));
@@ -4780,7 +4783,7 @@ async function unannouncedWebAgentsDirectory(session) {
   return discovered.manifest ? publicWebAgentsManifest(discovered.manifest) : null;
 }
 
-async function unannouncedUIDirectory(session) {
+async function unannouncedUIDirectory(session, result) {
   const page = session.pages.get(session.currentId);
   if (!page || page.isClosed()) return null;
   let key;
@@ -4795,8 +4798,9 @@ async function unannouncedUIDirectory(session) {
   const discovered = pageWebAgentsDiscovery.get(page);
   if (!discovered || discovered.manifest) return null;
   session.uiDirectoryAnnouncedOrigins.add(key);
+  if (hasReturnedUIDirectory(result)) return null;
   const directory = await inspectActionDirectory(page);
-  return directory.controls.length ? directory : null;
+  return directory.controls.length ? compactAutomaticUI(directory) : null;
 }
 
 async function inspectSiteAssets(page) {
@@ -4888,7 +4892,7 @@ function buildSandbox(session, consoleMessages, execution) {
     const page = adoptPage(rawPage, session.id);
     if (url) {
       assertModelNavigationUrl(url);
-      await page.goto(String(url), options);
+      await page.goto(String(url), navigationOptions(options));
     }
     return wrap(page, realm);
   });
@@ -7904,9 +7908,9 @@ async function execute(message) {
     const summarized = await summarize(result);
     const challenges = await detectSessionChallenges(session);
     const webagents = await unannouncedWebAgentsDirectory(session).catch(() => null);
-    const ui = webagents
+    const ui = webagents || message.automaticUI === false
       ? null
-      : await unannouncedUIDirectory(session).catch(() => null);
+      : await unannouncedUIDirectory(session, summarized).catch(() => null);
     await enforceArtifactQuota(session);
 
     let publicResult = summarized;

--- a/tests/node/automatic-ui.test.ts
+++ b/tests/node/automatic-ui.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { AUTOMATIC_UI_MAX_CHARS, compactAutomaticUI, hasReturnedUIDirectory } from "../../dist/src/automatic-ui.js";
+
+test("automatic discovery suppresses only a returned UI directory", () => {
+  for (const result of [null, true, 4, "ready", [], {}, { type: "Page", url: "https://example.com" },
+    { type: "Response", status: 200 }, [{ type: "Locator", locator: "button" }], `https://example.com/${"a".repeat(500)}`]) {
+    assert.equal(hasReturnedUIDirectory(result), false, JSON.stringify(result));
+  }
+  for (const result of [{ total: "$25.00" }, [{ name: "Stand", price: 12 }], { type: "product", name: "Stand" }, "page text\n".repeat(50)]) {
+    assert.equal(hasReturnedUIDirectory(result), false);
+  }
+  assert.equal(hasReturnedUIDirectory({ protocol: "betterwright-ui/1", controls: [] }), true);
+  assert.equal(hasReturnedUIDirectory({ protocol: "betterwright-ui/1" }), false);
+});
+
+test("automatic UI has a hard budget without changing exact targets or the full directory", () => {
+  const directory = {
+    protocol: "betterwright-ui/1", tool: "browser_batch", truncated: false,
+    controls: Array.from({ length: 40 }, (_, nth) => ({
+      target: { label: `Product ${nth}`, exact: true, nth, frameName: "catalog" },
+      actions: ["select", "read"],
+      options: Array.from({ length: 20 }, (_, i) => ({ text: "Option ".repeat(12), value: String(i) })),
+    })),
+    evidence: [{ kind: "status", text: "Cart subtotal: $25.00" }],
+  };
+  const before = JSON.stringify(directory);
+  const compact = compactAutomaticUI(directory);
+  assert.ok(JSON.stringify(compact).length <= AUTOMATIC_UI_MAX_CHARS);
+  assert.equal(compact.truncated, true);
+  assert.ok(compact.controls.length > 0 && compact.controls.length < 40);
+  for (const entry of compact.controls) {
+    assert.deepEqual(entry.target, directory.controls[entry.target.nth].target);
+    assert.equal(entry.options, undefined);
+  }
+  assert.deepEqual(compact.evidence, directory.evidence);
+  assert.equal(JSON.stringify(directory), before);
+});

--- a/tests/node/benchmark-provenance.test.ts
+++ b/tests/node/benchmark-provenance.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { assertSameSource, directoryIdentity, sha256, sourceIdentity } from "../../benchmarks/navigation-context/provenance.js";
+import { makeTempDir } from "./helpers/temp-dir.js";
+
+function repository() {
+  const root = makeTempDir("bw-benchmark-provenance-");
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: ["ignore", "pipe", "pipe"] }).toString().trim();
+  git("init", "-q");
+  git("config", "user.name", "Benchmark test");
+  git("config", "user.email", "benchmark@example.test");
+  git("config", "commit.gpgsign", "false");
+  git("config", "core.hooksPath", path.join(root, "empty-hooks"));
+  const write = (name: string, text: string) => {
+    fs.mkdirSync(path.dirname(path.join(root, name)), { recursive: true });
+    fs.writeFileSync(path.join(root, name), text);
+  };
+  const commit = () => { git("add", "."); git("commit", "-qm", "fixture"); return git("rev-parse", "HEAD"); };
+  write("src/runtime.ts", "export const value = 1;\n");
+  const baseline = commit();
+  return { root, git, write, commit, baseline };
+}
+
+test("benchmark provenance includes committed additions and the baseline-to-candidate difference", () => {
+  const repo = repository();
+  const baseline = sourceIdentity(repo.root);
+  repo.write("src/new-helper.ts", "export const helper = true;\n");
+  const candidateHead = repo.commit();
+  const candidate = sourceIdentity(repo.root, repo.baseline);
+  assert.equal(candidate.head, candidateHead);
+  assert.equal(candidate.baselineHead, repo.baseline);
+  assert.notEqual(candidate.sourceTreeSha256, baseline.sourceTreeSha256);
+  assert.equal(candidate.diffSha256, sha256(execFileSync("git", ["diff", "--no-ext-diff", "--no-textconv", "--no-color", "--binary", repo.baseline, candidateHead, "--", "src", "bin", "types"], { cwd: repo.root })));
+  assert.notEqual(candidate.diffSha256, sha256(""));
+});
+
+test("benchmark provenance rejects unstaged, staged, untracked and ignored source inputs", () => {
+  const repo = repository();
+  repo.write("src/runtime.ts", "changed\n");
+  assert.throws(() => sourceIdentity(repo.root), /changed source\/build inputs/);
+  repo.git("add", ".");
+  assert.throws(() => sourceIdentity(repo.root), /changed source\/build inputs/);
+  repo.commit();
+  repo.write("src/untracked.ts", "untracked\n");
+  assert.throws(() => sourceIdentity(repo.root), /changed source\/build inputs/);
+  repo.write(".gitignore", "src/ignored.ts\n");
+  repo.commit();
+  repo.write("src/ignored.ts", "ignored\n");
+  assert.throws(() => sourceIdentity(repo.root), /changed source\/build inputs/);
+});
+
+test("publishing results preserves measured source identity, but later runtime edits do not", () => {
+  const repo = repository();
+  const measured = sourceIdentity(repo.root, repo.baseline);
+  repo.write("benchmarks/results.json", "{}\n");
+  repo.commit();
+  const published = sourceIdentity(repo.root, repo.baseline);
+  assert.notEqual(published.head, measured.head);
+  assertSameSource(measured, published);
+  repo.write("src/runtime.ts", "export const value = 2;\n");
+  repo.commit();
+  assert.throws(() => assertSameSource(measured, sourceIdentity(repo.root, repo.baseline)), /differ from the measured revision/);
+});
+
+test("build fingerprint covers artifacts beyond the worker entrypoint", async () => {
+  const repo = repository();
+  repo.write("dist/src/worker.js", "import './helper.js';\n");
+  repo.write("dist/src/helper.js", "export const helper = 1;\n");
+  const before = await directoryIdentity(path.join(repo.root, "dist"));
+  repo.write("dist/src/helper.js", "export const helper = 2;\n");
+  const after = await directoryIdentity(path.join(repo.root, "dist"));
+  assert.equal(before.fileCount, 2);
+  assert.notEqual(after.sha256, before.sha256);
+});

--- a/tests/node/browser.test.ts
+++ b/tests/node/browser.test.ts
@@ -1741,6 +1741,27 @@ test("failed verification returns bounded observed evidence without replaying ac
   }
 });
 
+test("CLI run preserves JSON values in compact and explicit pretty output", opts, async () => {
+  const home = tempHome();
+  const cli = path.resolve(import.meta.dirname, "../../dist/bin/betterwright.js");
+  const code = 'return { nested: { text: "hello\\nworld" }, items: [1, 2] }';
+  const run = (extra) => spawnSync(process.execPath, [cli, "run", "--no-daemon", ...extra, "-c", code], {
+    encoding: "utf8", timeout: 20_000, env: { ...process.env, BETTERWRIGHT_HOME: home },
+  });
+  const compact = run([]);
+  const pretty = run(["--pretty"]);
+  assert.equal(compact.status, 0, compact.stderr);
+  assert.equal(pretty.status, 0, pretty.stderr);
+  assert.equal(compact.stdout.trim().split("\n").length, 1);
+  assert.ok(pretty.stdout.trim().split("\n").length > 1);
+  const decoded = JSON.parse(compact.stdout);
+  const indented = JSON.parse(pretty.stdout);
+  assert.equal(decoded.ok, true);
+  assert.deepEqual(decoded.result, { nested: { text: "hello\nworld" }, items: [1, 2] });
+  assert.deepEqual(decoded.result, indented.result);
+  assert.deepEqual(Object.keys(decoded).sort(), Object.keys(indented).sort());
+});
+
 test("ordinary navigation attaches one compact UI directory automatically", opts, async () => {
   let probes = 0;
   const site = await listen((request, response) => {
@@ -1775,6 +1796,89 @@ test("ordinary navigation attaches one compact UI directory automatically", opts
     assert.equal(nextPath.ui.protocol, "betterwright-ui/1");
     assert.equal(probes, 2);
   } finally {
+    await bw.close();
+    await site.close();
+  }
+});
+
+test("automatic UI avoids duplicate observations and bounds fallback context", opts, async () => {
+  const site = await listen((request, response) => {
+    if (request.url === "/webagents.md" || request.url === "/.well-known/webagents.json") {
+      response.writeHead(404).end("missing");
+      return;
+    }
+    response.setHeader("content-type", "text/html");
+    response.end(`<h1>Catalog</h1><div role="status">Catalog ready</div>${Array.from({ length: 40 }, (_, i) =>
+      `<label>Product ${i}<select><option>${"Long option ".repeat(12)}</option><option>Second</option></select></label>`).join("")}`);
+  });
+  const bw = new BetterWright({ home: tempHome(), headless: true, policy: new NetworkPolicy({ allowLoopback: true }) });
+  try {
+    const extracted = await bw.run(`await page.goto('${site.origin}/observed'); return { heading: await page.locator('h1').innerText() }`);
+    assert.equal(extracted.ok, true, extracted.error);
+    assert.deepEqual(extracted.result, { heading: "Catalog" });
+    assert.equal(extracted.ui.protocol, "betterwright-ui/1");
+    assert.ok(JSON.stringify(extracted.ui).length <= 2_400);
+    assert.equal((await bw.run("return page.url()")).ui, undefined);
+
+    const fallback = await bw.run(`return await page.goto('${site.origin}/unobserved')`);
+    assert.equal(fallback.ok, true, fallback.error);
+    assert.equal(fallback.result.type, "Response");
+    assert.ok(JSON.stringify(fallback.ui).length <= 2_400);
+    assert.equal(fallback.ui.truncated, true);
+    assert.ok(fallback.ui.controls.length > 0 && fallback.ui.controls.length < 40);
+    const full = await bw.run("const directory = await controls.directory(); return { count: directory.controls.length, first: directory.controls[0] }");
+    assert.equal(full.ok, true, full.error);
+    assert.equal(full.result.count, 36);
+    assert.equal(full.result.first.options.length, 2);
+    assert.deepEqual(fallback.ui.controls[0].target, full.result.first.target);
+    assert.equal(full.ui, undefined);
+    const returned = await bw.run(`await page.goto('${site.origin}/explicit-directory'); return await controls.directory()`);
+    assert.equal(returned.ok, true, returned.error);
+    assert.equal(returned.ui, undefined, "do not append another directory even if the full result spills");
+
+    const lean = await bw.run(`await page.goto('${site.origin}/lean'); return { heading: await page.locator('h1').innerText() }`, { automaticUI: false });
+    assert.equal(lean.ok, true, lean.error);
+    assert.equal(lean.ui, undefined);
+    const resumed = await bw.run("return page.url()");
+    assert.equal(resumed.ui.protocol, "betterwright-ui/1", "opt-out must not consume the announcement");
+    const failed = await bw.run("throw new Error('required check failed')", { automaticUI: false });
+    assert.equal(failed.ok, false);
+    assert.ok(failed.ui.evidence.some((entry) => entry.text.includes("Catalog ready")));
+  } finally {
+    await bw.close();
+    await site.close();
+  }
+});
+
+test("default navigation reaches a usable document while subresources are still loading", opts, async () => {
+  const pending = [];
+  const site = await listen((request, response) => {
+    if (request.url === "/slow.png") {
+      pending.push(response);
+      return;
+    }
+    if (request.url === "/webagents.md" || request.url === "/.well-known/webagents.json") {
+      response.writeHead(404).end("missing");
+      return;
+    }
+    response.setHeader("content-type", "text/html");
+    response.end('<h1>Ready</h1><img src="/slow.png">');
+  });
+  const bw = new BetterWright({ home: tempHome(), headless: true, policy: new NetworkPolicy({ allowLoopback: true }) });
+  try {
+    const opened = await bw.run(`await page.goto('${site.origin}/default', { timeout: 2000 }); return { heading: await page.locator('h1').innerText() }`);
+    assert.equal(opened.ok, true, opened.error);
+    assert.deepEqual(opened.result, { heading: "Ready" });
+    assert.ok(pending.length > 0, "the subresource is still pending");
+    const reloaded = await bw.run("await page.reload({ timeout: 2000 }); return { heading: await page.locator('h1').innerText() }");
+    assert.equal(reloaded.ok, true, reloaded.error);
+    const tab = await bw.run(`const tab = await openPage('${site.origin}/tab', { timeout: 2000 }); return { heading: await tab.locator('h1').innerText() }`);
+    assert.equal(tab.ok, true, tab.error);
+    const explicit = await bw.run(`await page.goto('${site.origin}/explicit', { waitUntil: 'load', timeout: 300 }); return 'loaded'`);
+    assert.equal(explicit.ok, false);
+    assert.match(explicit.error, /Timeout.*300ms/i);
+  } finally {
+    for (const response of pending) response.end();
     await bw.close();
     await site.close();
   }
@@ -1867,7 +1971,7 @@ test("WebAgents auto-discovery executes one same-origin operation DAG", opts, as
     policy: new NetworkPolicy({ allowLoopback: true }),
   });
   try {
-    const opened = await bw.run(`await page.goto('${site.origin}/tickets'); return page.url()`);
+    const opened = await bw.run(`await page.goto('${site.origin}/tickets'); return page.url()`, { automaticUI: false });
     assert.equal(opened.ok, true, opened.error);
     assert.equal(opened.webagents.protocol, "webagents/0.1");
     assert.deepEqual(opened.webagents.actions.map((action) => action.name), ["resolve", "status"]);
@@ -2544,6 +2648,8 @@ test("bot challenges in a cross-origin frame are detected", opts, async () => {
   try {
     const result = await bw.run(`
       await page.goto(${JSON.stringify(site.origin)});
+      // DOMContentLoaded does not imply that a cross-origin frame is ready.
+      await page.frameLocator('iframe').getByRole('heading', { name: 'Verify you are human', exact: true }).waitFor();
       const frames = page.frames();
       return frames.map(frame => frame.url());
     `);

--- a/tests/node/client.test.ts
+++ b/tests/node/client.test.ts
@@ -37,6 +37,28 @@ test("the encrypted local credential vault is enabled by default and can be repl
   }
 });
 
+test("automatic UI is a validated per-call option and does not become a session default", async () => {
+  const browser = new BetterWright({ home: makeTempDir("betterwright-ui-option-"), vault: false });
+  const messages = [];
+  browser._prepare = async () => ({});
+  browser._dispatch = async (message) => {
+    messages.push(message);
+    return { ok: true, result: "ready" };
+  };
+  try {
+    await browser.run("return 'ready'", { automaticUI: false });
+    await browser.run("return 'ready'");
+    assert.equal(messages[0].automaticUI, false);
+    assert.equal(messages[1].automaticUI, true);
+    const invalid = await browser.run("return 'ready'", { automaticUI: "false" });
+    assert.equal(invalid.ok, false);
+    assert.match(invalid.error, /automaticUI must be a boolean/);
+    assert.equal(messages.length, 2);
+  } finally {
+    await browser.close();
+  }
+});
+
 test("download approval is required by default and configurable", async () => {
   const guarded = new BetterWright();
   const allowed = new BetterWright({ downloadPolicy: "allow" });

--- a/tests/node/navigation-defaults.test.ts
+++ b/tests/node/navigation-defaults.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { applyNavigationDefaults, navigationOptions } from "../../dist/src/navigation-defaults.js";
+
+test("agent navigation defaults preserve explicit wait modes, timeouts and invalid options", () => {
+  assert.deepEqual(navigationOptions(), { waitUntil: "domcontentloaded" });
+  const supplied = { timeout: 150, referer: "https://example.com", waitUntil: undefined };
+  assert.deepEqual(navigationOptions(supplied), { ...supplied, waitUntil: "domcontentloaded" });
+  assert.equal(supplied.waitUntil, undefined);
+  for (const waitUntil of ["load", "commit", "networkidle", null, "invalid"]) {
+    assert.deepEqual(navigationOptions({ waitUntil, timeout: 150 }), { waitUntil, timeout: 150 });
+  }
+  for (const options of [null, false, "invalid"]) assert.equal(navigationOptions(options), options);
+});
+
+test("only navigation methods receive the new default", () => {
+  for (const kind of ["Page", "Frame"]) {
+    const args = ["https://example.com"];
+    applyNavigationDefaults(kind, "goto", args);
+    assert.deepEqual(args, ["https://example.com", { waitUntil: "domcontentloaded" }]);
+  }
+  for (const method of ["reload", "goBack", "goForward"]) {
+    const args = [{ timeout: 150 }];
+    applyNavigationDefaults("Page", method, args);
+    assert.deepEqual(args, [{ timeout: 150, waitUntil: "domcontentloaded" }]);
+  }
+  for (const [kind, method] of [["Page", "waitForLoadState"], ["Page", "setContent"], ["Locator", "click"]]) {
+    const args = ["load"];
+    applyNavigationDefaults(kind, method, args);
+    assert.deepEqual(args, ["load"]);
+  }
+});

--- a/tests/types/automatic-ui.test.ts
+++ b/tests/types/automatic-ui.test.ts
@@ -1,0 +1,8 @@
+import type { BetterWright, RunOptions } from "betterwright";
+
+const options: RunOptions = { automaticUI: false };
+declare const browser: BetterWright;
+void browser.run("return page.url()", options);
+void browser.run("return page.url()", { automaticUI: true });
+// @ts-expect-error Automatic discovery is a boolean per-call option.
+void browser.run("return page.url()", { automaticUI: "false" });

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": false,
     "types": []
   },
-  "include": ["package.test.ts", "sdk-callbacks.test.ts", "spill-result.test.ts"]
+  "include": ["package.test.ts", "sdk-callbacks.test.ts", "spill-result.test.ts", "automatic-ui.test.ts"]
 }

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -82,6 +82,9 @@ export interface RunOptions {
   note?: string;
   timeout?: number;
   approvedDownloads?: boolean;
+  /** Attach automatic UI discovery on successful calls (default true).
+   * False leaves on-demand discovery, WebAgents and failure evidence available. */
+  automaticUI?: boolean;
 }
 
 export interface FillCredentialOptions {


### PR DESCRIPTION
## What and why

Browser navigation can wait on slow images after the document is usable, while automatic UI catalogs and indented CLI envelopes add repeated context to agent calls. This change reduces those waits and observations without changing the native skill or model prompts.

- Default sandbox navigation to `domcontentloaded`, preserving explicit wait modes and timeouts.
- Bound automatic UI discovery to 2,400 JSON characters and omit a duplicate when the snippet returns the full directory. Full on-demand discovery and failure evidence retain their limits.
- Emit compact JSON when `run` stdout is piped; retain terminal indentation and add `--pretty`.
- Add per-call `automaticUI: false` / `run --no-auto-ui` for callers supplying their own observations. This does not consume the later automatic announcement or disable WebAgents, challenge reporting, or failure evidence.

The local benchmark covers article extraction, form submission, table filtering, delayed content, and explicit discovery. All 100 measured executions returned matching results. Piped observations were 25.8–72.6% smaller; the fixture with an 800 ms decorative-image delay fell from 859 ms to 239 ms. Ordinary-page timing differences include small regressions, so the report does not claim universal latency or API-cost savings. See [methodology and all results](https://github.com/BetterWright/betterwright/blob/7b19b0d/benchmarks/navigation-context/README.md).

## Checklist

- [x] `bun run release:check` passes locally (versions, lint, typecheck, build, unit tests, published declarations, tarball).
- [x] Locally launched browsers and Electron attachments stay on the guard proxy. Remote-provider exceptions and warnings are unchanged.
- [x] Secrets remain outside the model sandbox. Result envelopes still use the existing redaction path.
- [x] Dependency pins and their mirrored checks are unchanged; `check:versions` passes.
- [x] Public declarations include the new option, with positive and negative type checks.
- [x] The branch-protected CI job names and SHA-pinned actions are unchanged.
- [x] No unit test imports the worker entrypoint.
- [x] Changelog, browser API documentation, and CLI help describe the changes.
- [x] No private profiles, credentials, artifacts, or internal notes are included.

## How it was verified

- `bun run release:check`: 1,108 tests passed; three opt-in external CAPTCHA cases skipped; declarations and package smoke test passed.
- `BETTERWRIGHT_REQUIRE_BROWSER=1 bun test --timeout 120000 tests/node/browser.test.ts`: all 102 cases passed.
- Five-workload local benchmark: ten measured pairs per workload, alternating order, same browser binary, default options, and byte-identical native skills. All returned results matched.
- Regression coverage includes pending subresources, explicit `load` timeouts, full directory preservation, successful-call opt-out, later discovery, failure evidence, first-party discovery, and actual CLI compact/pretty JSON parity.

Benchmark provenance is regenerated from committed baseline `8a87ae6` and candidate `0714195`. The harness rebuilds both sources, hashes their committed runtime difference and all generated files, and checks for changes during measurement. The later report-only commit preserves those source inputs. Four regression tests cover provenance and publication.
