### PR TITLE
docs: add CLI/env references, fill index gaps, and JSDoc the declarations

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -197,6 +197,7 @@ The extension supports these optional host environment variables:
 | `BETTERWRIGHT_PI_AUTO_SCREENSHOT` | Attach the active page after a call that produced no image; defaults to true. |
 | `BETTERWRIGHT_PI_TIMEOUT_SECONDS` | Per-snippet BetterWright timeout. |
 | `BETTERWRIGHT_PI_DOWNLOAD_POLICY` | `ask`, `allow`, or `deny`; non-interactive `ask` mode fails closed. |
+| `BETTERWRIGHT_PI_REQUIRE_EVIDENCE` | When set, `browser` and `browser_download` refuse to run until `browser_evidence` has been initialized with every atomic task requirement. |
 
 Pi package extensions execute with host privileges, while model-authored browser
 code still runs inside BetterWright's guarded worker. Review package source and
@@ -393,6 +394,7 @@ or the MCP env vars):
 | Allow an otherwise-blocked host | `--allow-host staging.internal` / `allowHosts: ["staging.internal"]` | `BETTERWRIGHT_ALLOW_HOSTS=staging.internal` |
 | Block specific sites | `--block-host ads.example.com` / `blockHosts: [...]` | `BETTERWRIGHT_BLOCK_HOSTS=ads.example.com` |
 | `browser_download` may save files; the `browser` tool may not | `downloadPolicy: "ask"` (default) | `BETTERWRIGHT_DOWNLOAD_POLICY=ask` |
+| Approve downloads for one run | `--approve-downloads` / `approvedDownloads: true` | (the `browser_download` tool call is the grant) |
 | Allow downloads from any run | `downloadPolicy: "allow"` | `BETTERWRIGHT_DOWNLOAD_POLICY=allow` |
 | Disable all downloads | `downloadPolicy: "deny"` | `BETTERWRIGHT_DOWNLOAD_POLICY=deny` |
 | Block public search-result UIs | `publicSearchPolicy: "block"` | `BETTERWRIGHT_PUBLIC_SEARCH_POLICY=block` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,9 @@ whole path works by loading a real page.
 | [WebMCP page tools](browser-api.md#page-published-webmcp-tools) | Typed capabilities published by the current page; discovery, safe invocation, and timeout cancellation |
 | [Skill packs](skills.md) | Per-site / per-password-manager packs, plus the host e2e-review playbook loaded only when a review is requested |
 | [Agent guidance](agent-prompt.md) | The operator prompt and its guardrail options |
+| [Session recording](recording.md) | MP4/WebM capture of the current tab from the CLI, a snippet, or MCP |
+| [Ad blocking](ad-blocking.md) | The default-on Ghostery engine, its filter cache, and how to turn it off |
+| [Electron hosting](electron-host.md) | Drive a host-owned Electron tab through the same policy guard |
 
 ## Under the hood
 
@@ -52,3 +55,13 @@ whole path works by loading a real page.
 | [Chromium fork](chromium-fork.md) | BetterWright's own Chromium build: farbling, discovery |
 | [Chromium fork patches](chromium-fork-patches.md) | What each source patch in the pinned Chromium 151 build changes, and why |
 | [Headed / headless](attach-mode.md) | Display modes over one persistent profile |
+| [Runtime performance](runtime-performance.md) | Measured scan and Linux renderer improvements, with reproducer benchmarks |
+
+## Reference
+
+| Page | What it covers |
+| --- | --- |
+| [CLI reference](cli.md) | Every `betterwright` command and flag |
+| [Environment variables](environment.md) | Every `BETTERWRIGHT_*` variable, grouped by what it controls |
+| [Performance audit](performance-audit.md) | The dated measurement report behind the 2.3.0 efficiency work |
+| [Embedded browser verification](embedded-browser-verification.md) | The dated verification report for the Electron adapter |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,290 @@
+# CLI reference
+
+`betterwright <command>` runs one command. Bare `betterwright` opens the
+interactive agent console documented in [agent.md](agent.md#interactive-console-betterwright).
+
+`--version` (or `-v`) prints the package version without loading anything else.
+`betterwright <command> --help` prints the command's own help text, which this
+page mirrors. `betterwright help <command>` does the same thing.
+
+Commands group into setup, driving the browser, and agent integration. Options
+marked "shared" below are the browser options accepted by `run`, `repl`,
+`exec`, and the interactive console together:
+
+| Shared flag | Effect |
+| --- | --- |
+| `--session <name>` | Which persistent session to use (default `"default"`) |
+| `--profile <name>` | A separate identity with its own cookies and daemon (`BETTERWRIGHT_PROFILE` sets one for the whole shell) |
+| `--headed` | Show the browser window |
+| `--headed-invisible` | Headed window parked off-screen |
+| `--no-daemon` | Skip the session daemon; one-shot browser per call |
+| `--browser <name\|url>` | Cloud provider name or `wss://` CDP endpoint instead of the managed fork |
+| `--browser-key <key>` | Provider API key for this launch |
+| `--session-id <id>` | Attach to an existing cloud box instead of minting one |
+| `--ad-block` / `--no-ad-block` | Enable or disable ad/tracker blocking (default on; `BETTERWRIGHT_AD_BLOCK`) |
+| `--stealth` | Isolated-world driver; needs the optional `patchright-core` package |
+| `--block-private-network` | Deny RFC 1918/intranet destinations |
+| `--block-loopback` | Deny loopback destinations |
+| `--allow-host <host>` | Re-allow one blocked host (repeatable) |
+| `--block-host <host>` | Deny a host (repeatable) |
+| `--no-launch-identity` | Disable the coherent identity layer |
+| `--upstream-proxy <url>` | `http://`/`socks5://` egress proxy chained through the guard |
+| `--geoip` | Resolve locale/timezone from the egress IP |
+| `--locale <bcp47>` | Pin the browser locale |
+| `--timezone <iana>` | Pin the browser timezone |
+| `--platform <os>` | Pin the reported platform (`macos`, `windows`, `linux`) |
+
+## Setup and diagnosis
+
+### `betterwright init`
+
+Guided first-time setup: checks Bun, installs the managed browser, wires up
+detected agent hosts, and proves the path with a real page load. Idempotent.
+
+| Flag | Effect |
+| --- | --- |
+| `--yes` | Accept every default; never prompt |
+| `--skip-browser` | Do not download or verify the browser |
+| `--skip-agents` | Do not touch any agent configuration |
+
+See [getting started](getting-started.md#install-and-set-up).
+
+### `betterwright setup` / `betterwright update`
+
+Download or refresh the managed BetterChromium build. `setup` also refreshes
+already-installed agent skill files. `--force` re-downloads even when the
+pinned version is present. See [chromium-fork.md](chromium-fork.md).
+
+### `betterwright doctor`
+
+Readiness report grouped by area (runtime, browser, agent integration, model
+backends, credentials). Every `✗` names its fix; `!` lines are optional
+components that are not set up. Exits 0 when ready, 1 otherwise.
+
+| Flag | Effect |
+| --- | --- |
+| `--json` | Raw report for scripts |
+| `--quiet` | Print only the lines that need attention |
+
+### `betterwright configure`
+
+Persist the default browser in `<BETTERWRIGHT_HOME>/config.json`. With no
+flags on a terminal it walks through the choices and offers a connection test.
+Full semantics in [browser-providers.md](browser-providers.md#configuring-a-default).
+
+| Flag | Effect |
+| --- | --- |
+| `--show` | Print the current setting (default with no terminal); `--json` for scripts |
+| `--browser <name\|url\|path>` | Set the launch default: provider name, `wss://` CDP endpoint, or absolute Chromium path |
+| `--browser-key <key>` | Store the provider key in the config file |
+| `--key-env <NAME>` | Read the key from this environment variable instead |
+| `--connect <name>` | Save a provider key without changing the launch default (alias: `connect <name>`) |
+| `--disconnect <name>` | Forget a saved provider key |
+| `--managed` / `--reset` | Clear the default; launches use the managed fork again |
+| `--add <name>` | Add a custom provider, with `--cdp-url <template>` ( `${apiKey}` is replaced at launch ), `--key-env`/`--browser-key`, `--docs <url>`, `--display-name <label>` |
+| `--remove <name>` | Delete a custom provider |
+| `--test` | Connect to the configured browser and print its version |
+| `--no-test` | Do not offer the connection test in the interactive flow |
+
+## Driving the browser
+
+### `betterwright run`
+
+```bash
+betterwright run -c "await page.goto('https://example.com'); return page.title()"
+betterwright run snippet.js
+betterwright run -            # snippet from stdin
+```
+
+Runs one snippet of async Playwright JavaScript in the persistent browser and
+prints one JSON result envelope. Exits 0 on `ok: true`, 1 otherwise. All shared
+flags apply, plus:
+
+| Flag | Effect |
+| --- | --- |
+| `--close` | Close the session after this call |
+| `--pretty` | Indent JSON even when stdout is piped (terminals indent by default) |
+| `--no-auto-ui` | Omit the automatic UI catalog on a successful call; on-demand discovery still works |
+| `--approve-downloads` | Allow downloads for this one run |
+
+The globals inside a snippet are documented in [browser-api.md](browser-api.md).
+
+### `betterwright repl`
+
+Reads blank-line-separated snippets from stdin and runs each against the same
+live session, printing one JSON result per snippet. Ctrl-D quits. Takes the
+same session, profile, network, and browser flags as `run`, plus `--close` to
+end the session when input ends.
+
+### `betterwright exec "<task>"`
+
+Hands a whole task to BetterWright's own agent loop and prints one JSON answer.
+`--stdin` reads the task from stdin. Repeated execs on a session continue the
+same conversation and browser; `--fresh` forgets the conversation, `--close`
+ends the session after the task. All shared flags apply, plus the model flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--model <id>` | Real model id; `source/id` only to pin a collision (`BETTERWRIGHT_MODEL`) |
+| `--base-url <url>` | Pin a custom OpenAI-compatible `/v1` endpoint (`--endpoint` is an alias) |
+| `--api-key-env <name>` | Read the API key from a named environment variable |
+| `--protocol <name>` | `chat` (default) or `responses` |
+| `--effort <level>` | Reasoning effort where the model supports it (`--reasoning` is an alias) |
+| `--allow-insecure-model-endpoint` | Permit a key over non-loopback plain HTTP |
+| `--live-view` | Start the viewer at step 0 and print its URL |
+| `--fresh` | Forget this session's exec conversation |
+| `--stdin` | Read the task from stdin |
+
+Model sources, auth, and the result fields are in [agent.md](agent.md).
+
+### `betterwright view`
+
+Opens a live web view of the browser and holds it until Ctrl-C. Attaches to
+the running session daemon when one exists, so you see the tabs the agent is
+driving; otherwise starts a private browser. Hosting presets, the password
+gate, and the security model are in [live-view.md](live-view.md).
+
+| Flag | Effect |
+| --- | --- |
+| `--expose <preset>` | `lan` (default), `local`, or `tailscale` |
+| `--host <host>` | Bind address; overrides `--expose` |
+| `--port <port>` | Bind port (default ephemeral) |
+| `--public-host <host>` | Host printed in the URL when binding wildcard |
+| `--session <name>` | Watch that session's current tab (default `"default"`) |
+| `--profile <name>` | Watch that profile's browser |
+| `--watch-only` | No takeover controls |
+| `--set-password` | Store a password every viewer must enter |
+| `--clear-password` | Remove that password |
+
+### `betterwright record`
+
+```bash
+betterwright record start demo.mp4 --session demo --fps 60
+betterwright record restart take-2.mp4 --session demo
+betterwright record status --session demo
+betterwright record stop --session demo
+```
+
+Records the current tab as MP4/H.264 (`.webm` selects VP8/WebM) without
+replacing its page or session state. Requires the session daemon; `--no-daemon`
+and `--close` are rejected. FFmpeg must be on `PATH` (or
+`BETTERWRIGHT_FFMPEG_PATH`). See [recording.md](recording.md).
+
+`start`/`restart` options: `--fps <n>` (1-60, default 60), `--max-width <px>`
+(default 1280), `--max-height <px>` (default 720), `--quality <n>` (1-100,
+default 80), `--max-duration <s>` (default 300), `--session`, `--profile`.
+
+## Sessions, cookies, and credentials
+
+### `betterwright sessions`
+
+Lists the sessions held by each profile's daemon: pid, version, uptime, active
+runs, per-session idle time, watchers, and in-flight calls. Never starts a
+daemon. See [sessions.md](sessions.md#diagnosing).
+
+### `betterwright close [name]`
+
+Closes a session's tabs and forgets its live state; the on-disk profile and
+its logins survive. `--session <name>` picks the session (a positional name
+also works), `--profile <name>` picks the identity, `--all` closes every
+session of every profile and stops each daemon.
+
+### `betterwright cookies`
+
+```bash
+betterwright cookies browsers [--json]
+betterwright cookies profiles <browser> [--json]
+betterwright cookies sync <browser> (--domain <host>... | --all) [options]
+```
+
+Copies cookies from a local browser profile into the selected BetterWright
+profile, or into a cloud browser with per-call consent. Semantics, source
+support, and the trust boundary are in [cookie-sync.md](cookie-sync.md).
+
+`sync` options: `--domain <host>` (repeatable), `--all`, `--source-profile <id>`,
+`--include-session`, `--allow-app-bound`, `--profile <name>`,
+`--browser <name|url>`, `--browser-key <key>`, `--session-id <id>`,
+`--allow-cloud <target>`, `--no-daemon`, `--json`.
+
+### `betterwright vault`
+
+The owner-facing door to the credential vault. `list` and `show` are
+metadata-only; `--reveal`, `copy`, and `type` are the only paths to plaintext
+and every reveal is audited. Full rules in
+[credentials.md](credentials.md#getting-a-password-back-betterwright-vault).
+
+| Subcommand | Effect |
+| --- | --- |
+| `status` | Master-password protection and lock state |
+| `setup` | Set a master password (hidden terminal prompt) |
+| `unlock` | Unlock the selected profile's session daemon |
+| `lock` | Lock the vault across all profiles and processes |
+| `settings [agent-use\|offer-save\|autosave on\|off]` | Inspect or change saving preferences |
+| `list [--query <text>] [--category <c>]` | Saved credentials, metadata only |
+| `show <id> [--reveal]` | One credential; `--reveal` prints the password to a terminal only |
+| `get <id>` | Alias for `show` |
+| `copy <id>` | Copy the password to the clipboard |
+| `type <id> [--delay <s>] [--key-delay <ms>]` | Type the password into the focused window (`paste` is an alias) |
+| `rm <id> [--yes]` | Delete one credential |
+| `audit [--limit <n>]` | Recent vault activity, metadata only |
+| `path` | Where the encrypted files live |
+
+Options: `--json`, `--force` (allow `--reveal` when stdout is not a terminal).
+
+## Cloud browser boxes
+
+### `betterwright boxes`
+
+```bash
+betterwright boxes list [--browser <name>] [--status <s>]
+betterwright boxes start [--browser <name>]
+betterwright boxes show <id> [--browser <name>]
+betterwright boxes stop <id> [--browser <name>]
+```
+
+Manages billed sessions on the six REST-backed providers. `--browser-key`
+passes a key for one call only; `--key-env <NAME>` reads it from the
+environment; `--json` masks credentials in output. Browserless, Bright Data,
+and Oxylabs are connect-only and have no session lifecycle. See
+[browser-providers.md](browser-providers.md#managing-boxes).
+
+## Agent integration
+
+### `betterwright auth`
+
+`auth --login codex` or `auth --login grok` runs the provider's OAuth PKCE
+flow and stores the tokens for `exec`. `auth --status` shows which backends
+are signed in. Anthropic models use `ANTHROPIC_API_KEY` instead; local models
+need no sign-in. See [agent.md](agent.md#signing-in-betterwright-auth).
+
+### `betterwright models [source]`
+
+Lists the models reachable right now: native backends plus local Ollama/vLLM
+servers, and OpenRouter when `OPENROUTER_API_KEY` is set. `source` limits the
+list to `openrouter`, `ollama`, or `vllm`. `--base-url <url>` queries a custom
+endpoint, `--api-key-env <name>` supplies its key, `--json` prints the
+machine-readable catalog. See [agent.md](agent.md#how-selection-works).
+
+### `betterwright skill`
+
+Prints the agent instructions that teach a shell-capable agent to drive the
+browser. `--install` writes the browser and e2e-review skills to
+`~/.claude/skills` and `~/.agents/skills`; `--all` adds `~/.cursor/skills`.
+`--claude` prints the Claude-form SKILL.md to stdout; `--status` shows where
+the skills are installed and whether they are current. See
+[SETUP.md](../SETUP.md#1--cli--skill-any-agent-that-can-run-shell-commands).
+
+### `betterwright skills [list | show <name>]`
+
+Reads the on-demand site knowledge packs. `list` prints name and description
+per pack; `show <name>` prints a pack's body. See [skills.md](skills.md).
+
+### `betterwright mcp`
+
+Serves the MCP stdio server: `browser`, `browser_batch`, `browser_download`,
+`browser_record`, `browser_handoff`, `browser_doctor`, plus `browser_login`
+when the vault is enabled. `--check` verifies the server can start, which is
+the way to debug a client that shows no tools. `--ad-block`/`--no-ad-block`
+override `BETTERWRIGHT_AD_BLOCK`. Policy comes from the environment; the full
+variable list is in [environment.md](environment.md). Registration and client
+notes are in [SETUP.md](../SETUP.md#3--mcp-client).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -170,6 +170,11 @@ replacing its page or session state. Requires the session daemon; `--no-daemon`
 and `--close` are rejected. FFmpeg must be on `PATH` (or
 `BETTERWRIGHT_FFMPEG_PATH`). See [recording.md](recording.md).
 
+The name is a filename, not a path; `record start /abs/path.mp4` is rejected.
+When the daemon was started with display flags, `record` needs the same ones:
+a `run --headed` session takes `record start demo.mp4 --headed`, and the same
+applies to `--headed-invisible`.
+
 `start`/`restart` options: `--fps <n>` (1-60, default 60), `--max-width <px>`
 (default 1280), `--max-height <px>` (default 720), `--quality <n>` (1-100,
 default 80), `--max-duration <s>` (default 300), `--session`, `--profile`.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,135 @@
+# Environment variables
+
+Every `BETTERWRIGHT_*` variable the runtime reads, grouped by what it
+controls. Flags and constructor options beat the environment where both exist.
+Variables for external services (`ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`,
+provider keys, endpoint base URLs) are listed in [agent.md](agent.md) and
+[browser-providers.md](browser-providers.md), not here.
+
+A handful of `BETTERWRIGHT_*` names exist only for the build and test harness
+(`BETTERWRIGHT_COVERAGE`, `BETTERWRIGHT_REQUIRE_BROWSER`,
+`BETTERWRIGHT_REQUIRE_RECORDING`, `BETTERWRIGHT_LIVE_CAPTCHA`) or as internal
+overrides used by development and CI. They are not supported configuration and
+are not listed below.
+
+## Home, sessions, and the daemon
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_HOME` | `~/.betterwright` | State directory: profiles, vault, artifacts, daemon sockets, `config.json` |
+| `BETTERWRIGHT_PROFILE` | unset | Select a named identity for a whole shell; `--profile` wins. The only way to pick a profile for the MCP server |
+| `BETTERWRIGHT_SESSION_TTL_SECONDS` | `900` | Idle time before a session's pages close |
+| `BETTERWRIGHT_ORPHAN_GRACE_SECONDS` | `30` | Grace period before the daemon stops a run whose watcher disappeared; `0` lets detached runs finish |
+| `BETTERWRIGHT_NO_DAEMON` | unset | `1` forces one-shot browsers, skipping the session daemon entirely |
+
+See [sessions.md](sessions.md).
+
+## Browser selection
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_BACKEND` | `auto` | `chromium-fork` requires the managed build and fails closed; any other value is an error |
+| `BETTERWRIGHT_CHROMIUM_PATH` | unset | Absolute path to a BetterChromium executable; wins over the root |
+| `BETTERWRIGHT_CHROMIUM_ROOT` | unset | Absolute path to an artifact root with the fixed platform layout |
+| `BETTERWRIGHT_CHROMIUM_ARGS` | unset | Extra whitespace-separated Chromium switches for a managed launch; BetterWright-owned switches are rejected, duplicates dropped with a warning |
+| `BETTERWRIGHT_CDP_URL` | unset | Shorthand for `provider: { cdpUrl }`; sits between `--browser` and the configured default in precedence |
+
+`BETTERWRIGHT_BROWSER` is a rejected legacy value; it once selected a bundled
+fallback browser that no longer exists. See
+[attach-mode.md](attach-mode.md#managed-browser-enforcement) and
+[chromium-fork.md](chromium-fork.md).
+
+## Display and identity
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_HEADLESS` | unset | MCP only: `0` requests a visible window, `1` forces headless |
+| `BETTERWRIGHT_DISPLAY` | detected | `1` forces headed-capable detection, `0` forces headless |
+| `BETTERWRIGHT_LOCALE` | unset | Browser locale (BCP 47) for the MCP server; the CLI uses `--locale` |
+| `BETTERWRIGHT_TIMEZONE` | unset | Browser timezone (IANA) for the MCP server; the CLI uses `--timezone` |
+
+Identity must match egress geography; see
+[launch-identity.md](launch-identity.md) and
+[attach-mode.md](attach-mode.md#choosing-the-display-mode).
+
+## Network and downloads
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_BLOCK_PRIVATE_NETWORK` | unset | `1` denies RFC 1918/intranet destinations |
+| `BETTERWRIGHT_BLOCK_LOOPBACK` | unset | `1` denies loopback destinations |
+| `BETTERWRIGHT_ALLOW_HOSTS` | unset | Re-allow listed hosts inside a blocked scope |
+| `BETTERWRIGHT_BLOCK_HOSTS` | unset | Deny listed hosts |
+| `BETTERWRIGHT_PUBLIC_SEARCH_POLICY` | `allow` | `block` has the worker refuse public search-result UIs |
+| `BETTERWRIGHT_DOWNLOAD_POLICY` | `ask` | `allow` lets any run save files; `deny` disables downloads entirely |
+
+See [network-policy.md](network-policy.md) and
+[SETUP.md](../SETUP.md#6--safeguards-configure-to-taste).
+
+## Features
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_AD_BLOCK` | on | `0` disables ad/tracker blocking across the API, CLI, MCP, and Pi; `1` enables it. An explicit option or flag wins |
+| `BETTERWRIGHT_PARK_BACKGROUND_PAGES` | on | `0` keeps idle headless pages running between calls instead of parking them |
+| `BETTERWRIGHT_STEALTH_RUNTIME_FIX` | off | `1` runs snippets in an isolated world through the optional `patchright-core` driver |
+| `BETTERWRIGHT_FFMPEG_PATH` | `PATH` lookup | Absolute path to an FFmpeg binary for recording |
+
+## Live view
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_LIVE_VIEW` | unset | MCP only: `1` permits a non-loopback bind host |
+| `BETTERWRIGHT_LIVE_VIEW_EXPOSE` | `lan` | Hosting preset: `lan`, `local`, or `tailscale` |
+| `BETTERWRIGHT_LIVE_VIEW_HOST` | `0.0.0.0` | Bind host |
+| `BETTERWRIGHT_LIVE_VIEW_PORT` | ephemeral | Bind port |
+| `BETTERWRIGHT_LIVE_VIEW_PUBLIC_HOST` | LAN IPv4 | Host printed in the URL when binding wildcard |
+| `BETTERWRIGHT_LIVE_VIEW_PASSWORD` | unset | Viewer password for MCP deployments that cannot use `view --set-password` |
+
+See [live-view.md](live-view.md).
+
+## Timeouts
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_TIMEOUT_SECONDS` | `120` (MCP) | Per-snippet timeout for the MCP server, minimum 5 |
+| `BETTERWRIGHT_WORKER_START_TIMEOUT_MS` | `15000` | How long the client waits for a fresh worker's ready handshake before killing it |
+
+## Credential vault
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_VAULT_ALLOW_NON_INTERACTIVE` | unset | `1` lets `vault show --reveal` write to a redirected or piped stdout, same as `--force` |
+
+See [credentials.md](credentials.md#getting-a-password-back-betterwright-vault).
+
+## Model backends
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_MODEL` | unset | Default `--model` for `exec` and the console |
+| `BETTERWRIGHT_MODEL_BASE_URL` | unset | Default custom OpenAI-compatible endpoint |
+| `BETTERWRIGHT_MODEL_API_KEY` | unset | Key for that custom endpoint |
+| `BETTERWRIGHT_MODEL_PROTOCOL` | `chat` | `chat` or `responses` |
+| `BETTERWRIGHT_CLAUDE_MODEL` | built-in | Default id `betterwright models` shows for Claude |
+| `BETTERWRIGHT_CODEX_MODEL` | built-in | Default id shown for Codex |
+| `BETTERWRIGHT_GROK_MODEL` | built-in | Default id shown for Grok |
+
+Endpoint and key variables for each source (`OPENROUTER_API_KEY`,
+`OLLAMA_BASE_URL`, `CODEX_BASE_URL`, `XAI_API_KEY`, and friends) are tabulated
+in [agent.md](agent.md#preset-endpoints-and-environment).
+
+## Pi extension
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `BETTERWRIGHT_PI_START_URL` | unset | Navigate once to an HTTP(S) start page before the first tool call |
+| `BETTERWRIGHT_PI_MAX_STEPS` | unset | Positive browser-tool step budget |
+| `BETTERWRIGHT_PI_SESSION` | `pi` | Persistent BetterWright session name |
+| `BETTERWRIGHT_PI_TRACE_DIR` | unset | Write JSONL steps and copied screenshots for evaluation or audit |
+| `BETTERWRIGHT_PI_AUTO_SCREENSHOT` | on | Attach the active page after a call that produced no image |
+| `BETTERWRIGHT_PI_TIMEOUT_SECONDS` | unset | Per-snippet BetterWright timeout |
+| `BETTERWRIGHT_PI_DOWNLOAD_POLICY` | `ask` | `ask`, `allow`, or `deny`; non-interactive `ask` fails closed |
+| `BETTERWRIGHT_PI_REQUIRE_EVIDENCE` | off | When set, browser tools refuse to run until `browser_evidence` is initialized with every atomic task requirement |
+
+See [SETUP.md](../SETUP.md#2--pi-coding-agent).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,8 +37,8 @@ betterwright init
 the agent skill into whichever hosts it finds on this machine, and then loads a
 real page to confirm the path works end to end. It is safe to re-run — it
 reports what is already done and changes only what is not. Add `--yes` to skip
-the prompts (CI, scripts), or `--skip-agents` to leave your agent configuration
-alone.
+the prompts (CI, scripts), `--skip-browser` to leave the managed browser
+alone, or `--skip-agents` to leave your agent configuration alone.
 
 The individual steps remain available when you want them:
 

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -78,7 +78,7 @@ Install the optional dependency (`npm install patchright-core`) to use it;
 
 | Method | Description |
 | --- | --- |
-| `run(code, { session, note, timeout, approvedDownloads, signal }) => Promise<envelope>` | Execute one snippet. Calls within a session are queued; different sessions may execute concurrently. |
+| `run(code, { session, note, timeout, approvedDownloads, automaticUI, signal }) => Promise<envelope>` | Execute one snippet. Calls within a session are queued; different sessions may execute concurrently. `automaticUI: false` omits the automatic UI catalog on a successful call. |
 | `close() => Promise<void>` | Shut the worker down. Idempotent. |
 | `closeSession(session?) => Promise<{ ok, closed, pagesClosed, error? }>` | Close one session's pages and forget its state without closing other sessions or the browser. |
 | `syncCookies(options) => Promise<CookieSyncResult>` | Import cookies from a local browser into this identity. See [Cookie Sync](cookie-sync.md). |

--- a/docs/launch-identity.md
+++ b/docs/launch-identity.md
@@ -112,8 +112,8 @@ reCAPTCHA v2 escalated to an image grid that requires vision. The report prints
 | `launchIdentity` | `true` | Coherent locale/timezone identity layer. CLI: `--no-launch-identity` |
 | `upstreamProxy` | - | `http://` / `socks5://` egress proxy. CLI: `--upstream-proxy` |
 | `geoip` | `false` | Locale/timezone from egress IP. CLI: `--geoip` |
-| `locale` | - | Explicit BCP 47 locale. CLI: `--locale` |
-| `timezone` | - | Explicit IANA timezone. CLI: `--timezone` |
+| `locale` | - | Explicit BCP 47 locale. CLI: `--locale`; MCP: `BETTERWRIGHT_LOCALE` |
+| `timezone` | - | Explicit IANA timezone. CLI: `--timezone`; MCP: `BETTERWRIGHT_TIMEZONE` |
 | `platform` | host | Identity platform pin (default: the real host OS). CLI: `--platform` |
 | `headedInvisible` | `false` | Off-screen headed window. CLI: `--headed-invisible` |
 | `stealthRuntimeFix` | `false` | Optional patchright isolated-world execution |

--- a/tests/node/cli-help-inventory.test.ts
+++ b/tests/node/cli-help-inventory.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { helpFor } from "../../dist/src/cli-help.js";
+import { COMMAND_SUMMARIES, helpFor } from "../../dist/src/cli-help.js";
 
 test("MCP help lists batching, recording, and conditional credential tools", () => {
   const help = helpFor("mcp");
@@ -19,4 +20,26 @@ test("MCP help lists batching, recording, and conditional credential tools", () 
   assert.match(help, /browser_login when the credential vault is enabled/);
   assert.match(help, /browser_batch runs guarded UI batches/);
   assert.match(help, /browser_record controls local video recording/);
+});
+
+// docs/cli.md is the published command reference; it must name every
+// subcommand so a page that drifts behind cli-help.ts fails here, not in a
+// user's hands. Flag coverage stays looser on purpose: only the flags that
+// change behavior in ways a user cannot discover otherwise are pinned.
+test("docs/cli.md covers every subcommand and the shared flag set", () => {
+  const doc = readFileSync(new URL("../../docs/cli.md", import.meta.url), "utf8");
+  for (const [name] of COMMAND_SUMMARIES) {
+    assert.match(doc, new RegExp(`betterwright ${name}\\b`), `docs/cli.md is missing "${name}"`);
+  }
+  for (const flag of [
+    "--session", "--profile", "--headed", "--headed-invisible", "--no-daemon",
+    "--browser", "--browser-key", "--session-id", "--ad-block", "--no-ad-block",
+    "--stealth", "--block-private-network", "--block-loopback", "--allow-host",
+    "--block-host", "--no-launch-identity", "--upstream-proxy", "--geoip",
+    "--locale", "--timezone", "--platform",
+    "--approve-downloads", "--no-auto-ui", "--close", "--pretty",
+    "--skip-browser", "--skip-agents",
+  ]) {
+    assert.ok(doc.includes(flag), `docs/cli.md is missing ${flag}`);
+  }
 });

--- a/tests/types/captcha-solver.test.ts
+++ b/tests/types/captcha-solver.test.ts
@@ -1,0 +1,15 @@
+import { dedupeBoxes, sortTilesReadingOrder } from "../../types/captcha-solver.js";
+
+const tiles = [
+  { x: 5, y: 0, width: 10, height: 10 },
+  { x: 1, y: 0, width: 10, height: 10 },
+];
+const ordered: Array<{ x: number; y: number; width: number; height: number }> = sortTilesReadingOrder(tiles, 12);
+
+// dedupeBoxes normalises partial rectangles; sortTilesReadingOrder compares
+// x/y directly and would produce NaN comparisons for missing coordinates.
+const normalised = dedupeBoxes([{ x: 1 }, {}]);
+// @ts-expect-error Reading-order sort requires complete rectangles.
+sortTilesReadingOrder([{ x: 1 }, {}]);
+
+void [ordered, normalised];

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": false,
     "types": []
   },
-  "include": ["package.test.ts", "sdk-callbacks.test.ts", "spill-result.test.ts", "automatic-ui.test.ts"]
+  "include": ["package.test.ts", "sdk-callbacks.test.ts", "spill-result.test.ts", "automatic-ui.test.ts", "captcha-solver.test.ts"]
 }

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -56,7 +56,7 @@ export function refreshGrokToken(): Promise<string>;
 /** A JWT is expired, or within `skewSeconds` (default 120) of it. */
 export function isJwtExpired(token: string, skewSeconds?: number): boolean;
 
-/** Directory holding the codex token file, under `BETTERWRIGHT_HOME`. */
+/** Directory holding the codex token file: `CODEX_HOME`, else `~/.codex`. */
 export function codexHome(): string;
-/** Directory holding the grok token file, under `BETTERWRIGHT_HOME`. */
+/** Directory holding the grok token file: `GROK_HOME`, else `~/.grok`. */
 export function grokHome(): string;

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -8,8 +8,11 @@ export interface LoginResult {
 
 export interface LoginProviderOptions {
   provider: "codex" | "grok";
+  /** Called with the authorization URL to show or open for the user. */
   onUrl?: (url: string) => void;
+  /** Progress lines from the flow. */
   log?: (line: string) => void;
+  /** Open the URL in the system browser instead of only reporting it. */
   open?: boolean;
   timeoutMs?: number;
 }
@@ -33,17 +36,27 @@ export interface GrokAuth {
   expiresAt: number | null;
 }
 
+/** Run the provider's OAuth PKCE flow and store the resulting tokens. */
 export function loginProvider(options: LoginProviderOptions): Promise<LoginResult>;
 
+/** Stored codex session, or null. BetterWright and the codex CLI share this file. */
 export function loadCodexAuth(): CodexAuth | null;
+/** Stored grok session, or null. */
 export function loadGrokAuth(): GrokAuth | null;
 
+/** A valid access token, refreshing when expired. Throws when not signed in. */
 export function codexAccessToken(): Promise<{ accessToken: string; accountId: string | null }>;
+/** A valid access token, refreshing when expired. Throws when not signed in. */
 export function grokAccessToken(): Promise<{ accessToken: string; accountId: string | null }>;
+/** Exchange the stored refresh token for a fresh access token and persist it. */
 export function refreshCodexToken(): Promise<string>;
+/** Exchange the stored refresh token for a fresh access token and persist it. */
 export function refreshGrokToken(): Promise<string>;
 
+/** A JWT is expired, or within `skewSeconds` (default 120) of it. */
 export function isJwtExpired(token: string, skewSeconds?: number): boolean;
 
+/** Directory holding the codex token file, under `BETTERWRIGHT_HOME`. */
 export function codexHome(): string;
+/** Directory holding the grok token file, under `BETTERWRIGHT_HOME`. */
 export function grokHome(): string;

--- a/types/captcha-solver.d.ts
+++ b/types/captcha-solver.d.ts
@@ -1,11 +1,18 @@
 import type { UntrustedValue } from "./untrusted-value.js";
 
+// The local solver's shared primitives: stage classification, tile-grid
+// geometry, frame-diff blob analysis, and the solve-result envelope. The
+// worker's `captcha.*` sandbox helpers are built on these. Exported for hosts
+// and tests; most consumers only need the helpers in docs/captcha.md.
+
+/** Solve outcome strings for `CaptchaSolveResult.status`. */
 export const CAPTCHA_SOLVE_STATUSES: Readonly<{
   READY: "ready";
   PROCESSING: "processing";
   ERROR: "error";
 }>;
 
+/** Challenge stages the classifier can return. */
 export const CAPTCHA_STAGES: Readonly<{
   NONE: "none";
   CHECKBOX: "checkbox";
@@ -19,59 +26,85 @@ export const CAPTCHA_STAGES: Readonly<{
   UNKNOWN: "unknown";
 }>;
 
+/** Provider names the classifier recognizes. */
 export const CAPTCHA_PROVIDERS: readonly string[];
 
+/** What `classifyChallengeStage` decided about a page's challenge state. */
 export interface ChallengeStageClassification {
+  /** One of `CAPTCHA_STAGES`. */
   stage: string;
+  /** The recognized provider name, or a best-effort label. */
   provider: string;
+  /** The detail that drove the classification, when one exists. */
   signal: string | null;
+  /** Where the deciding evidence came from: a child frame or the main document. */
   source: {
     kind: string;
     url: string;
     index: number | null;
   };
+  /** The stage can be attempted without host vision. */
   autoSolvable: boolean;
+  /** The stage needs a vision model (image grids, text puzzles). */
   needsVision: boolean;
 }
 
+/** The `captcha.solve()` result envelope. */
 export interface CaptchaSolveResult {
   status: "ready" | "processing" | "error" | string;
+  /** What was asked for: "detect" or "solve". */
   request: string;
   requestId: string;
   provider: string;
   stage: string;
+  /** The challenge is gone and the page is usable. */
   cleared: boolean;
+  /** A response token when the widget minted one, else null. */
   token: string | null;
   errorCode: string | null;
   errorText: string | null;
   attempts: unknown[];
+  /** Image artifact for the challenge crop, when one was captured. */
   artifact: unknown;
   tiles: unknown;
   grid: unknown;
+  /** The instruction text a vision host should answer. */
   instruction: string | null;
   challenge: unknown;
   local: true;
   externalApi: false;
 }
 
+/** One automatic step `nextSolveAction` recommends for a stage. */
 export interface SolveAction {
   action: string;
+  /** How long the worker waits after performing it. */
   waitMs: number;
   description: string;
 }
 
+/**
+ * Classify page metadata (frames, titles, URLs, visible text) into a stage and
+ * provider. Child frames are checked before the main document so host-page
+ * copy cannot override a live provider widget.
+ */
 export function classifyChallengeStage(metadata?: UntrustedValue): ChallengeStageClassification;
+/** Fill a partial solve result out to the full envelope shape. */
 export function buildSolveResult(input?: Partial<CaptchaSolveResult> & {
   status?: string;
   requestId?: string | null;
 }): CaptchaSolveResult;
+/** The next automatic action for a stage and attempt number. */
 export function nextSolveAction(
   classification: { stage?: string } | null | undefined,
   attemptIndex?: number,
 ): SolveAction;
+/** Automatic stages allowed per solve: clamped to 1..3, default 3. */
 export function maxAutoStages(options?: { maxStages?: number; maxAttempts?: number }): number;
+/** Solve wall-clock bound: clamped to 3..180 s, default 45 s. */
 export function solveTimeoutMs(options?: { timeout?: number; timeoutMs?: number }): number;
 
+/** Frame-URL patterns keyed by provider name. */
 export const WIDGET_FRAME_PATTERNS: Readonly<Record<string, RegExp>>;
 export const CHECKBOX_SELECTORS: readonly string[];
 export const VERIFY_BUTTON_SELECTORS: readonly string[];
@@ -82,36 +115,48 @@ export const SELECTED_IMAGE_TILE_SELECTORS: readonly string[];
 export const CHALLENGE_WIDGET_SELECTORS: readonly string[];
 export const CHALLENGE_INSTRUCTION_SELECTORS: readonly string[];
 
+/** Coerce untrusted input into sorted, unique tile indexes. */
 export function parseTileIndexes(value?: UntrustedValue): number[];
+/** Merge rectangles within `quantum` pixels of each other. */
 export function dedupeBoxes(
   boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
   quantum?: number,
 ): Array<{ x: number; y: number; width: number; height: number }>;
+/** Order rectangles top-to-bottom, left-to-right within a row. */
 export function sortTilesReadingOrder(
-  boxes?: Array<{ x: number; y: number; width: number; height: number }>,
+  boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
   yTolerance?: number,
 ): Array<{ x: number; y: number; width: number; height: number }>;
+/** Find groups of similar-sized boxes; how a tile grid is located. */
 export function clusterSimilarBoxes(
   boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
   options?: { minCount?: number; sizeSlack?: number },
 ): Array<{ x: number; y: number; width: number; height: number }>;
+/** Drop boxes contained inside larger ones. */
 export function collapseNestedBoxes(
   boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
   options?: { overlap?: number; minAreaRatio?: number },
 ): Array<{ x: number; y: number; width: number; height: number }>;
+/** Label belongs to the widget's chrome, not a control (reCAPTCHA logo links). */
 export function isCaptchaChromeLabel(label?: UntrustedValue): boolean;
+/** Label is a "skip"/"next" control that advances without solving. */
 export function isCaptchaSkipSubmitLabel(label?: UntrustedValue): boolean;
+/** Label is a verify/submit control. */
 export function isCaptchaVerifySubmitLabel(label?: UntrustedValue): boolean;
+/** The verify control exists and is enabled in the scanned state. */
 export function isCaptchaVerifySubmitReady(state?: UntrustedValue): boolean;
+/** Boxes plausibly form an image-grid puzzle (enough tiles, sensible size). */
 export function isPlausibleImageGrid(
   boxes?: UntrustedValue,
   options?: { minTiles?: number; minSide?: number },
 ): boolean;
+/** The best tile set among candidate grids: coverage, then regularity. */
 export function pickBestTileSet(sets?: UntrustedValue): Array<{
   index: number;
   bounds: { x: number; y: number; width: number; height: number };
   label: string | null;
 }>;
+/** Sanitize internal tile records into the shape results expose. */
 export function publicCaptchaTiles(tiles?: UntrustedValue): Array<{
   index: number;
   bounds: { x: number; y: number; width: number; height: number };
@@ -121,12 +166,15 @@ export function publicCaptchaTiles(tiles?: UntrustedValue): Array<{
   height: number;
   label: string | null;
 }> | null;
+/** Derive row/column counts from a tile list's positions. */
 export function gridFromTiles(tiles?: UntrustedValue): { rows: number; cols: number };
+/** Synthesize `cols` x `rows` tile bounds inside a containing box. */
 export function inferGridTiles(
   box: { x?: number; y?: number; width?: number; height?: number },
   cols?: number,
   rows?: number,
 ): Array<{ index: number; bounds: { x: number; y: number; width: number; height: number }; label: null }>;
+/** Bounding box over boxes plus padding, clamped to the viewport. */
 export function unionClip(
   boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
   options?: {
@@ -135,11 +183,13 @@ export function unionClip(
     viewport?: { width?: number; height?: number } | null;
   },
 ): { x: number; y: number; width: number; height: number } | null;
+/** Build the "pick the numbered tiles that contain X" text for host vision. */
 export function visionGridInstruction(options?: {
   prompt?: string;
   grid?: { rows?: number; cols?: number };
   tileCount?: number;
 }): string;
+/** Dark connected regions in raw RGBA image data; piece/shadow shapes. */
 export function extractDarkBlobs(
   image?: { width?: number; height?: number; data?: ArrayLike<number> },
   options?: {
@@ -168,6 +218,7 @@ type DarkBlobList = ReadonlyArray<{
   cy: number;
 }>;
 
+/** The blob that grew between two sampled frames; motion-challenge answer. */
 export function pickGrowingBlob(
   first?: DarkBlobList,
   second?: DarkBlobList,
@@ -186,6 +237,7 @@ export function pickGrowingBlob(
   matched: boolean;
   confidence: number;
 } | null;
+/** `extractDarkBlobs` on two frames, then `pickGrowingBlob` on the pair. */
 export function findGrowingRegion(
   firstImage?: { width?: number; height?: number; data?: ArrayLike<number> },
   secondImage?: { width?: number; height?: number; data?: ArrayLike<number> },
@@ -199,6 +251,7 @@ export function findGrowingRegion(
     minRatio?: number;
   },
 ): ReturnType<typeof pickGrowingBlob>;
+/** Pair the puzzle piece with the hole it fits for drag-to-fit challenges. */
 export function pickDragFitPair(
   blobs?: DarkBlobList,
   options?: { minSide?: number },
@@ -207,6 +260,7 @@ export function pickDragFitPair(
   hole: { cx: number; cy: number; width: number; height: number; count: number; density: number };
   score: number;
 } | null;
+/** Map a blob in image pixels to page CSS bounds inside a captured box. */
 export function blobToPageBounds(
   blob: { cx?: number; cy?: number; width?: number; height?: number },
   image: { width?: number; height?: number },

--- a/types/captcha-solver.d.ts
+++ b/types/captcha-solver.d.ts
@@ -124,7 +124,7 @@ export function dedupeBoxes(
 ): Array<{ x: number; y: number; width: number; height: number }>;
 /** Order rectangles top-to-bottom, left-to-right within a row. */
 export function sortTilesReadingOrder(
-  boxes?: Array<{ x?: number; y?: number; width?: number; height?: number }>,
+  boxes?: Array<{ x: number; y: number; width: number; height: number }>,
   yTolerance?: number,
 ): Array<{ x: number; y: number; width: number; height: number }>;
 /** Find groups of similar-sized boxes; how a tile grid is located. */

--- a/types/capture.d.ts
+++ b/types/capture.d.ts
@@ -2,12 +2,24 @@ import type { BrowserContext, Page } from "playwright-core";
 import type { VaultMatchMode } from "./vault.js";
 import type { UntrustedValue } from "./untrusted-value.js";
 
+/**
+ * Wiring for `installVaultCapture`: how the sensor reaches the vault, maps
+ * pages to sessions, and asks the host whether to save. The sensor never
+ * returns a captured password; `shouldCapture` sees one only to approve or
+ * reject the save.
+ */
 export interface CaptureOptions {
+  /** Forward a vault action for a session, scoped to the page's origin. */
   vaultCallAtOrigin(session: CaptureSession, origin: string, action: string, payload: Record<string, UntrustedValue>): Promise<{ credentials?: Array<{ username: string }> }>;
+  /** The session a page belongs to, for scoping vault lookups. */
   sessionForPage(page: Page): CaptureSession;
+  /** Add a captured secret to the result redaction set. */
   trackSecret(value: string): void;
+  /** Is the browser showing a window? Prompts only appear headed. */
   isHeaded(): boolean;
+  /** Epoch ms of the model's last activity on this page; gates capture timing. */
   lastModelActivity(page: Page, origin: string): number;
+  /** URL scope for saved credentials. */
   matchMode?: VaultMatchMode;
   /** Trusted host callback only. Captured passwords must never enter agent context. */
   shouldCapture?(capture: { page: Page; origin: string; username: string; password: string }): boolean | Promise<boolean>;
@@ -23,7 +35,9 @@ export interface CaptureOptions {
   modelWindowMs?: number;
 }
 
+/** The opaque session identity `sessionForPage` returns. */
 export interface CaptureSession { id: string }
+/** The http(s) origin of a URL, for vault scoping. */
 export function httpOrigin(url: UntrustedValue): string;
 /** One capture owner per context. Await disposal before attaching a replacement. */
 export function installVaultCapture(context: BrowserContext, options: CaptureOptions): {

--- a/types/challenges.d.ts
+++ b/types/challenges.d.ts
@@ -1,8 +1,11 @@
 import type { UntrustedValue } from "./untrusted-value.js";
 
+/** Guidance text returned when `publicSearchPolicy: "block"` stops a navigation. */
 export const PUBLIC_SEARCH_BLOCK_ADVICE: string;
+/** Guidance text attached to a detected search-provider challenge. */
 export const SEARCH_CHALLENGE_ADVICE: string;
 
+/** A detected bot challenge as results report it to the caller. */
 export interface BotChallenge {
   type: "bot_challenge";
   provider: string;
@@ -18,9 +21,16 @@ export interface BotChallenge {
   advice: string;
 }
 
+/** How long a recorded 403/429/503 block keeps forcing the full challenge scan. */
 export const CHALLENGE_BLOCK_WINDOW_MS: number;
+/**
+ * Up to this many unreadable frames force the full scan (reading them costs
+ * less than the round trips the gate saves). Past the budget, only a
+ * challenge-looking frame URL triggers it.
+ */
 export const CHALLENGE_UNREAD_FRAME_BUDGET: number;
 
+/** Cheap per-run state used to decide whether a full challenge scan is due. */
 export interface ChallengeScanState {
   /** Providers left unresolved by the previous completed scan. */
   openProviders?: { size: number } | readonly unknown[];
@@ -41,7 +51,11 @@ export interface ChallengeScanState {
   solvedProviders?: readonly string[];
 }
 
+/** Should the worker pay for a full challenge scan before this run? */
 export function challengeScanNeeded(state?: ChallengeScanState): boolean;
+/** Scan page metadata for a known bot challenge; null when none matches. */
 export function detectBotChallenge(metadata?: UntrustedValue): BotChallenge | null;
+/** Does this frame URL host a challenge widget? */
 export function frameUrlLooksLikeChallenge(url: string): boolean;
+/** Is this navigation targeting a public search-result UI? */
 export function isPublicSearchNavigation(url: string): boolean;

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -25,33 +25,59 @@ import type { NetworkPolicy } from "./policy.js";
 import type { UntrustedValue } from "./untrusted-value.js";
 import type { VaultMatchMode } from "./vault.js";
 
+/**
+ * Thrown by `BetterWright` methods for lifecycle and configuration failures
+ * (closed instance, invalid option combination, worker not running). Errors
+ * inside a snippet instead come back in the `run()` envelope's `error` field.
+ */
 export class BrowserError extends Error {}
 
+/** Narrow an untrusted value to a `VaultMatchMode`; throws on anything else. */
 export function validateCredentialMatchMode(value: UntrustedValue): VaultMatchMode;
 
+/**
+ * A persistent, policy-guarded browser. Keep one instance alive for the whole
+ * process; constructing one per call throws away the persistent session.
+ * All browser work goes through `run()`, which executes async Playwright
+ * JavaScript in the guarded worker and returns one result envelope. The
+ * globals available inside a snippet (`page`, `snapshot`, `controls`,
+ * `credentials`, `captcha`, `human`, `recording`, `webagents`, `webmcp`, and
+ * friends) are documented in docs/browser-api.md.
+ */
 export class BetterWright {
   constructor(options?: BetterWrightOptions);
 
+  /** State directory (`BETTERWRIGHT_HOME` or `~/.betterwright`). */
   home: string;
+  /** The policy this browser enforces; `new NetworkPolicy()` when unset. */
   policy: NetworkPolicy;
+  /** The active vault, or null when constructed with `vault: false`. */
   vault: CredentialVault | null;
   credentialCapture: boolean;
   browserFlavor: "chromium-fork";
   /** The configured provider, or null for the managed BetterChromium fork. */
   provider: import("./public.js").BrowserProviderOptions | null;
+  /** Resolved headed/headless choice (`"auto"` has already been decided). */
   headless: boolean;
+  /** Minimum gap between public-search navigations, when allowed. */
   searchMinIntervalMs: number;
   publicSearchPolicy: "block" | "allow";
+  /** Ghostery ad/tracker blocking in effect. */
   adBlock: boolean;
   downloadPolicy: "ask" | "allow" | "deny";
+  /** Whether snippets run in an isolated world via patchright-core. */
   stealthRuntimeFix: boolean;
   launchIdentity: boolean;
   fingerprintNoise: boolean;
+  /** Egress proxy URL, or null for direct egress. */
   upstreamProxy: string | null;
+  /** Whether locale/timezone resolve from the upstream egress IP. */
   geoip: boolean;
   locale: string | null;
   timezone: string | null;
+  /** Whether the headed window is parked off-screen. */
   headedInvisible: boolean;
+  /** Identity platform pin, or null for the real host OS. */
   platform: "macos" | "windows" | "linux" | null;
   /** Validated extra Chromium switches, from the option and the environment. */
   chromiumArgs: string[];
@@ -69,12 +95,22 @@ export class BetterWright {
    */
   liveView: Omit<LiveViewOptions, "expose"> & { expose?: string };
 
+  /**
+   * Execute one snippet in the worker and return its result envelope.
+   * `result` is the trailing expression or explicit `return`, JSON-summarized
+   * (oversized output spills to a file as `SpilledRunOutput`). Calls within a
+   * session are queued; different sessions may run concurrently. Never returns
+   * stored secrets; a `pendingCredential` field carries secret-free recovery
+   * metadata when a generated credential still needs a decision.
+   */
   run<T = unknown>(code: string, options?: RunOptions): Promise<RunResult<T>>;
   /** Merge local browser cookies into this browser's persistent context. */
   syncCookies(options: CookieSyncOptions): Promise<CookieSyncResult>;
+  /** Master-password protection and lock state for the vault. */
   vaultStatus(): Promise<{ available: boolean; configured?: boolean; locked?: boolean; osProtected?: boolean; exists?: boolean }>;
   /** Trusted host only. Never expose password input to a model tool. */
   unlockVault(options: { password: string }): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
+  /** Revoke cached unlocks across every process sharing this home. */
   lockVault(): Promise<{ configured: boolean; locked: boolean; osProtected: boolean }>;
   /**
    * Close one session's pages and forget its state (tabs, `state`, cursor)
@@ -104,18 +140,32 @@ export class BetterWright {
   liveViewDrainChat(): Promise<LiveViewDrainChatResult>;
   /** Block until a human answers a question in the live-view chat. */
   waitForAsk(options?: WaitForAskOptions): Promise<AskResult>;
+  /**
+   * Fill a stored credential into the active page through trusted input; the
+   * secret never enters model-authored code or the result. Call from trusted
+   * host code, never expose to a model tool.
+   */
   fillCredential(options?: FillCredentialOptions): Promise<CredentialFillResult>;
+  /**
+   * Generate a password, fill it, and stage it pending commit. The pending
+   * secret is recoverable by `pendingId` until `commitGeneratedCredential` or
+   * `discardGeneratedCredential` resolves it.
+   */
   generateAndFillCredential(
     options?: GenerateAndFillCredentialOptions,
   ): Promise<CredentialFillResult>;
+  /** Commit a staged generated credential after the signup is verified. */
   commitGeneratedCredential(
     options: PendingCredentialOptions,
   ): Promise<PendingCredentialResult>;
+  /** Discard a staged generated credential the site rejected. */
   discardGeneratedCredential(
     options: PendingCredentialOptions,
   ): Promise<PendingCredentialResult>;
+  /** Metadata for generated credentials still awaiting commit/discard. */
   listPendingCredentials(
     options?: PendingCredentialListOptions,
   ): Promise<PendingCredentialListResult>;
+  /** Shut the worker down. Idempotent. */
   close(): Promise<void>;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,8 @@
+// Hand-written declarations for the package root ("betterwright"). Every
+// public symbol lives beside its implementation module; this file re-exports
+// them so `import { ... } from "betterwright"` works. The behavior contract
+// behind these symbols is documented in docs/, not repeated here.
+
 export {
   claudeModel,
   codexModel,
@@ -27,6 +32,10 @@ export {
   loadGrokAuth,
   loginProvider,
 } from "./auth.js";
+// The local CAPTCHA solver's stage classification, tile geometry, and blob
+// helpers. Exported for hosts and tests that need the same primitives the
+// worker's captcha.* helpers are built on; most consumers only need the
+// sandbox helpers documented in docs/captcha.md.
 export {
   buildSolveResult,
   CAPTCHA_SOLVE_STATUSES,
@@ -53,13 +62,18 @@ export {
 } from "./captcha-solver.js";
 export { detectBotChallenge } from "./challenges.js";
 export { BetterWright, BrowserError } from "./client.js";
+
+/** Local browsers readable as a cookie-sync source. */
 export function listCookieSourceBrowsers(): Promise<
   import("./public.js").CookieSourceBrowser[]
 >;
+
+/** Profiles inside one source browser, for `syncCookies({ source })`. */
 export function listCookieSourceProfiles(
   browser: string,
   options?: { timeoutMs?: number },
 ): Promise<import("./public.js").CookieSourceProfile[]>;
+
 export { METADATA_ADDRESSES, METADATA_HOSTNAMES, NetworkPolicy } from "./policy.js";
 export {
   piImageArtifacts,

--- a/types/pi-extension.d.ts
+++ b/types/pi-extension.d.ts
@@ -3,22 +3,50 @@ import type { Guardrails } from "./prompt.js";
 import type { BetterWrightOptions } from "./public.js";
 import type { UntrustedValue } from "./untrusted-value.js";
 
+/**
+ * Options for `createPiExtension`. Every field has a `BETTERWRIGHT_PI_*`
+ * environment counterpart the option overrides; see docs/environment.md.
+ */
 export interface PiExtensionOptions {
+  /**
+   * Attach the active page as an image after a tool call that produced none.
+   * Default true (`BETTERWRIGHT_PI_AUTO_SCREENSHOT`).
+   */
   autoScreenshot?: boolean;
+  /**
+   * A caller-supplied browser instead of the one the extension creates. Only
+   * the methods the tools call need to exist.
+   */
   browser?: Pick<
     BetterWright,
     "run" | "close" | "downloadPolicy" | "fillCredential"
   >;
+  /** Constructor options for the browser the extension creates. */
   browserOptions?: BetterWrightOptions;
+  /** Close the browser on host shutdown. Default true. */
   closeBrowserOnShutdown?: boolean;
+  /** Guardrails appended to the operator guidance the extension adds. */
   guardrails?: Guardrails;
+  /**
+   * Browser-tool step budget; reaching it deactivates the tools and the model
+   * must answer from collected evidence (`BETTERWRIGHT_PI_MAX_STEPS`).
+   */
   maxSteps?: number;
+  /**
+   * Require `browser_evidence` to be initialized with every atomic task
+   * requirement before `browser`/`browser_download` will run
+   * (`BETTERWRIGHT_PI_REQUIRE_EVIDENCE`).
+   */
   requireEvidence?: boolean;
+  /** BetterWright session name for the created browser. Default `"pi"`. */
   session?: string;
+  /** HTTP(S) page to open once before the first tool call. */
   startUrl?: string;
+  /** Directory for JSONL step traces and copied screenshots. */
   traceDir?: string;
 }
 
+/** The slice of Pi's extension API the extension uses. */
 export interface PiExtensionApiLike {
   registerTool(tool: {
     name: string;
@@ -43,11 +71,21 @@ export interface PiExtensionApiLike {
   setActiveTools?(names: string[]): void;
 }
 
+/** A Pi extension entrypoint: registers the tools and lifecycle handlers. */
 export type PiExtension = (pi: PiExtensionApiLike) => void;
 
+/** JSON Schemas for the registered tools, exported for tests and audits. */
 export const PI_BROWSER_PARAMETERS: Readonly<object>;
 export const PI_LOGIN_PARAMETERS: Readonly<object>;
 export const PI_EVIDENCE_PARAMETERS: Readonly<object>;
+
+/**
+ * Build the extension `pi install npm:betterwright` loads: registers
+ * `browser`, `browser_download`, `browser_evidence`, and `browser_login`
+ * (the last only when the vault is enabled), keeps one browser session
+ * alive, and appends the operator guidance to the system prompt.
+ * See SETUP.md §2.
+ */
 export function createPiExtension(options?: PiExtensionOptions): PiExtension;
 
 declare const extension: PiExtension;

--- a/types/pi-extension.d.ts
+++ b/types/pi-extension.d.ts
@@ -4,8 +4,10 @@ import type { BetterWrightOptions } from "./public.js";
 import type { UntrustedValue } from "./untrusted-value.js";
 
 /**
- * Options for `createPiExtension`. Every field has a `BETTERWRIGHT_PI_*`
- * environment counterpart the option overrides; see docs/environment.md.
+ * Options for `createPiExtension`. The environment-backed fields name their
+ * `BETTERWRIGHT_PI_*` counterpart inline (see docs/environment.md);
+ * `browser`, `browserOptions`, `closeBrowserOnShutdown`, and `guardrails`
+ * are programmatic-only.
  */
 export interface PiExtensionOptions {
   /**

--- a/types/pi.d.ts
+++ b/types/pi.d.ts
@@ -1,5 +1,10 @@
 import type { UntrustedValue } from "./untrusted-value.js";
 
+/**
+ * A result artifact from any browser call, shaped loosely enough to accept
+ * both the client's own `BetterWrightArtifact` and a deserialized envelope
+ * from another host. Only `kind` and `media`/`path` matter to the helpers.
+ */
 export interface BetterWrightArtifactLike {
   kind?: UntrustedValue;
   media?: UntrustedValue;
@@ -7,35 +12,53 @@ export interface BetterWrightArtifactLike {
   [key: string]: UntrustedValue;
 }
 
+/** A browser run envelope that may carry artifacts. */
 export interface BetterWrightResultLike {
   artifacts?: readonly BetterWrightArtifactLike[];
   [key: string]: UntrustedValue;
 }
 
 export interface PiImageContentOptions {
+  /**
+   * Per-image byte ceiling. Images above it are skipped rather than
+   * downscaled. Defaults to 2,500,000 bytes.
+   */
   maxImageBytes?: number;
 }
 
+/** An image content block in the shape Pi tool results expect. */
 export interface PiImageContentBlock {
   type: "image";
+  /** Base64 image bytes. */
   data: string;
   mimeType: "image/png" | "image/jpeg" | "image/webp" | "image/gif";
 }
 
+/** An artifact that points at an image file on disk. */
 export interface PiImageArtifact {
   path: string;
   mimeType: "image/png" | "image/jpeg" | "image/webp" | "image/gif";
 }
 
+/**
+ * Image artifacts in a result that are safe to hand to a vision model:
+ * `MEDIA:`-tagged files and screenshot kinds (proof, question, debug,
+ * screenshot, captcha), deduplicated by path.
+ */
 export function piImageArtifacts(
   result: BetterWrightResultLike | null | undefined,
 ): PiImageArtifact[];
 
+/** Read those image files and return them as Pi image content blocks. */
 export function piImageContent(
   result: BetterWrightResultLike | null | undefined,
   options?: PiImageContentOptions,
 ): Promise<PiImageContentBlock[]>;
 
+/**
+ * The screenshot that best represents the step in a trace: the last
+ * non-captcha image, or the last image when only captcha shots exist.
+ */
 export function piPrimaryImageArtifact(
   result: BetterWrightResultLike | null | undefined,
 ): PiImageArtifact | null;

--- a/types/policy.d.ts
+++ b/types/policy.d.ts
@@ -1,30 +1,87 @@
 import type { UntrustedValue } from "./untrusted-value.js";
 
+/** The verdict a policy returns for one request. */
 export interface NetworkDecision {
   allowed: boolean;
+  /** Why a request was denied; surfaced in worker warnings and errors. */
   reason?: string;
 }
 
+/**
+ * What the worker knows about a request: `method`, `resourceType`,
+ * `isNavigation`, and `resolvedFrom` when the connect target is a resolved
+ * address literal. Custom hooks may key decisions on any of these.
+ */
 export interface NetworkRequestDetails {
   [key: string]: UntrustedValue;
 }
 
+/**
+ * Final say on a request, evaluated last. Return a decision to override the
+ * built-in rules, or `null`/`undefined` to keep the decision made so far. An
+ * `allowed: true` from this hook still cannot reach a metadata endpoint. A
+ * policy carrying a hook is never answerable from the worker's decision cache:
+ * every request reaches it.
+ */
 export type NetworkPolicyCustom = (
   url: string,
   details: NetworkRequestDetails,
 ) => NetworkDecision | null | undefined;
 
 export interface NetworkPolicyOptions {
+  /**
+   * Permit RFC 1918 ranges, link-local, and `*.internal`/`*.local`/`*.lan`
+   * hosts. Implies loopback. Default `true`; set `false` to restrict the
+   * browser to the public internet plus `allowHosts`.
+   */
   allowPrivateNetwork?: boolean;
+  /**
+   * Permit `127.0.0.1`/`localhost` for local dev servers. Does not open the
+   * wider private network. Default `true`.
+   */
   allowLoopback?: boolean;
+  /**
+   * Re-allow these hosts inside an otherwise blocked scope. An entry matches
+   * a host exactly or as a parent domain; add `:port` to pin a port. This is
+   * an exception list, not an exclusive allowlist: other public sites stay
+   * reachable.
+   */
   allowHosts?: string[];
+  /** Deny these hosts ahead of `allowHosts` and the private-network rules. */
   blockHosts?: string[];
+  /** A hook evaluated last; see `NetworkPolicyCustom`. */
   custom?: NetworkPolicyCustom;
 }
 
+/**
+ * Cloud instance-metadata hostnames in the unliftable floor
+ * (`metadata.google.internal`, `metadata.goog`). Nothing can allowlist them:
+ * not `allowHosts`, not `custom`, not a subclass.
+ */
 export const METADATA_HOSTNAMES: Set<string>;
+
+/**
+ * Cloud instance-metadata addresses in the same floor
+ * (`169.254.169.254`, `169.254.170.2`, `100.100.100.200`, `fd00:ec2::…`).
+ */
 export const METADATA_ADDRESSES: Set<string>;
 
+/**
+ * The allow/deny rules applied to every browser request: navigations,
+ * subresources, WebSocket upgrades, and the transport connections the worker's
+ * guard proxy makes on the browser's behalf.
+ *
+ * Defaults permit the public internet, private networks, and loopback while
+ * blocking non-web schemes and the metadata floor. Decisions from a stock
+ * policy may be reused by the worker's five-second cache; a `custom` hook,
+ * a subclass, or any other `check` implementation is asked every time.
+ * Evaluation order: scheme, metadata floor, `blockHosts`, `allowHosts`,
+ * private-network rules, `custom`. A check that throws denies the request.
+ *
+ * For ordinary remote CDP/provider browsers the transport floor does not
+ * apply; supported Playwright routing checks still do. See
+ * docs/network-policy.md.
+ */
 export class NetworkPolicy {
   constructor(options?: NetworkPolicyOptions);
 
@@ -34,8 +91,12 @@ export class NetworkPolicy {
   blockHosts: string[];
   custom: NetworkPolicyCustom | null;
 
+  /** Does an `allowHosts`/`blockHosts` entry cover this host (and port)? */
   hostMatches(entry: UntrustedValue, hostname: string, port: number | null): boolean;
+  /** Is this hostname in the unliftable metadata floor? */
   isMetadata(hostname: string): boolean;
+  /** Decide one request URL with its request details. */
   check(url: UntrustedValue, details?: NetworkRequestDetails): NetworkDecision;
+  /** Decide a connect target the transport guard resolved to. */
   checkHost(hostname: string, port: number | null): NetworkDecision;
 }

--- a/types/prompt.d.ts
+++ b/types/prompt.d.ts
@@ -1,11 +1,50 @@
+/**
+ * Prompt-level behavior switches for the operator guidance. Each one appends a
+ * clause to the "Guardrails for this session" section, which overrides the
+ * default autonomy where they conflict. They shape model behavior only;
+ * enforcement belongs to the network policy, the vault, or the host's own
+ * gates. See docs/agent-prompt.md.
+ */
 export interface Guardrails {
+  /**
+   * Pause before submitting any payment or order: capture a `question`
+   * screenshot of the order summary and get explicit user confirmation.
+   */
   confirmBeforePurchase?: boolean;
+  /**
+   * Pause for explicit confirmation before any irreversible action: deleting
+   * data, sending a message or email, submitting an application, confirming
+   * a booking.
+   */
   confirmBeforeIrreversible?: boolean;
+  /**
+   * Never complete a purchase or payment. The agent may still reach the
+   * checkout page; it stops before submitting payment. Overrides
+   * `confirmBeforePurchase` and `spendingLimit`.
+   */
   forbidPurchases?: boolean;
+  /** Never create accounts; a task that requires signing up stops and reports. */
   forbidAccountCreation?: boolean;
+  /**
+   * Per-purchase cap, inserted into the guidance verbatim (for example
+   * `"$50"`). Purchases above it need explicit confirmation. Ignored when
+   * `forbidPurchases` is set.
+   */
   spendingLimit?: string;
+  /** Additional instruction lines appended verbatim to the guardrail list. */
   extraRules?: string[];
+  /**
+   * Name of the password-manager extension installed and unlocked in the
+   * browser (for example "1Password" or "Bitwarden"). Adds a section teaching
+   * the model to drive that extension's inline menu and fall back to trusted
+   * host-side fill.
+   */
   passwordManager?: string;
 }
 
+/**
+ * The BetterWright operator guidance: how to observe, act, verify, handle
+ * credentials and challenges, and prove results. Paste it into a host's
+ * system prompt (`betterwright skill` prints the CLI-shaped variant).
+ */
 export function agentSystemPrompt(guardrails?: Guardrails): string;

--- a/types/recording.d.ts
+++ b/types/recording.d.ts
@@ -1,18 +1,27 @@
 export interface RecordingOptions {
   /** Defaults to recording.mp4. A .webm filename selects VP8 instead of H.264. */
   name?: string;
+  /** Requested output rate, 1-60 (default 60). Output FPS is not capture cadence. */
   fps?: number;
+  /** Video width bound in px (default 1280). */
   maxWidth?: number;
+  /** Video height bound in px (default 720). */
   maxHeight?: number;
+  /** Capture quality 1-100 (default 80). */
   quality?: number;
+  /** Stop after this long (default 300000). */
   maxDurationMs?: number;
 }
 
 export interface RecordingStats {
+  /** Video path inside the session artifact directory. */
   path: string;
   fps: number;
+  /** Frames the capture delivered. */
   capturedFrames: number;
+  /** Frames written to the video, including repeated stills. */
   outputFrames: number;
+  /** Captures discarded when the encoder fell behind. */
   droppedFrames: number;
   durationMs: number;
   bytes: number;


### PR DESCRIPTION
## Summary

- New `docs/cli.md`: every `betterwright` command and flag, grouped by setup, driving, sessions/credentials, boxes, and agent integration. One shared-flags table covers the options `run`, `repl`, `exec`, and the console all accept, so they aren't repeated four times.
- New `docs/environment.md`: every user-facing `BETTERWRIGHT_*` variable in grouped tables with defaults. Test-harness and internal-only vars are called out as unsupported rather than silently absent.
- `docs/README.md` now links the six pages it didn't reach before (`recording`, `ad-blocking`, `electron-host`, `runtime-performance`, plus a Reference section for the two new pages and the dated audit reports).
- Documented real-but-undocumented switches: `run --approve-downloads` (in `--help` but no doc), `init --skip-browser`, `BETTERWRIGHT_PI_REQUIRE_EVIDENCE`, and the MCP-only `BETTERWRIGHT_LOCALE`/`BETTERWRIGHT_TIMEZONE`. Added `automaticUI` to the `run()` signature in `javascript.md`.
- JSDoc for the previously bare declaration files (`policy`, `prompt`, `pi`, `pi-extension`, `index`, `captcha-solver`) and the uncommented symbols in `client`, `auth`, `challenges`, `capture`, `recording`, so IDE hover carries the semantics the guides already document.
- `cli-help-inventory.test.ts` now fails if `docs/cli.md` drops a command or a non-obvious flag, so the reference cannot silently drift from `cli-help.ts`.

#### Test plan

- [x] `bun run test:types` — declarations compile
- [x] `bun run lint` — no new warnings
- [x] `bun run check:package` — tarball smoke + shipped-docs IP scan pass
- [x] `bun test tests/node/cli-help-inventory.test.ts` — new drift check passes
- [x] `bun test` on skill-md/onboard/cli-help/skills — 77 pass, 0 fail

Generated with [Devin](https://devin.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/betterwright/betterwright/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->