### PR TITLE
chore: release BetterWright 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Releases before 1.1.3 predate this file; their notes live on the
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-09-11
+
+### Added
+
+- `docs/cli.md`, a reference for every command and flag, and
+  `docs/environment.md`, a reference for every user-facing `BETTERWRIGHT_*`
+  variable with defaults and scope.
+- JSDoc across the public type declarations (network policy, prompt
+  guardrails, Pi extension, captcha solver, client, auth, challenge scan,
+  credential capture, recording) so editor hover shows the documented
+  semantics.
+
+### Fixed
+
+- Documentation gaps: the index now links the recording, ad-blocking,
+  Electron hosting, and runtime-performance pages; `run --approve-downloads`,
+  `init --skip-browser`, `BETTERWRIGHT_PI_REQUIRE_EVIDENCE`, and the MCP-only
+  `BETTERWRIGHT_LOCALE`/`BETTERWRIGHT_TIMEZONE` are documented; `automaticUI`
+  appears in the `run()` signature in docs/javascript.md.
+- `sortTilesReadingOrder` keeps required box coordinates in the public
+  declarations, matching the runtime.
+
 ## [2.7.0] - 2026-09-11
 
 ### Changed
@@ -1570,7 +1592,8 @@ number to be reused.
   refresh already-installed skill files but never create new ones; `doctor`
   tips when a managed skill is stale.
 
-[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.7.0...HEAD
+[Unreleased]: https://github.com/BetterWright/betterwright/compare/v2.7.1...HEAD
+[2.7.1]: https://github.com/BetterWright/betterwright/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/BetterWright/betterwright/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/BetterWright/betterwright/compare/v2.5.2...v2.6.0
 [2.5.2]: https://github.com/BetterWright/betterwright/compare/v2.5.1...v2.5.2

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Drive a persistent, policy-guarded real web browser via the betterwright CLI. Use for any task that needs the live web — logging in, filling forms, booking, buying, or reading a page an API will not give you.
-generated_by: betterwright@2.7.0
+generated_by: betterwright@2.7.1
 ---
 
 # BetterWright browser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "betterwright",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A persistent, policy-guarded Playwright browser for AI agents with network controls, trusted credential filling, proof screenshots, and CAPTCHA helpers.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

Documentation patch release. Ships #183's docs and declaration improvements in the npm tarball:

- New `docs/cli.md` (full command/flag reference) and `docs/environment.md` (`BETTERWRIGHT_*` reference) — both ship in the package
- Docs index now reaches recording, ad-blocking, Electron, and runtime-performance pages
- Previously undocumented behavior: `run --approve-downloads`, `init --skip-browser`, `BETTERWRIGHT_PI_REQUIRE_EVIDENCE`, MCP-only `BETTERWRIGHT_LOCALE`/`BETTERWRIGHT_TIMEZONE`, `automaticUI` in `run()`
- JSDoc across the public type declarations so editor hover carries the documented semantics
- `sortTilesReadingOrder` declaration keeps required coordinates, matching the runtime

Version bumped to 2.7.1 in package.json; SKILL.md generated_by stamp refreshed; CHANGELOG entry and compare links updated.

#### Test plan

- [x] `bun run release:check` green under pinned Bun 1.4.0 (versions, lint, typecheck, build, 1117 unit tests, test:types, package smoke)

Generated with [Devin](https://devin.ai)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/betterwright/betterwright/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->